### PR TITLE
test: Bump GCE jobs to Ubuntu 22.04 Jammy

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -253,10 +253,10 @@ presubmits:
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
             - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
             - --extract=local
             - --gcp-master-image=ubuntu
@@ -312,10 +312,10 @@ presubmits:
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
             - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
             - --extract=local
             - --gcp-master-image=ubuntu
@@ -419,10 +419,10 @@ presubmits:
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
             - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
             - --extract=local
             - --gcp-master-image=ubuntu
@@ -552,10 +552,10 @@ periodics:
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
           - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-          - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+          - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
           - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
           - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-          - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+          - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
           - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
           - --extract=ci/latest-fast
           - --extract-ci-bucket=k8s-release-dev


### PR DESCRIPTION
```
$ gcloud compute images list --project="ubuntu-os-cloud" --no-standard-images | grep "2204"
ubuntu-2204-jammy-arm64-v20220712a           ubuntu-os-cloud  ubuntu-2204-lts-arm64                      READY
ubuntu-2204-jammy-v20220712a                 ubuntu-os-cloud  ubuntu-2204-lts                            READY
ubuntu-minimal-2204-jammy-arm64-v20220712    ubuntu-os-cloud  ubuntu-minimal-2204-lts-arm64              READY
ubuntu-minimal-2204-jammy-v20220712          ubuntu-os-cloud  ubuntu-minimal-2204-lts                    READY

$ sed -i 's/ubuntu-2004-focal-v20200423/ubuntu-2204-jammy-v20220712a/g' config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
```

Ubuntu Jammy Jellyfish changelog - https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668

Notable changes:
* 5.15 kernel
* systemd v249
* cgroupv2 enabled by default

Signed-off-by: David Porter <porterdavid@google.com>