### PR TITLE
Enable abort job functionality.

### DIFF
--- a/prow/cmd/deck/abort.go
+++ b/prow/cmd/deck/abort.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
+	"k8s.io/test-infra/prow/githuboauth"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func handleAbort(prowJobClient prowv1.ProwJobInterface, cfg authCfgGetter, goa *githuboauth.Agent, ghc githuboauth.AuthenticatedUserIdentifier, cli deckGitHubClient, pluginAgent *plugins.ConfigAgent, log *logrus.Entry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.TODO()
+		name := r.URL.Query().Get("prowjob")
+		l := log.WithField("prowjob", name)
+		if name == "" {
+			http.Error(w, "request did not provide the 'prowjob' query parameter", http.StatusBadRequest)
+			return
+		}
+		pj, err := prowJobClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			http.Error(w, fmt.Sprintf("ProwJob not found: %v", err), http.StatusNotFound)
+			if !kerrors.IsNotFound(err) {
+				// admins only care about errors other than not found
+				l.WithError(err).Warning("ProwJob not found.")
+			}
+			return
+		}
+		switch r.Method {
+		case http.MethodPost:
+			if pj.Status.State != prowapi.TriggeredState && pj.Status.State != prowapi.PendingState {
+				http.Error(w, fmt.Sprintf("Cannot abort job with state: %q", pj.Status.State), http.StatusBadRequest)
+				l.Error("Cannot abort job with state")
+				return
+			}
+			authConfig := cfg(pj.Spec.Refs, pj.Spec.Cluster)
+			var allowed bool
+			if pj.Spec.RerunAuthConfig.IsAllowAnyone() || authConfig.IsAllowAnyone() {
+				// Skip getting the users login via GH oauth if anyone is allowed to abort
+				// jobs so that GH oauth doesn't need to be set up for private Prows.
+				allowed = true
+			} else {
+				if goa == nil {
+					msg := "GitHub oauth must be configured to abort jobs unless 'allow_anyone: true' is specified."
+					http.Error(w, msg, http.StatusInternalServerError)
+					l.Error(msg)
+					return
+				}
+				login, err := goa.GetLogin(r, ghc)
+				if err != nil {
+					l.WithError(err).Errorf("Error retrieving GitHub login")
+					http.Error(w, "Error retrieving GitHub login", http.StatusUnauthorized)
+					return
+				}
+				l = l.WithField("user", login)
+				allowed, err = canTriggerJob(login, *pj, authConfig, cli, pluginAgent.Config, l)
+				if err != nil {
+					http.Error(w, fmt.Sprintf("Error checking if user can trigger job: %v", err), http.StatusInternalServerError)
+					l.WithError(err).Errorf("Error checking if user can trigger job")
+					return
+				}
+			}
+
+			l = l.WithField("allowed", allowed)
+			l.Info("Attempted abort")
+			if !allowed {
+				http.Error(w, "You don't have permission to abort this job", http.StatusUnauthorized)
+				l.Error("Error writing to abort response.")
+				return
+			}
+			pj.SetComplete()
+			pj.Status.State = prowapi.AbortedState
+			jsonPJ, err := json.Marshal(pj)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Error marshal source job: %v", err), http.StatusInternalServerError)
+				l.WithError(err).Errorf("Error marshal source job")
+			}
+			pj, err := prowJobClient.Patch(ctx, pj.Name, ktypes.MergePatchType, jsonPJ, metav1.PatchOptions{})
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Could not patch aborted job: %v", err), http.StatusInternalServerError)
+				l.WithError(err).Errorf("Could not patch aborted job")
+			}
+			l.Info("Successfully aborted PJ.")
+			json.NewEncoder(w).Encode(pj)
+			if _, err = w.Write([]byte("Job successfully aborted.")); err != nil {
+				l.WithError(err).Error("Error writing to abort response.")
+			}
+			return
+		default:
+			http.Error(w, fmt.Sprintf("bad verb %v", r.Method), http.StatusMethodNotAllowed)
+			return
+		}
+	}
+}

