### PR TITLE
Skips specialized-infra tests for CAPV e2e periodic job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
@@ -21,7 +21,7 @@ periodics:
             - ./hack/e2e.sh
           env:
             - name: GINKGO_SKIP
-              value: "\\[Conformance\\] \\[clusterctl-Upgrade\\]"
+              value: "\\[Conformance\\] \\[clusterctl-Upgrade\\] \\[specialized-infra\\]"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true


### PR DESCRIPTION
To add a way to skip the PCI passthrough e2e tests which require specialized-infrastructure during normal e2e test runs.