### PR TITLE
CA Cert and Server Implementation 

### DIFF
--- a/prow/.prow-images.yaml
+++ b/prow/.prow-images.yaml
@@ -25,6 +25,7 @@ images:
   - dir: prow/cmd/tot
   - dir: prow/cmd/pipeline
   - dir: prow/cmd/prow-controller-manager
+  - dir: prow/cmd/webhook-server
   # pod utils
   - dir: prow/cmd/clonerefs
     arch: all

--- a/prow/cmd/webhook-server/helpers.go
+++ b/prow/cmd/webhook-server/helpers.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+const org = "prow.k8s.io"
+
+func genCert(expiry int, dnsNames []string) (string, string, string, error) {
+
+	//https://gist.github.com/velotiotech/2e0cfd15043513d253cad7c9126d2026#file-initcontainer_main-go
+	var caPEM, serverCertPEM, serverPrivKeyPEM *bytes.Buffer
+	// CA config
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2020), //unique identifier for cert
+		Subject: pkix.Name{
+			Organization: []string{org},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(expiry, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// CA private key
+	caPrivKey, err := rsa.GenerateKey(cryptorand.Reader, 4096)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error generating ca private key: %v", err)
+	}
+
+	// Self signed CA certificate
+	caBytes, err := x509.CreateCertificate(cryptorand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error generating signed ca certificate: %v", err)
+	}
+
+	// PEM encode CA cert
+	caPEM = new(bytes.Buffer)
+	err = pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("error encoding ca certificate: %v", err)
+	}
+
+	// server cert config
+	cert := &x509.Certificate{
+		DNSNames:     dnsNames,
+		SerialNumber: big.NewInt(1658), //unique identifier for cert
+		Subject: pkix.Name{
+			CommonName:   "validation-webhook-service.default.svc",
+			Organization: []string{org},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(expiry, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6}, //unique identifier for cert
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	// server private key
+	serverPrivKey, err := rsa.GenerateKey(cryptorand.Reader, 4096)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error generating server private key: %v", err)
+	}
+
+	// sign the server cert
+	serverCertBytes, err := x509.CreateCertificate(cryptorand.Reader, cert, ca, &serverPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error generating signed server certificate: %v", err)
+	}
+
+	// PEM encode the  server cert and key
+	serverCertPEM = new(bytes.Buffer)
+	err = pem.Encode(serverCertPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: serverCertBytes,
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("error encoding server certificate: %v", err)
+	}
+
+	serverPrivKeyPEM = new(bytes.Buffer)
+	err = pem.Encode(serverPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(serverPrivKey),
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("error encoding server private key: %v", err)
+	}
+
+	return serverCertPEM.String(), serverPrivKeyPEM.String(), caPEM.String(), nil
+
+}
+
+func isCertValid(cert string) error {
+	block, _ := pem.Decode([]byte(cert))
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+	if time.Now().After(certificate.NotAfter) {
+		return fmt.Errorf("certificated expired at %v", certificate.NotAfter)
+	}
+	return nil
+}