--- a/prow/cmd/deck/abort_test.go
+++ b/prow/cmd/deck/abort_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gorilla/sessions"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/client/clientset/versioned/fake"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/githuboauth"
+	"k8s.io/test-infra/prow/plugins"
+	"sigs.k8s.io/yaml"
+)
+
+// TestAbort that an aborted job has an updated status and
+// that permissions were granted appropriately
+func TestAbort(t *testing.T) {
+	testCases := []struct {
+		name        string
+		login       string
+		authorized  []string
+		allowAnyone bool
+		jobState    prowapi.ProwJobState
+		httpCode    int
+		httpMethod  string
+	}{
+		{
+			name:        "Abort on triggered state",
+			login:       "authorized",
+			authorized:  []string{"authorized", "alsoauthorized"},
+			allowAnyone: false,
+			jobState:    prowapi.TriggeredState,
+			httpCode:    http.StatusOK,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "Abort on pending state",
+			login:       "authorized",
+			authorized:  []string{"authorized", "alsoauthorized"},
+			allowAnyone: false,
+			jobState:    prowapi.PendingState,
+			httpCode:    http.StatusOK,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "Attempt to abort on success state",
+			login:       "authorized",
+			authorized:  []string{"authorized", "alsoauthorized"},
+			allowAnyone: false,
+			jobState:    prowapi.SuccessState,
+			httpCode:    http.StatusBadRequest,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "Attempt to abort on aborted state",
+			login:       "authorized",
+			authorized:  []string{"authorized", "alsoauthorized"},
+			allowAnyone: false,
+			jobState:    prowapi.AbortedState,
+			httpCode:    http.StatusBadRequest,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "User not authorized to abort job",
+			login:       "random-dude",
+			authorized:  []string{"authorized", "alsoauthorized"},
+			allowAnyone: false,
+			jobState:    prowapi.PendingState,
+			httpCode:    http.StatusUnauthorized,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "Allow anyone set to true, abort job",
+			login:       "ugh",
+			authorized:  []string{"authorized", "alsoauthorized"},
+			allowAnyone: true,
+			jobState:    prowapi.PendingState,
+			httpCode:    http.StatusOK,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "User permitted to abort on specific job",
+			login:       "authorized",
+			authorized:  []string{},
+			allowAnyone: false,
+			jobState:    prowapi.PendingState,
+			httpCode:    http.StatusOK,
+			httpMethod:  http.MethodPost,
+		},
+		{
+			name:        "User on permitted team",
+			login:       "sig-lead",
+			authorized:  []string{},
+			allowAnyone: false,
+			jobState:    prowapi.PendingState,
+			httpCode:    http.StatusOK,
+			httpMethod:  http.MethodPost,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeProwJobClient := fake.NewSimpleClientset(&prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wowsuch",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Job:  "whoa",
+					Type: prowapi.PresubmitJob,
+					Refs: &prowapi.Refs{
+						Org:  "org",
+						Repo: "repo",
+						Pulls: []prowapi.Pull{
+							{
+								Number: 1,
+								Author: tc.login,
+							},
+						},
+					},
+					RerunAuthConfig: &prowapi.RerunAuthConfig{
+						AllowAnyone:   false,
+						GitHubUsers:   []string{"authorized", "alsoauthorized"},
+						GitHubTeamIDs: []int{42},
+					},
+				},
+				Status: prowapi.ProwJobStatus{
+					State: tc.jobState,
+				},
+			})
+			authCfgGetter := func(refs *prowapi.Refs, cluster string) *prowapi.RerunAuthConfig {
+				return &prowapi.RerunAuthConfig{
+					AllowAnyone: tc.allowAnyone,
+					GitHubUsers: tc.authorized,
+				}
+			}
+
+			req, err := http.NewRequest(tc.httpMethod, "/abort?prowjob=wowsuch", nil)
+			if err != nil {
+				t.Fatalf("Error making request: %v", err)
+			}
+			req.AddCookie(&http.Cookie{
+				Name:    "github_login",
+				Value:   tc.login,
+				Path:    "/",
+				Expires: time.Now().Add(time.Hour * 24 * 30),
+				Secure:  true,
+			})
+			mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
+			session, err := sessions.GetRegistry(req).Get(mockCookieStore, "access-token-session")
+			if err != nil {
+				t.Fatalf("Error making access token session: %v", err)
+			}
+			session.Values["access-token"] = &oauth2.Token{AccessToken: "validtoken"}
+
+			rr := httptest.NewRecorder()
+			mockConfig := &githuboauth.Config{
+				CookieStore: mockCookieStore,
+			}
+			goa := githuboauth.NewAgent(mockConfig, &logrus.Entry{})
+			ghc := &fakeAuthenticatedUserIdentifier{login: tc.login}
+			rc := fakegithub.NewFakeClient()
+			rc.OrgMembers = map[string][]string{"org": {"org-member"}}
+			pca := plugins.NewFakeConfigAgent()
+			handler := handleAbort(fakeProwJobClient.ProwV1().ProwJobs("prowjobs"), authCfgGetter, goa, ghc, rc, &pca, logrus.WithField("handler", "/abort"))
+			handler.ServeHTTP(rr, req)
+			if rr.Code != tc.httpCode {
+				t.Fatalf("Bad error code: %d", rr.Code)
+			}
+
+			if tc.httpCode == http.StatusOK {
+				pj, err := fakeProwJobClient.ProwV1().ProwJobs("prowjobs").Get(context.TODO(), "wowsuch", metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Job not found: %v", err)
+				}
+				resp := rr.Result()
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("Error reading response body: %v", err)
+				}
+				var res prowapi.ProwJob
+				if err := yaml.Unmarshal(body, &res); err != nil {
+					t.Fatalf("Error unmarshaling: %v", err)
+				}
+				if !res.Complete() {
+					t.Error("Job is not complete, was expected to be complete")
+				}
+				if res.Status.State != prowapi.AbortedState {
+					t.Errorf("Wrong state, expected \"%v\", got \"%v\"", prowapi.AbortedState, res.Status.State)
+				}
+				if diff := cmp.Diff(res, *pj); diff != "" {
+					t.Fatalf("Job mismatch. Want: (-), got: (+). \n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -650,6 +650,7 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, authCfgGe
 	}
 
 	mux.Handle("/rerun", gziphandler.GzipHandler(handleRerun(cfg, prowJobClient, o.rerunCreatesJob, authCfgGetter, goa, githuboauth.NewAuthenticatedUserIdentifier(&o.github), githubClient, pluginAgent, logrus.WithField("handler", "/rerun"))))
+	mux.Handle("/abort", gziphandler.GzipHandler(handleAbort(prowJobClient, authCfgGetter, goa, githuboauth.NewAuthenticatedUserIdentifier(&o.github), githubClient, pluginAgent, logrus.WithField("handler", "/abort"))))
 
 	// optionally inject http->https redirect handler when behind loadbalancer
 	if o.redirectHTTPTo != "" {

--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -209,28 +209,30 @@ func canTriggerJob(user string, pj prowapi.ProwJob, cfg *prowapi.RerunAuthConfig
 	return false, nil
 }
 
-func isAllowedToRerun(r *http.Request, acfg authCfgGetter, goa *githuboauth.Agent, ghc githuboauth.AuthenticatedUserIdentifier, pj prowapi.ProwJob, cli deckGitHubClient, pluginAgent *plugins.ConfigAgent, log *logrus.Entry) (bool, error, int) {
-	authConfig := acfg(pj.Spec.Refs, pj.Spec.Cluster)
+func isAllowedToRerun(r *http.Request, acfg authCfgGetter, goa *githuboauth.Agent, ghc githuboauth.AuthenticatedUserIdentifier, pj prowapi.ProwJob, cli deckGitHubClient, pluginAgent *plugins.ConfigAgent, log *logrus.Entry) (bool, string, error, int) {
+	authConfig := acfg(&pj.Spec)
 	var allowed bool
+	var login string
 	if pj.Spec.RerunAuthConfig.IsAllowAnyone() || authConfig.IsAllowAnyone() {
 		// Skip getting the users login via GH oauth if anyone is allowed to rerun
 		// jobs so that GH oauth doesn't need to be set up for private Prows.
 		allowed = true
 	} else {
 		if goa == nil {
-			return allowed, errors.New("GitHub oauth must be configured to rerun jobs unless 'allow_anyone: true' is specified."), http.StatusInternalServerError
+			return allowed, "", errors.New("GitHub oauth must be configured to rerun jobs unless 'allow_anyone: true' is specified."), http.StatusInternalServerError
 		}
-		login, err := goa.GetLogin(r, ghc)
+		var err error
+		login, err = goa.GetLogin(r, ghc)
 		if err != nil {
-			return allowed, errors.New("Error retrieving GitHub login."), http.StatusUnauthorized
+			return allowed, "", errors.New("Error retrieving GitHub login."), http.StatusUnauthorized
 		}
 		log = log.WithField("user", login)
 		allowed, err = canTriggerJob(login, pj, authConfig, cli, pluginAgent.Config, log)
 		if err != nil {
-			return allowed, err, http.StatusInternalServerError
+			return allowed, "", err, http.StatusInternalServerError
 		}
 	}
-	return allowed, nil, http.StatusOK
+	return allowed, login, nil, http.StatusOK
 }
 
 // Valid value for query parameter mode in rerun route
@@ -301,7 +303,7 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 				http.Error(w, "Direct rerun feature is not enabled. Enable with the '--rerun-creates-job' flag.", http.StatusMethodNotAllowed)
 				return
 			}
-			allowed, err, code := isAllowedToRerun(r, acfg, goa, ghc, newPJ, cli, pluginAgent, l)
+			allowed, user, err, code := isAllowedToRerun(r, acfg, goa, ghc, newPJ, cli, pluginAgent, l)
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Could not verify if allowed to rerun: %v", err), code)
 				l.WithError(err).Debug("Could not verify if allowed to rerun")
@@ -321,7 +323,11 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 				return
 			}
 			l = l.WithField("new-prowjob", created.Name)
-			l.Info("Successfully created a rerun PJ.")
+			if len(user) > 0 {
+				l.Info(fmt.Sprintf("%v successfully created a rerun of %v.", user, name))
+			} else {
+				l.Info(fmt.Sprintf("Successfully created a rerun of %v.", name))
+			}
 			if _, err = w.Write([]byte("Job successfully triggered. Wait 30 seconds and refresh the page for the job to show up")); err != nil {
 				l.WithError(err).Error("Error writing to rerun response.")
 			}


### PR DESCRIPTION
This PR adds the abort feature to the backend. Future work will be done on the UI side, to enable the user to abort jobs while they are in a Triggered or Pending state in Prow's UI.

Fixes: https://github.com/kubernetes/test-infra/issues/24390

/cc @chaodaiG @cjwagner