### PR TITLE
Add perfDash tags to Windows periodic soak tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -89,6 +89,9 @@ periodics:
     decoration_config:
       timeout: 8h
     path_alias: k8s.io/perf-tests
+    tags:
+      - "perfDashPrefix: soak-tests-capz-windows-2019"
+      - "perfDashJobType: windows"
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Add tags for perfDash to be able to pull metrics from periodic Windows soak tests job

part of https://github.com/kubernetes/perf-tests/pull/2088