### PR TITLE
Update Ubuntu image to `ubuntu-gke-2204-1-24-v20220623` and latest family

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -826,7 +826,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=pipeline-1-20
+      - --image-family=pipeline-1-24
       - --image-project=ubuntu-os-gke-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8

--- a/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-23
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-23
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     machine: n1-standard-16  # node performance tests will be skipped on smaller machines
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env"

--- a/jobs/e2e_node/containerd/containerd-release-1.5/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.5/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-21-v20210722 # docker 19.03.8 / containerd 1.4.3
+    image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.5/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-21-v20210722 # docker 19.03.8 / containerd 1.4.3
+    image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/image-cadvisor.yaml
+++ b/jobs/e2e_node/containerd/image-cadvisor.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-23
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:

--- a/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-20
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation

--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-20
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-20
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     machine: n1-standard-2 # These tests need a lot of memory
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-23
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:

--- a/jobs/e2e_node/dockershim/image-config.yaml
+++ b/jobs/e2e_node/dockershim/image-config.yaml
@@ -6,7 +6,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
   cos-stable1:
     image_family: cos-89-lts

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4

--- a/jobs/e2e_node/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/image-config-serial-hugepages.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml"
     # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    image: ubuntu-gke-2204-1-24-v20220623
     machine: n1-standard-2 # These tests need a lot of memory
     project: ubuntu-os-gke-cloud
   cos-stable2:

--- a/jobs/e2e_node/swap/image-config-swap.yaml
+++ b/jobs/e2e_node/swap/image-config-swap.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-23
+    image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     machine: n1-standard-2


### PR DESCRIPTION
As per https://github.com/kubernetes/kubernetes/pull/110618#issuecomment-1164683932, we now use the latest `image` ubuntu-gke as well as `image_family` in test-infra.

Refers to https://github.com/kubernetes/kubernetes/pull/110618