### PR TITLE
Avoid using github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,6 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/pelletier/go-toml v1.9.3
 	github.com/peterbourgon/diskv v2.0.1+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
@@ -187,6 +186,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -17,13 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
 	"os"
 	"regexp"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/maintenance/migratestatus/migrator"

--- a/maintenance/migratestatus/migrator/migrator_test.go
+++ b/maintenance/migratestatus/migrator/migrator_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package migrator
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/test-infra/prow/github"
 )
 

--- a/prow/plugins/retitle/retitle_test.go
+++ b/prow/plugins/retitle/retitle_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package retitle
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/test-infra/prow/github"


### PR DESCRIPTION
The project is in maintenance mode so we can safely switch to the golang
native `errors` package.

cc @kubernetes/release-engineering @kubernetes/test-infra-maintainers 