### PR TITLE
Add testgrid-json-exporter container image build job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-tg-exporter.yaml
+++ b/config/jobs/image-pushing/k8s-staging-tg-exporter.yaml
@@ -1,0 +1,23 @@
+postsubmits:
+  kubernetes-sigs/testgrid-json-exporter:
+    - name: post-testgrid-json-exporter-push-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-k8s-infra-gcb
+      decorate: true
+      always_run: true
+      branches:
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20220428-ae431ed1aa
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-tg-exporter
+              - --scratch-bucket=gs://k8s-staging-tg-exporter
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

We migrated the [testgrid-json-exporter](https://github.com/kubernetes-sigs/testgrid-json-exporter) repo and would like a GCR staging repo to host container images. 
1. done: The staging repo for k8s-staging-testgrid-json-exporter have already been created (see [PR](https://github.com/kubernetes/k8s.io/pull/3910))
2. in progress: The config to specify the codebuild spec is currently getting reviewed (see [PR](https://github.com/kubernetes-sigs/testgrid-json-exporter/pull/9)). 

See tracking issue: https://github.com/kubernetes-sigs/testgrid-json-exporter/issues/1

cc @saschagrunert 

/hold until https://github.com/kubernetes-sigs/testgrid-json-exporter/pull/9 merged