### PR TITLE
Add fakegcsserver

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -48,6 +48,7 @@ baseImageOverrides:
   k8s.io/test-infra/prow/test/integration/cmd/fakeghserver: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/test/integration/cmd/fakegitserver: gcr.io/k8s-prow/git:v20220523-6026203ca9
   k8s.io/test-infra/prow/test/integration/cmd/fakepubsub: google/cloud-sdk:389.0.0
+  k8s.io/test-infra/prow/test/integration/cmd/fakegcsserver: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
 
 # https://pkg.go.dev/cmd/link
 # -s: omit symbol/debug info

--- a/prow/test/integration/cmd/fakegcsserver/main.go
+++ b/prow/test/integration/cmd/fakegcsserver/main.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// fakegcsserver runs the open source GCS emulator from
+// https://github.com/fsouza/fake-gcs-server.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/sirupsen/logrus"
+
+	configflagutil "k8s.io/test-infra/prow/flagutil/config"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/pjutil"
+)
+
+type options struct {
+	// config is the Prow configuration. We need this to read in GCS
+	// configurations under plank's default_decoration_config_entries field set
+	// in the integration test's Prow configuration, because we have to
+	// initialize (create) these buckets before we upload into them with
+	// initupload.
+	config              configflagutil.ConfigOptions
+	emulatorPort        uint
+	emulatorPublicHost  string
+	emulatorStorageRoot string
+}
+
+func (o *options) validate() error {
+	if o.emulatorPort > 65535 {
+		return fmt.Errorf("-emulator-port range (got %d) must be 0 - 65535", o.emulatorPort)
+	}
+
+	return nil
+}
+
+func flagOptions() *options {
+	o := &options{config: configflagutil.ConfigOptions{ConfigPath: "/etc/config/config.yaml"}}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.UintVar(&o.emulatorPort, "emulator-port", 8888, "Port to use for the GCS emulator.")
+	fs.StringVar(&o.emulatorPublicHost, "emulator-public-host", "fakegcsserver.default:80", "Address of the GCS emulator as seen by other Prow components in the test cluster.")
+	fs.StringVar(&o.emulatorStorageRoot, "emulator-storage-root", "/gcs", "Folder to store GCS buckets and objects.")
+	o.config.AddFlags(fs)
+
+	fs.Parse(os.Args[1:])
+
+	return o
+}
+
+func main() {
+	logrusutil.ComponentInit()
+
+	o := flagOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid arguments.")
+	}
+
+	health := pjutil.NewHealth()
+	health.ServeReady()
+
+	defer interrupts.WaitForGracefulShutdown()
+
+	initialObjects, err := getInitialObjects(o)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not initialize emulator state")
+	}
+
+	logrus.Info("Starting server...")
+
+	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		Scheme:         "http",
+		Host:           "0.0.0.0",
+		Port:           uint16(o.emulatorPort),
+		PublicHost:     o.emulatorPublicHost,
+		Writer:         logrus.New().Writer(),
+		StorageRoot:    o.emulatorStorageRoot,
+		InitialObjects: *initialObjects,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	logrus.Infof("Server started at %s", server.URL())
+	logrus.Infof("PublicURL: %s", server.PublicURL())
+}
+
+// getInitialObjects creates GCS buckets, because every time the emulator
+// starts, it starts off from a clean slate.
+func getInitialObjects(o *options) (*[]fakestorage.Object, error) {
+	initialObjects := []fakestorage.Object{}
+	configAgent, err := o.config.ConfigAgent()
+	if err != nil {
+		return &initialObjects, fmt.Errorf("Error starting config agent: %v", err)
+	}
+
+	ddcs := configAgent.Config().Plank.DefaultDecorationConfigs
+
+	for _, ddc := range ddcs {
+		logrus.Infof("detected bucket %q from configuration", ddc.Config.GCSConfiguration.Bucket)
+		initialObjects = append(initialObjects, fakestorage.Object{
+			BucketName: ddc.Config.GCSConfiguration.Bucket,
+			Name:       "placeholder",
+			Content:    []byte("This file is here so that we can create the parent directory."),
+		})
+	}
+
+	return &initialObjects, nil
+}

--- a/prow/test/integration/config/prow/cluster/fakegcsserver.yaml
+++ b/prow/test/integration/config/prow/cluster/fakegcsserver.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: fakegcsserver
+  labels:
+    app: fakegcsserver
+spec:
+  selector:
+    matchLabels:
+      app: fakegcsserver
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fakegcsserver
+    spec:
+      containers:
+      - name: fakegcsserver
+        image: localhost:5001/fakegcsserver
+        args:
+        - --config-path=/etc/config/config.yaml
+        ports:
+        - containerPort: 8888
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: fakegcsserver
+  namespace: default
+  name: fakegcsserver
+spec:
+  ports:
+  - name: main
+    port: 80
+    targetPort: 8888
+    protocol: TCP
+  selector:
+    app: fakegcsserver
+  type: ClusterIP

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -38,13 +38,16 @@ plank:
       grace_period: 15s
       utility_images:
         clonerefs: localhost:5001/clonerefs-ssl-disabled:latest
-        initupload: localhost:5001/initupload:latest
+        # By default, use the version of initupload that has
+        # STORAGE_EMULATOR_HOST set to fakegcsserver.
+        initupload: localhost:5001/initupload-fakegcsserver:latest
         entrypoint: localhost:5001/entrypoint:latest
         sidecar: localhost:5001/sidecar:latest
       gcs_configuration:
