### PR TITLE
Run post-test-infra-upload-boskos-config postsubmit

### DIFF
--- a/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
+++ b/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
@@ -351,3 +351,4 @@ resources:
   - k8s-jkns-gke-ubuntu-updown
   state: dirty
   type: node-e2e-project
+# TODO: Remove this comment after post-test-infra-upload-boskos-config succeeds


### PR DESCRIPTION
post-test-infra-upload-boskos-config was fixed in #26569 but this did not cause a rerun. Because of that we have a missing boskos pool, namely scalability-presubmit-5k-project.
This change modfies the file that triggers the postsubmit. After it finishes running this commit may be reverted.