### PR TITLE
Enable cherrypick for kubernetes-sigs/secrets-store-csi-driver

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1380,3 +1380,9 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/secrets-store-csi-driver:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

Enable [cherrypick](https://prow.k8s.io/command-help#cherrypick) plugin for [secrets-store-csi-driver](https://sigs.k8s.io/secrets-store-csi-driver)

/cc @tam7t 