-        bucket: "none"
-        path_strategy: "explicit"
-        local_output_dir: "/output"
+        bucket: "bucket-foo"
+        path_strategy: "legacy"
+        default_org: "org-foo"
+        default_repo: "repo-foo"
 
 # fakepubsub will read this config and create all necessary subscriptions.
 pubsub_subscriptions:

--- a/prow/test/integration/lib.sh
+++ b/prow/test/integration/lib.sh
@@ -37,6 +37,7 @@ declare -ra PROW_COMPONENTS=(
   crier
   deck
   deck-tenanted
+  fakegcsserver
   fakegerritserver
   fakegitserver
   fakeghserver
@@ -66,6 +67,7 @@ declare -rA PROW_IMAGES=(
   [sub]=prow/cmd/sub
   [tide]=prow/cmd/tide
   # Fakes.
+  [fakegcsserver]=prow/test/integration/cmd/fakegcsserver
   [fakegerritserver]=prow/test/integration/cmd/fakegerritserver
   [fakegitserver]=prow/test/integration/cmd/fakegitserver
   [fakeghserver]=prow/test/integration/cmd/fakeghserver
@@ -92,6 +94,7 @@ declare -rA PROW_IMAGES_TO_COMPONENTS=(
   [sinker]=sinker
   [sub]=sub
   [tide]=tide
+  [fakegcsserver]=fakegcsserver
   [fakegerritserver]=fakegerritserver
   [fakegitserver]=fakegitserver
   [fakeghserver]=fakeghserver
@@ -120,6 +123,7 @@ declare -ra PROW_DEPLOYMENT_ORDER=(
   # tests on a cold machine), it takes a long time for the deployment to pull it
   # from the local registry.
   fakepubsub.yaml
+  fakegcsserver.yaml
   fakegerritserver.yaml
   fakegitserver.yaml
   gerrit.yaml
@@ -169,6 +173,7 @@ declare -ra PROW_DEPLOYMENT_ORDER=(
   WAIT_fakepubsub
   sub.yaml
   WAIT_sub
+  WAIT_fakegcsserver
 )
 
 function do_kubectl() {

--- a/prow/test/integration/setup-prow-components.sh
+++ b/prow/test/integration/setup-prow-components.sh
@@ -140,7 +140,7 @@ function main() {
     delete_components "${components[@]}"
   fi
 
-  deploy_prow "${fakepubsub_node_port}"
+  deploy_prow "${fakepubsub_node_port:-30303}"
 
   wait_for_nginx
 }
@@ -273,7 +273,7 @@ function delete_components() {
 function deploy_prow() {
   local component
   local fakepubsub_node_port
-  fakepubsub_node_port="${1:-30303}"
+  fakepubsub_node_port="${1}"
   log "Deploying Prow components"
 
   # Even though we apply the entire Prow configuration, Kubernetes is smart

--- a/prow/test/integration/setup-prow-components.sh
+++ b/prow/test/integration/setup-prow-components.sh
@@ -190,6 +190,7 @@ function build_extra_images() {
   log "Building extra images"
 
   build_clonerefs_ssl_disabled
+  build_initupload_fakegcsserver
 }
 
 function build_clonerefs_ssl_disabled() {
@@ -203,6 +204,25 @@ function build_clonerefs_ssl_disabled() {
 FROM ${src}
 # Allow Git to accept traffic from HTTPS servers with self-signed certs.
 ENV GIT_SSL_NO_VERIFY 1
+EOF
+
+  docker push "${dest}"
+
+}
+
+function build_initupload_fakegcsserver() {
+  echo >&2 "Building initupload-fakegcsserver"
+  local src
+  local dest
+  src="localhost:${LOCAL_DOCKER_REGISTRY_PORT}/initupload:latest"
+  dest="localhost:${LOCAL_DOCKER_REGISTRY_PORT}/initupload-fakegcsserver:latest"
+
+  docker build --tag "${dest}" - <<EOF
+FROM ${src}
+# Create directory to hold all buckets.
+RUN mkdir /gcs
+# Force GCS client running in this image to always talk to fakegcsserver.
+ENV STORAGE_EMULATOR_HOST http://fakegcsserver.default:80
 EOF
 
   docker push "${dest}"

--- a/prow/test/integration/test/pod-utils_test.go
+++ b/prow/test/integration/test/pod-utils_test.go
@@ -468,14 +468,13 @@ ls-tree (submodule):
 				UtilityImages: &prowjobv1.UtilityImages{
 					// These images get created by the integration test.
 					CloneRefs:  "localhost:5001/clonerefs:latest",
-					InitUpload: "localhost:5001/initupload:latest",
+					InitUpload: "localhost:5001/initupload-fakegcsserver:latest",
 					Entrypoint: "localhost:5001/entrypoint:latest",
 					Sidecar:    "localhost:5001/sidecar:latest",
 				},
 				GCSConfiguration: &prowjobv1.GCSConfiguration{
 					PathStrategy: prowjobv1.PathStrategyExplicit,
-					// This field makes initupload skip the upload to GCS.
-					LocalOutputDir: "/output",
+					Bucket:       "bucket-foo",
 				},
 			}
 


### PR DESCRIPTION
This adds a new fakegcsserver component, which is used to act as a fake GCS for testing. For proof we modify the pod-utils tests to use the new fakegcsserver (to push to it) instead of saving the artifacts locally with LocalOutputDir.

This PR builds on https://github.com/kubernetes/test-infra/pull/26689; it's not related but I didn't want to keep delaying this PR for review.

/assign @chaodaiG 
/cc @mpherman2 @cjwagner 