### PR TITLE
CAPI: add presubmit equivalent for periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -275,3 +275,45 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main-1-24-latest
+  - name: pull-cluster-api-e2e-workload-upgrade-1-21-1-22-main
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: sigs.k8s.io/cluster-api
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-1.24
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "stable-1.21"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "stable-1.22"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.5.3-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "v1.8.4"
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-main-1-21-1-22


### PR DESCRIPTION
For further testing fix for https://github.com/kubernetes-sigs/cluster-api/issues/6676

/assign @sbueringer 