### PR TITLE
Spyglass junit: Display stderr for failures if present

### DIFF
--- a/prow/spyglass/lenses/junit/lens.ts
+++ b/prow/spyglass/lenses/junit/lens.ts
@@ -34,8 +34,8 @@ function addTestExpanders(): void {
   }
 }
 
-function addStdoutOpeners(): void {
-  const links = document.querySelectorAll<HTMLAnchorElement>('a.open-stdout');
+function addStdoutStderrOpeners(): void {
+  const links = document.querySelectorAll<HTMLAnchorElement>('a.open-stdout-stderr');
   for (const link of Array.from(links)) {
     link.onclick = (e) => {
       e.preventDefault();
@@ -52,7 +52,7 @@ function addStdoutOpeners(): void {
 
 function loaded(): void {
   addTestExpanders();
-  addStdoutOpeners();
+  addStdoutStderrOpeners();
   addSectionExpanders();
 }
 

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -36,8 +36,12 @@
               <td colspan="2" class="mdl-data-table__cell--non-numeric">
                 <div>{{$firstTest.Failure}}</div>
                 {{if $firstTest.Output}}
-                <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
                 <pre style="display: none;">{{$firstTest.Output}}</pre>
+                {{end}}
+                {{if $firstTest.Error}}
+                <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                <pre style="display: none;">{{$firstTest.Error}}</pre>
                 {{end}}
               </td>
             </tr>
@@ -66,8 +70,12 @@
                           <td colspan="2" class="mdl-data-table__cell--non-numeric">
                             <div>{{$indTest.Failure}}</div>
                             {{if $indTest.Output}}
-                            <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                            <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
                             <pre style="display: none;">{{$indTest.Output}}</pre>
+                            {{end}}
+                            {{if $indTest.Error}}
+                            <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                            <pre style="display: none;">{{$indTest.Error}}</pre>
                             {{end}}
                           </td>
                         </tr>
@@ -114,8 +122,12 @@
                           <td colspan="2" class="mdl-data-table__cell--non-numeric">
                             <div>{{$indTest.Failure}}</div>
                             {{if $indTest.Output}}
-                            <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                            <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
                             <pre style="display: none;">{{$indTest.Output}}</pre>
+                            {{end}}
+                            {{if $indTest.Error}}
+                            <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                            <pre style="display: none;">{{$indTest.Error}}</pre>
                             {{end}}
                           </td>
                         </tr>


### PR DESCRIPTION
Currently, the junit lens only displays the stdout and ignores stderr if
present. This change extends to display to allow allow seeing stderr.

Fixes https://github.com/kubernetes/kubernetes/issues/111089

Below some screenshots for this job: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/111104/pull-kubernetes-e2e-kind-ipv6/1547149455797522432

Old/Curernt:
<img width="820" alt="junit_old" src="https://user-images.githubusercontent.com/6496100/179363402-18a8d467-547b-4fd0-9a9a-e1dea7f1ec95.png">

With this change:
<img width="1451" alt="junit_overview" src="https://user-images.githubusercontent.com/6496100/179363416-9bdb7987-4437-454c-ac64-9b66500050ae.png">

stdout:
<img width="1306" alt="junit_stdout" src="https://user-images.githubusercontent.com/6496100/179363427-68cbe3a1-15b1-446f-9a79-652940f238cd.png">
stderr (excerpt, there is a lot of output):
<img width="855" alt="junit_stderr" src="https://user-images.githubusercontent.com/6496100/179363441-e2022c3f-3335-4a91-9162-578dace9a0f8.png">

/cc @aojea @chendave 