### PR TITLE
Test `gcloud-terraform` image in presubmits

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -209,5 +209,5 @@ presubmits:
         - name: IMAGE
           value: gcloud-terraform
     annotations:
-      testgrid-dashboards: "sig-testing-images"
-      testgrid-tab-name: "gcloud-terraform"
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: images-gcloud-terraform

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -186,3 +186,26 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-test
+  - name: pull-test-infra-push-gcloud-terraform
+    cluster: test-infra-trusted
+    run_if_changed: '^images/gcloud-terraform/'
+    decorate: true
+    branches:
+    - ^master$
+    max_concurrency: 1
+    spec:
+      serviceAccountName: deployer # TODO(fejta): should be pusher
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20220428-ae431ed1aa
+        command:
+        - /run.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - --build-dir=.
+        - images/gcloud-terraform/
+        env:
+        - name: IS_PRESUBMIT
+          value: "true"
+        - name: IMAGE
+          value: gcloud-terraform

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -187,14 +187,13 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-test
   - name: pull-test-infra-push-gcloud-terraform
-    cluster: test-infra-trusted
     run_if_changed: '^images/gcloud-terraform/'
     decorate: true
     branches:
     - ^master$
     max_concurrency: 1
     spec:
-      serviceAccountName: deployer # TODO(fejta): should be pusher
+      serviceAccountName: image-builder
       containers:
       - image: gcr.io/k8s-staging-test-infra/image-builder:v20220428-ae431ed1aa
         command:
@@ -209,3 +208,6 @@ presubmits:
           value: "true"
         - name: IMAGE
           value: gcloud-terraform
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "gcloud-terraform"

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:343.0.0-alpine
+FROM google/cloud-sdk:390.0.0-alpine
+ARG YQ_VERSION
+RUN wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 COPY builder run.sh /
 CMD ["/run.sh"]

--- a/images/builder/cloudbuild.yaml
+++ b/images/builder/cloudbuild.yaml
@@ -22,6 +22,7 @@ steps:
 substitutions:
   _GIT_TAG: '12345'
   _GO_VERSION: '1.18'
+  _YQ_VERSION: v4.23.1
 images:
   - 'gcr.io/$PROJECT_ID/image-builder:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/image-builder:latest'

--- a/images/builder/run.sh
+++ b/images/builder/run.sh
@@ -23,6 +23,12 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
 
+# If IS_PRESUBMIT & IMAGE env is set, use yq to strip images key
+# from cloudbuild.yaml file to avoid pushing images to GCR/AR.
+
+if [[ -n "${IS_PRESUBMIT:-}" ]]; then
+  yq 'del(.images)' -i images/${IMAGE}/cloudbuild.yaml --exit-status
+fi
 
 echo "Running..."
 if [ -n "${ARTIFACTS}" ] && [ -z "${LOG_TO_STDOUT}" ]; then


### PR DESCRIPTION
Part of: https://github.com/kubernetes/test-infra/issues/26617

Modified `run.sh` and image-builder to use yq to strip images keys from cloudbuild.yaml. I also bumped gcloud to get a fresher image.

I will submit a change to gcloud-terraform after this change is merged, image promoted and job autobumped.

https://cloud.google.com/build/docs/build-config-file-schema#images

/cc @BenTheElder 
