### PR TITLE
Update cloud-provider-azure serial job to lower parallel testing nodes

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -862,7 +862,9 @@ periodics:
       - name: CLUSTER_PROVISIONING_TOOL
         value: "capz"
       - name: GINKGO_PARALLEL_NODES
-        value: "30"
+        value: "4"
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "y"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-conformance-serial-vmss-capz


### PR DESCRIPTION
Update cloud-provider-azure conformance serial job to lower parallel testing nodes
Lower GINKGO_PARALLEL_NODES and set GINKGO_TOLERATE_FLAKES="y" to increase the possibility of success, otherwise chances are that tests will fail due to time-out reason

Signed-off-by: Lan Lou [t-lanlou@microsoft.com](mailto:t-lanlou@microsoft.com)