### PR TITLE
Switch to sig-windows scripts for ws2022

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
       preset-capz-windows-common-main: "true"
       preset-capz-containerd-latest: "true"
     extra_refs:
-    - org: jsturtevant
+    - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: reuse-logging
       path_alias: sigs.k8s.io/cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -143,27 +143,34 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-windows-private-registry-cred: "true"
     preset-capz-windows-common-main: "true"
-    preset-capz-windows-2022: "true"
     preset-capz-containerd-latest: "true"
-    preset-capz-windows-parallel: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
     base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: k8s.io/windows-testing
+    workdir: true
   spec:
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
         command:
           - "runner.sh"
-          - "./scripts/ci-conformance.sh"
+          - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: 2
             memory: "9Gi"
+        env:
+          - name: WINDOWS_SERVER_VERSION
+            value: "windows-2022"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
@@ -177,27 +184,38 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-windows-private-registry-cred: "true"
     preset-capz-windows-common-main: "true"
-    preset-capz-windows-2022: "true"
     preset-capz-containerd-latest: "true"
-    preset-capz-serial-slow: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
     base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: k8s.io/windows-testing
+    workdir: true
   spec:
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
         command:
           - "runner.sh"
-          - "./scripts/ci-conformance.sh"
+          - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: 2
             memory: "9Gi"
+        env:
+          - name: WINDOWS_SERVER_VERSION
+            value: "windows-2022"
+          - name: GINKGO_FOCUS
+            value: "(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector"
+          - name: GINKGO_SKIP
+            value: "\[LinuxOnly\]|device.plugin.for.Windows"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -213,9 +213,9 @@ periodics:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
           - name: GINKGO_FOCUS
-            value: "(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector"
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP
-            value: "\[LinuxOnly\]|device.plugin.for.Windows"
+            value: \[LinuxOnly\]|device.plugin.for.Windows
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release


### PR DESCRIPTION
We needed more flexibility with templates and ability to install additional tooling for things like gmsa so we've developed a new script for Windows e2e using capz. This script is a WIP so have using a few branches to run the job until it stable. This script does work locally.

This also fixes the issue with failing test `Container Runtime blackbox test` https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-2022/1537753577135542272

points the capz reference to the main branch.  and logging in capz is now merged: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2345

/sig windows
/assign @marosset 