### PR TITLE
Build cluster creation fix: ES in service project

### DIFF
--- a/prow/create-build-cluster.sh
+++ b/prow/create-build-cluster.sh
@@ -280,7 +280,7 @@ metadata:
   namespace: default
 spec:
   backendType: gcpSecretsManager
-  projectId: ${PROJECT}
+  projectId: ${PROW_SERVICE_PROJECT}
   data:
   - key: ${gsm_secret_name}
     name: kubeconfig


### PR DESCRIPTION
the GSM secret was generated by gencred and stored in service project as of https://github.com/kubernetes/test-infra/blob/d16106951e0af3e58fe4c42fc7992bc3fc8957ad/prow/create-build-cluster.sh#L299