### PR TITLE
Bump image promoter jobs to v3.4.4

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
         command:
         - /kpromo
         args:
@@ -34,7 +34,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
         command:
         - /kpromo
         args:
@@ -77,7 +77,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
         command:
         - /kpromo
         args:
@@ -40,7 +40,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
         command:
         - /kpromo
         args:
@@ -101,7 +101,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
       command:
       - /kpromo
       args:
@@ -139,7 +139,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.3-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.4-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
This PR bumps the image promoter jobs to v3.4.4.

Part of: https://github.com/kubernetes-sigs/promo-tools/issues/589

/cc @Verolop @justaugustus @saschagrunert @cpanato



Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>