### PR TITLE
config/testgrids: use correct GCS URL for kcp presubmits

### DIFF
--- a/config/testgrids/kcp/kcp.yaml
+++ b/config/testgrids/kcp/kcp.yaml
@@ -1,10 +1,10 @@
 test_groups:
   - name: pull-ci-kcp-dev-kcp-main-test
-    gcs_prefix: origin-ci-test/pr-logs/pull/kcp-dev_kcp
+    gcs_prefix: origin-ci-test/pr-logs/directory/pull-ci-kcp-dev-kcp-main-test
   - name: pull-ci-kcp-dev-kcp-main-e2e
-    gcs_prefix: origin-ci-test/pr-logs/pull/kcp-dev_kcp
+    gcs_prefix: origin-ci-test/pr-logs/directory/pull-ci-kcp-dev-kcp-main-e2e
   - name: pull-ci-kcp-dev-kcp-main-e2e-multiple-runs
-    gcs_prefix: origin-ci-test/pr-logs/pull/kcp-dev_kcp
+    gcs_prefix: origin-ci-test/pr-logs/directory/pull-ci-kcp-dev-kcp-main-e2e-multiple-runs
 
 dashboards:
   - name: kcp-main


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @nc