### PR TITLE
Add sig-windows leads email to alerts

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
@@ -52,7 +52,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.21-release
     testgrid-tab-name: aks-engine-windows-dockershim-1.21
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-serial-slow
@@ -106,63 +106,8 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.21-release
     testgrid-tab-name: aks-engine-windows-dockershim-serial-slow-1.21
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release serial tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-# This job lives in config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml instead
-# - interval: 24h
-#   name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-containerd
-#   decorate: true
-#   decoration_config:
-#     timeout: 3h
-#   labels:
-#     preset-service-account: "true"
-#     preset-azure-cred: "true"
-#     preset-azure-windows: "true"
-#     preset-windows-repo-list-master: "true"
-#     preset-k8s-ssh: "true"
-#     preset-dind-enabled: "true"
-#   extra_refs:
-#   - org: kubernetes
-#     repo: kubernetes
-#     base_ref: release-1.21
-#     path_alias: k8s.io/kubernetes
-#   spec:
-#     containers:
-#     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-1.21
-#       command:
-#       - runner.sh
-#       - kubetest
-#       args:
-#       # Generic e2e test args
-#       - --test
-#       - --up
-#       - --down
-#       - --build=quick
-#       - --dump=$(ARTIFACTS)
-#       # Azure-specific test args
-#       - --deployment=aksengine
-#       - --provider=skeleton
-#       - --aksengine-orchestratorRelease=1.21
-#       - --aksengine-admin-username=azureuser
-#       - --aksengine-admin-password=AdminPassw0rd
-#       - --aksengine-creds=$(AZURE_CREDENTIALS)
-#       - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-#       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
-#       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-#       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-#       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_21.json
-#       - --aksengine-win-binaries
-#       - --aksengine-deploy-custom-k8s
-#       # Specific test args
-#       - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
-#       - --ginkgo-parallel=4
-#       securityContext:
-#         privileged: true
-#   annotations:
-#     testgrid-dashboards: sig-release-1.21-informing, sig-windows-1.21-release
-#     testgrid-tab-name: aks-engine-windows-containerd-1.21
-#     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-#     description: Runs SIG-Windows release tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud#
 - interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-containerd-serial-slow
   decorate: true
@@ -215,5 +160,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.21-release
     testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.21
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release serial tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
@@ -1,6 +1,6 @@
 periodics:
 - annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.22-informing, sig-windows-signal, sig-windows-1.22-release
     testgrid-tab-name: aks-engine-windows-containerd-1.22
   decorate: true
@@ -106,7 +106,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.22-release
     testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.22
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release serial tests on K8s 1.22 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-1-22-windows
@@ -161,5 +161,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.22-release
     testgrid-tab-name: aks-engine-windows-dockershim-1.22
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release tests on K8s 1.22 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
@@ -1,6 +1,6 @@
 periodics:
 - annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.23-informing, sig-windows-signal, sig-windows-1.23-release
     testgrid-tab-name: aks-engine-windows-containerd-1.23
   decorate: true
@@ -106,7 +106,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.23-release
     testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.23
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release serial tests on K8s 1.23 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-1-23-windows
@@ -161,5 +161,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.23-release
     testgrid-tab-name: aks-engine-windows-dockershim-1.23
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release tests on K8s 1.23 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -43,7 +43,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.24-informing, sig-windows-1.24-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-1.24
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow-1-24
@@ -77,7 +77,7 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-1.24-release
     testgrid-tab-name: capz-windows-containerd-serial-slow-1.24
 - name: ci-kubernetes-e2e-azure-disk-windows-containerd-1-24
@@ -140,7 +140,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.24-release
     testgrid-tab-name: aks-engine-windows-containerd-azure-disk-1.24
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Run Azure Disk e2e test with Azure Disk in a Windows cluster configured with CSI proxy and containerd.
 - name: ci-kubernetes-e2e-azure-file-windows-containerd
   interval: 48h
@@ -202,5 +202,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-1.24-release
     testgrid-tab-name: aks-engine-windows-containerd-azure-file-1.24
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Run Azure File e2e test with Azure File in a Windows cluster configured with CSI proxy and containerd.

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -90,6 +90,5 @@ presubmits:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
     annotations:
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-containerd-extension

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -97,7 +97,7 @@ periodics:
             memory: "9Gi"
   annotations:
     fork-per-release: "true"
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-master
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow
@@ -131,7 +131,7 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-2022
@@ -165,7 +165,7 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-containerd-2022-master
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-2022-serial-slow
@@ -199,7 +199,7 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-containerd-2022-master-serial-slow
 - name: ci-kubernetes-e2e-azuredisk-capz-windows-2019
@@ -241,7 +241,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-azuredisk-windows-2019
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Run Azure Disk e2e test in a CAPZ cluster on Windows 2019 nodes
 - name: ci-kubernetes-e2e-azurefile-capz-windows-2019
   interval: 48h
@@ -282,7 +282,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-azurefile-windows-2019
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Run Azure File e2e test in a CAPZ cluster on Windows 2019 nodes
 - name: ci-kubernetes-e2e-capz-master-containerd-nightly-windows
   interval: 24h
@@ -317,6 +317,6 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
@@ -53,7 +53,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-sac
     testgrid-tab-name: aks-engine-windows-20h2-containerd-1.24
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
   name: ci-kubernetes-e2e-aks-engine-azure-1-24-windows-20h2-containerd-serial-slow
@@ -108,5 +108,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-windows-sac
     testgrid-tab-name: aks-engine-windows-20h2-containerd-serial-slow-1.24
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud


### PR DESCRIPTION
The sets up the dashboard that sig-windows monitors to send emails to the leads if a test fails.

/sig windows
/assign @marosset @claudiubelu 