### PR TITLE
add release-team-jobs/release-team-periodics.yaml 

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,0 +1,28 @@
+periodics:
+- name: periodic-sync-enhancements-github-project-beta-1-26
+  interval: 6h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: sig-release-release-team-periodics
+    description: Periodically syncs the opted-in k/enhancements issues on the Enhancements Tracking GitHub Beta Project Board
+  extra_refs:
+  - org: kubernetes
+    repo: sig-release
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+      command:
+      - ./release-team/hack/sync-enhancements-github-project-beta.sh
+      env:
+        - name: GITHUB_PROJECT_BETA_NUMBER
+          value: "98"
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -20,6 +20,7 @@ dashboard_groups:
   - sig-release-publishing-bot
   - sig-release-release-notes-presubmits
   - sig-release-job-config-errors
+  - sig-release-release-team-periodics
 
 # Dashboards
 
@@ -63,3 +64,4 @@ dashboards:
     test_group_name: pull-release-notes-test
     base_options: width=10
 - name: sig-release-job-config-errors
+- name: sig-release-release-team-periodics


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR adds a periodic Prow job `periodic-sync-enhancements-github-project-beta-1-25` that will sync all open KEP issues from the k/enhancements repository under a current release milestone (say v1.25) to an Enhancements GitHub Project Beta board (similar to https://github.com/orgs/kubernetes/projects/87).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/community/issues/6735