### PR TITLE
add kubekins translation for new bazel version

### DIFF
--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -38,8 +38,8 @@ steps:
     - gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG
     dir: .
 substitutions:
-  _BAZEL_VERSION: 3.4.1
-  _OLD_BAZEL_VERSION: 2.2.0
+  _BAZEL_VERSION: 5.2.0
+  _OLD_BAZEL_VERSION: 3.4.1
   _CFSSL_VERSION: R1.2
   _CONFIG: master
   _GIT_TAG: '12345'


### PR DESCRIPTION
this binary is only used in cloud-provider-gcp, AFAIK. At this point, should we just switch this to bazelisk since downloads of bazel versions is probably not much of any issue anymore?