### PR TITLE
Add win-soak-test build cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -1,4 +1,21 @@
 ---
+presets:
+- labels:
+    preset-azure-win-soak-test-creds: "true"
+  env:
+  - name: KUBECONFIG
+    value: "/root/.kube/win-soak-test"
+  volumeMounts:
+  - name: win-soak-test
+    mountPath: /root/.kube/win-soak-test
+  volumes:
+  - name: win-soak-test
+    secret:
+      secretName: win-soak-test
+      defaultMode: 420
+      items:
+      - key: win-soak-test
+        path: win-soak-test.kubeconfig
 presubmits:
   kubernetes/perf-tests:
   - name: soak-tests-capz-windows-2019

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -100,6 +100,39 @@ presubmits:
       description: "Run clusterloader2 tests on a capz Windows 2019 cluster"
       testgrid-num-columns-recent: '30'
 periodics:
+  - name: delete-win-soak-test-cluster
+    cron: "0 0 * * SUN"
+    decorate: true
+    always_run: true
+    optional: true
+    decoration_config:
+      timeout: 8h
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-master
+          command:
+            - az
+          args:
+            - >-
+              group
+              delete
+              --resource-group
+              win-soak-test
+              -y
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-windows-soak-tests
+      testgrid-tab-name: delete-win-soak-test-cluster
+      description: "Delete win-soak-test cluster"
+      testgrid-num-columns-recent: '30'
+
   - interval: 24h
     name: periodic-soak-tests-capz-windows-2019
     decorate: true

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -17,14 +17,13 @@ presets:
       - key: win-soak-test
         path: win-soak-test.kubeconfig
 presubmits:
-  kubernetes/test-infra:
+  kubernetes/perf-tests:
   - name: soak-tests-capz-windows-2019
     decorate: true
     always_run: false
     optional: true
     decoration_config:
       timeout: 8h
-    path_alias: k8s.io/perf-tests
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -32,12 +31,6 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
       preset-azure-win-soak-test-creds: "true"
-    extra_refs:
-      - org: kubernetes
-        repo: perf-tests
-        base_ref: "main"
-        path_alias: "k8s.io/perf-tests"
-        workdir: true
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -133,6 +133,65 @@ periodics:
       description: "Delete win-soak-test cluster"
       testgrid-num-columns-recent: '30'
 
+  - name: build-win-soak-test-cluster
+    cron: "0 1 * * SUN"
+    decorate: true
+    always_run: true
+    optional: true
+    decoration_config:
+      timeout: 8h
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: main
+        path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-master
+          command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+          args:
+            - bash
+            - -c
+            - >-
+              az keyvault secret set
+              --name win-soak-test-kubeconfig
+              --vault-name win-soak-test
+              --file ./kubeconfig
+              --encoding base64 &&
+              az group update
+              --tags DO-NOT-DELETE=$(date)
+              -n win-soak-test
+          securityContext:
+            privileged: true
+          env:
+            # CAPZ variables
+            - name: NODE_MACHINE_TYPE
+              value: "Standard_D4s_v3"
+            - name: TEST_WINDOWS
+              value: "true"
+            - name: KUBERNETES_VERSION
+              value: "latest"
+            - name: WINDOWS_WORKER_MACHINE_COUNT
+              value: "1"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create linux worker nodes
+            - name: SKIP_CLEANUP # Do not delete workload cluster
+              value: "true"
+    annotations:
+      testgrid-dashboards: sig-windows-soak-tests
+      testgrid-tab-name: build-win-soak-test-cluster
+      description: "Build win-soak-test cluster"
+      testgrid-num-columns-recent: '30'
+
   - interval: 24h
     name: periodic-soak-tests-capz-windows-2019
     decorate: true

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -25,7 +25,6 @@ presubmits:
     decoration_config:
       timeout: 8h
     path_alias: k8s.io/perf-tests
-    cluster: win-soak-test
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -75,6 +74,58 @@ presubmits:
       description: "Run clusterloader2 tests on a capz Windows 2019 cluster"
       testgrid-num-columns-recent: '30'
 periodics:
+  - name: hourly-soak-tests-capz-windows-2019
+    cron: "0 * * * MON-SAT"
+    decorate: true
+    path_alias: k8s.io/perf-tests
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-win-soak-test-creds: "true"
+    extra_refs:
+      - org: kubernetes
+        repo: perf-tests
+        base_ref: "main"
+        path_alias: "k8s.io/perf-tests"
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
+          command:
+            - ./run-e2e.sh
+          args:
+            - bash
+            - -c
+            - >-
+              cluster-loader2
+              --testconfig=testing/windows-tests/config.yaml
+              --provider=aks
+              --report-dir=${ARTIFACTS}
+              --v=2
+          securityContext:
+            privileged: true
+          env:
+            # clusterloader2 variables
+            - name: ENABLE_PROMETHEUS_SERVER
+              value: "true"
+            - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+              value: "true"
+            - name: PROMETHEUS_APISERVER_SCRAPE_PORT
+              value: "6443"
+            - name: PROMETHEUS_SCRAPE_WINDOWS_NODE_EXPORTER
+              value: "true"
+            - name: CL2_PROMETHEUS_TOLERATE_MASTER
+              value: "true"
+            - name: CL2_POD_COUNT
+              value: "10"
+    annotations:
+      testgrid-dashboards: sig-windows-soak-tests
+      testgrid-tab-name: hourly-soak-tests-capz-windows-2019
+      description: "Run clusterloader2 tests every hour on a capz Windows 2019 cluster"
+      testgrid-num-columns-recent: '30'
   - name: delete-win-soak-test-cluster
     cron: "0 0 * * SUN"
     decorate: true

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -17,7 +17,7 @@ presets:
       - key: win-soak-test
         path: win-soak-test.kubeconfig
 presubmits:
