### PR TITLE
Enable Webhook server to use FileSystem in case project id is not specified

### DIFF
--- a/prow/cmd/webhook-server/clients.go
+++ b/prow/cmd/webhook-server/clients.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/test-infra/experiment/clustersecretbackup/secretmanager"
+)
+
+type GCPClient struct {
+	client *secretmanager.Client
+}
+
+func newGCPClient(client *secretmanager.Client) *GCPClient {
+	return &GCPClient{
+		client: client,
+	}
+}
+
+func (g *GCPClient) CreateSecret(ctx context.Context, secretID string) error {
+	_, err := g.client.CreateSecret(ctx, secretID)
+	if err != nil {
+		return fmt.Errorf("could not create secret %v", err)
+	}
+	return nil
+}
+
+func (g *GCPClient) AddSecretVersion(ctx context.Context, secretName string, payload []byte) error {
+	if err := g.client.AddSecretVersion(ctx, secretName, payload); err != nil {
+		return fmt.Errorf("could not add secret data %v", err)
+	}
+	return nil
+}
+
+func (g *GCPClient) GetSecretValue(ctx context.Context, secretName string, versionName string) ([]byte, bool, error) {
+	err := g.checkSecret(ctx, secretName)
+	if err != nil && err == os.ErrNotExist {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+	payload, err := g.client.GetSecretValue(ctx, secretName, versionName)
+	if err != nil {
+		return nil, false, fmt.Errorf("error getting secret value %v", err)
+	}
+
+	return payload, true, nil
+}
+
+func (g *GCPClient) checkSecret(ctx context.Context, secretName string) error {
+	res, err := g.client.ListSecrets(ctx)
+	if err != nil {
+		return fmt.Errorf("could not make call to list secrets successfully %v", err)
+	}
+	for _, secret := range res {
+		if strings.Contains(secret.Name, secretID) {
+			return nil
+		}
+	}
+	return os.ErrNotExist
+}
+
+//for integration testing purposes. Not to be used in prod
+type localFSClient struct {
+	path   string
+	expiry int
+	dns    []string
+}
+
+func NewLocalFSClient(path string, expiry int, dns []string) *localFSClient {
+	return &localFSClient{
+		path:   path,
+		expiry: expiry,
+		dns:    dns,
+	}
+}
+
+func (l *localFSClient) CreateSecret(ctx context.Context, secretID string) error {
+	if _, err := os.Stat(l.path); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(l.path, 0755)
+		if err != nil {
+			return fmt.Errorf("unable to create secret dir %v", err)
+		}
+	}
+	return nil
+}
+
+func (l *localFSClient) AddSecretVersion(ctx context.Context, secretName string, payload []byte) error {
+	certFile := filepath.Join(l.path, certFile)
+	privKeyFile := filepath.Join(l.path, privKeyFile)
+	caBundleFile := filepath.Join(l.path, caBundleFile)
+
+	serverCertPerm, serverPrivKey, caPem, _, err := genSecretData(l.expiry, l.dns)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(certFile, []byte(serverCertPerm), 0666); err != nil {
+		return fmt.Errorf("could not write contents of cert file")
+	}
+	if err := ioutil.WriteFile(privKeyFile, []byte(serverPrivKey), 0666); err != nil {
+		return fmt.Errorf("could not write contents of privkey file")
+	}
+	if err := ioutil.WriteFile(caBundleFile, []byte(caPem), 0666); err != nil {
+		return fmt.Errorf("could not write contents of caBundle file")
+	}
+	return nil
+}
+
+func (l *localFSClient) GetSecretValue(ctx context.Context, secretName string, versionName string) ([]byte, bool, error) {
+	err := l.checkSecret(ctx, secretName)
+	if err != nil && err == os.ErrNotExist {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+	secretsMap := make(map[string]string)
+	files, err := ioutil.ReadDir(l.path)
+	if err != nil {
+		return nil, false, fmt.Errorf("could not read file path")
+	}
+	for _, f := range files {
+		content, err := ioutil.ReadFile(filepath.Join(l.path, f.Name()))
+		if err != nil {
+			return nil, false, fmt.Errorf("error reading file %v", err)
+		}
+		switch f.Name() {
+		case certFile:
+			secretsMap[certFile] = string(content)
+		case privKeyFile:
+			secretsMap[privKeyFile] = string(content)
+		case caBundleFile:
+			secretsMap[caBundleFile] = string(content)
+		}
+	}
+	res, err := json.Marshal(secretsMap)
+	if err != nil {
+		return nil, false, fmt.Errorf("could not marshal secrets data %v", err)
+	}
+	return res, true, nil
+}
+
+func (l *localFSClient) checkSecret(ctx context.Context, secretName string) error {
+	_, err := os.Stat(l.path)
+	if err != nil && os.IsNotExist(err) {
+		return os.ErrNotExist
+	} else if err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(l.path)
+	if err != nil {
+		return err
+	}
+	if len(files) < 2 {
+		return nil
+	}
+	for _, f := range files {
+		_, err := ioutil.ReadFile(filepath.Join(l.path, f.Name()))
+		if err != nil {
+			return fmt.Errorf("error reading file %v", err)
+		}
+	}
+	return nil
+}

--- a/prow/cmd/webhook-server/helpers.go
+++ b/prow/cmd/webhook-server/helpers.go
@@ -18,20 +18,32 @@ package main
 
 import (
 	"bytes"
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	b64 "encoding/base64"
+
+	"encoding/json"
 	"encoding/pem"
+
 	"fmt"
+
 	"math/big"
+	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	admregistration "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const org = "prow.k8s.io"
 
 func genCert(expiry int, dnsNames []string) (string, string, string, error) {
-
 	//https://gist.github.com/velotiotech/2e0cfd15043513d253cad7c9126d2026#file-initcontainer_main-go
 	var caPEM, serverCertPEM, serverPrivKeyPEM *bytes.Buffer
 	// CA config
@@ -128,6 +140,137 @@ func isCertValid(cert string) error {
 	}
 	if time.Now().After(certificate.NotAfter) {
 		return fmt.Errorf("certificated expired at %v", certificate.NotAfter)
+	}
+	return nil
+}
+
+func createSecret(client ClientInterface, ctx context.Context, expiry int, dns []string) (string, string, string, error) {
+	if err := client.CreateSecret(ctx, secretID); err != nil {
+		return "", "", "", fmt.Errorf("unable to create secret %v", err)
+	}
+
+	serverCertPerm, serverPrivKey, caPem, err := updateSecret(client, ctx, expiry, dns)
+	if err != nil {
+		return "", "", "", fmt.Errorf("unable to write secret value %v", err)
+	}
+	return serverCertPerm, serverPrivKey, caPem, nil
+}
+
+func updateSecret(client ClientInterface, ctx context.Context, expiry int, dns []string) (string, string, string, error) {
+	serverCertPerm, serverPrivKey, caPem, secretData, err := genSecretData(expiry, dns)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	if err := client.AddSecretVersion(ctx, secretID, secretData); err != nil {
+		return "", "", "", fmt.Errorf("unable to add secret version %v", err)
+	}
+
+	return serverCertPerm, serverPrivKey, caPem, nil
+}
+
+func genSecretData(expiry int, dns []string) (string, string, string, []byte, error) {
+	serverCertPerm, serverPrivKey, caPem, err := genCert(expiry, dns)
+	if err != nil {
+		return "", "", "", nil, fmt.Errorf("could not generate ca credentials")
+	}
+	caSecrets := map[string]string{
+		certFile:     serverCertPerm,
+		privKeyFile:  serverPrivKey,
+		caBundleFile: caPem,
+	}
+	secretData, err := json.Marshal(caSecrets)
+
+	if err != nil {
+		return "", "", "", nil, fmt.Errorf("error unmarshalling CA cert secret data: %v", err)
+	}
+
+	return serverCertPerm, serverPrivKey, caPem, secretData, nil
+}
+
+func createValidatingWebhookConfig(ctx context.Context, caPem string, client ctrlruntimeclient.Client) error {
+	operations := []admregistration.OperationType{"CREATE", "UPDATE"}
+	scope := admregistration.ScopeType("*")
+	path := "/validate"
+	sideEffects := admregistration.SideEffectClass("None")
+	caPemEncoded := []byte(b64.StdEncoding.EncodeToString([]byte(caPem)))
+
+	validatingWebhookConfig := &admregistration.ValidatingWebhookConfiguration{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "ValidatingWebhookConfiguration",
+			APIVersion: "admissionregistration.k8s.io/v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "prow-job-validating-webhook-config.prow.k8s.io",
+		},
+		Webhooks: []admregistration.ValidatingWebhook{
+			{
+				Name: "prow-job-validating-webhook-config.prow.k8s.io",
+				ObjectSelector: &v1.LabelSelector{
+					MatchLabels: map[string]string{
+						"admission-webhook": "enabled",
+					},
+				},
+				Rules: []admregistration.RuleWithOperations{
+					{
+						Operations: operations,
+						Rule: admregistration.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"prowjobs"},
+							Scope:       &scope,
+						},
+					},
+				},
+				ClientConfig: admregistration.WebhookClientConfig{
+					Service: &admregistration.ServiceReference{
+						Namespace: "default",
+						Name:      "prowjob-validation-webhook",
+						Path:      &path,
+					},
+					CABundle: caPemEncoded,
+				},
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+
+	createOptions := &ctrlruntimeclient.CreateOptions{
+		FieldManager: "webhook-server",
+	}
+
+	err := client.Create(ctx, validatingWebhookConfig, createOptions)
+	if err != nil && strings.Contains(err.Error(), configAlreadyExistsError) {
+		logrus.Info("ValidatingWebhookConfiguration already exists, proceeding to patch")
+		if err := patchValidatingWebhookConfig(ctx, caPem, client); err != nil {
+			return fmt.Errorf("failed to patch validation webhook config: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to create validation webhook config: %w", err)
+	}
+
+	return nil
+}
+
+func patchValidatingWebhookConfig(ctx context.Context, caPem string, client ctrlruntimeclient.Client) error {
+	caPemEncoded := []byte(b64.StdEncoding.EncodeToString([]byte(caPem)))
+	key := types.NamespacedName{
+		Namespace: "default",
+		Name:      "prow-job-validating-webhook-config.prow.k8s.io",
+	}
+
+	patchOptions := &ctrlruntimeclient.PatchOptions{
+		FieldManager: "webhook-server",
+	}
+	var validatingWebhookConfig admregistration.ValidatingWebhookConfiguration
+	if err := client.Get(ctx, key, &validatingWebhookConfig); err != nil {
+		return fmt.Errorf("failed to get validation webhook config: %w", err)
+	}
+	oldValidatingWebhook := validatingWebhookConfig.DeepCopy()
+	validatingWebhookConfig.Webhooks[0].ClientConfig.CABundle = caPemEncoded
+	if err := client.Patch(ctx, &validatingWebhookConfig, ctrlruntimeclient.MergeFrom(oldValidatingWebhook), patchOptions); err != nil {
+		return fmt.Errorf("failed to patch validation webhook config: %w", err)
 	}
 	return nil
 }

--- a/prow/cmd/webhook-server/main.go
+++ b/prow/cmd/webhook-server/main.go
@@ -25,141 +25,175 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/sirupsen/logrus"
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"k8s.io/test-infra/experiment/clustersecretbackup/secretmanager"
-	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/pkg/flagutil"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/logrusutil"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	secretID  = "prowjob-webhook-ca-cert"
-	caCert = "ca-cert"
-	caPrivKey = "ca-priv-key"
-	caBundle = "ca-bundle"
-	gcpSecretError = "failed to access secret version"
+	configAlreadyExistsError = "already exists"
+	certFile                 = "certFile.pem"
+	privKeyFile              = "privKeyFile.pem"
+	caBundleFile             = "caBundle.pem"
 )
 
 type ClientInterface interface {
-	CreateSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error)
+	CreateSecret(ctx context.Context, secretID string) error
 	AddSecretVersion(ctx context.Context, secretName string, payload []byte) error
-	GetSecretValue(ctx context.Context, secretName, versionName string) ([]byte, error)
+	GetSecretValue(ctx context.Context, secretName string, versionName string) ([]byte, bool, error)
+}
+
+type options struct {
+	projectId      string
+	expiryInYears  int
+	dnsNames       []string
+	dryRun         bool
+	kubernetes     prowflagutil.KubernetesOptions
+	fileSystemPath string
+	secretID       string
+}
+
+var secretID string
+
+func (o *options) Validate() error {
+	optionGroup := []flagutil.OptionGroup{&o.kubernetes}
+	if err := optionGroup[0].Validate(o.dryRun); err != nil {
+		return err
+	}
+	if o.expiryInYears < 0 {
+		return fmt.Errorf("invalid expiry years")
+	}
+	if o.projectId == "" && o.fileSystemPath == "" {
+		return fmt.Errorf("both projectid and filesystem path cannot be specified")
+	}
+	if o.projectId != "" && o.fileSystemPath != "" {
+		return fmt.Errorf("either projectid or filesystem path must be specified")
+	}
+	if o.projectId != "" && o.secretID == "" {
+		return fmt.Errorf("secretID must be specified if choosing to use a GCP project")
+	}
+	return nil
+}
+
+func gatherOptions(fs *flag.FlagSet, args ...string) options {
+	var o options
+	fs.StringVar(&o.projectId, "project-id", "", "Project ID for storing GCP Secrets")
+	fs.StringVar(&o.fileSystemPath, "filesys-path", "./hello", "File system path for storing ca-cert secrets")
+	fs.StringVar(&o.secretID, "secret-id", "", "GCP Project secret name")
+	fs.IntVar(&o.expiryInYears, "expiry-years", 30, "CA certificate expiry in years")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to mutate any real-world state")
+	optionGroup := []flagutil.OptionGroup{&o.kubernetes}
+	optionGroup[0].AddFlags(fs)
+	fs.Parse(args)
+	return o
 }
 
 func main() {
 	logrusutil.ComponentInit()
 	logrus.SetLevel(logrus.DebugLevel)
-	p := flag.String("project-id", 
-	"", "Project ID for storing GCP Secrets")
-	e := flag.Int("expiry-years", 30, "CA certificate expiry in years")
-	dns := flagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
+	dns := prowflagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
 	flag.Var(&dns, "dns", "DNS Names CA-Cert config")
 	flag.Parse()
-	exp := *e
-	projectId := *p
-	if len(projectId) == 0 {
-		logrus.Fatal("project-id flag not supplied")
+	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
+	o.dnsNames = dns.Strings()
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
 	}
-	client, err := secretmanager.NewClient(projectId, false)
+	secretID = o.secretID
+	kubeCfg, err := o.kubernetes.InfrastructureClusterConfig(o.dryRun)
 	if err != nil {
-		logrus.WithError(err).Fatal("Unable to create secret manager client")
+		logrus.WithError(err).Fatal("Error getting kubeconfig")
 	}
+	var certFile string
+	var privKeyFile string
 	ctx := context.Background()
-	cert, privKey, err := getGCPSecrets(client, ctx, exp, dns)
-	if err != nil && strings.Contains(err.Error(), gcpSecretError) {
-		logrus.Infof("%v, Will now proceed to create GCP Secret", err)
-		cert, privKey, err = createGCPSecret(client, ctx, exp, dns.Strings())
-		if err != nil {
-			logrus.WithError(err).Fatal("Unable to create ca certificate")
-		}
-	} else if err != nil {
-		logrus.WithError(err).Fatal("Unable to get GCP Secret")
-	}
-	if err = isCertValid(cert); err != nil {
-		logrus.WithError(err).Info("Certificate is not valid, will replace.")
-		cert, privKey, err = updateGCPSecret(client, ctx, exp, dns.Strings())
-		if err != nil {
-			logrus.WithError(err).Fatal("Unable to update GCP Secret")
-		}
-	} 
-	tempDir, err := ioutil.TempDir("", "cert")
+	cl, err := ctrlruntimeclient.New(kubeCfg, ctrlruntimeclient.Options{})
 	if err != nil {
-		logrus.WithError(err).Fatal("Unable to create temp directory")
+		logrus.WithError(err).Fatal("Could not create writer client")
 	}
-	defer os.RemoveAll(tempDir)
-	certFile := filepath.Join(tempDir, "certFile.pem")
-	if err := ioutil.WriteFile(certFile, []byte(cert), 0666); err != nil {
-		logrus.WithError(err).Fatal("Could not write contents of cert file")
+	var client ClientInterface
+	if o.projectId != "" {
+		secretManagerClient, err := secretmanager.NewClient(o.projectId, false)
+		if err != nil {
+			logrus.WithError(err).Fatal("Unable to create secretmanager client", err)
+		}
+		client = newGCPClient(secretManagerClient)
+		if err != nil {
+			logrus.WithError(err).Fatal("Unable to create secret manager client")
+		}
 	}
-	privKeyFile := filepath.Join(tempDir, "privKey.pem")
-	if err := ioutil.WriteFile(privKeyFile, []byte(privKey), 0666); err != nil {
-		logrus.WithError(err).Fatal("Could not write contents of privKey file")
+	if o.fileSystemPath != "" {
+		absPath, err := filepath.Abs(o.fileSystemPath)
+		if err != nil {
+			logrus.WithError(err).Fatal("Unable to generate absolute file path")
+		}
+		client = NewLocalFSClient(absPath, o.expiryInYears, o.dnsNames)
+	}
+	certFile, privKeyFile, err = handleSecrets(client, ctx, o, cl)
+	if err != nil {
+		logrus.WithError(err).Fatal("could not get necessary ca secret files", err)
 	}
 	http.HandleFunc("/validate", serveValidate)
 	logrus.Info("Listening on port 8008...")
 	logrus.Fatal(http.ListenAndServeTLS(":8008", certFile, privKeyFile, nil))
 }
 
-func getGCPSecrets(client ClientInterface, ctx context.Context, expiry int, dns flagutil.Strings) (string, string, error) {
+//get or creates the necessary ca secret files and returns the ca-cert file name, priv-key file name and tempDir name
+//for use by the http listenAndServe
+func handleSecrets(client ClientInterface, ctx context.Context, o options, cl ctrlruntimeclient.Client) (string, string, error) {
+	var cert string
+	var privKey string
+	var caPem string
 	secretsMap := make(map[string]string)
-	data, err := client.GetSecretValue(ctx, secretID, "latest")
-	if err != nil {
-		return "", "", fmt.Errorf("%s, unable to get secret value: %v", gcpSecretError, err)
-	}
-
-	err = json.Unmarshal(data, &secretsMap)
-	if err != nil {
-		return "", "", fmt.Errorf("error unmarshalling CA cert secret data: %v", err)
-	}
-
-	cert := secretsMap[caCert]
-	privKey := secretsMap[caPrivKey]
-
-	return cert, privKey, nil
-}
-
-
-func createGCPSecret(client ClientInterface, ctx context.Context, expiry int, dns []string) (string, string, error) {
-	if _, err := client.CreateSecret(ctx, secretID); err != nil {
-		return "", "", fmt.Errorf("unable to create secret %v", err)
-	}
-	serverCertPerm, serverPrivKey, err := updateGCPSecret(client, ctx, expiry, dns)
-	if err != nil {
-		return "", "", fmt.Errorf("unable to write secret value %v", err)
-	}
-	return serverCertPerm, serverPrivKey, nil
-}
-
-func updateGCPSecret(client ClientInterface, ctx context.Context, expiry int, dns[] string) (string, string, error) {
-	serverCertPerm, serverPrivKey, secretData, err := genSecretData(expiry, dns)
+	data, exist, err := client.GetSecretValue(ctx, secretID, "latest")
 	if err != nil {
 		return "", "", err
 	}
-
-	if err := client.AddSecretVersion(ctx, secretID, secretData); err != nil {
-		return "", "", fmt.Errorf("unable to add secret version %v", err)
+	if !exist {
+		logrus.WithError(err).Info("Secret does not exist, now creating")
+		cert, privKey, caPem, err = createSecret(client, ctx, o.expiryInYears, o.dnsNames)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to create ca certificate %v", err)
+		}
+		if err = createValidatingWebhookConfig(ctx, caPem, cl); err != nil {
+			return "", "", fmt.Errorf("unable to generate ValidationWebhookConfig %v", err)
+		}
+	} else {
+		err = json.Unmarshal(data, &secretsMap)
+		if err != nil {
+			return "", "", fmt.Errorf("error marshalling CA cert secret data: %v", err)
+		}
+		cert = secretsMap[certFile]
+		privKey = secretsMap[privKeyFile]
 	}
 
-	return serverCertPerm, serverPrivKey, nil
-}
+	if err := isCertValid(cert); err != nil {
+		logrus.WithError(err).Info("Certificate is not valid, will replace.")
+		cert, privKey, caPem, err = updateSecret(client, ctx, o.expiryInYears, o.dnsNames)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to update secret %v", err)
+		}
+		if err := patchValidatingWebhookConfig(ctx, caPem, cl); err != nil {
+			return "", "", fmt.Errorf("unable to generate ValidationWebhookConfig %v", err)
+		}
+	}
 
-func genSecretData(expiry int, dns []string) (string, string, []byte, error) {
-	serverCertPerm, serverPrivKey, caPem, err := genCert(expiry, dns)
+	tempDir, err := ioutil.TempDir("", "cert")
 	if err != nil {
-		return "", "", nil, fmt.Errorf("could not generate ca credentials")
+		return "", "", fmt.Errorf("unable to create temp directory %v", err)
 	}
-	caSecrets := map[string]string{
-	    caCert: serverCertPerm,
-	    caPrivKey: serverPrivKey,
-	    caBundle: caPem,
+	certFile := filepath.Join(tempDir, certFile)
+	if err := ioutil.WriteFile(certFile, []byte(cert), 0666); err != nil {
+		return "", "", fmt.Errorf("could not write contents of cert file %v", err)
 	}
-	secretData, err := json.Marshal(caSecrets)
-
-	if err != nil {
-		return "", "", nil, fmt.Errorf("error marshalling CA cert secret data: %v", err)
+	privKeyFile := filepath.Join(tempDir, privKeyFile)
+	if err := ioutil.WriteFile(privKeyFile, []byte(privKey), 0666); err != nil {
+		return "", "", fmt.Errorf("could not write contents of privKey file %v", err)
 	}
 
-	return serverCertPerm, serverPrivKey, secretData, nil
+	return certFile, privKeyFile, nil
 }

--- a/prow/cmd/webhook-server/main_test.go
+++ b/prow/cmd/webhook-server/main_test.go
@@ -14,30 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package main
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"testing"
-
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"k8s.io/test-infra/prow/flagutil"
+	"testing"
 )
 
 type secretStore struct {
 	store map[string]string
-} 
+}
 
 type fakeClient struct {
 	project secretStore
 }
 
-func (f *fakeClient) CreateSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error) {
+func (f *fakeClient) CreateSecret(ctx context.Context, secretID string) error {
 	f.project.store[secretID] = ""
-	return nil, nil
+	return nil
 }
 
 func (f *fakeClient) AddSecretVersion(ctx context.Context, secretName string, payload []byte) error {
@@ -45,62 +42,49 @@ func (f *fakeClient) AddSecretVersion(ctx context.Context, secretName string, pa
 	return nil
 }
 
-func (f *fakeClient) GetSecretValue(ctx context.Context, secretName string, versionName string) ([]byte, error) {
+func (f *fakeClient) GetSecretValue(ctx context.Context, secretName string, versionName string) ([]byte, bool, error) {
 	if len(f.project.store) == 0 {
-		return nil, errors.New("Secret was not created!")
+		return nil, false, errors.New("Secret was not created!")
 	} else {
 		if val, ok := f.project.store[secretName]; ok {
-			return []byte(val), nil
+			return []byte(val), true, nil
 		} else {
 			err := fmt.Sprintf("Secret with name %s was never added", secretName)
-			return nil, errors.New(err)
+			return nil, false, errors.New(err)
 		}
 	}
 }
 
-func TestCreateGCPSecrets(t * testing.T) {
+func (f *fakeClient) CheckSecret(ctx context.Context, secretName string) (bool, error) {
+	if len(f.project.store) == 0 {
+		return false, errors.New("Secret was not created!")
+	} else {
+		if _, ok := f.project.store[secretName]; ok {
+			return true, nil
+		} else {
+			err := fmt.Sprintf("Secret with name %s was never added", secretName)
+			return false, errors.New(err)
+		}
+	}
+}
+
+func TestCreateSecrets(t *testing.T) {
 	dns := flagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
 	store := make(map[string]string)
 	ctx := context.Background()
-	f := &fakeClient {
+	f := &fakeClient{
 		project: secretStore{
 			store: store,
 		},
 	}
-	cert, key, err := createGCPSecret(f, ctx, 30, dns.Strings())
+	cert, key, caPem, err := createSecret(f, ctx, 30, dns.Strings())
 	if err != nil {
 		t.Errorf("Unable to create GCP Secrets %v", err)
 	}
-	if len(cert) == 0 || len(key) == 0 {
+	if len(cert) == 0 || len(key) == 0 || len(caPem) == 0 {
 		t.Errorf("Issue generating ca certificate")
 	}
 	if len(store) == 0 {
 		t.Errorf("Error populating store")
 	}
 }
-
-func TestGetGCPSecrets(t *testing.T) {
-	dns := flagutil.NewStrings("validation-webhook-service", "validation-webhook-service.default", "validation-webhook-service.default.svc")
-	ctx := context.Background()
-	store := make(map[string]string)
-	f := &fakeClient {
-		project: secretStore{
-			store: store,
-		},
-	}
-	origCert, origKey, err := createGCPSecret(f, ctx, 30, dns.Strings())
-	if err != nil {
-		t.Errorf("Unable to create GCP Secrets %v", err)
-	}
-	cert, key, err := getGCPSecrets(f, ctx,  30, dns)
-	if err != nil {
-		t.Errorf("Unable to get GCP Secrets %v", err)
-	}
-	if (origCert != cert || origKey != key) {
-		t.Errorf("Error getting certificate and key")
-	}
-	if len(cert) == 0 || len(key) == 0 {
-		t.Errorf("Error creating certificate and key")
-	}
-}
-


### PR DESCRIPTION
In the case of the project ID for secrets manager not being specified, the webhook server will make use of the filesystem to store ca-cert secrets. I also included implementation of creating and patching the validating webhook configuration