### PR TITLE
feat: added presubmit for capa gc

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -283,3 +283,41 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks-main
       testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-eks-gc
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e-eks-gc.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-eks-gc-main
+      testgrid-num-columns-recent: '20'


### PR DESCRIPTION
This adds a new presubmit job for CAPA that will run the new CAPA garbage collection tests for EKS.

This will be used with this change: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3518

Signed-off-by: Richard Case <richard.case@outlook.com>