### PR TITLE
remove 1.21 test jobs for secrets-store-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -377,7 +377,7 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-build
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-21-10
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-22-9
     decorate: true
     decoration_config:
       timeout: 25m
@@ -407,17 +407,17 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.21.10"
+          value: "1.22.9"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-21-10
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.21.10"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-22-9
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.22.9"
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-22-7
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-23-6
     decorate: true
     decoration_config:
       timeout: 25m
@@ -447,17 +447,17 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.22.7"
+          value: "1.23.6"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-22-7
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.22.7"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-23-6
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.23.6"
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-23-5
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-2
     decorate: true
     decoration_config:
       timeout: 25m
@@ -487,55 +487,15 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.23.5"
+          value: "1.24.2"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-23-5
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.23.5"
-      testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-0
-    decorate: true
-    decoration_config:
-      timeout: 25m
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/secrets-store-csi-driver
-    branches:
-    - ^main$
-    # e2e-provider is only available in release-1.* branches
-    - ^release-1.*
-    labels:
-      # this is required because we want to run kind in docker
-      preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220722-16ae0286c2-master
-        command:
-          - runner.sh
-        args:
-          - bash
-          - -c
-          - >-
-            ./test/scripts/e2e_provider.sh
-        securityContext:
-          privileged: true
-        env:
-        - name: KUBERNETES_VERSION
-          value: "1.24.0"
-        resources:
-          requests:
-            cpu: "4"
-            memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-0
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.0"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-2
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.2"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-akeyless
     decorate: true


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Remove Kubernetes version 1.21 from docs and CI since it has reached EOL
- Update Kubernetes versions to latest in CI for supported releases

/assign @tam7t 