### PR TITLE
Add abort UI to Prow UI and Spyglass.

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1013,7 +1013,7 @@ lensesLoop:
 	}
 
 	var prowJobLink string
-	prowJobName, prowJobState, err := sg.ProwJob(src)
+	prowJob, prowJobName, prowJobState, err := sg.ProwJob(src)
 	if err == nil {
 		if prowJobName != "" {
 			u, err := url.Parse("/prowjob")
@@ -1122,6 +1122,7 @@ lensesLoop:
 		PRLink          string
 		ExtraLinks      []spyglass.ExtraLink
 		ReRunCreatesJob bool
+		ProwJob         string
 		ProwJobName     string
 		ProwJobState    string
 	}
@@ -1141,6 +1142,7 @@ lensesLoop:
 		PRLink:          prLink,
 		ExtraLinks:      extraLinks,
 		ReRunCreatesJob: o.rerunCreatesJob,
+		ProwJob:         prowJob,
 		ProwJobName:     prowJobName,
 		ProwJobState:    string(prowJobState),
 	}

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1013,15 +1013,15 @@ lensesLoop:
 	}
 
 	var prowJobLink string
-	prowJobName, err := sg.ProwJobName(src)
+	prowJob, err := sg.ProwJob(src)
 	if err == nil {
-		if prowJobName != "" {
+		if prowJob != nil {
 			u, err := url.Parse("/prowjob")
 			if err != nil {
 				return "", fmt.Errorf("error parsing prowjob path: %w", err)
 			}
 			query := url.Values{}
-			query.Set("prowjob", prowJobName)
+			query.Set("prowjob", prowJob.Name)
 			u.RawQuery = query.Encode()
 			prowJobLink = u.String()
 		}
@@ -1123,6 +1123,7 @@ lensesLoop:
 		ExtraLinks      []spyglass.ExtraLink
 		ReRunCreatesJob bool
 		ProwJobName     string
+		ProwJobState    string
 	}
 	sTmpl := spyglassTemplate{
 		Lenses:          ls,
@@ -1140,7 +1141,8 @@ lensesLoop:
 		PRLink:          prLink,
 		ExtraLinks:      extraLinks,
 		ReRunCreatesJob: o.rerunCreatesJob,
-		ProwJobName:     prowJobName,
+		ProwJobName:     prowJob.Name,
+		ProwJobState:    string(prowJob.Status.State),
 	}
 	t := template.New("spyglass.html")
 

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1013,15 +1013,15 @@ lensesLoop:
 	}
 
 	var prowJobLink string
-	prowJob, err := sg.ProwJob(src)
+	prowJobName, prowJobState, err := sg.ProwJob(src)
 	if err == nil {
-		if prowJob != nil {
+		if prowJobName != "" {
 			u, err := url.Parse("/prowjob")
 			if err != nil {
 				return "", fmt.Errorf("error parsing prowjob path: %w", err)
 			}
 			query := url.Values{}
-			query.Set("prowjob", prowJob.Name)
+			query.Set("prowjob", prowJobName)
 			u.RawQuery = query.Encode()
 			prowJobLink = u.String()
 		}
@@ -1141,8 +1141,8 @@ lensesLoop:
 		PRLink:          prLink,
 		ExtraLinks:      extraLinks,
 		ReRunCreatesJob: o.rerunCreatesJob,
-		ProwJobName:     prowJob.Name,
-		ProwJobState:    string(prowJob.Status.State),
+		ProwJobName:     prowJobName,
+		ProwJobState:    string(prowJobState),
 	}
 	t := template.New("spyglass.html")
 

--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -306,20 +306,20 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 			}
 			allowed, user, err, code := isAllowedToRerun(r, acfg, goa, ghc, newPJ, cli, pluginAgent, l)
 			if err != nil {
-				http.Error(w, fmt.Sprintf("Could not verify if allowed to rerun: %v", err), code)
-				l.WithError(err).Debug("Could not verify if allowed to rerun")
+				http.Error(w, fmt.Sprintf("Could not verify if allowed to rerun: %v.", err), code)
+				l.WithError(err).Debug("Could not verify if allowed to rerun.")
 			}
 			l = l.WithField("allowed", allowed)
 			l.Info("Attempted rerun")
 			if !allowed {
-				if _, err = w.Write([]byte("You don't have permission to rerun that job")); err != nil {
+				if _, err = w.Write([]byte("You don't have permission to rerun that job.")); err != nil {
 					l.WithError(err).Error("Error writing to rerun response.")
 				}
 				return
 			}
 			created, err := prowJobClient.Create(context.TODO(), &newPJ, metav1.CreateOptions{})
 			if err != nil {
-				l.WithError(err).Error("Error creating job")
+				l.WithError(err).Error("Error creating job.")
 				http.Error(w, fmt.Sprintf("Error creating job: %v", err), http.StatusInternalServerError)
 				return
 			}
@@ -329,7 +329,7 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 			} else {
 				l.Info(fmt.Sprintf("Successfully created a rerun of %v.", name))
 			}
