### PR TITLE
Deck: Improve startup time when Tide is unavailable

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -579,9 +579,11 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, authCfgGe
 			tenantIDs:  sets.NewString(o.tenantIDs.Strings()...),
 			cfg:        cfg,
 		}
-		ta.start()
-		mux.Handle("/tide.js", gziphandler.GzipHandler(handleTidePools(cfg, ta, logrus.WithField("handler", "/tide.js"))))
-		mux.Handle("/tide-history.js", gziphandler.GzipHandler(handleTideHistory(ta, logrus.WithField("handler", "/tide-history.js"))))
+		go func() {
+			ta.start()
+			mux.Handle("/tide.js", gziphandler.GzipHandler(handleTidePools(cfg, ta, logrus.WithField("handler", "/tide.js"))))
+			mux.Handle("/tide-history.js", gziphandler.GzipHandler(handleTideHistory(ta, logrus.WithField("handler", "/tide-history.js"))))
+		}()
 	}
 
 	secure := !o.allowInsecure


### PR DESCRIPTION
Deck currently synchronously tries to contact Tide during startup to get
pool and history information. For both of these it retries four times
using the standard http client which has a thirty second connect timeout
with a 5 second sleep that gets increased by factor four for each retry.

This means that when Tide is unavailable Deck needs 2 * 225 seconds/7.5
minutes to time out trying to contact it until it actually starts up.

This change moves the trying to connect to Tide into a goroutine to
avoid delaying Deck startup.