### PR TITLE
Update Hypershift testgrids

### DIFF
--- a/config/testgrids/openshift/OWNERS
+++ b/config/testgrids/openshift/OWNERS
@@ -16,3 +16,4 @@ approvers:
 - bparees
 - jeefy
 - jeremyeder
+- alvaroaleman

--- a/config/testgrids/openshift/hypershift.yaml
+++ b/config/testgrids/openshift/hypershift.yaml
@@ -1,22 +1,22 @@
 test_groups:
-- name: redhat-hypershift-aws-conformance-4.10
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.10-periodics-aws-conformance
 - name: redhat-hypershift-main-periodic-ci-openshift-hypershift-main-periodics-e2e-conformance-azure
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-e2e-conformance-azure
 - name: redhat-hypershift-main-aws-4-11-conformance
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.11-periodics-aws-conformance
+- name: redhat-hypershift-main-aws-4-12-conformance
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-aws-conformance
 
 dashboards:
 - name: redhat-hypershift
   dashboard_tab:
-  - name: aws-conformance-4.10
-    test_group_name: redhat-hypershift-aws-conformance-4.10
+  - name: aws-conformance-4.11
+    test_group_name: redhat-hypershift-main-aws-4-11-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-  - name: aws-conformance-4.11
-    test_group_name: redhat-hypershift-main-aws-4-11-conformance
+  - name: aws-conformance-4.12
+    test_group_name: redhat-hypershift-main-aws-4-12-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:


### PR DESCRIPTION
* Conformance for 4.10 is removed
* 4.11 is updated to not point to the `main` job
* 4.12 is added and uses the `main` job

Also adding myself for the Openshift testgrid approvers, so this can be taken care of teaminternal in the future