### PR TITLE
use clusterctl v1.2.0 for upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -122,7 +122,7 @@ periodics:
       - name: GINKGO_FOCUS
         value: "\\[clusterctl-Upgrade\\]"
       - name: INIT_WITH_BINARY
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0-beta.2/clusterctl-{OS}-{ARCH}
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-{OS}-{ARCH}
       - name: INIT_WITH_PROVIDERS_CONTRACT
         value: v1beta1
       - name: INIT_WITH_KUBERNETES_VERSION


### PR DESCRIPTION
PR upgrade the clusterctl version to `v1.2.0` from the `v1.2.0-beta.2`.

Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/6835

Part of : https://github.com/kubernetes-sigs/cluster-api/issues/6615