-			if _, err = w.Write([]byte("Job successfully triggered. Wait 30 seconds and refresh the page for the job to show up")); err != nil {
+			if _, err = w.Write([]byte("Job successfully triggered. Wait 30 seconds and refresh the page for the job to show up.")); err != nil {
 				l.WithError(err).Error("Error writing to rerun response.")
 			}
 			return

--- a/prow/cmd/deck/static/common/abort.ts
+++ b/prow/cmd/deck/static/common/abort.ts
@@ -7,7 +7,7 @@ export function createAbortProwJobIcon(state: string, prowjob: string, csrfToken
   button.innerHTML = '<i class="icon-button material-icons" title="Cancel this job" style="color: gray">cancel</i>';
 
   if (state !== State.TRIGGERED && state !== State.PENDING) {
-    button.innerHTML = `<i class="icon-button material-icons" title="Can't cancel job in ${state} state" style="color: lightgray">cancel</i>`;
+    button.innerHTML = `<i class="icon-button material-icons" title="Can't abort job in ${state} state" style="color: lightgray">cancel</i>`;
     button.classList.remove('icon-button');
     button.disabled = true;
   }

--- a/prow/cmd/deck/static/common/abort.ts
+++ b/prow/cmd/deck/static/common/abort.ts
@@ -1,0 +1,40 @@
+import {icon, showAlert, showToast, State} from "./common";
+
+export function createAbortProwJobIcon(state: string, prowjob: string, csrfToken: string): HTMLElement {
+  const url = `${location.protocol}//${location.host}/abort?prowjob=${prowjob}`;
+  const button = document.createElement('button');
+  button.classList.add('mdl-button', 'mdl-js-button', 'mdl-button--icon');
+  button.innerHTML = '<i class="icon-button material-icons" title="Cancel this job" style="color: gray">cancel</i>';
+
+  if (state !== State.TRIGGERED && state !== State.PENDING) {
+    button.innerHTML = `<i class="icon-button material-icons" title="Can't cancel job in ${state} state" style="color: lightgray">cancel</i>`;
+    button.classList.remove('icon-button');
+    button.disabled = true;
+  }
+
+  button.onclick = async () => {
+    gtag('event', 'abort', {
+      event_category: 'engagement',
+      transport_type: 'beacon',
+    });
+    try {
+      const result = await fetch(url, {
+        headers: {
+          'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+          'X-CSRF-Token': csrfToken,
+        },
+        method: 'post',
+      });
+      const data = await result.text();
+      if (result.status >= 400) {
+        showAlert(data);
+      } else {
+        showToast(data);
+      }
+    } catch (e) {
+      showAlert(`Could not send request to abort job: ${e}`);
+    }
+  };
+
+  return button;
+}

--- a/prow/cmd/deck/static/common/abort.ts
+++ b/prow/cmd/deck/static/common/abort.ts
@@ -1,41 +1,75 @@
 import {ProwJobState} from "../api/prow";
 import {showAlert, showToast, State} from "./common";
 
-export function createAbortProwJobIcon(state: ProwJobState, prowjob: string, csrfToken: string): HTMLElement {
+export function createAbortProwJobIcon(modal: HTMLElement, parentEl: Element, job: string, state: ProwJobState, prowjob: string, csrfToken: string): HTMLElement {
   const url = `${location.protocol}//${location.host}/abort?prowjob=${prowjob}`;
-  const button = document.createElement('button');
-  button.classList.add('mdl-button', 'mdl-js-button', 'mdl-button--icon');
-  button.innerHTML = '<i class="icon-button material-icons" title="Cancel this job" style="color: gray">cancel</i>';
+  const abortButton = document.createElement('button');
+  abortButton.classList.add('mdl-button', 'mdl-js-button', 'mdl-button--icon');
+  abortButton.innerHTML = '<i class="icon-button material-icons" title="Cancel this job" style="color: gray">cancel</i>';
 
-  if (state !== State.TRIGGERED && state !== State.PENDING) {
-    button.innerHTML = `<i class="icon-button material-icons" title="Can't abort job in ${state} state" style="color: lightgray">cancel</i>`;
-    button.classList.remove('icon-button');
-    button.disabled = true;
-  }
-
-  button.onclick = async () => {
-    gtag('event', 'abort', {
-      event_category: 'engagement',
-      transport_type: 'beacon',
-    });
-    try {
-      const result = await fetch(url, {
-        headers: {
-          'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-          'X-CSRF-Token': csrfToken,
-        },
-        method: 'post',
-      });
-      const data = await result.text();
-      if (result.status >= 400) {
-        showAlert(data);
-      } else {
-        showToast(data);
-      }
-    } catch (e) {
-      showAlert(`Could not send request to abort job: ${e}`);
+  const closeModal = (): void => {
+    modal.style.display = "none";
+    // Resets modal content. If removed, elements will be concatenated, causing duplicates.
+    parentEl.classList.remove('abort-content', 'rerun-content');
+    parentEl.innerHTML = '';
+  };
+  window.onkeydown = (event: any) => {
+    if (event.key === "Escape") {
+      closeModal();
     }
   };
+  window.onclick = (event: any) => {
+    if (event.target === modal) {
+      closeModal();
+    }
+  };
+  if (state !== State.TRIGGERED && state !== State.PENDING) {
+    abortButton.innerHTML = `<i class="icon-button material-icons" title="Can't abort job in ${state} state" style="color: lightgray">cancel</i>`;
+    abortButton.disabled = true;
+  }
+  abortButton.onclick = async () => {
+    modal.style.display = 'block';
+    // Add the styles for abort modal
+    parentEl.classList.add('abort-content');
+    parentEl.innerHTML = `
+      <h2 class="abortModal-title">Abort ProwJob</h2>
+      <p class="abortModal-description">Would you like to abort <b>${job}</b>?</p>
+    `;
 
-  return button;
+    const buttonDiv = document.createElement('div');
+    buttonDiv.classList.add('abortModal-buttonDiv');
+    const confirmAbortButton = document.createElement('a');
+    confirmAbortButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-button--colored'>Confirm</button>";
+    const cancelAbortButton = document.createElement('a');
+    cancelAbortButton.innerHTML = "<button class='mdl-button mdl-js-button mdl-button--raised mdl-color--red mdl-button--colored'>Cancel</button>";
+    buttonDiv.appendChild(confirmAbortButton);
+    buttonDiv.appendChild(cancelAbortButton);
+    parentEl.appendChild(buttonDiv);
+
+    confirmAbortButton.onclick = async () => {
+      gtag('event', 'abort', {
+        event_category: 'engagement',
+        transport_type: 'beacon',
+      });
+      try {
+        const result = await fetch(url, {
+          headers: {
+            'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-CSRF-Token': csrfToken,
+          },
+          method: 'post',
+        });
+        const data = await result.text();
+        if (result.status >= 400) {
+          showAlert(data);
+        } else {
+          showToast(data);
+        }
+      } catch (e) {
+        showAlert(`Could not send request to abort job: ${e}`);
+      }
+    };
+    cancelAbortButton.onclick = closeModal;
+  };
+  return abortButton;
 }

--- a/prow/cmd/deck/static/common/abort.ts
+++ b/prow/cmd/deck/static/common/abort.ts
@@ -1,4 +1,4 @@
-import {icon, showAlert, showToast, State} from "./common";
+import {showAlert, showToast, State} from "./common";
 
 export function createAbortProwJobIcon(state: string, prowjob: string, csrfToken: string): HTMLElement {
   const url = `${location.protocol}//${location.host}/abort?prowjob=${prowjob}`;

--- a/prow/cmd/deck/static/common/abort.ts
+++ b/prow/cmd/deck/static/common/abort.ts
@@ -1,6 +1,7 @@
+import {ProwJobState} from "../api/prow";
 import {showAlert, showToast, State} from "./common";
 
-export function createAbortProwJobIcon(state: string, prowjob: string, csrfToken: string): HTMLElement {
+export function createAbortProwJobIcon(state: ProwJobState, prowjob: string, csrfToken: string): HTMLElement {
   const url = `${location.protocol}//${location.host}/abort?prowjob=${prowjob}`;
   const button = document.createElement('button');
   button.classList.add('mdl-button', 'mdl-js-button', 'mdl-button--icon');

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -4,6 +4,16 @@ import {ProwJobState, Pull} from "../api/prow";
 // This file likes namespaces, so stick with it for now.
 /* tslint:disable:no-namespace */
 
+// State enum describes different state a job can be in
+export enum State {
+  TRIGGERED = 'triggered',
+  PENDING = 'pending',
+  SUCCESS = 'success',
+  FAILURE = 'failure',
+  ABORTED = 'aborted',
+  ERROR = 'error',
+}
+
 // The cell namespace exposes functions for constructing common table cells.
 export namespace cell {
 
@@ -48,22 +58,22 @@ export namespace cell {
     displayState = displayState[0].toUpperCase() + displayState.slice(1);
     let displayIcon = "";
     switch (s) {
-      case "triggered":
+      case State.TRIGGERED:
         displayIcon = "schedule";
         break;
-      case "pending":
+      case State.PENDING:
         displayIcon = "watch_later";
         break;
-      case "success":
+      case State.SUCCESS:
         displayIcon = "check_circle";
         break;
-      case "failure":
+      case State.FAILURE:
         displayIcon = "error";
         break;
-      case "aborted":
+      case State.ABORTED:
         displayIcon = "remove_circle";
         break;
-      case "error":
+      case State.ERROR:
         displayIcon = "warning";
         break;
     }

--- a/prow/cmd/deck/static/common/rerun.ts
+++ b/prow/cmd/deck/static/common/rerun.ts
@@ -1,7 +1,7 @@
 import {copyToClipboard, icon, showAlert, showToast} from "./common";
 import {relativeURL} from "./urls";
 
-export function createRerunProwJobIcon(modal: HTMLElement, parentEl: HTMLElement, prowjob: string, showRerunButton: boolean, csrfToken: string): HTMLElement {
+export function createRerunProwJobIcon(modal: HTMLElement, parentEl: Element, prowjob: string, showRerunButton: boolean, csrfToken: string): HTMLElement {
   const LATEST_JOB = 'latest';
   const ORIGINAL_JOB = 'original';
   const inrepoconfigURL = 'https://github.com/kubernetes/test-infra/blob/master/prow/inrepoconfig.md';
@@ -10,6 +10,7 @@ export function createRerunProwJobIcon(modal: HTMLElement, parentEl: HTMLElement
   const closeModal = (): void => {
     modal.style.display = "none";
     // Resets modal content. If removed, elements will be concatenated, causing duplicates.
+    parentEl.classList.remove('rerun-content', 'abort-content');
     parentEl.innerHTML = '';
   };
   window.onkeydown = (event: any) => {
@@ -37,6 +38,8 @@ export function createRerunProwJobIcon(modal: HTMLElement, parentEl: HTMLElement
   // access it from the frontend. "github_login" should be set whenever "access-token-session" is
   i.onclick = () => {
     modal.style.display = "block";
+    // Add the styles for rerun modal
+    parentEl.classList.add('rerun-content');
 
     parentEl.innerHTML = `
       <h2 class="rerunModal-title">Rerun ProwJob</h2>

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -2,6 +2,7 @@ import moment from "moment";
 import {ProwJob, ProwJobList, ProwJobState, ProwJobType, Pull} from "../api/prow";
 import {cell, formatDuration, icon} from "../common/common";
 import {createRerunProwJobIcon} from "../common/rerun";
+import {createAbortProwJobIcon} from "../common/abort";
 import {getParameterByName} from "../common/urls";
 import {FuzzySearch} from './fuzzy-search';
 import {JobHistogram, JobSample} from './histogram';
@@ -611,6 +612,8 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
         r.appendChild(createLogCell(build, buildUrl));
         // Rerun column
         r.appendChild(createRerunCell(modal, rerunCommand, prowJobName));
+        // Abort column
+        r.appendChild(createAbortCell(state, prowJobName))
         // Job Yaml column
         r.appendChild(createViewJobCell(prowJobName));
         // Repository column
@@ -721,6 +724,12 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
     // see https://getmdl.io/started/index.html#dynamic
     componentHandler.upgradeDom();
 }
+
+function createAbortCell(state: string, prowjob: string): HTMLTableCellElement {
+    const c = document.createElement("td");
+    c.appendChild(createAbortProwJobIcon(state, prowjob, csrfToken));
+    return c;
+} 
 
 function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {
     const c = document.createElement("td");

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -432,7 +432,7 @@ function escapeRegexLiteral(s: string): string {
 function redraw(fz: FuzzySearch, pushState: boolean = true): void {
     const rerunStatus = getParameterByName("rerun");
     const modal = document.getElementById('rerun')!;
-    const rerunCommand = document.getElementById('rerun-content')!;
+    const modalContent = document.querySelector('.modal-content')!;
     const builds = document.getElementById("builds")!.getElementsByTagName(
         "tbody")[0];
     while (builds.firstChild) {
@@ -611,9 +611,9 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
         // Log column
         r.appendChild(createLogCell(build, buildUrl));
         // Rerun column
-        r.appendChild(createRerunCell(modal, rerunCommand, prowJobName));
+        r.appendChild(createRerunCell(modal, modalContent, prowJobName));
         // Abort column
-        r.appendChild(createAbortCell(state, prowJobName));
+        r.appendChild(createAbortCell(modal, modalContent, job, state, prowJobName));
         // Job Yaml column
         r.appendChild(createViewJobCell(prowJobName));
         // Repository column
@@ -718,20 +718,20 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
     drawJobHistogram(totalJob, jobHistogram, now - (12 * 3600), now, max);
     if (rerunStatus === "gh_redirect") {
         modal.style.display = "block";
-        rerunCommand.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
+        modalContent.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
     }
     // we need to upgrade DOM for new created dynamic elements
     // see https://getmdl.io/started/index.html#dynamic
     componentHandler.upgradeDom();
 }
 
-function createAbortCell(state: ProwJobState, prowjob: string): HTMLTableCellElement {
+function createAbortCell(modal: HTMLElement, modalContent: Element, job: string, state: ProwJobState, prowjob: string): HTMLTableCellElement {
     const c = document.createElement("td");
-    c.appendChild(createAbortProwJobIcon(state, prowjob, csrfToken));
+    c.appendChild(createAbortProwJobIcon(modal, modalContent, job, state, prowjob, csrfToken));
     return c;
 }
 
-function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {
+function createRerunCell(modal: HTMLElement, rerunElement: Element, prowjob: string): HTMLTableDataCellElement {
     const c = document.createElement("td");
     c.appendChild(createRerunProwJobIcon(modal, rerunElement, prowjob, rerunCreatesJob, csrfToken));
     return c;

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -1,8 +1,8 @@
 import moment from "moment";
 import {ProwJob, ProwJobList, ProwJobState, ProwJobType, Pull} from "../api/prow";
+import {createAbortProwJobIcon} from "../common/abort";
 import {cell, formatDuration, icon} from "../common/common";
 import {createRerunProwJobIcon} from "../common/rerun";
-import {createAbortProwJobIcon} from "../common/abort";
 import {getParameterByName} from "../common/urls";
 import {FuzzySearch} from './fuzzy-search';
 import {JobHistogram, JobSample} from './histogram';
@@ -613,7 +613,7 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
         // Rerun column
         r.appendChild(createRerunCell(modal, rerunCommand, prowJobName));
         // Abort column
-        r.appendChild(createAbortCell(state, prowJobName))
+        r.appendChild(createAbortCell(state, prowJobName));
         // Job Yaml column
         r.appendChild(createViewJobCell(prowJobName));
         // Repository column
@@ -729,7 +729,7 @@ function createAbortCell(state: string, prowjob: string): HTMLTableCellElement {
     const c = document.createElement("td");
     c.appendChild(createAbortProwJobIcon(state, prowjob, csrfToken));
     return c;
-} 
+}
 
 function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {
     const c = document.createElement("td");

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -725,7 +725,7 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
     componentHandler.upgradeDom();
 }
 
-function createAbortCell(state: string, prowjob: string): HTMLTableCellElement {
+function createAbortCell(state: ProwJobState, prowjob: string): HTMLTableCellElement {
     const c = document.createElement("td");
     c.appendChild(createAbortProwJobIcon(state, prowjob, csrfToken));
     return c;

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -1,3 +1,4 @@
+import {ProwJobState} from "../api/prow";
 import {createAbortProwJobIcon} from "../common/abort";
 import {createRerunProwJobIcon} from "../common/rerun";
 import {getParameterByName} from "../common/urls";
@@ -9,7 +10,7 @@ declare const lensIndexes: number[];
 declare const csrfToken: string;
 declare const rerunCreatesJob: boolean;
 declare const prowJobName: string;
-declare const prowJobState: string;
+declare const prowJobState: ProwJobState;
 
 // Loads views for this job
 function loadLenses(): void {

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -1,3 +1,4 @@
+import {createAbortProwJobIcon} from "../common/abort";
 import {createRerunProwJobIcon} from "../common/rerun";
 import {getParameterByName} from "../common/urls";
 import {isTransitMessage, serialiseHashes} from "./common";
@@ -8,6 +9,7 @@ declare const lensIndexes: number[];
 declare const csrfToken: string;
 declare const rerunCreatesJob: boolean;
 declare const prowJobName: string;
+declare const prowJobState: string;
 
 // Loads views for this job
 function loadLenses(): void {
@@ -165,6 +167,7 @@ window.addEventListener('hashchange', (e) => {
 window.addEventListener('load', () => {
     loadLenses();
     handleRerunButton();
+    handleAbortButton();
 });
 
 function handleRerunButton() {
@@ -186,4 +189,16 @@ function handleRerunButton() {
     modal.style.display = "block";
     rerunCommand.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
   }
+}
+
+function handleAbortButton(): void {
+  // In case prowJob is unavailable, the abort button shouldn't be shown
+  if (!prowJobName) {
+    return;
+  }
+
+  const r = document.getElementById("header-title")!;
+  const c = document.createElement("div");
+  c.appendChild(createAbortProwJobIcon(prowJobState, prowJobName, csrfToken));
+  r.appendChild(c);
 }

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -9,6 +9,7 @@ declare const lensArtifacts: {[index: string]: string[]};
 declare const lensIndexes: number[];
 declare const csrfToken: string;
 declare const rerunCreatesJob: boolean;
+declare const prowJob: string;
 declare const prowJobName: string;
 declare const prowJobState: ProwJobState;
 
@@ -179,16 +180,16 @@ function handleRerunButton() {
 
   const rerunStatus = getParameterByName("rerun");
   const modal = document.getElementById('rerun')!;
-  const rerunCommand = document.getElementById('rerun-content')!;
+  const modalContent = document.querySelector('.modal-content')!;
 
   const r = document.getElementById("header-title")!;
   const c = document.createElement("div");
-  c.appendChild(createRerunProwJobIcon(modal, rerunCommand, prowJobName, rerunCreatesJob, csrfToken));
+  c.appendChild(createRerunProwJobIcon(modal, modalContent, prowJobName, rerunCreatesJob, csrfToken));
   r.appendChild(c);
 
   if (rerunStatus === "gh_redirect") {
     modal.style.display = "block";
-    rerunCommand.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
+    modalContent.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
   }
 }
 
@@ -198,8 +199,11 @@ function handleAbortButton(): void {
     return;
   }
 
+  const modal = document.getElementById('rerun')!;
+  const modalContent = document.querySelector('.modal-content')!;
+
   const r = document.getElementById("header-title")!;
   const c = document.createElement("div");
-  c.appendChild(createAbortProwJobIcon(prowJobState, prowJobName, csrfToken));
+  c.appendChild(createAbortProwJobIcon(modal, modalContent, prowJob, prowJobState, prowJobName, csrfToken));
   r.appendChild(c);
 }

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -324,7 +324,7 @@ i.state {
     background-color: rgba(0,0,0,0.4);
 }
 
-#rerun-content {
+.rerun-content {
     font-family: monospace;
     background-color: #fefefe;
     margin: auto;
@@ -334,7 +334,35 @@ i.state {
     max-width: 1500px;
     color: #444;
     border-radius: 10px;
-    box-shadow: 0px 20px 80px 0px; 
+    box-shadow: 0px 20px 80px 0px;
+}
+
+.abort-content {
+    font-family: monospace;
+    background-color: #fefefe;
+    margin: auto;
+    padding: 40px;
+    border: 1px solid #888;
+    width: 25%;
+    max-width: 1500px;
+    color: #444;
+    border-radius: 10px;
+    box-shadow: 0px 20px 80px 0px;
+}
+
+.abortModal-title {
+    font-size: 35px;
+    margin-top: 0px;
+}
+
+.abortModal-description {
+    font-size: 16px;
+    margin-bottom: 24px;
+}
+
+.abortModal-buttonDiv {
+    display: flex;
+    justify-content: space-around;
 }
 
 .rerunModal-title {

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -66,6 +66,7 @@
           <th class="icon-cell-32">State</th>
           <th class="icon-cell-32">Log</th>
           <th class="icon-cell-32">Rerun</th>
+          <th class="icon-cell-32">Abort</th>
           <th>Job YML</th>
           <th>Repository</th>
           <th>Revision</th>

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -82,7 +82,7 @@
     </div>
   </article>
   <div id="rerun">
-    <div id="rerun-content"></div>
+    <div class="modal-content"></div>
   </div>
 </div>
 {{end}}

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -7,6 +7,7 @@
   var lensIndexes = {{.LensIndexes}};
   var rerunCreatesJob = {{.ReRunCreatesJob}};
   var prowJobName = {{.ProwJobName}};
+  var prowJobState = {{.ProwJobState}};
 </script>
 <script type="text/javascript" src="/static/spyglass_bundle.min.js"></script>
 <link rel="stylesheet" type="text/css" href="/static/spyglass/spyglass.css">

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -6,6 +6,7 @@
   var lensArtifacts = {{.LensArtifacts}};
   var lensIndexes = {{.LensIndexes}};
   var rerunCreatesJob = {{.ReRunCreatesJob}};
+  var prowJob = {{.ProwJob}};
   var prowJobName = {{.ProwJobName}};
   var prowJobState = {{.ProwJobState}};
 </script>
@@ -52,5 +53,5 @@
 {{template "page" (settings mobileUnfriendly darkMode "spyglass" .)}}
 
 <div id="rerun">
-  <div id="rerun-content"></div>
+  <div class="modal-content"></div>
 </div>

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -269,8 +269,8 @@ func (sg *Spyglass) JobPath(src string) (string, error) {
 	}
 }
 
-// ProwJob returns a prowjob to the YAML for the job specified in src.
-// If no job is found, it returns nil and nil error.
+// ProwJob returns a link and state to the YAML for the job specified in src.
+// If no job is found, it returns empty strings and nil error.
 func (sg *Spyglass) ProwJob(src string) (string, prowapi.ProwJobState, error) {
 	src = strings.TrimSuffix(src, "/")
 	keyType, key, err := splitSrc(src)

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/deck/jobs"
@@ -268,13 +269,13 @@ func (sg *Spyglass) JobPath(src string) (string, error) {
 	}
 }
 
-// ProwJobName returns a link to the YAML for the job specified in src.
-// If no job is found, it returns an empty string and nil error.
-func (sg *Spyglass) ProwJobName(src string) (string, error) {
+// ProwJob returns a prowjob to the YAML for the job specified in src.
+// If no job is found, it returns nil and nil error.
+func (sg *Spyglass) ProwJob(src string) (*prowapi.ProwJob, error) {
 	src = strings.TrimSuffix(src, "/")
 	keyType, key, err := splitSrc(src)
 	if err != nil {
-		return "", fmt.Errorf("error parsing src: %v", src)
+		return nil, fmt.Errorf("error parsing src: %v", src)
 	}
 	split := strings.Split(key, "/")
 	var jobName string
@@ -282,13 +283,13 @@ func (sg *Spyglass) ProwJobName(src string) (string, error) {
 	switch keyType {
 	case prowKeyType:
 		if len(split) < 2 {
-			return "", fmt.Errorf("invalid key %s: expected <job-name>/<build-id>", key)
+			return nil, fmt.Errorf("invalid key %s: expected <job-name>/<build-id>", key)
 		}
 		jobName = split[0]
 		buildID = split[1]
 	default:
 		if len(split) < 4 {
-			return "", fmt.Errorf("invalid key %s: expected <bucket-name>/<log-type>/.../<job-name>/<build-id>", key)
+			return nil, fmt.Errorf("invalid key %s: expected <bucket-name>/<log-type>/.../<job-name>/<build-id>", key)
 		}
 		jobName = split[len(split)-2]
 		buildID = split[len(split)-1]
@@ -296,11 +297,11 @@ func (sg *Spyglass) ProwJobName(src string) (string, error) {
 	job, err := sg.jobAgent.GetProwJob(jobName, buildID)
 	if err != nil {
 		if jobs.IsErrProwJobNotFound(err) {
-			return "", nil
+			return nil, nil
 		}
-		return "", err
+		return nil, err
 	}
-	return job.Name, nil
+	return &job, nil
 }
 
 // RunPath returns the path to the directory for the job run specified in src.

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -271,11 +271,11 @@ func (sg *Spyglass) JobPath(src string) (string, error) {
 
 // ProwJob returns a link and state to the YAML for the job specified in src.
 // If no job is found, it returns empty strings and nil error.
-func (sg *Spyglass) ProwJob(src string) (string, prowapi.ProwJobState, error) {
+func (sg *Spyglass) ProwJob(src string) (string, string, prowapi.ProwJobState, error) {
 	src = strings.TrimSuffix(src, "/")
 	keyType, key, err := splitSrc(src)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing src: %v", src)
+		return "", "", "", fmt.Errorf("error parsing src: %v", src)
 	}
 	split := strings.Split(key, "/")
 	var jobName string
@@ -283,13 +283,13 @@ func (sg *Spyglass) ProwJob(src string) (string, prowapi.ProwJobState, error) {
 	switch keyType {
 	case prowKeyType:
 		if len(split) < 2 {
-			return "", "", fmt.Errorf("invalid key %s: expected <job-name>/<build-id>", key)
+			return "", "", "", fmt.Errorf("invalid key %s: expected <job-name>/<build-id>", key)
 		}
 		jobName = split[0]
 		buildID = split[1]
 	default:
 		if len(split) < 4 {
-			return "", "", fmt.Errorf("invalid key %s: expected <bucket-name>/<log-type>/.../<job-name>/<build-id>", key)
+			return "", "", "", fmt.Errorf("invalid key %s: expected <bucket-name>/<log-type>/.../<job-name>/<build-id>", key)
 		}
 		jobName = split[len(split)-2]
 		buildID = split[len(split)-1]
@@ -297,11 +297,11 @@ func (sg *Spyglass) ProwJob(src string) (string, prowapi.ProwJobState, error) {
 	job, err := sg.jobAgent.GetProwJob(jobName, buildID)
 	if err != nil {
 		if jobs.IsErrProwJobNotFound(err) {
-			return "", "", nil
+			return "", "", "", nil
 		}
-		return "", "", err
+		return "", "", "", err
 	}
-	return job.Name, job.Status.State, nil
+	return job.Spec.Job, job.Name, job.Status.State, nil
 }
 
 // RunPath returns the path to the directory for the job run specified in src.

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -503,7 +503,7 @@ func TestJobPath(t *testing.T) {
 	}
 }
 
-func TestProwJobName(t *testing.T) {
+func TestProwJob(t *testing.T) {
 	kc := fkc{
 		prowapi.ProwJob{
 			ObjectMeta: metav1.ObjectMeta{Name: "flying-whales-1"},
@@ -517,6 +517,7 @@ func TestProwJobName(t *testing.T) {
 				},
 			},
 			Status: prowapi.ProwJobStatus{
+				State:   prowapi.TriggeredState,
 				PodName: "flying-whales",
 				BuildID: "1111",
 			},
@@ -533,6 +534,7 @@ func TestProwJobName(t *testing.T) {
 				},
 			},
 			Status: prowapi.ProwJobStatus{
+				State:   prowapi.PendingState,
 				PodName: "flying-whales",
 				BuildID: "2222",
 			},
@@ -544,6 +546,7 @@ func TestProwJobName(t *testing.T) {
 				Job:  "undecorated-job",
 			},
 			Status: prowapi.ProwJobStatus{
+				State:   prowapi.SuccessState,
 				PodName: "flying-whales",
 				BuildID: "1",
 			},
@@ -563,45 +566,53 @@ func TestProwJobName(t *testing.T) {
 	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 	testCases := []struct {
-		name       string
-		src        string
-		expJobPath string
-		expError   bool
+		name        string
+		src         string
+		expJobPath  string
+		expJobState prowapi.ProwJobState
+		expError    bool
 	}{
 		{
-			name:       "non-presubmit job in GCS without trailing /",
-			src:        "gcs/kubernetes-jenkins/logs/example-periodic-job/1111/",
-			expJobPath: "flying-whales-1",
+			name:        "non-presubmit job in GCS without trailing /",
+			src:         "gcs/kubernetes-jenkins/logs/example-periodic-job/1111/",
+			expJobPath:  "flying-whales-1",
+			expJobState: prowapi.TriggeredState,
 		},
 		{
-			name:       "presubmit job in GCS with trailing /",
-			src:        "gcs/kubernetes-jenkins/pr-logs/pull/test-infra/0000/example-presubmit-job/2222/",
-			expJobPath: "flying-whales-2",
+			name:        "presubmit job in GCS with trailing /",
+			src:         "gcs/kubernetes-jenkins/pr-logs/pull/test-infra/0000/example-presubmit-job/2222/",
+			expJobPath:  "flying-whales-2",
+			expJobState: prowapi.PendingState,
 		},
 		{
-			name:       "non-presubmit Prow job",
-			src:        "prowjob/example-periodic-job/1111",
-			expJobPath: "flying-whales-1",
+			name:        "non-presubmit Prow job",
+			src:         "prowjob/example-periodic-job/1111",
+			expJobPath:  "flying-whales-1",
+			expJobState: prowapi.TriggeredState,
 		},
 		{
-			name:       "Prow presubmit job",
-			src:        "prowjob/example-presubmit-job/2222",
-			expJobPath: "flying-whales-2",
+			name:        "Prow presubmit job",
+			src:         "prowjob/example-presubmit-job/2222",
+			expJobPath:  "flying-whales-2",
+			expJobState: prowapi.PendingState,
 		},
 		{
-			name:       "nonexistent job",
-			src:        "prowjob/example-periodic-job/0000",
-			expJobPath: "",
+			name:        "nonexistent job",
+			src:         "prowjob/example-periodic-job/0000",
+			expJobPath:  "",
+			expJobState: "",
 		},
 		{
-			name:       "job missing name",
-			src:        "prowjob/missing-name-job/1",
-			expJobPath: "",
+			name:        "job missing name",
+			src:         "prowjob/missing-name-job/1",
+			expJobPath:  "",
+			expJobState: "",
 		},
 		{
-			name:       "previously invalid key type is now valid but nonexistent",
-			src:        "oh/my/glob/drama/bomb",
-			expJobPath: "",
+			name:        "previously invalid key type is now valid but nonexistent",
+			src:         "oh/my/glob/drama/bomb",
+			expJobPath:  "",
+			expJobState: "",
 		},
 		{
 			name:     "invalid GCS path",
@@ -614,7 +625,7 @@ func TestProwJobName(t *testing.T) {
 		fakeOpener := io.NewGCSOpener(fakeGCSClient)
 		fca := config.Agent{}
 		sg := New(context.Background(), fakeJa, fca.Config, fakeOpener, false)
-		jobPath, err := sg.ProwJobName(tc.src)
+		jobPath, jobState, err := sg.ProwJob(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: JobPath(%q) expected error", tc.name, tc.src)
 			continue
@@ -625,6 +636,9 @@ func TestProwJobName(t *testing.T) {
 		}
 		if jobPath != tc.expJobPath {
 			t.Errorf("test %q: JobPath(%q) expected %q, got %q", tc.name, tc.src, tc.expJobPath, jobPath)
+		}
+		if jobState != tc.expJobState {
+			t.Errorf("test %q: JobState(%q) expected %q, got %q", tc.name, tc.src, tc.expJobState, jobState)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the interface to users to be able to abort a ProwJob on the Prow UI and Spyglass. The abort button will be disabled whenever a Job is not in a Triggered, or Pending state.

![Screenshot 2022-07-19 2 11 41 PM](https://user-images.githubusercontent.com/55557781/179849363-1173ed76-35bf-4d04-a839-c1190382908d.png)
![image](https://user-images.githubusercontent.com/55557781/179849832-92036097-8494-4124-b483-83a3af44fc95.png)
![image](https://user-images.githubusercontent.com/55557781/181125506-cbc8aff6-51e4-42e7-8e2d-ff6dde082ac9.png)


Fixes: https://github.com/kubernetes/test-infra/issues/24390

/cc @chaodaiG @cjwagner @e-blackwelder 
