### PR TITLE
Add release-1.2 upgrade tests for secrets-store-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -960,7 +960,7 @@ periodics:
           - bash
           - -c
           - >-
-            HELM_CHART_DIR=$(ls -h charts/*.tgz | sort --version-sort --field-separator=- --key=5 | tail -n 1) make e2e-bootstrap e2e-helm-deploy-release e2e-azure && HELM_CHART_DIR=manifest_staging/charts/secrets-store-csi-driver make e2e-helm-upgrade e2e-azure
+            make e2e-bootstrap e2e-helm-deploy-release e2e-azure && make e2e-helm-upgrade e2e-azure
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.1-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.1-config.yaml
@@ -25,7 +25,7 @@ periodics:
           - bash
           - -c
           - >-
-          - HELM_CHART_DIR=$(ls -h charts/*.tgz | sort --version-sort --field-separator=- --key=5 | tail -n 1) make e2e-bootstrap e2e-helm-deploy-release e2e-azure && HELM_CHART_DIR=manifest_staging/charts/secrets-store-csi-driver make e2e-helm-upgrade e2e-azure
+            make e2e-bootstrap e2e-helm-deploy-release e2e-azure && make e2e-helm-upgrade e2e-azure
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.2-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.2-config.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 12h
-  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-0
+  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-2
   decorate: true
   decoration_config:
     timeout: 30m
@@ -14,7 +14,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
-    base_ref: release-1.0
+    base_ref: release-1.2
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
@@ -25,13 +25,13 @@ periodics:
           - bash
           - -c
           - >-
-          - HELM_CHART_DIR=$(ls -h charts/*.tgz | sort --version-sort --field-separator=- --key=5 | tail -n 1) make e2e-bootstrap e2e-helm-deploy-release e2e-azure && HELM_CHART_DIR=manifest_staging/charts/secrets-store-csi-driver make e2e-helm-upgrade e2e-azure
+            make e2e-bootstrap e2e-helm-deploy-release e2e-azure && make e2e-helm-upgrade e2e-azure
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
-    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-0
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-2
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
     description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Removes release-1.0 upgrade job
- Adds release-1.2 upgrade job
- Fixes the yaml that was causing upgrade job tests to be skipped
- Removes `HELM_CHART_DIR` variable as it's never used

