### PR TITLE
Rework cloud-provider-gcp tests

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -10,9 +10,10 @@ periodics:
     testgrid-dashboards: provider-gcp-periodics
     description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
   labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
+    preset-cloud-provider-gcp-e2e-common: "true"
     preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
   extra_refs:
   - org: kubernetes
     repo: cloud-provider-gcp
@@ -48,3 +49,54 @@ periodics:
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
         kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --focus-regex='\[Conformance\]'
+- interval: 24h
+  cluster: k8s-infra-prow-build
+  name: ci-cloud-provider-gcp-e2e-latest
+  decorate: true
+  decoration_config:
+    timeout: 80m
+  annotations:
+    testgrid-tab-name: E2E Full - Cloud Provider GCP - master
+    testgrid-dashboards: provider-gcp-periodics
+    description: Runs e2e-full tests using kubetest2 against cloud-provider-gcp master on GCE
+  labels:
+    preset-cloud-provider-gcp-e2e-common: "true"
+    preset-cloud-provider-gcp-e2e-full: "true"
+    preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-gcp
+    base_ref: master
+    path_alias: k8s.io/cloud-provider-gcp
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
+      resources:
+        limits:
+          cpu: 4
+          memory: 14Gi
+        requests:
+          cpu: 4
+          memory: 14Gi
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      command:
+      - runner.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      # TODO: Use published release tars for cloud-provider-gcp if/once they exist
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
+        cd;
+        export GO111MODULE=on;
+        go install sigs.k8s.io/kubetest2@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presets.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presets.yaml
@@ -1,0 +1,11 @@
+presets:
+- labels:
+    preset-cloud-provider-gcp-e2e-common: "true"
+  env:
+  - name: MASTER_SIZE
+    value: "n1-standard-2"
+- labels:
+    preset-cloud-provider-gcp-e2e-full: "true"
+  env:
+  - name: NODE_SIZE
+    value: "n1-standard-4"

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -51,9 +51,11 @@ presubmits:
       timeout: 80m
     path_alias: k8s.io/cloud-provider-gcp
     labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
+      preset-cloud-provider-gcp-e2e-common: "true"
+      preset-cloud-provider-gcp-e2e-full: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
     annotations:
       testgrid-dashboards: provider-gcp-presubmits
       description: End to end test of kubernetes/cloud-provider-gcp.


### PR DESCRIPTION
* Add periodic test that duplicates presubmit to have a visiblity into flakines
* Fix flakiness of e2e-full test by increasing node size
* Bootstrap cloud-provide-gcp presets