### PR TITLE
Windows: fix commit ids for temp comparison jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
@@ -179,7 +179,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: 46d58cc17 #before #110701
+    base_ref: 46d58cc173c854673b7da34f8ccc0dc0b201e5c0 #before #110701
     path_alias: k8s.io/kubernetes
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
@@ -179,7 +179,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: 938a3203c #before #110702
+    base_ref: d11725a28e7e6e6d69f267a90028004133f6f108 #before #110702
     path_alias: k8s.io/kubernetes
   spec:
     containers:


### PR DESCRIPTION
This is a follow up to https://github.com/kubernetes/test-infra/pull/26768 which added a temp job to help debug some flakes we are seeing

/assign @marosset 