--- a/prow/cmd/webhook-server/main.go
+++ b/prow/cmd/webhook-server/main.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+	"k8s.io/test-infra/experiment/clustersecretbackup/secretmanager"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/logrusutil"
+)
+
+const (
+	secretID  = "prowjob-webhook-ca-cert"
+	caCert = "ca-cert"
+	caPrivKey = "ca-priv-key"
+	caBundle = "ca-bundle"
+	gcpSecretError = "failed to access secret version"
+)
+
+type ClientInterface interface {
+	CreateSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error)
+	AddSecretVersion(ctx context.Context, secretName string, payload []byte) error
+	GetSecretValue(ctx context.Context, secretName, versionName string) ([]byte, error)
+}
+
+func main() {
+	logrusutil.ComponentInit()
+	logrus.SetLevel(logrus.DebugLevel)
+	p := flag.String("project-id", 
+	"", "Project ID for storing GCP Secrets")
+	e := flag.Int("expiry-years", 30, "CA certificate expiry in years")
+	dns := flagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
+	flag.Var(&dns, "dns", "DNS Names CA-Cert config")
+	flag.Parse()
+	exp := *e
+	projectId := *p
+	if len(projectId) == 0 {
+		logrus.Fatal("project-id flag not supplied")
+	}
+	client, err := secretmanager.NewClient(projectId, false)
+	if err != nil {
+		logrus.WithError(err).Fatal("Unable to create secret manager client")
+	}
+	ctx := context.Background()
+	cert, privKey, err := getGCPSecrets(client, ctx, exp, dns)
+	if err != nil && strings.Contains(err.Error(), gcpSecretError) {
+		logrus.Infof("%v, Will now proceed to create GCP Secret", err)
+		cert, privKey, err = createGCPSecret(client, ctx, exp, dns.Strings())
+		if err != nil {
+			logrus.WithError(err).Fatal("Unable to create ca certificate")
+		}
+	} else if err != nil {
+		logrus.WithError(err).Fatal("Unable to get GCP Secret")
+	}
+	if err = isCertValid(cert); err != nil {
+		logrus.WithError(err).Info("Certificate is not valid, will replace.")
+		cert, privKey, err = updateGCPSecret(client, ctx, exp, dns.Strings())
+		if err != nil {
+			logrus.WithError(err).Fatal("Unable to update GCP Secret")
+		}
+	} 
+	tempDir, err := ioutil.TempDir("", "cert")
+	if err != nil {
+		logrus.WithError(err).Fatal("Unable to create temp directory")
+	}
+	defer os.RemoveAll(tempDir)
+	certFile := filepath.Join(tempDir, "certFile.pem")
+	if err := ioutil.WriteFile(certFile, []byte(cert), 0666); err != nil {
+		logrus.WithError(err).Fatal("Could not write contents of cert file")
+	}
+	privKeyFile := filepath.Join(tempDir, "privKey.pem")
+	if err := ioutil.WriteFile(privKeyFile, []byte(privKey), 0666); err != nil {
+		logrus.WithError(err).Fatal("Could not write contents of privKey file")
+	}
+	http.HandleFunc("/validate", serveValidate)
+	logrus.Info("Listening on port 8008...")
+	logrus.Fatal(http.ListenAndServeTLS(":8008", certFile, privKeyFile, nil))
+}
+
+func getGCPSecrets(client ClientInterface, ctx context.Context, expiry int, dns flagutil.Strings) (string, string, error) {
+	secretsMap := make(map[string]string)
+	data, err := client.GetSecretValue(ctx, secretID, "latest")
+	if err != nil {
+		return "", "", fmt.Errorf("%s, unable to get secret value: %v", gcpSecretError, err)
+	}
+
+	err = json.Unmarshal(data, &secretsMap)
+	if err != nil {
+		return "", "", fmt.Errorf("error unmarshalling CA cert secret data: %v", err)
+	}
+
+	cert := secretsMap[caCert]
+	privKey := secretsMap[caPrivKey]
+
+	return cert, privKey, nil
+}
+
+
+func createGCPSecret(client ClientInterface, ctx context.Context, expiry int, dns []string) (string, string, error) {
+	if _, err := client.CreateSecret(ctx, secretID); err != nil {
+		return "", "", fmt.Errorf("unable to create secret %v", err)
+	}
+	serverCertPerm, serverPrivKey, err := updateGCPSecret(client, ctx, expiry, dns)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to write secret value %v", err)
+	}
+	return serverCertPerm, serverPrivKey, nil
+}
+
+func updateGCPSecret(client ClientInterface, ctx context.Context, expiry int, dns[] string) (string, string, error) {
+	serverCertPerm, serverPrivKey, secretData, err := genSecretData(expiry, dns)
+	if err != nil {
+		return "", "", err
+	}
+
+	if err := client.AddSecretVersion(ctx, secretID, secretData); err != nil {
+		return "", "", fmt.Errorf("unable to add secret version %v", err)
+	}
+
+	return serverCertPerm, serverPrivKey, nil
+}
+
+func genSecretData(expiry int, dns []string) (string, string, []byte, error) {
+	serverCertPerm, serverPrivKey, caPem, err := genCert(expiry, dns)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("could not generate ca credentials")
+	}
+	caSecrets := map[string]string{
+	    caCert: serverCertPerm,
+	    caPrivKey: serverPrivKey,
+	    caBundle: caPem,
+	}
+	secretData, err := json.Marshal(caSecrets)
+
+	if err != nil {
+		return "", "", nil, fmt.Errorf("error marshalling CA cert secret data: %v", err)
+	}
+
+	return serverCertPerm, serverPrivKey, secretData, nil
+}

