### PR TITLE
Revert "Run post-test-infra-upload-boskos-config postsubmit"

### DIFF
--- a/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
+++ b/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
@@ -351,4 +351,3 @@ resources:
   - k8s-jkns-gke-ubuntu-updown
   state: dirty
   type: node-e2e-project
-# TODO: Remove this comment after post-test-infra-upload-boskos-config succeeds


### PR DESCRIPTION
Reverts kubernetes/test-infra#26696. We don't need this comment + we need to run the `post-test-infra-upload-boskos-config` postsubmit again (see https://github.com/kubernetes/test-infra/pull/26709).

/assign @chaodaiG 
/hold until https://github.com/kubernetes/test-infra/pull/26709 is merged.