### PR TITLE
CAPI: bump coredns version for tests upgrading to v1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -293,7 +293,7 @@ periodics:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.6"
+            value: "v1.9.3"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1-upgrades.yaml
@@ -293,7 +293,7 @@ periodics:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.6"
+            value: "v1.9.3"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -263,7 +263,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.6"
+            value: "v1.9.3"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
@@ -289,7 +289,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.6"
+            value: "v1.9.3"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Bumps the target coredns version for all upgrade tests having target version v1.25

Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/6641

To align with https://github.com/kubernetes/kubernetes/pull/110489