### PR TITLE
capz: debug failing periodic main job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -187,9 +187,9 @@ periodics:
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
   extra_refs:
-    - org: kubernetes-sigs
+    - org: jackfrancis
       repo: cluster-api-provider-azure
-      base_ref: main
+      base_ref: capz-periodic-flakes
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:


### PR DESCRIPTION
This PR updates the capz periodic main test job to this dedicated PR branch used for turning these flakes green:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2451

As of 5 July 2022 8 of the past 10 jobs have failed, so it would be defensible to consider this job (or capz @ main) unstable. Having a dedicated branch to change and observe outcomes to test configuration (or code) changes will help us triage which of those two possibilities are true, and how best to make things healthy again.