### PR TITLE
`rerun`: use extra_refs to allow rerunning periodics

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -215,7 +215,7 @@ var (
 	traceHandler        = metrics.TraceHandler(simplifier, httpRequestDuration, httpResponseSize)
 )
 
-type authCfgGetter func(*prowapi.Refs, string) *prowapi.RerunAuthConfig
+type authCfgGetter func(*prowapi.ProwJobSpec) *prowapi.RerunAuthConfig
 
 func init() {
 	prometheus.MustRegister(httpRequestDuration)
@@ -418,8 +418,8 @@ func main() {
 		}
 	}
 
-	authCfgGetter := func(refs *prowapi.Refs, cluster string) *prowapi.RerunAuthConfig {
-		return cfg().Deck.GetRerunAuthConfig(refs, cluster)
+	authCfgGetter := func(jobSpec *prowapi.ProwJobSpec) *prowapi.RerunAuthConfig {
+		return cfg().Deck.GetRerunAuthConfig(jobSpec)
 	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -490,8 +490,8 @@ func main() {
 
 	// if we allow direct reruns, we must protect against CSRF in all post requests using the cookie secret as a token
 	// for more information about CSRF, see https://github.com/kubernetes/test-infra/blob/master/prow/cmd/deck/csrf.md
-	empty := prowapi.Refs{}
-	if o.rerunCreatesJob && csrfToken == nil && !authCfgGetter(&empty, "").IsAllowAnyone() {
+	empty := prowapi.ProwJobSpec{}
+	if o.rerunCreatesJob && csrfToken == nil && !authCfgGetter(&empty).IsAllowAnyone() {
 		logrus.Fatal("Rerun creates job cannot be enabled without CSRF protection, which requires --cookie-secret to be exactly 32 bytes")
 		return
 	}

--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -277,7 +277,7 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 				http.Error(w, "Direct rerun feature is not enabled. Enable with the '--rerun-creates-job' flag.", http.StatusMethodNotAllowed)
 				return
 			}
-			authConfig := acfg(newPJ.Spec.Refs, newPJ.Spec.Cluster)
+			authConfig := acfg(&newPJ.Spec)
 			var allowed bool
 			if newPJ.Spec.RerunAuthConfig.IsAllowAnyone() || authConfig.IsAllowAnyone() {
 				// Skip getting the users login via GH oauth if anyone is allowed to rerun

--- a/prow/cmd/deck/rerun_test.go
+++ b/prow/cmd/deck/rerun_test.go
@@ -218,7 +218,7 @@ func TestRerun(t *testing.T) {
 					State: prowapi.PendingState,
 				},
 			})
-			authCfgGetter := func(refs *prowapi.Refs, cluster string) *prowapi.RerunAuthConfig {
+			authCfgGetter := func(refs *prowapi.ProwJobSpec) *prowapi.RerunAuthConfig {
 				return &prowapi.RerunAuthConfig{
 					AllowAnyone: tc.allowAnyone,
 					GitHubUsers: tc.authorized,
@@ -476,7 +476,7 @@ func TestLatestRerun(t *testing.T) {
 					State: prowapi.PendingState,
 				},
 			})
-			authCfgGetter := func(refs *prowapi.Refs, cluster string) *prowapi.RerunAuthConfig {
+			authCfgGetter := func(refs *prowapi.ProwJobSpec) *prowapi.RerunAuthConfig {
 				return &prowapi.RerunAuthConfig{
 					AllowAnyone: tc.allowAnyone,
 					GitHubUsers: tc.authorized,

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1281,16 +1281,18 @@ type DefaultRerunAuthConfigEntry struct {
 	Config *prowapi.RerunAuthConfig `json:"rerun_auth_configs,omitempty"`
 }
 
-func (d *Deck) GetRerunAuthConfig(refs *prowapi.Refs, cluster string) *prowapi.RerunAuthConfig {
+func (d *Deck) GetRerunAuthConfig(jobSpec *prowapi.ProwJobSpec) *prowapi.RerunAuthConfig {
 	var config *prowapi.RerunAuthConfig
 
 	var orgRepo string
-	if refs != nil {
-		orgRepo = refs.OrgRepoString()
+	if jobSpec.Refs != nil {
+		orgRepo = jobSpec.Refs.OrgRepoString()
+	} else if len(jobSpec.ExtraRefs) > 0 {
+		orgRepo = jobSpec.ExtraRefs[0].OrgRepoString()
 	}
 
 	for _, drac := range d.DefaultRerunAuthConfigs {
-		if drac.matches(orgRepo, cluster) {
+		if drac.matches(orgRepo, jobSpec.Cluster) {
 			config = drac.Config
 		}
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -3820,6 +3820,18 @@ func TestRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
 			},
 			expected: &prowapi.RerunAuthConfig{GitHubUsers: []string{"skywalker"}},
 		},
+		{
+			name: "use only org/repo from first extra refs entry",
+			configs: RerunAuthConfigs{
+				"*":                    prowapi.RerunAuthConfig{GitHubUsers: []string{"clarketm"}},
+				"istio/istio":          prowapi.RerunAuthConfig{GitHubUsers: []string{"skywalker"}},
+				"other-org/other-repo": prowapi.RerunAuthConfig{GitHubUsers: []string{"anakin"}},
+			},
+			jobSpec: &prowapi.ProwJobSpec{
+				ExtraRefs: []prowapi.Refs{{Org: "istio", Repo: "istio"}, {Org: "other-org", Repo: "other-repo"}},
+			},
+			expected: &prowapi.RerunAuthConfig{GitHubUsers: []string{"skywalker"}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -4082,6 +4094,30 @@ func TestDefaultRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
 			},
 			jobSpec: &prowapi.ProwJobSpec{
 				ExtraRefs: []prowapi.Refs{{Org: "istio", Repo: "istio"}},
+			},
+			expected: &prowapi.RerunAuthConfig{GitHubUsers: []string{"skywalker"}},
+		},
+		{
+			name: "use only org/repo from first extra refs entry",
+			configs: []*DefaultRerunAuthConfigEntry{
+				{
+					OrgRepo: "*",
+					Cluster: "",
+					Config:  &prowapi.RerunAuthConfig{GitHubUsers: []string{"clarketm"}},
+				},
+				{
+					OrgRepo: "istio/istio",
+					Cluster: "",
+					Config:  &prowapi.RerunAuthConfig{GitHubUsers: []string{"skywalker"}},
+				},
+				{
+					OrgRepo: "other-org/other-repo",
+					Cluster: "",
+					Config:  &prowapi.RerunAuthConfig{GitHubUsers: []string{"anakin"}},
+				},
+			},
+			jobSpec: &prowapi.ProwJobSpec{
+				ExtraRefs: []prowapi.Refs{{Org: "istio", Repo: "istio"}, {Org: "other-org", Repo: "other-repo"}},
 			},
 			expected: &prowapi.RerunAuthConfig{GitHubUsers: []string{"skywalker"}},
 		},


### PR DESCRIPTION
Utilizing the precedent to use the first entry in `extra_refs` to determine the `org/repo` on periodic jobs so that we can resolve the `rerun_auth_config` for periodics.

This implements option 1 from https://github.com/kubernetes/test-infra/issues/25570.

See https://github.com/kubernetes/test-infra/issues/25570#issuecomment-1185643239 for explanation.