### PR TITLE
Add rerun with latest configuration UI.

### DIFF
--- a/prow/cmd/deck/static/command-help/command-help.ts
+++ b/prow/cmd/deck/static/command-help/command-help.ts
@@ -1,5 +1,6 @@
 import dialogPolyfill from "dialog-polyfill";
 import {Command, Help, PluginHelp} from "../api/help";
+import {showToast} from "../common/common";
 import {getParameterByName} from '../common/urls';
 
 declare const allHelp: Help;
@@ -266,8 +267,7 @@ function createCommandLink(name: string, no: number): HTMLTableDataCellElement {
         document.execCommand("copy");
         document.body.removeChild(tempInput);
 
-        const toast = document.body.querySelector("#toast")! as SnackbarElement;
-        toast.MaterialSnackbar.showSnackbar({message: "Copied to clipboard"});
+        showToast("Copied to clipboard");
     });
 
     link.appendChild(iconButton);

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -1,6 +1,5 @@
 import moment from "moment";
 import {ProwJobState, Pull} from "../api/prow";
-import {relativeURL} from "./urls";
 
 // This file likes namespaces, so stick with it for now.
 /* tslint:disable:no-namespace */
@@ -216,61 +215,7 @@ export function getCookieByName(name: string): string {
   return "";
 }
 
-export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string, rerunCreatesJob: boolean, csrfToken: string): HTMLElement {
-  const url = `${location.protocol}//${location.host}/rerun?prowjob=${prowjob}`;
-  const i = icon.create("refresh", "Show instructions for rerunning this job");
-
-  window.onkeydown = (event: any) => {
-    if ( event.key === "Escape" ) {
-      modal.style.display = "none";
-    }
-  };
-  window.onclick = (event: any) => {
-    if (event.target === modal) {
-      modal.style.display = "none";
-    }
-  };
-
-  // we actually want to know whether the "access-token-session" cookie exists, but we can't always
-  // access it from the frontend. "github_login" should be set whenever "access-token-session" is
-  i.onclick = () => {
-    modal.style.display = "block";
-    rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
-    const copyButton = document.createElement('a');
-    copyButton.className = "mdl-button mdl-js-button mdl-button--icon";
-    copyButton.onclick = () => copyToClipboardWithToast(`kubectl create -f "${url}"`);
-    copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
-    rerunElement.appendChild(copyButton);
-    if (rerunCreatesJob) {
-        const runButton = document.createElement('a');
-        runButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-button--colored'>Rerun</button>";
-        runButton.onclick = async () => {
-            gtag("event", "rerun", {
-                event_category: "engagement",
-                transport_type: "beacon",
-            });
-            const result = await fetch(url, {
-                headers: {
-                    "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-                    "X-CSRF-Token": csrfToken,
-                },
-                method: 'post',
-            });
-            const data = await result.text();
-            if (result.status === 401) {
-                window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
-            } else {
-                rerunElement.innerHTML = data;
-            }
-        };
-        rerunElement.appendChild(runButton);
-    }
-  };
-
-  return i;
-}
-
-function copyToClipboardWithToast(text: string): void {
+export function copyToClipboardWithToast(text: string): void {
   copyToClipboard(text);
 
   const toast = document.getElementById("toast") as SnackbarElement<HTMLDivElement>;

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -181,6 +181,16 @@ export namespace icon {
 
     return container;
   }
+
+  export function createAsString(iconString: string, tip: string = "", onClick?: (this: HTMLElement, ev: MouseEvent) => any, href?: string): string {
+    return `
+      <a class="mdl-button mdl-js-button mdl-button--icon" ${href ? `href="${href}"` : ''}>
+        <i class="icon-button material-icons" title=${(tip !== "") ? `"${tip}"` : ''} onclick=${onClick}>
+          ${iconString}
+        </i>
+      </a>
+    `;
+  }
 }
 
 export namespace tidehistory {
@@ -250,7 +260,6 @@ function copyToClipboard(text: string) {
       }
   }
 }
