### PR TITLE
Force Redirect Registry URL because of redirect failures

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -67,6 +67,7 @@ periodics:
         # container images scan
         echo "Fetch the list of k8s images"
         curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release | grep 'PackageName: registry.k8s.io/' | awk '{print $2}' > images
+        sed 's/registry.k8s.io/k8s.gcr.io/' images > redirect-images
         while read image; do
           echo "Running container image scan.."
           EXIT_CODE=0
@@ -83,7 +84,7 @@ periodics:
           else
             echo "Scan completed image $image"
           fi
-        done < images
+        done < redirect-images
   annotations:
     testgrid-create-test-group: "true"
     testgrid-alert-email: security-tooling-private@kubernetes.io


### PR DESCRIPTION
Current Image scan job is failing, where redirect from `registry.k8s.io` to `k8s.gcr.io` fails. 

This PR will prevent this redirect failures until snyk client fix is available

Slack thread: https://kubernetes.slack.com/archives/C01CUSVMHPY/p1656438863833769

Error message sample when the reproduced locally:

```
Failed to run snyk scan with exit code 2 . Error message: {
  "ok": false,
  "error": "<a href=\"https://k8s.gcr.io/v2/kube-scheduler-amd64/manifests/v1.25.0-alpha.2\">Permanent Redirect</a>.\n\n",
  "path": "registry.k8s.io/kube-scheduler-amd64:v1.25.0-alpha.2"
}
```

Job URL: https://testgrid.k8s.io/sig-security-snyk-scan#ci-kubernetes-snyk-master

/cc @nehaLohia27 