### PR TITLE
Write `k8s-stable1` version marker for `release-1.24` jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -153,7 +153,7 @@ periodics:
       - --allow-dup
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-master
+      - --extra-version-markers=k8s-stable1
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""


### PR DESCRIPTION
The file does not exist right now which makes other jobs failing. Fixing this my providing the correct extra version marker to the 1.24 periodic job.

Fixes https://github.com/kubernetes/kubernetes/issues/111161