-
 export function formatDuration(seconds: number): string {
   const parts: string[] = [];
   if (seconds >= 3600) {

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -225,6 +225,11 @@ export function getCookieByName(name: string): string {
   return "";
 }
 
+export function alertToast(text: string): void {
+  const toast = document.getElementById("toastAlert") as SnackbarElement<HTMLDivElement>;
+  toast.MaterialSnackbar.showSnackbar({message: text});
+}
+
 export function copyToClipboardWithToast(text: string): void {
   copyToClipboard(text);
 

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -181,16 +181,6 @@ export namespace icon {
 
     return container;
   }
-
-  export function createAsString(iconString: string, tip: string = "", onClick?: (this: HTMLElement, ev: MouseEvent) => any, href?: string): string {
-    return `
-      <a class="mdl-button mdl-js-button mdl-button--icon" ${href ? `href="${href}"` : ''}>
-        <i class="icon-button material-icons" title=${(tip !== "") ? `"${tip}"` : ''} onclick=${onClick}>
-          ${iconString}
-        </i>
-      </a>
-    `;
-  }
 }
 
 export namespace tidehistory {
@@ -225,16 +215,14 @@ export function getCookieByName(name: string): string {
   return "";
 }
 
-export function alertToast(text: string): void {
-  const toast = document.getElementById("toastAlert") as SnackbarElement<HTMLDivElement>;
+export function showToast(text: string): void {
+  const toast = document.getElementById("toast") as SnackbarElement<HTMLDivElement>;
   toast.MaterialSnackbar.showSnackbar({message: text});
 }
 
-export function copyToClipboardWithToast(text: string): void {
-  copyToClipboard(text);
-
-  const toast = document.getElementById("toast") as SnackbarElement<HTMLDivElement>;
-  toast.MaterialSnackbar.showSnackbar({message: "Copied to clipboard"});
+export function showAlert(text: string): void {
+  const toast = document.getElementById("toastAlert") as SnackbarElement<HTMLDivElement>;
+  toast.MaterialSnackbar.showSnackbar({message: text});
 }
 
 // copyToClipboard is from https://stackoverflow.com/a/33928558
@@ -245,7 +233,7 @@ export function copyToClipboardWithToast(text: string): void {
 // IE: The clipboard feature may be disabled by an administrator. By
 // default a prompt is shown the first time the clipboard is
 // used (per session).
-function copyToClipboard(text: string) {
+export function copyToClipboard(text: string) {
   if (window.clipboardData && window.clipboardData.setData) {
       // IE specific code path to prevent textarea being shown while dialog is visible.
       return window.clipboardData.setData("Text", text);

--- a/prow/cmd/deck/static/common/rerun.ts
+++ b/prow/cmd/deck/static/common/rerun.ts
@@ -1,0 +1,56 @@
+import {copyToClipboardWithToast, icon} from "./common";
+import {relativeURL} from "./urls";
+
+export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string, rerunCreatesJob: boolean, csrfToken: string): HTMLElement {
+  const url = `${location.protocol}//${location.host}/rerun?prowjob=${prowjob}`;
+  const i = icon.create("refresh", "Show instructions for rerunning this job");
+
+  window.onkeydown = (event: any) => {
+    if ( event.key === "Escape" ) {
+      modal.style.display = "none";
+    }
+  };
+  window.onclick = (event: any) => {
+    if (event.target === modal) {
+      modal.style.display = "none";
+    }
+  };
+
+  // we actually want to know whether the "access-token-session" cookie exists, but we can't always
+  // access it from the frontend. "github_login" should be set whenever "access-token-session" is
+  i.onclick = () => {
+    modal.style.display = "block";
+    rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
+    const copyButton = document.createElement('a');
+    copyButton.className = "mdl-button mdl-js-button mdl-button--icon";
+    copyButton.onclick = () => copyToClipboardWithToast(`kubectl create -f "${url}"`);
+    copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
+    rerunElement.appendChild(copyButton);
+    if (rerunCreatesJob) {
+        const runButton = document.createElement('a');
+        runButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-button--colored'>Rerun</button>";
+        runButton.onclick = async () => {
+            gtag("event", "rerun", {
+                event_category: "engagement",
+                transport_type: "beacon",
+            });
+            const result = await fetch(url, {
+                headers: {
+                    "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+                    "X-CSRF-Token": csrfToken,
+                },
+                method: 'post',
+            });
+            const data = await result.text();
+            if (result.status === 401) {
+                window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
+            } else {
+                rerunElement.innerHTML = data;
+            }
+        };
+        rerunElement.appendChild(runButton);
+    }
+  };
+
+  return i;
+}

--- a/prow/cmd/deck/static/common/rerun.ts
+++ b/prow/cmd/deck/static/common/rerun.ts
@@ -1,4 +1,4 @@
-import {copyToClipboardWithToast, icon} from "./common";
+import {alertToast, copyToClipboardWithToast, icon} from "./common";
 import {relativeURL} from "./urls";
 
 export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string, rerunCreatesJob: boolean, csrfToken: string): HTMLElement {
@@ -128,7 +128,7 @@ export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLEle
             if (result.status === 401) {
                 window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
             } else {
-                rerunElement.innerHTML = data;
+                alertToast(data)
             }
         };
         rerunElement.appendChild(runButton);

--- a/prow/cmd/deck/static/common/rerun.ts
+++ b/prow/cmd/deck/static/common/rerun.ts
@@ -1,34 +1,36 @@
-import {alertToast, copyToClipboardWithToast, icon} from "./common";
+import {copyToClipboard, icon, showAlert, showToast} from "./common";
 import {relativeURL} from "./urls";
 
-export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string, rerunCreatesJob: boolean, csrfToken: string): HTMLElement {
-  const LATEST = 'latest';
-  const ORIGINAL = 'original';
-  const latestURL = `${location.protocol}//${location.host}/rerun?mode=latest&prowjob=${prowjob}`;
-  const originalURL = `${location.protocol}//${location.host}/rerun?mode=original&prowjob=${prowjob}`;
-  let commandURL = latestURL;
+export function createRerunProwJobIcon(modal: HTMLElement, parentEl: HTMLElement, prowjob: string, showRerunButton: boolean, csrfToken: string): HTMLElement {
+  const LATEST_JOB = 'latest';
+  const ORIGINAL_JOB = 'original';
+  const inrepoconfigURL = 'https://github.com/kubernetes/test-infra/blob/master/prow/inrepoconfig.md';
   const i = icon.create("refresh", "Show instructions for rerunning this job");
 
+  const closeModal = (): void => {
+    modal.style.display = "none";
+    // Resets modal content. If removed, elements will be concatenated, causing duplicates.
+    parentEl.innerHTML = '';
+  };
   window.onkeydown = (event: any) => {
-    if ( event.key === "Escape" ) {
-      modal.style.display = "none";
-      // Resets modal content. If removed elements will be concatenated, causing duplicates.
-      rerunElement.innerHTML = '';
+    if (event.key === "Escape") {
+      closeModal();
     }
   };
   window.onclick = (event: any) => {
     if (event.target === modal) {
-      modal.style.display = "none";
-      // Resets modal content. If removed elements will be concatenated, causing duplicates.
-      rerunElement.innerHTML = '';
+      closeModal();
     }
   };
-  
+  const getJobURL = (mode: string): string => {
+    return `${location.protocol}//${location.host}/rerun?mode=${mode}&prowjob=${prowjob}`;
+  };
+  let commandURL = getJobURL(LATEST_JOB);
   const getCommandDescription = (mode: string): string => {
-    return `The command is for the ${mode} configuration. Note: Admin permissions are required to rerun via kubectl.`
-  }
-  const getCommand = (url: string):string => {
-    return `kubectl create -f "${url}"`
+    return `The command is for the ${mode} configuration. Admin permissions are required to rerun via kubectl.`;
+  };
+  const getCommand = (url: string): string => {
+    return `kubectl create -f "${url}"`;
   };
 
   // we actually want to know whether the "access-token-session" cookie exists, but we can't always
@@ -36,41 +38,50 @@ export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLEle
   i.onclick = () => {
     modal.style.display = "block";
 
-    rerunElement.innerHTML = `
+    parentEl.innerHTML = `
       <h2 class="rerunModal-title">Rerun ProwJob</h2>
       <p class="rerunModal-description">
-        Rerun the latest or original configuration. Rerunning a ProwJob will create a new one.
-        The old ProwJob will not stop or cancel. Inrepoconfig is currently not supported for
-        latest configuration.
+        Below you can choose to rerun this ProwJob with either the original or latest configuration.
+        <br><br>
+        Note: Rerunning a ProwJob will create a new instance of a ProwJob. Any ProwJobs already running will not be interrupted.
+        <a href="${inrepoconfigURL}" target="_blank">
+          Inrepoconfig
+          <i class='rerunModal-openOut material-icons state triggered' style='color: gray'>open_in_new</i>
+        </a>
+        is currently not supported with the latest configuration option.
       </p>
       <div class="rerunModal-radioButtonGroup">
         <div class="rerunModal-radioButtonRow">
           <label class="rerunModal-radioLabel mdl-radio mdl-js-radio mdl-js-ripple-effect" for="rerunLatestOption">
-            <input type="radio" id="rerunLatestOption" class="mdl-radio__button" name="rerunOptions" checked>
+            <input type="radio" id="rerunLatestOption" class="rerunLatestOption mdl-radio__button" name="rerunOptions" checked>
             <span class="mdl-radio__label">Latest Configuration</span>
           </label>
-          ${icon.createAsString('description', 'View latest job', null, latestURL)}
+          (<a href="${getJobURL(LATEST_JOB)}" target="_blank">View YAML
+          <i class="rerunModal-openOut material-icons state triggered" style="color: gray">open_in_new</i>
+          </a>)
         </div>
         <div class="rerunModal-radioButtonRow">
           <label class="rerunModal-radioLabel mdl-radio mdl-js-radio mdl-js-ripple-effect" for="rerunOriginalOption">
-            <input type="radio" id="rerunOriginalOption" class="mdl-radio__button" name="rerunOptions">
+            <input type="radio" id="rerunOriginalOption" class="rerunOriginalOption mdl-radio__button" name="rerunOptions">
             <span class="mdl-radio__label">Original Configuration</span>
           </label>
-          ${icon.createAsString('description', 'View original job', null, originalURL)}
+          (<a href="${getJobURL(ORIGINAL_JOB)}" target="_blank">View YAML
+          <i class="rerunModal-openOut material-icons state triggered" style="color: gray">open_in_new</i>
+          </a>)
         </div>
       </div>
       <div class="rerunModal-accordion">
         <button class="rerunModal-accordionButton">
-        <i class='rerunModal-expandIcon material-icons state triggered' style='color: gray'>expand_more</i>
-          Rerun Command
+          <i class="rerunModal-expandIcon material-icons state triggered" style="color: gray">expand_more</i>
+          kubectl command
         </button>
         <div class="rerunModal-accordionPanel">
           <div class="accordion-panel-content">
-            <p class="rerunModal-commandDescription">${getCommandDescription(LATEST)}</p>
+            <p class="rerunModal-commandDescription">${getCommandDescription(LATEST_JOB)}</p>
             <div class="rerunModal-commandContent">
               <div class="rerunModal-command">${getCommand(commandURL)}</div>
               <a class="rerunModal-copyButton mdl-button mdl-js-button mdl-button--icon">
-                <i class='material-icons state triggered' style='color: gray'>content_copy</i>
+                <i class="material-icons state triggered" style="color: gray">content_copy</i>
               </a>
             </div>
           </div>
@@ -78,27 +89,28 @@ export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLEle
       </div>
     `;
 
-    const rerunLatestOption = rerunElement.querySelector('#rerunLatestOption');
-    const rerunCommand = rerunElement.querySelector('.rerunModal-command');
-    const rerunCommandDescription = rerunElement.querySelector('.rerunModal-commandDescription');
-    rerunLatestOption.addEventListener('click', () => {
-      commandURL = latestURL;
-      rerunCommandDescription.innerHTML = getCommandDescription(LATEST);
-      rerunCommand.innerHTML = getCommand(commandURL);
+    const latestOption = parentEl.querySelector('.rerunLatestOption');
+    const command = parentEl.querySelector('.rerunModal-command');
+    const commandDescription = parentEl.querySelector('.rerunModal-commandDescription');
+    latestOption.addEventListener('click', () => {
+      commandURL = getJobURL(LATEST_JOB);
+      commandDescription.innerHTML = getCommandDescription(LATEST_JOB);
+      command.innerHTML = getCommand(commandURL);
     });
-    const rerunOriginalOption = rerunElement.querySelector('#rerunOriginalOption');
-    rerunOriginalOption.addEventListener('click', () => {
-      commandURL = originalURL;
-      rerunCommandDescription.innerHTML = getCommandDescription(ORIGINAL);
-      rerunCommand.innerHTML = getCommand(commandURL);
+    const originalOption = parentEl.querySelector('.rerunOriginalOption');
+    originalOption.addEventListener('click', () => {
+      commandURL = getJobURL(ORIGINAL_JOB);
+      commandDescription.innerHTML = getCommandDescription(ORIGINAL_JOB);
+      command.innerHTML = getCommand(commandURL);
     });
-    const rerunCopyButton = rerunElement.querySelector('.rerunModal-copyButton');
-    rerunCopyButton.addEventListener('click', () => {
-      copyToClipboardWithToast(getCommand(commandURL));
-    })
-    const accordion = rerunElement.querySelector('.rerunModal-accordionButton');
-    const accordionPanel = rerunElement.querySelector('.rerunModal-accordionPanel');
-    const expandIcon = rerunElement.querySelector('.rerunModal-expandIcon');
+    const copyButton = parentEl.querySelector('.rerunModal-copyButton');
+    copyButton.addEventListener('click', () => {
+      copyToClipboard(getCommand(commandURL));
+      showToast("Copied to clipboard");
+    });
+    const accordion = parentEl.querySelector('.rerunModal-accordionButton');
+    const accordionPanel = parentEl.querySelector('.rerunModal-accordionPanel');
+    const expandIcon = parentEl.querySelector('.rerunModal-expandIcon');
     accordion.addEventListener('click', () => {
       if (!accordionPanel.classList.contains('rerunModal-accordionPanel--expanded')) {
         accordionPanel.classList.add('rerunModal-accordionPanel--expanded');
@@ -109,29 +121,36 @@ export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLEle
       }
     });
 
-    if (rerunCreatesJob) {
-        const runButton = document.createElement('a');
-        runButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-button--colored'>Rerun</button>";
-        runButton.onclick = async () => {
-            gtag("event", "rerun", {
-                event_category: "engagement",
-                transport_type: "beacon",
-            });
-            const result = await fetch(commandURL, {
-                headers: {
-                    "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-                    "X-CSRF-Token": csrfToken,
-                },
-                method: 'post',
-            });
-            const data = await result.text();
-            if (result.status === 401) {
-                window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
-            } else {
-                alertToast(data)
-            }
-        };
-        rerunElement.appendChild(runButton);
+    if (showRerunButton) {
+      const runButton = document.createElement('a');
+      runButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-button--colored'>Rerun</button>";
+      runButton.onclick = async () => {
+        gtag("event", "rerun", {
+          event_category: "engagement",
+          transport_type: "beacon",
+        });
+        try {
+          const result = await fetch(commandURL, {
+            headers: {
+              "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+              "X-CSRF-Token": csrfToken,
+            },
+            method: 'post',
+          });
+          if (result.status === 401) {
+            window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
+          }
+          const data = await result.text();
+          if (result.status >= 400) {
+            showAlert(data);
+          } else {
+            showToast(data);
+          }
+        } catch (e) {
+          showAlert(`Could not send request to rerun job: ${e}`);
+        }
+      };
+      parentEl.appendChild(runButton);
     }
   };
 

--- a/prow/cmd/deck/static/common/rerun.ts
+++ b/prow/cmd/deck/static/common/rerun.ts
@@ -2,30 +2,113 @@ import {copyToClipboardWithToast, icon} from "./common";
 import {relativeURL} from "./urls";
 
 export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string, rerunCreatesJob: boolean, csrfToken: string): HTMLElement {
-  const url = `${location.protocol}//${location.host}/rerun?prowjob=${prowjob}`;
+  const LATEST = 'latest';
+  const ORIGINAL = 'original';
+  const latestURL = `${location.protocol}//${location.host}/rerun?mode=latest&prowjob=${prowjob}`;
+  const originalURL = `${location.protocol}//${location.host}/rerun?mode=original&prowjob=${prowjob}`;
+  let commandURL = latestURL;
   const i = icon.create("refresh", "Show instructions for rerunning this job");
 
   window.onkeydown = (event: any) => {
     if ( event.key === "Escape" ) {
       modal.style.display = "none";
+      // Resets modal content. If removed elements will be concatenated, causing duplicates.
+      rerunElement.innerHTML = '';
     }
   };
   window.onclick = (event: any) => {
     if (event.target === modal) {
       modal.style.display = "none";
+      // Resets modal content. If removed elements will be concatenated, causing duplicates.
+      rerunElement.innerHTML = '';
     }
+  };
+  
+  const getCommandDescription = (mode: string): string => {
+    return `The command is for the ${mode} configuration. Note: Admin permissions are required to rerun via kubectl.`
+  }
+  const getCommand = (url: string):string => {
+    return `kubectl create -f "${url}"`
   };
 
   // we actually want to know whether the "access-token-session" cookie exists, but we can't always
   // access it from the frontend. "github_login" should be set whenever "access-token-session" is
   i.onclick = () => {
     modal.style.display = "block";
-    rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
-    const copyButton = document.createElement('a');
-    copyButton.className = "mdl-button mdl-js-button mdl-button--icon";
-    copyButton.onclick = () => copyToClipboardWithToast(`kubectl create -f "${url}"`);
-    copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
-    rerunElement.appendChild(copyButton);
+
+    rerunElement.innerHTML = `
+      <h2 class="rerunModal-title">Rerun ProwJob</h2>
+      <p class="rerunModal-description">
+        Rerun the latest or original configuration. Rerunning a ProwJob will create a new one.
+        The old ProwJob will not stop or cancel. Inrepoconfig is currently not supported for
+        latest configuration.
+      </p>
+      <div class="rerunModal-radioButtonGroup">
+        <div class="rerunModal-radioButtonRow">
+          <label class="rerunModal-radioLabel mdl-radio mdl-js-radio mdl-js-ripple-effect" for="rerunLatestOption">
+            <input type="radio" id="rerunLatestOption" class="mdl-radio__button" name="rerunOptions" checked>
+            <span class="mdl-radio__label">Latest Configuration</span>
+          </label>
+          ${icon.createAsString('description', 'View latest job', null, latestURL)}
+        </div>
+        <div class="rerunModal-radioButtonRow">
+          <label class="rerunModal-radioLabel mdl-radio mdl-js-radio mdl-js-ripple-effect" for="rerunOriginalOption">
+            <input type="radio" id="rerunOriginalOption" class="mdl-radio__button" name="rerunOptions">
+            <span class="mdl-radio__label">Original Configuration</span>
+          </label>
+          ${icon.createAsString('description', 'View original job', null, originalURL)}
+        </div>
+      </div>
+      <div class="rerunModal-accordion">
+        <button class="rerunModal-accordionButton">
+        <i class='rerunModal-expandIcon material-icons state triggered' style='color: gray'>expand_more</i>
+          Rerun Command
+        </button>
+        <div class="rerunModal-accordionPanel">
+          <div class="accordion-panel-content">
+            <p class="rerunModal-commandDescription">${getCommandDescription(LATEST)}</p>
+            <div class="rerunModal-commandContent">
+              <div class="rerunModal-command">${getCommand(commandURL)}</div>
+              <a class="rerunModal-copyButton mdl-button mdl-js-button mdl-button--icon">
+                <i class='material-icons state triggered' style='color: gray'>content_copy</i>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const rerunLatestOption = rerunElement.querySelector('#rerunLatestOption');
+    const rerunCommand = rerunElement.querySelector('.rerunModal-command');
+    const rerunCommandDescription = rerunElement.querySelector('.rerunModal-commandDescription');
+    rerunLatestOption.addEventListener('click', () => {
+      commandURL = latestURL;
+      rerunCommandDescription.innerHTML = getCommandDescription(LATEST);
+      rerunCommand.innerHTML = getCommand(commandURL);
+    });
+    const rerunOriginalOption = rerunElement.querySelector('#rerunOriginalOption');
+    rerunOriginalOption.addEventListener('click', () => {
+      commandURL = originalURL;
+      rerunCommandDescription.innerHTML = getCommandDescription(ORIGINAL);
+      rerunCommand.innerHTML = getCommand(commandURL);
+    });
+    const rerunCopyButton = rerunElement.querySelector('.rerunModal-copyButton');
+    rerunCopyButton.addEventListener('click', () => {
+      copyToClipboardWithToast(getCommand(commandURL));
+    })
+    const accordion = rerunElement.querySelector('.rerunModal-accordionButton');
+    const accordionPanel = rerunElement.querySelector('.rerunModal-accordionPanel');
+    const expandIcon = rerunElement.querySelector('.rerunModal-expandIcon');
+    accordion.addEventListener('click', () => {
+      if (!accordionPanel.classList.contains('rerunModal-accordionPanel--expanded')) {
+        accordionPanel.classList.add('rerunModal-accordionPanel--expanded');
+        expandIcon.classList.add('rerunModal-expandIcon--expanded');
+      } else {
+        accordionPanel.classList.remove('rerunModal-accordionPanel--expanded');
+        expandIcon.classList.remove('rerunModal-expandIcon--expanded');
+      }
+    });
+
     if (rerunCreatesJob) {
         const runButton = document.createElement('a');
         runButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-button--colored'>Rerun</button>";
@@ -34,7 +117,7 @@ export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLEle
                 event_category: "engagement",
                 transport_type: "beacon",
             });
-            const result = await fetch(url, {
+            const result = await fetch(commandURL, {
                 headers: {
                     "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
                     "X-CSRF-Token": csrfToken,

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -1,6 +1,7 @@
 import moment from "moment";
 import {ProwJob, ProwJobList, ProwJobState, ProwJobType, Pull} from "../api/prow";
-import {cell, createRerunProwJobIcon, formatDuration, icon} from "../common/common";
+import {cell, formatDuration, icon} from "../common/common";
+import {createRerunProwJobIcon} from "../common/rerun";
 import {getParameterByName} from "../common/urls";
 import {FuzzySearch} from './fuzzy-search';
 import {JobHistogram, JobSample} from './histogram';

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -1,4 +1,4 @@
-import {createRerunProwJobIcon} from "../common/common";
+import {createRerunProwJobIcon} from "../common/rerun";
 import {getParameterByName} from "../common/urls";
 import {isTransitMessage, serialiseHashes} from "./common";
 

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -344,10 +344,17 @@ i.state {
 
 .rerunModal-description {
     font-size: 16px;
+    margin-bottom: 24px;
+}
+
+.rerunModal-openOut {
+    /* HACK: "open out" icon scaling is off otherwise. */
+    transform: scale(.75);
+    margin: 0px -7px;
 }
 
 .rerunModal-radioButtonGroup {
-    margin: 10px 0px 10px 0px;
+    margin: 10px 0px;
 }
 
 .rerunModal-radioButtonRow {
@@ -402,6 +409,7 @@ i.state {
 }
 
 .rerunModal-commandContent {
+    display: flex;
     background-color: lightgrey;
     padding: 10px;
     border-radius: 5px;

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -306,6 +306,10 @@ i.state {
     width: 52px;
 }
 
+#toastAlert {
+    background-color: #F44336;
+}
+
 #rerun {
     display: none;
     position: fixed;
@@ -327,6 +331,7 @@ i.state {
     padding: 40px;
     border: 1px solid #888;
     width: 50%;
+    max-width: 1500px;
     color: #444;
     border-radius: 10px;
     box-shadow: 0px 20px 80px 0px; 
@@ -390,10 +395,6 @@ i.state {
 
 .accordion-panel-content {
     padding: 20px;
-}
-
-.rerunModal-commandContent {
-    display: flex;
 }
 
 .rerunModal-accordionDescription {

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -324,11 +324,97 @@ i.state {
     font-family: monospace;
     background-color: #fefefe;
     margin: auto;
-    padding: 20px;
+    padding: 40px;
     border: 1px solid #888;
-    width: 80%;
-    text-align: center;
+    width: 50%;
     color: #444;
+    border-radius: 10px;
+    box-shadow: 0px 20px 80px 0px; 
+}
+
+.rerunModal-title {
+    font-size: 35px;
+    margin-top: 0px;
+}
+
+.rerunModal-description {
+    font-size: 16px;
+}
+
+.rerunModal-radioButtonGroup {
+    margin: 10px 0px 10px 0px;
+}
+
+.rerunModal-radioButtonRow {
+    margin: 10px;
+}
+
+.rerunModal-radioLabel {
+    min-width: 250px;
+}
+
+.rerunModal-accordion {
+    margin-bottom: 20px;
+}
+
+.rerunModal-accordionButton {
+    background-color: #ccc;
+    color: #444;
+    font-size: 16px;
+    cursor: pointer;
+    width: 100%;
+    height: 40px;
+    border: none;
+    text-align: left;
+    outline: none;
+}
+
+.rerunModal-expandIcon {
+    transition: all 0.2s ease-out;
+}
+
+.rerunModal-expandIcon--expanded {
+    transform: rotate(-180deg);
+}
+
+.rerunModal-accordionPanel {
+    background-color: #e5e5e5;
+    max-height: 0px;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+}
+
+.rerunModal-accordionPanel--expanded {
+    max-height: 250px;
+}
+
+.accordion-panel-content {
+    padding: 20px;
+}
+
+.rerunModal-commandContent {
+    display: flex;
+}
+
+.rerunModal-accordionDescription {
+    font-size: 16px;
+}
+
+.rerunModal-commandContent {
+    background-color: lightgrey;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.rerunModal-commandDescription {
+    font-size: 16px;
+}
+
+.rerunModal-command {
+    overflow-x: auto;
+    white-space: nowrap;
+    background-color: #efefef;
+    margin-right: 5px;
 }
 
 #queries li {

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -78,6 +78,10 @@
   <div class="mdl-snackbar__text"></div>
   <button class="mdl-snackbar__action" type="button"></button>
 </div>
+<div id="toastAlert" class="mdl-js-snackbar mdl-snackbar">
+  <div class="mdl-snackbar__text"></div>
+  <button class="mdl-snackbar__action" type="button"></button>
+</div>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
This PR adds the UI for rerunning with the latest configuration feature. It moves existing code into `rerun.ts`, adds new UI, and creates a new way of alerting the user of any errors using a toast instead of changing the modal's inner html.

![image](https://user-images.githubusercontent.com/55557781/178372316-d7d70a5f-863f-48fe-bc77-429e7f31bbeb.png)
![Screenshot 2022-07-13 8 41 13 AM](https://user-images.githubusercontent.com/55557781/178777314-7a3e1dba-02c7-4c0b-ae80-de8e17885efb.png)


For more details on the purpose of the change view: [design document](https://docs.google.com/document/d/1zARYe3xK4kprEdySiWP6We3Y9BLT1gdSxIrw63moR9g/edit?usp=sharing)

Fixes https://github.com/kubernetes/test-infra/issues/26416

/cc @chaodaiG @cjwagner @e-blackwelder 