### PR TITLE
Add a unit test for ensuring that gerrit sync state is threadsafe

### DIFF
--- a/prow/gerrit/adapter/syncer_test.go
+++ b/prow/gerrit/adapter/syncer_test.go
@@ -21,13 +21,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/io"
 )
@@ -124,6 +127,75 @@ func TestSyncTime(t *testing.T) {
 	}
 	if actual := st.Current()["foo"]["bar"]; now.After(actual) || actual.After(later) {
 		t.Fatalf("should initialize to start %v <= actual <= later %v, but got %v", now, later, actual)
+	}
+}
+
+// TestSyncTimeThreadSafe ensures that the sync time can be updated threadsafe
+// without lock.
+func TestSyncTimeThreadSafe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.txt")
+	var noCreds string
+	ctx := context.Background()
+	open, err := io.NewOpener(ctx, noCreds, noCreds)
+	if err != nil {
+		t.Fatalf("Failed to create opener: %v", err)
+	}
+
+	st := syncTime{
+		path:   path,
+		opener: open,
+		ctx:    ctx,
+	}
+	testProjectsFlag := client.ProjectsFlag{
+		"foo1": []string{"bar1"},
+		"foo2": []string{"bar2"},
+	}
+	if err := st.init(testProjectsFlag); err != nil {
+		t.Fatalf("Failed init: %v", err)
+	}
+
+	// This is for detecting threading issue, running 100 times should be
+	// sufficient for catching the issue.
+	for i := 0; i < 100; i++ {
+		// Two threads, one update foo1, the other update foo2
+		var wg sync.WaitGroup
+		wg.Add(2)
+		later := time.Now().Add(time.Hour)
+		var threadErr error
+		go func() {
+			defer wg.Done()
+			syncTime := st.Current()
+			latest := syncTime.DeepCopy()
+			latest["foo1"]["bar1"] = later
+			if err := st.Update(latest); err != nil {
+				threadErr = fmt.Errorf("failed update: %v", err)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			syncTime := st.Current()
+			latest := syncTime.DeepCopy()
+			latest["foo2"]["bar2"] = later
+			if err := st.Update(latest); err != nil {
+				threadErr = fmt.Errorf("failed update: %v", err)
+			}
+		}()
+
+		wg.Wait()
+		if threadErr != nil {
+			t.Fatalf("Failed running goroutines: %v", err)
+		}
+
+		want := client.LastSyncState(map[string]map[string]time.Time{
+			"foo1": {"bar1": later},
+			"foo2": {"bar2": later},
+		})
+
+		if diff := cmp.Diff(st.Current(), want); diff != "" {
+			t.Fatalf("Mismatch. Want(-), got(+):\n%s", diff)
+		}
 	}
 }
 


### PR DESCRIPTION
Gerrit instances are processed in parallel right now and each thread updates the sync state async, adding a test to ensure that thread for instance-A won't set back the sync time of instance-B to an earlier timestamp.

/cc @mpherman2 @cjwagner 