### PR TITLE
Parallel processing gerrit instances

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -137,11 +137,7 @@ func main() {
 
 	defer interrupts.WaitForGracefulShutdown()
 	interrupts.Tick(func() {
-		start := time.Now()
-		if err := c.Sync(); err != nil {
-			logrus.WithError(err).Error("Error syncing.")
-		}
-		logrus.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Synced")
+		c.Sync()
 	}, func() time.Duration {
 		return cfg().Gerrit.TickInterval.Duration
 	})

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -74,6 +74,10 @@ func (f *fgc) QueryChanges(lastUpdate client.LastSyncState, rateLimit int) map[s
 	return nil
 }
 
+func (f *fgc) QueryChangesForInstance(instance string, lastState client.LastSyncState, rateLimit int) []client.ChangeInfo {
+	return nil
+}
+
 func (f *fgc) SetReview(instance, id, revision, message string, labels map[string]string) error {
 	f.reviews++
 	return nil

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -331,6 +331,18 @@ func (c *Client) QueryChanges(lastState LastSyncState, rateLimit int) map[string
 	return result
 }
 
+func (c *Client) QueryChangesForInstance(instance string, lastState LastSyncState, rateLimit int) []ChangeInfo {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	h, ok := c.handlers[instance]
+	if !ok {
+		logrus.WithField("instance", instance).WithField("laststate", lastState).Warn("Instance not registered as handlers.")
+		return []ChangeInfo{}
+	}
+	lastStateForInstance := lastState[instance]
+	return h.queryAllChanges(lastStateForInstance, rateLimit)
+}
+
 func (c *Client) GetChange(instance, id string) (*ChangeInfo, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -18,7 +18,7 @@ prowjob_default_entries:
       tenant_id: 'tester'
 
 gerrit:
-  tick_interval: 10s
+  tick_interval: 1s
   org_repos_config:
   - org: http://fakegerritserver
     repos:


### PR DESCRIPTION
Previous PR parallelized the processing of gerrit instances but wait for all instances finish before starting another batch of query, this means the longest leg still blocks short legs.

/cc @cjwagner @mpherman2 
/hold
I'd like to control when to merge this