### PR TITLE
bugzilla client: check for statusCode 401 when validating if access is denied

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -796,7 +796,10 @@ func IsAccessDenied(err error) bool {
 	if !ok {
 		return false
 	}
-	return reqError.bugzillaCode == 102
+	if reqError.bugzillaCode == 102 || reqError.statusCode == 401 {
+		return true
+	}
+	return false
 }
 
 // AddPullRequestAsExternalBug attempts to add a PR to the external tracker list.


### PR DESCRIPTION
The current function (`IsAccessDenied`) validates only the `bugzillCode` to determine if access is denied. We have observed that when access to certain bugs is restricted, Bugzilla will respond with a `statusCode` 401 and a `bugzillaCode` 0.
The `statusCode` 401 is included in the check. 
 