### PR TITLE
azure: ensure ci-entrypoint CI job is required for capz

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -465,7 +465,7 @@ presubmits:
       description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
   - name: pull-cluster-api-provider-azure-ci-entrypoint
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: true
+    optional: false
     decorate: true
     # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
     run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -313,7 +313,7 @@ presubmits:
       testgrid-tab-name: capz-pr-apidiff-v1beta1
   - name: pull-cluster-api-provider-azure-ci-entrypoint-v1beta1
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: true
+    optional: false
     decorate: true
     # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
     run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)


### PR DESCRIPTION
This PR ensures that the `ci-entrypoint.sh` CI validation runs as a required job for capz presubmits.