--- a/prow/cmd/webhook-server/main_test.go
+++ b/prow/cmd/webhook-server/main_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+	"k8s.io/test-infra/prow/flagutil"
+)
+
+type secretStore struct {
+	store map[string]string
+} 
+
+type fakeClient struct {
+	project secretStore
+}
+
+func (f *fakeClient) CreateSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error) {
+	f.project.store[secretID] = ""
+	return nil, nil
+}
+
+func (f *fakeClient) AddSecretVersion(ctx context.Context, secretName string, payload []byte) error {
+	f.project.store[secretName] = string(payload)
+	return nil
+}
+
+func (f *fakeClient) GetSecretValue(ctx context.Context, secretName string, versionName string) ([]byte, error) {
+	if len(f.project.store) == 0 {
+		return nil, errors.New("Secret was not created!")
+	} else {
+		if val, ok := f.project.store[secretName]; ok {
+			return []byte(val), nil
+		} else {
+			err := fmt.Sprintf("Secret with name %s was never added", secretName)
+			return nil, errors.New(err)
+		}
+	}
+}
+
+func TestCreateGCPSecrets(t * testing.T) {
+	dns := flagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
+	store := make(map[string]string)
+	ctx := context.Background()
+	f := &fakeClient {
+		project: secretStore{
+			store: store,
+		},
+	}
+	cert, key, err := createGCPSecret(f, ctx, 30, dns.Strings())
+	if err != nil {
+		t.Errorf("Unable to create GCP Secrets %v", err)
+	}
+	if len(cert) == 0 || len(key) == 0 {
+		t.Errorf("Issue generating ca certificate")
+	}
+	if len(store) == 0 {
+		t.Errorf("Error populating store")
+	}
+}
+
+func TestGetGCPSecrets(t *testing.T) {
+	dns := flagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
+	ctx := context.Background()
+	store := make(map[string]string)
+	f := &fakeClient {
+		project: secretStore{
+			store: store,
+		},
+	}
+	origCert, origKey, err := createGCPSecret(f, ctx, 30, dns.Strings())
+	if err != nil {
+		t.Errorf("Unable to create GCP Secrets %v", err)
+	}
+	cert, key, err := getGCPSecrets(f, ctx,  30, dns)
+	if err != nil {
+		t.Errorf("Unable to get GCP Secrets %v", err)
+	}
+	if (origCert != cert || origKey != key) {
+		t.Errorf("Error getting certificate and key")
+	}
+	if len(cert) == 0 || len(key) == 0 {
+		t.Errorf("Error creating certificate and key")
+	}
+}
+

--- a/prow/cmd/webhook-server/validation.go
+++ b/prow/cmd/webhook-server/validation.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "net/http"
+
+func serveValidate(http.ResponseWriter, *http.Request) {
+
+}


### PR DESCRIPTION
This PR includes the implementation for CA-certificate generation, storing and retrieving these secrets from the GCP secret manager as well as unit tests for the proposed validation web hook.