### PR TITLE
Replace prometheus labels named instance with org

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -58,7 +58,7 @@ var gerritMetrics = struct {
 		Name: "gerrit_processing_results",
 		Help: "Count of change processing by instance, repo, and result.",
 	}, []string{
-		"instance",
+		"org",
 		"repo",
 		"result",
 	}),
@@ -67,7 +67,7 @@ var gerritMetrics = struct {
 		Help:    "Histogram of seconds between triggering event and ProwJob creation time.",
 		Buckets: []float64{5, 10, 20, 30, 60, 120, 180, 300, 600, 1200, 3600},
 	}, []string{
-		"instance",
+		"org",
 		// Omit repo to avoid excessive cardinality due to the number of buckets.
 	}),
 	changeProcessDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -75,7 +75,7 @@ var gerritMetrics = struct {
 		Help:    "Histogram of seconds spent processing a single gerrit instance.",
 		Buckets: []float64{5, 10, 20, 30, 60, 120, 180, 300, 600, 1200, 3600},
 	}, []string{
-		"instance",
+		"org",
 	}),
 }
 

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -73,7 +73,7 @@ var clientMetrics = struct {
 		Name: "gerrit_query_results",
 		Help: "Count of Gerrit API queries by instance, repo, and result.",
 	}, []string{
-		"instance",
+		"org",
 		"repo",
 		"result",
 	}),


### PR DESCRIPTION
instance is an automatically generated label from prometheus: https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series, the value is the <host>:<port> part of the target, in our use case it would be <GERRIT_POD_NAME>:metrics, which is almost useless in most cases

/cc @cjwagner @mpherman2 