### PR TITLE
Create prow jobs for Cluster-API-Provider-Cloudstack sig repo

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/main/OWNERS
+approvers:
+  - rohityadavcloud
+  - davidjumani

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -1,0 +1,123 @@
+presets:
+- labels:
+    preset-image-build: "true"
+  env:
+  - name: AWS_SDK_LOAD_CONFIG
+    value: "true"
+  - name: GOPROXY
+  volumeMounts:
+  - name: docker-registry-config
+    readOnly: false
+    mountPath: /root/.docker
+  - name: run-buildkit
+    readOnly: false
+    mountPath: /run/buildkit
+  - name: entrypoint
+    readOnly: false
+    mountPath: /script
+  - name: status
+    readOnly: false
+    mountPath: /status
+  volumes:
+  # The files in this repo update the respective configmaps
+  # via the config-updater plugin in plugins.yaml for hook
+  - name: docker-registry-config
+    configMap:
+      name: build-setup
+      items:
+      - key: docker-ecr-config.json
+        path: config.json
+  - name: entrypoint
+    configMap:
+      name: buildkitd-entrypoint
+      items:
+      - key: buildkitd-entrypoint.sh
+        path: entrypoint.sh
+  - name: run-buildkit
+    emptyDir: {}
+  - name: status
+    emptyDir: {}
+- env:
+  - name: AWS_ROLE_SESSION_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+
+
+presubmits:
+  kubernetes-sigs/cluster-api-provider-cloudstack:
+    - name: "capi-provider-cloudstack-presubmit-build"
+      labels:
+        preset-service-account: "true"
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      always_run: false
+      run_if_changed: ".*"
+      max_concurrency: 10
+      decorate: true
+      decoration_config:
+        timeout: 1h
+      skip_report: false
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-cloudstack
+        testgrid-tab-name: pr-build
+      spec:
+        serviceaccountName: presubmits-build-account
+        automountServiceAccountToken: false
+        containers:
+        - name: build-container
+          image: public.ecr.aws/r9t0b9f2/capc-builder:latest
+          command:
+          - bash
+          - -c
+          - >
+            mv /mybin ./bin && make build
+          resources:
+            requests:
+              memory: "8Gi"
+              cpu: "1024m"
+            limits:
+              memory: "8Gi"
+              cpu: "1024m"
+    - name: capi-provider-cloudstack-presubmit-unit-test
+      labels:
+        preset-service-account: "true"
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      always_run: false
+      run_if_changed: ".*"
+      max_concurrency: 10
+      decorate: true
+      decoration_config:
+        timeout: 1h
+      skip_report: false
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-cloudstack
+        testgrid-tab-name: pr-unit-test
+      spec:
+        serviceaccountName: presubmits-build-account
+        automountServiceAccountToken: false
+        containers:
+        - name: build-container
+          image: public.ecr.aws/r9t0b9f2/capc-builder:latest
+          command:
+          - bash
+          - -c
+          - >
+            cp /secrets/cloud-config ./cloud-config && cat ./cloud-config && mv /mybin ./bin && make test
+          resources:
+            requests:
+              memory: "8Gi"
+              cpu: "1024m"
+            limits:
+              memory: "8Gi"
+              cpu: "1024m"
+          volumeMounts:
+          - mountPath: /secrets
+            name: secrets
+            readOnly: true
+        volumes:
+        - name: secrets
+          secret:
+            defaultMode: 256
+            secretName: cloudstack-token

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -17,6 +17,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-gcp
     - sig-cluster-lifecycle-cluster-api-provider-ibmcloud
     - sig-cluster-lifecycle-cluster-api-provider-openstack
+    - sig-cluster-lifecycle-cluster-api-provider-cloudstack
     - sig-cluster-lifecycle-cluster-api-provider-nested
     - sig-cluster-lifecycle-cluster-api-operator
     - sig-cluster-lifecycle-kops
@@ -54,6 +55,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
+- name: sig-cluster-lifecycle-cluster-api-provider-cloudstack
 - name: sig-cluster-lifecycle-cluster-api-provider-nested
 - name: sig-cluster-lifecycle-cluster-api-operator
 - name: sig-cluster-lifecycle-kops


### PR DESCRIPTION
As part of migrating [cluster-api-provider-cloudstack](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack) repository to kubernetes-sigs GitHub organization, we are migrating the prow based CI tools to leverage [Kubernete's maintained prow](https://prow.k8s.io/).

The contents of this pull request establish an OWNERS file for prow jobs ongoing and land the presubmit jobs which function on privately controlled prow instances and with local testing via `pj-on-kind.sh` transformations.


/sig cluster-lifecycle 
/cc @fabriziopandini @rejoshed
