### PR TITLE
[go1.19] kubekins/krte: Build go-canary variant using go1.19rc2

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.19beta1
+    GO_VERSION: 1.19rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2575.

For Golang pre-releases, the go-canary variant needs to be built ahead of the master variant to enable testing go canary presubmits for:
https://github.com/kubernetes/kubernetes/pull/111254

/assign @saschagrunert @puerco @justaugustus
/cc https://github.com/orgs/kubernetes/teams/release-engineering

Signed-off-by: Davanum Srinivas <davanum@gmail.com>