### PR TITLE
CAPZ: fix kubernetes version in apiversion test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -127,6 +127,8 @@ periodics:
         env:
           - name: GINKGO_FOCUS
             value: "API Version Upgrade"
+          - name: KUBERNETES_VERSION
+            value: "v1.22.9"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -447,6 +447,8 @@ presubmits:
           env:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
+            - name: KUBERNETES_VERSION
+              value: "v1.22.9"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -89,6 +89,8 @@ presubmits:
           env:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
+            - name: KUBERNETES_VERSION
+              value: "v1.22.9"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Fixes https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-periodic-apiversion-upgrade-main

The apiversion upgrade test attempts to create a test workload cluster from an "old" management cluster (created with capz v1alpha4). However, CAPZ v0.5.x does not support new Kubernetes versions due to the SKU naming change (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2302). 

Since CAPZ e2e tests were updated to use the latest version available in new image SKUs, this test broke as the older management cluster is unable to find the new images. This pins the test to the latest supported 1.22 version in v1alpha4.