### PR TITLE
Add presubmit job for CAPA ClusterClass test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
@@ -1,0 +1,45 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-aws:
+    - name: pull-cluster-api-provider-aws-e2e-clusterclass
+      branches:
+        # The script this job runs is not in all branches.
+        - ^main$
+      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-service-account: "true"
+        preset-aws-ssh: "true"
+        preset-aws-credential: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220708-6b0cfd300e-master
+            command:
+              - "runner.sh"
+              - "./scripts/ci-e2e.sh"
+            env:
+              - name: BOSKOS_HOST
+                value: "boskos.test-pods.svc.cluster.local"
+              - name: AWS_REGION
+                value: "us-west-2"
+              - name: E2E_FOCUS
+                value: "\\[ClusterClass\\]"
+              # Parallelize tests
+              - name: GINKGO_ARGS
+                value: "-nodes 20"
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: "9Gi"
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+        testgrid-tab-name: pr-e2e-main-clusterclass
+        testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
@@ -19,7 +19,7 @@ presubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220708-6b0cfd300e-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220727-f055b40439-1.24
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
This job will make it possible to run ClusterClass tests on PRs.

