### PR TITLE
[go1.19] kubekins/krte: Build main/master variants using go1.19rc2

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -22,13 +22,13 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.18.3
+    GO_VERSION: 1.19rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.18.3
+    GO_VERSION: 1.19rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2575.

https://github.com/kubernetes/kubernetes/pull/111254 which switches master branch to go1.19rc2 is now ready! (go-canary verify job works!)

/assign @saschagrunert @puerco @justaugustus
/cc https://github.com/orgs/kubernetes/teams/release-engineering

Signed-off-by: Davanum Srinivas [davanum@gmail.com](mailto:davanum@gmail.com)