### PR TITLE
Kops - Revert #26669 use IMDSv2 for Flatcar tests

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -125,6 +125,10 @@ def build_test(cloud='aws',
 
     node_ig_overrides = ""
     cp_ig_overrides = ""
+    if distro == "flatcar":
+        # https://github.com/flatcar-linux/Flatcar/issues/220
+        node_ig_overrides += "spec.instanceMetadata.httpTokens=optional"
+        cp_ig_overrides += "spec.instanceMetadata.httpTokens=optional"
 
     if tab in skip_jobs:
         return None

--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -97,7 +97,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220706' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220713' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -229,7 +229,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220706' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220713' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -95,7 +95,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -159,7 +159,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220616' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220711' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -287,7 +287,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220706' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220713' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -351,7 +351,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220708' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220712.1' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -415,7 +415,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -672,6 +672,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --validation-wait=20m \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -788,6 +788,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -852,6 +854,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -916,6 +920,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -980,6 +986,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -1044,6 +1052,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -1108,6 +1118,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -2684,6 +2696,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -2748,6 +2762,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -2812,6 +2828,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -2876,6 +2894,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -2940,6 +2960,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -3004,6 +3026,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -7604,6 +7628,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -7668,6 +7694,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -7732,6 +7760,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -7796,6 +7826,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -7860,6 +7892,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -7924,6 +7958,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -11264,6 +11300,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -11328,6 +11366,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -11392,6 +11432,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -11456,6 +11498,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -11520,6 +11564,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -11584,6 +11630,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -11648,6 +11696,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -11712,6 +11762,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -13792,6 +13844,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -13856,6 +13910,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -13920,6 +13976,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -13984,6 +14042,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -14048,6 +14108,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -14112,6 +14174,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -14176,6 +14240,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -14240,6 +14306,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -20352,6 +20420,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -20416,6 +20486,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -20480,6 +20552,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -20544,6 +20618,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -20608,6 +20684,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -20672,6 +20750,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -20736,6 +20816,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -20800,6 +20882,8 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3227.1.1-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
+          --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -95,7 +95,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -161,7 +161,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -227,7 +227,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -293,7 +293,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -688,7 +688,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
           --test=kops \
@@ -752,7 +752,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -818,7 +818,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -99,7 +99,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -164,7 +164,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220616' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220711' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -294,7 +294,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220706' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220713' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -359,7 +359,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -424,7 +424,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -980,7 +980,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220708' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220712.1' --channel=alpha --networking=calico --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -100,7 +100,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=amazonvpc --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=amazonvpc --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -232,7 +232,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -430,7 +430,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='136693071363/debian-11-amd64-20220613-1045' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='136693071363/debian-11-amd64-20220711-1073' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \


### PR DESCRIPTION
These jobs are now failing to launch clusters, so reverting the IMDSv2 requirement for now

https://testgrid.k8s.io/kops-grid#kops-grid-calico-flatcar-k22-containerd

```
Jul 16 13:20:41.458383 ip-172-20-45-32 bash[1660]: 2022/07/16 13:20:41 Checking availability of "ec2-metadata-service"
Jul 16 13:20:41.458945 ip-172-20-45-32 bash[1660]: 2022/07/16 13:20:41 Checking availability of "cloud-drive"
Jul 16 13:21:11.488569 ip-172-20-45-32 bash[1660]: 2022/07/16 13:21:11 Checking availability of "ec2-metadata-service"
Jul 16 13:21:11.489220 ip-172-20-45-32 bash[1660]: 2022/07/16 13:21:11 Checking availability of "cloud-drive"
Jul 16 13:21:41.518917 ip-172-20-45-32 bash[1660]: 2022/07/16 13:21:41 Checking availability of "ec2-metadata-service"
Jul 16 13:21:41.518917 ip-172-20-45-32 bash[1660]: 2022/07/16 13:21:41 Checking availability of "cloud-drive"
Jul 16 13:22:11.519369 ip-172-20-45-32 bash[1660]: 2022/07/16 13:22:11 Checking availability of "cloud-drive"
Jul 16 13:22:11.520462 ip-172-20-45-32 bash[1660]: 2022/07/16 13:22:11 Checking availability of "ec2-metadata-service"
Jul 16 13:22:20.274462 ip-172-20-45-32 bash[1660]: 2022/07/16 13:22:20 No datasources available in time
Jul 16 13:22:20.296586 ip-172-20-45-32 systemctl[1459]: Job for oem-cloudinit.service failed because the control process exited with error code.
Jul 16 13:22:20.296586 ip-172-20-45-32 systemctl[1459]: See "systemctl status oem-cloudinit.service" and "journalctl -xeu oem-cloudinit.service" for details.
Jul 16 13:22:20.275375 ip-172-20-45-32 systemd[1]: oem-cloudinit.service: Main process exited, code=exited, status=1/FAILURE
Jul 16 13:22:20.275528 ip-172-20-45-32 systemd[1]: oem-cloudinit.service: Failed with result 'exit-code'.
Jul 16 13:22:20.275781 ip-172-20-45-32 systemd[1]: Failed to start Run cloudinit.
Jul 16 13:22:20.277788 ip-172-20-45-32 systemd[1]: enable-oem-cloudinit.service: Main process exited, code=exited, status=1/FAILURE
Jul 16 13:22:20.277950 ip-172-20-45-32 systemd[1]: enable-oem-cloudinit.service: Failed with result 'exit-code'.
```

/cc @hakman