### PR TITLE
Fix post-test-infra-upload-boskos-config postsubmit job

### DIFF
--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -44,7 +44,7 @@ deploy-build: get-build-cluster-credentials
 	kubectl apply -f ./cluster/build/
 
 update-boskos-resources: get-build-cluster-credentials
-	kubectl create configmap resources --from-file=config=./cluster/build/boskos-resources.yaml --dry-run=client -o yaml | kubectl --namespace=test-pods replace configmap resources -f -
+	kubectl create configmap resources --from-file=config=./cluster/build/boskos-resources/boskos-resources.yaml --dry-run=client -o yaml | kubectl --namespace=test-pods replace configmap resources -f -
 
 deploy-monitoring: get-cluster-credentials
 	$(MAKE) -C ./cluster/monitoring apply


### PR DESCRIPTION
This is a follow-up to https://github.com/kubernetes/test-infra/pull/26364 and https://github.com/kubernetes/test-infra/pull/26569. Makefile does also neeed to be updated, as evidenced by [a postsubmit run](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-upload-boskos-config/1541752270666862592).