### PR TITLE
Separate request throttling max delay param for APIv4

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -95,6 +95,8 @@ type RequestThrottlingTimes struct {
 	throttlingTimeForGET uint
 	// maxDelayTime is applied when formed queue is too large, it allows to temporarily set max delay time provided by user instead of calculated value
 	maxDelayTime uint
+	// maxDelayTimeV4 is maxDelayTime for APIv4
+	maxDelayTimeV4 uint
 }
 
 func (rtt *RequestThrottlingTimes) isEnabled() bool {
@@ -109,12 +111,13 @@ func (rtt *RequestThrottlingTimes) getThrottlingTimeV4() uint {
 }
 
 // NewRequestThrottlingTimes creates a new RequestThrottlingTimes and returns it
-func NewRequestThrottlingTimes(requestThrottlingTime, requestThrottlingTimeV4, requestThrottlingTimeForGET, requestThrottlingMaxDelayTime uint) RequestThrottlingTimes {
+func NewRequestThrottlingTimes(requestThrottlingTime, requestThrottlingTimeV4, requestThrottlingTimeForGET, requestThrottlingMaxDelayTime, requestThrottlingMaxDelayTimeV4 uint) RequestThrottlingTimes {
 	return RequestThrottlingTimes{
 		throttlingTime:       requestThrottlingTime,
 		throttlingTimeV4:     requestThrottlingTimeV4,
 		throttlingTimeForGET: requestThrottlingTimeForGET,
 		maxDelayTime:         requestThrottlingMaxDelayTime,
+		maxDelayTimeV4:       requestThrottlingMaxDelayTimeV4,
 	}
 }
 
@@ -182,7 +185,7 @@ func newThrottlingTransport(maxConcurrency int, roundTripper http.RoundTripper, 
 		timeThrottlingEnabled: throttlingTimes.isEnabled(),
 		hasher:                hasher,
 		registryApiV3:         newTokensRegistry(throttlingTimes.throttlingTime, throttlingTimes.throttlingTimeForGET, throttlingTimes.maxDelayTime),
-		registryApiV4:         newTokensRegistry(throttlingTimes.getThrottlingTimeV4(), throttlingTimes.throttlingTimeForGET, throttlingTimes.maxDelayTime),
+		registryApiV4:         newTokensRegistry(throttlingTimes.getThrottlingTimeV4(), throttlingTimes.throttlingTimeForGET, throttlingTimes.maxDelayTimeV4),
 	}
 }
 

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -99,11 +99,12 @@ type options struct {
 	upstream       string
 	upstreamParsed *url.URL
 
-	maxConcurrency                int
-	requestThrottlingTime         uint
-	requestThrottlingTimeV4       uint
-	requestThrottlingTimeForGET   uint
-	requestThrottlingMaxDelayTime uint
+	maxConcurrency                  int
+	requestThrottlingTime           uint
+	requestThrottlingTimeV4         uint
+	requestThrottlingTimeForGET     uint
+	requestThrottlingMaxDelayTime   uint
+	requestThrottlingMaxDelayTimeV4 uint
 
 	// pushGateway fields are used to configure pushing prometheus metrics.
 	pushGateway         string
@@ -149,6 +150,7 @@ func flagOptions() *options {
 	flag.UintVar(&o.requestThrottlingTimeV4, "throttling-time-v4-ms", 0, "Additional throttling mechanism which imposes time spacing between outgoing requests. Counted per organization. Overrides --throttling-time-ms setting for API v4.")
 	flag.UintVar(&o.requestThrottlingTimeForGET, "get-throttling-time-ms", 0, "Additional throttling mechanism which imposes time spacing between outgoing GET requests. Counted per organization. Has to be set together with --throttling-time-ms.")
 	flag.UintVar(&o.requestThrottlingMaxDelayTime, "throttling-max-delay-duration-seconds", 30, "Maximum delay for throttling in seconds. Requests will never be throttled for longer than this, used to avoid building a request backlog when the GitHub api has performance issues. Default is 30 seconds.")
+	flag.UintVar(&o.requestThrottlingMaxDelayTimeV4, "throttling-max-delay-duration-v4-seconds", 30, "Maximum delay for throttling in seconds for APIv4. Requests will never be throttled for longer than this, used to avoid building a request backlog when the GitHub api has performance issues. Default is 30 seconds.")
 	flag.StringVar(&o.pushGateway, "push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
 	flag.DurationVar(&o.pushGatewayInterval, "push-gateway-interval", time.Minute, "Interval at which prometheus metrics are pushed.")
 	flag.StringVar(&o.logLevel, "log-level", "debug", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
@@ -198,7 +200,7 @@ func main() {
 
 func proxy(o *options, upstreamTransport http.RoundTripper, diskCachePruneInterval time.Duration) http.Handler {
 	var cache http.RoundTripper
-	throttlingTimes := ghcache.NewRequestThrottlingTimes(o.requestThrottlingTime, o.requestThrottlingTimeV4, o.requestThrottlingTimeForGET, o.requestThrottlingMaxDelayTime)
+	throttlingTimes := ghcache.NewRequestThrottlingTimes(o.requestThrottlingTime, o.requestThrottlingTimeV4, o.requestThrottlingTimeForGET, o.requestThrottlingMaxDelayTime, o.requestThrottlingMaxDelayTimeV4)
 	if o.redisAddress != "" {
 		cache = ghcache.NewRedisCache(apptokenequalizer.New(upstreamTransport), o.redisAddress, o.maxConcurrency, throttlingTimes)
 	} else if o.dir == "" {


### PR DESCRIPTION
Our GraphQL queries are hitting 403s often (even 20% of all APIv4 requests for tide in peak) and I can't do really much about that since V3 and V4 share the same max delay time in the throttling algorithm. I need them to be different since I want to keep the current one for V3 and increase it for V4.