### PR TITLE
Add logging for rerun auth IsAuthorized

### DIFF
--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"github.com/sirupsen/logrus"
 	"strconv"
 	"testing"
 	"time"
@@ -537,7 +538,7 @@ func TestRerunAuthConfigIsAuthorized(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			if actual, _ := tc.config.IsAuthorized("", tc.user, nil); actual != tc.authorized {
+			if actual, _ := tc.config.IsAuthorized("", tc.user, nil, &logrus.Entry{}); actual != tc.authorized {
 				t.Errorf("Expected %v, got %v", tc.authorized, actual)
 			}
 		})

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1433,14 +1433,14 @@ func canTriggerJob(user string, pj prowapi.ProwJob, cfg *prowapi.RerunAuthConfig
 	}
 
 	// Then check config-level rerun auth config.
-	if auth, err := cfg.IsAuthorized(org, user, cli); err != nil {
+	if auth, err := cfg.IsAuthorized(org, user, cli, log); err != nil {
 		return false, err
 	} else if auth {
 		return true, err
 	}
 
 	// Check job-level rerun auth config.
-	if auth, err := pj.Spec.RerunAuthConfig.IsAuthorized(org, user, cli); err != nil {
+	if auth, err := pj.Spec.RerunAuthConfig.IsAuthorized(org, user, cli, log); err != nil {
 		return false, err
 	} else if auth {
 		return true, nil


### PR DESCRIPTION
We are attempting to use the `github_team_slugs` configuration for the first time and have received reports that it is not working as expected. Some additional logging would help to triage the issue.