### PR TITLE
CAPZ: update Kubernetes upgrade tests with newer versions

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,93 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-19-1-20-main
-  interval: 24h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-1.23
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.19"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.20"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.4.13-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "1.7.0"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7300m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-19-1-20
-
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-20-1-21-main
-  interval: 24h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-1.23
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.20"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.21"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.4.13-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.0"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7300m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-20-1-21
-
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-21-1-22-main
   interval: 24h
   decorate: true
@@ -117,7 +29,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -161,7 +73,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.6"
         - name: GINKGO_FOCUS
@@ -175,3 +87,47 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-22-1-23
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-23-1-24-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-1.23
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.23"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.24"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.3-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.8.6"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-periodic-upgrade-main-1-23-1-24


### PR DESCRIPTION
Refresh k8s version upgrade tests:

- removes 1.19 -> 1.20 
- removes 1.20 -> 1.21
- adds 1.23 -> 1.24