### PR TITLE
Crier doesn't log error when pubsub topic doesn't exist

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -85,7 +85,11 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	log.Debug("processing next key")
 	result, err := r.reconcile(ctx, log, req)
 	if err != nil {
-		log.WithError(err).Error("Reconciliation failed")
+		if criercommonlib.IsUserError(err) {
+			log.WithError(err).Debug("Reconciliation failed")
+		} else {
+			log.WithError(err).Error("Reconciliation failed")
+		}
 	}
 	if result == nil {
 		result = &reconcile.Result{}
@@ -135,7 +139,11 @@ func (r *reconciler) reconcile(ctx context.Context, log *logrus.Entry, req recon
 	log.Info("Will report state")
 	pjs, requeue, err := r.reporter.Report(ctx, log, &pj)
 	if err != nil {
-		log.WithError(err).Error("failed to report job")
+		if criercommonlib.IsUserError(err) {
+			log.WithError(err).Debug("Failed to report job.")
+		} else {
+			log.WithError(err).Error("Failed to report job.")
+		}
 		crierMetrics.reportingResults.WithLabelValues(r.reporter.GetName(), ResultError).Inc()
 		return nil, fmt.Errorf("failed to report job: %w", err)
 	}

--- a/prow/crier/reporters/criercommonlib/errors.go
+++ b/prow/crier/reporters/criercommonlib/errors.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package criercommonlib contains shared lib used by reporters
+package criercommonlib
+
+import (
+	"errors"
+	"fmt"
+)
+
+type userError struct {
+	err error
+}
+
+func (ue userError) Error() string {
+	return fmt.Sprintf("this is a user error: %s", ue.err.Error())
+}
+
+func (userError) Is(err error) bool {
+	_, ok := err.(userError)
+	return ok
+}
+
+// UserError wraps an error and return a userError error.
+func UserError(err error) error {
+	return &userError{err: err}
+}
+
+// IsUserError checks whether the returned error is a user error.
+func IsUserError(err error) bool {
+	return errors.Is(err, userError{})
+}


### PR DESCRIPTION
This is clearly a user error and should not spam the logs.

Also by the way removed the duplicated logs from Reconcile function.