### PR TITLE
Add err to error message

### DIFF
--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -267,7 +267,7 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 			if err != nil {
 				// These are user errors, i.e. missing fields, requested prowjob doesn't exist etc.
 				// These errors are already surfaced to user via pubsub two lines below.
-				http.Error(w, "Could not create new prowjob: Failed getting prowjob spec", http.StatusBadRequest)
+				http.Error(w, fmt.Sprintf("Could not create new prowjob: Failed getting prowjob spec: %v", err), http.StatusBadRequest)
 				l.WithError(err).Debug("Could not create new prowjob")
 				return
 			}


### PR DESCRIPTION
This PR adds an error string to an http error response when rerunning.

/cc @chaodaiG
