### PR TITLE
Add control-plane tolerations for Windows soak tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -66,6 +66,8 @@ presubmits:
               value: "6443"
             - name: PROMETHEUS_SCRAPE_WINDOWS_NODE_EXPORTER
               value: "true"
+            - name: CL2_PROMETHEUS_TOLERATE_MASTER
+              value: "true"
             # azuredisk variables - required for Prometheus PVC
             - name: DEPLOY_AZURE_CSI_DRIVER
               value: "true"
@@ -148,6 +150,8 @@ periodics:
             - name: PROMETHEUS_APISERVER_SCRAPE_PORT
               value: "6443"
             - name: PROMETHEUS_SCRAPE_WINDOWS_NODE_EXPORTER
+              value: "true"
+            - name: CL2_PROMETHEUS_TOLERATE_MASTER
               value: "true"
             # azuredisk variables - required for Prometheus PVC
             - name: DEPLOY_AZURE_CSI_DRIVER

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -101,9 +101,9 @@ periodics:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
     extra_refs:
-      - org: oprinmarius
+      - org: kubernetes
         repo: perf-tests
-        base_ref: "windows-soak-tests"
+        base_ref: "master"
         path_alias: "k8s.io/perf-tests"
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure


### PR DESCRIPTION
Add control-plane tolerations for Windows soak tests
Point periodic windows soak tests job to kubernetes/perf-tests master