### PR TITLE
Temporarily use release-1.24 for k/k test in master branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -153,7 +153,7 @@ presubmits:
         workdir: true
       - org: kubernetes
         repo: kubernetes
-        base_ref: master
+        base_ref: release-1.24
         path_alias: k8s.io/kubernetes
         workdir: false
     spec:
@@ -495,7 +495,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -552,7 +552,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -616,7 +616,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -726,7 +726,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -786,7 +786,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -847,7 +847,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -908,7 +908,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs


### PR DESCRIPTION
Because of a possible bug, switch back the k/k version to release-1.24.
https://github.com/kubernetes/kubernetes/issues/111040

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>