-  kubernetes/perf-tests:
+  kubernetes/test-infra:
   - name: soak-tests-capz-windows-2019
     decorate: true
     always_run: false
@@ -25,35 +25,30 @@ presubmits:
     decoration_config:
       timeout: 8h
     path_alias: k8s.io/perf-tests
+    cluster: win-soak-test
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-win-soak-test-creds: "true"
     extra_refs:
-      # This needs to be uncommented when we switch to periodic job.
-      # - org: kubernetes
-      #   repo: perf-tests
-      #   base_ref: "main"
-      #   path_alias: "k8s.io/perf-tests"
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.6
-        path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+      - org: kubernetes
+        repo: perf-tests
+        base_ref: "main"
+        path_alias: "k8s.io/perf-tests"
         workdir: true
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
           command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - ./run-e2e.sh
           args:
             - bash
             - -c
             - >-
-              cd ${GOPATH}/src/k8s.io/perf-tests/ &&
-              ./run-e2e.sh cluster-loader2
+              cluster-loader2
               --testconfig=testing/windows-tests/config.yaml
               --provider=aks
               --report-dir=${ARTIFACTS}
@@ -61,19 +56,6 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            # CAPZ variables
-            - name: NODE_MACHINE_TYPE
-              value: "Standard_D4s_v3"
-            - name: TEST_WINDOWS
-              value: "true"
-            - name: KUBERNETES_VERSION
-              value: "v1.25.3"
-            - name: WINDOWS_WORKER_MACHINE_COUNT
-              value: "1"
-            - name: WORKER_MACHINE_COUNT
-              value: "0" # Don't create linux worker nodes
-            - name: CL2_POD_COUNT
-              value: "10"
             # clusterloader2 variables
             - name: ENABLE_PROMETHEUS_SERVER
               value: "true"
@@ -85,15 +67,8 @@ presubmits:
               value: "true"
             - name: CL2_PROMETHEUS_TOLERATE_MASTER
               value: "true"
-            # azuredisk variables - required for Prometheus PVC
-            - name: DEPLOY_AZURE_CSI_DRIVER
-              value: "true"
-            - name: AZUREDISK_CSI_DRIVER_VERSION
-              value: "master"
-            - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
-              value: "kubernetes.io/azure-disk"
-            - name: PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE
-              value: "StandardSSD_LRS"
+            - name: CL2_POD_COUNT
+              value: "10"
     annotations:
       testgrid-dashboards: sig-windows-soak-tests
       testgrid-tab-name: soak-tests-capz-windows-2019
@@ -103,8 +78,6 @@ periodics:
   - name: delete-win-soak-test-cluster
     cron: "0 0 * * SUN"
     decorate: true
-    always_run: true
-    optional: true
     decoration_config:
       timeout: 8h
     labels:
@@ -136,8 +109,6 @@ periodics:
   - name: build-win-soak-test-cluster
     cron: "0 1 * * SUN"
     decorate: true
-    always_run: true
-    optional: true
     decoration_config:
       timeout: 8h
     labels:

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -24,23 +24,31 @@ presubmits:
     optional: true
     decoration_config:
       timeout: 8h
+    path_alias: k8s.io/perf-tests
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
-      preset-azure-win-soak-test-creds: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.6
+        path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+        workdir: true
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
           command:
-            - ./run-e2e.sh
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
           args:
             - bash
             - -c
             - >-
-              cluster-loader2
+              cd ${GOPATH}/src/k8s.io/perf-tests/ &&
+              ./run-e2e.sh cluster-loader2
               --testconfig=testing/windows-tests/config.yaml
               --provider=aks
               --report-dir=${ARTIFACTS}
@@ -48,6 +56,19 @@ presubmits:
           securityContext:
             privileged: true
           env:
+            # CAPZ variables
+            - name: NODE_MACHINE_TYPE
+              value: "Standard_D4s_v3"
+            - name: TEST_WINDOWS
+              value: "true"
+            - name: KUBERNETES_VERSION
+              value: "v1.25.3"
+            - name: WINDOWS_WORKER_MACHINE_COUNT
+              value: "1"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create linux worker nodes
+            - name: CL2_POD_COUNT
+              value: "10"
             # clusterloader2 variables
             - name: ENABLE_PROMETHEUS_SERVER
               value: "true"
@@ -59,8 +80,15 @@ presubmits:
               value: "true"
             - name: CL2_PROMETHEUS_TOLERATE_MASTER
               value: "true"
-            - name: CL2_POD_COUNT
-              value: "10"
+            # azuredisk variables - required for Prometheus PVC
+            - name: DEPLOY_AZURE_CSI_DRIVER
+              value: "true"
+            - name: AZUREDISK_CSI_DRIVER_VERSION
+              value: "master"
+            - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
+              value: "kubernetes.io/azure-disk"
+            - name: PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE
+              value: "StandardSSD_LRS"
     annotations:
       testgrid-dashboards: sig-windows-soak-tests
       testgrid-tab-name: soak-tests-capz-windows-2019


### PR DESCRIPTION
* Add preset for win-soak-test cluster
  - mount Kubeconfig for win-soak-test cluster

* Add the following periodic jobs:
  - delete-win-soak-test-cluster
    - Deletes win-soak-test cluster on Sunday at midnight
  - build-win-soak-test-cluster
    - Builds a new win-soak-test cluster on Sunday at 1 am
    - Updates win-soak-test Azure keyvault with the new cluster KUBECONFIG

* Update soak-tests-capz-windows-2019 presubmit job:
  - Run clusterloader against win-soak-test cluster instead of deploying a new one

