### PR TITLE
Update cloud-provider-azure windows job to support conformance tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -603,7 +603,7 @@ periodics:
       - name: KUBERNETES_VERSION
         value: "latest"
       - name: GINKGO_ARGS
-        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[LinuxOnly\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\] --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "1"
       - name: TEST_WINDOWS
@@ -615,7 +615,9 @@ periodics:
       - name: CLUSTER_PROVISIONING_TOOL
         value: "capz"
       - name: GINKGO_PARALLEL_NODES
-        value: "30"
+        value: "20"
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "y"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-conformance-windows-capz


### PR DESCRIPTION
Update cloud-provider-azure windows job to support conformance tests.
1. set --node-os-distro=windows in GINKGO_ARGS to specify windows job
2. skip [LinuxOnly] because some [LinuxOnly] tests don't support windows 
3. lower GINKGO_PARALLEL_NODES and set GINKGO_TOLERATE_FLAKES="y" to increase the possibility of success, otherwise chances are that tests will fail due to time-out reason

Signed-off-by: Lan Lou [t-lanlou@microsoft.com](mailto:t-lanlou@microsoft.com)