### PR TITLE
Add jobs for distroless-iptables image

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -64,6 +64,38 @@ postsubmits:
         github_team_slugs:
           - org: kubernetes
             slug: release-managers
+    - name: post-release-push-image-distroless-iptables
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
+      decorate: true
+      run_if_changed: '^images\/build\/distroless-iptables\/'
+      branches:
+        - ^main$
+        # TODO(releng): Remove once repo default branch has been renamed
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20220428-ae431ed1aa
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-build-image
+              - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - --env-passthrough=REGISTRY
+              - --build-dir=.
+              - images/build/distroless-iptables
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+              - name: REGISTRY
+                value: "gcr.io/k8s-staging-build-image"
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
     - name: post-release-push-image-go-runner
       cluster: k8s-infra-prow-build-trusted
       annotations:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -231,6 +231,41 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
+  - name: pull-release-image-distroless-iptables
+    cluster: k8s-infra-prow-build
+    decorate: true
+    run_if_changed: '^images\/build\/distroless-iptables\/'
+    path_alias: k8s.io/release
+    spec:
+      serviceAccountName: gcb-builder-releng-test
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20220428-ae431ed1aa
+          command:
+            - /run.sh
+          args:
+            - --project=k8s-staging-releng-test
+            - --scratch-bucket=gs://k8s-staging-releng-test
+            - --build-dir=.
+            - --env-passthrough=REGISTRY
+            - images/build/distroless-iptables
+          env:
+            - name: LOG_TO_STDOUT
+              value: "y"
+            - name: REGISTRY
+              value: "gcr.io/k8s-staging-releng-test"
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-image-distroless-iptables
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
   - name: pull-release-image-setcap
     cluster: k8s-infra-prow-build
     decorate: true


### PR DESCRIPTION
Cross PR with https://github.com/kubernetes/release/pull/2502

We are creating the distroless-iptables image to be used with kube-proxy release.

We need:

* The presubmit job to check if all the cloudbuild stuff runs fine
* The postsubmit job to send the generated image for staging bucket (to be promoted later)