### PR TITLE
Create set of component specified labels and annotations.

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package kube
 
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/gerrit/client"
+	"k8s.io/test-infra/prow/github"
+)
+
 const (
 	// CreatedByProw is added on resources created by prow.
 	// Since resources often live in another cluster/namespace,
@@ -66,4 +72,18 @@ const (
 	// IsOptionalLabel is added in resources created by prow and
 	// carries the Optional from a Presubmit job.
 	IsOptionalLabel = "prow.k8s.io/is-optional"
+)
+
+var (
+	ComponentSpecifiedAnnotationsAndLabels = sets.NewString(
+		// Labels
+		client.GerritRevision,
+		client.GerritPatchset,
+		client.GerritReportLabel,
+		github.EventGUID,
+		"created-by-tide",
+		// Annotations
+		client.GerritID,
+		client.GerritInstance,
+	)
 )


### PR DESCRIPTION
This PR creates a set of labels and annotations that are specified by components. This set will be used when rerunning a new test with the latest configuration. It is key in helping to determine which labels/annotations should be copied over, from the an old configuration to the new.

For more detail visit the [design document](https://docs.google.com/document/d/1zARYe3xK4kprEdySiWP6We3Y9BLT1gdSxIrw63moR9g/edit#bookmark=id.mzq97mgkkhsn) for this change.

/cc @chaodaiG