### PR TITLE
CAPZ: remove apiversion upgrade init variables from job config

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -125,12 +125,6 @@ periodics:
         args:
           - ./scripts/ci-e2e.sh
         env:
-          - name: INIT_WITH_BINARY
-            value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}"
-          - name: INIT_WITH_PROVIDERS_CONTRACT
-            value: "v1alpha4"
-          - name: INIT_WITH_KUBERNETES_VERSION
-            value: "v1.21.2"
           - name: GINKGO_FOCUS
             value: "API Version Upgrade"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -445,12 +445,6 @@ presubmits:
             - runner.sh
             - "./scripts/ci-e2e.sh"
           env:
-            - name: INIT_WITH_BINARY
-              value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}"
-            - name: INIT_WITH_PROVIDERS_CONTRACT
-              value: "v1alpha4"
-            - name: INIT_WITH_KUBERNETES_VERSION
-              value: "v1.21.2"
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
           # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -87,12 +87,6 @@ presubmits:
           args:
             - ./scripts/ci-e2e.sh
           env:
-            - name: INIT_WITH_BINARY
-              value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}"
-            - name: INIT_WITH_PROVIDERS_CONTRACT
-              value: "v1alpha4"
-            - name: INIT_WITH_KUBERNETES_VERSION
-              value: "v1.21.2"
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
           # docker-in-docker needs privileged mode


### PR DESCRIPTION
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2433/files#r914293762

Removes some variables from the apiversion upgrade CAPZ tests so we can control them directly from the jobs. These would have been helpful if we wanted to test one specific version upgrade per job but as it is we're using the same values across all jobs and it's easier to maintain them from the CAPZ repo.