### PR TITLE
Enable project plugin for ingress-nginx repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -922,6 +922,7 @@ plugins:
     plugins:
     - require-matching-label
     - milestone
+    - project
 
   kubernetes/k8s.io:
     plugins:


### PR DESCRIPTION
We created a Project  https://github.com/kubernetes/ingress-nginx/projects/52 enabling this plugin can make it easier for others to use it together


/cc @rikatz @strongjz 