### PR TITLE
add optional VMSS flex presubmit job for cloud-provider-azure

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -71,6 +71,60 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
+  # pull-cloud-provider-azure-e2e-ccm-vmss-flex-capz runs Azure specific e2e tests on VMSS Flex.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-flex-capz
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+      - master
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+      - org: jackfrancis
+        repo: cluster-api-provider-azure
+        base_ref: vmss-flex-cloudprovider
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
+          command:
+          - runner.sh
+          args:
+          - ./scripts/ci-entrypoint.sh
+          - bash
+          - -c
+          - >-
+            cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+            make test-ccm-e2e
+          securityContext:
+            privileged: true
+          env:
+            - name: TEST_CCM
+              value: "true"
+            - name: TEST_WINDOWS
+              value: "true"
+            - name: WINDOWS_SERVER_VERSION
+              value: "windows-2022"
+            - name: CONTROL_PLANE_MACHINE_COUNT
+              value: "1"
+            - name: KUBERNETES_VERSION
+              value: "latest"
+            - name: CLUSTER_TEMPLATE
+              value: templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+            - name: AZURE_LOADBALANCER_SKU
+              value: "Standard"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-flex-capz
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS Flex, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-capz runs kubernetes conformance tests.
   - name: pull-cloud-provider-azure-e2e-capz
     skip_if_only_changed: "^docs/|^site/|^helm/|^tests/e2e/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"


### PR DESCRIPTION
This PR adds an optional cloud-provider-azure presubmit job to test implementations of cloud-controller-manager and cloud-node-manager running on top of VMSS Flex-backed nodes.

The test currently depends upon a known-working branch of capz that implements AzureMachinePool using VMSS Flex:

https://github.com/jackfrancis/cluster-api-provider-azure/commits/vmss-flex-cloudprovider