### PR TITLE
Add MinimumInterval option to periodic jobs

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -226,13 +226,19 @@ type Periodic struct {
 	JobBase
 
 	// (deprecated)Interval to wait between two runs of the job.
+	// Consecutive jobs are run at `interval` duration apart, provided the
+	// previous job has completed.
 	Interval string `json:"interval,omitempty"`
+	// MinimumInterval to wait between two runs of the job.
+	// Consecutive jobs are run at `interval` + `duration of previous job` apart.
+	MinimumInterval string `json:"minimun_interval,omitempty"`
 	// Cron representation of job trigger time
 	Cron string `json:"cron,omitempty"`
 	// Tags for config entries
 	Tags []string `json:"tags,omitempty"`
 
-	interval time.Duration
+	interval         time.Duration
+	minimum_interval time.Duration
 }
 
 // JenkinsSpec holds optional Jenkins job config
@@ -250,6 +256,16 @@ func (p *Periodic) SetInterval(d time.Duration) {
 // GetInterval returns interval, the frequency duration it runs.
 func (p *Periodic) GetInterval() time.Duration {
 	return p.interval
+}
+
+// SetMinimumInterval updates minimum_interval, the minimum frequency duration it runs.
+func (p *Periodic) SetMinimumInterval(d time.Duration) {
+	p.minimum_interval = d
+}
+
+// GetMinimumInterval returns minimum_interval, the minimum frequency duration it runs.
+func (p *Periodic) GetMinimumInterval() time.Duration {
+	return p.minimum_interval
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
Compared to the periodic job defined with the `interval` option, the periodic jobs defined with the new `minimum_interval` option take into account the duration of the previous job. This allows jobs to spread and make it nicer for smaller infra.

Fixes #26478.