### PR TITLE
Kubetest2 is incompatible with presets

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -10,7 +10,6 @@ periodics:
     testgrid-dashboards: provider-gcp-periodics
     description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
   labels:
-    preset-cloud-provider-gcp-e2e-common: "true"
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -48,7 +47,7 @@ periodics:
         go install sigs.k8s.io/kubetest2@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --focus-regex='\[Conformance\]'
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size n1-standard-2  -- --test-package-version=v1.23.0 --focus-regex='\[Conformance\]'
 - interval: 24h
   cluster: k8s-infra-prow-build
   name: ci-cloud-provider-gcp-e2e-latest
@@ -60,8 +59,6 @@ periodics:
     testgrid-dashboards: provider-gcp-periodics
     description: Runs e2e-full tests using kubetest2 against cloud-provider-gcp master on GCE
   labels:
-    preset-cloud-provider-gcp-e2e-common: "true"
-    preset-cloud-provider-gcp-e2e-full: "true"
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -99,4 +96,4 @@ periodics:
         go install sigs.k8s.io/kubetest2@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-2 -- --test-package-version=v1.23.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presets.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presets.yaml
@@ -1,11 +1,1 @@
-presets:
-- labels:
-    preset-cloud-provider-gcp-e2e-common: "true"
-  env:
-  - name: MASTER_SIZE
-    value: "n1-standard-2"
-- labels:
-    preset-cloud-provider-gcp-e2e-full: "true"
-  env:
-  - name: NODE_SIZE
-    value: "n1-standard-4"
+# No presets, as kubetest2 gce deployer does not support environment viariables.

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -51,8 +51,6 @@ presubmits:
       timeout: 80m
     path_alias: k8s.io/cloud-provider-gcp
     labels:
-      preset-cloud-provider-gcp-e2e-common: "true"
-      preset-cloud-provider-gcp-e2e-full: "true"
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -81,4 +79,4 @@ presubmits:
           go install sigs.k8s.io/kubetest2@latest;
           go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
           go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-2 -- --test-package-version=v1.23.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
Removing presets as they are incompatible with kubetest2, [see kubernetes/cloud-provider-gcp#341 comments](https://github.com/kubernetes/cloud-provider-gcp/pull/341#issuecomment-1165546712) .

Following up to kubetest2 with kubernetes-sigs/kubetest2#196 to remove kube-up.sh script modification.