### PR TITLE
Enable in-tree gcepd driver for e2e tests

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -115,3 +115,119 @@ periodics:
           echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
         fi;
         kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+- interval: 3h
+  cluster: k8s-infra-prow-build
+  name: ci-cloud-provider-gcp-conformance-latest-with-gcepd
+  decorate: true
+  decoration_config:
+    timeout: 150m
+  annotations:
+    testgrid-tab-name: Conformance - Cloud Provider GCP with GCE-PD - master
+    testgrid-dashboards: provider-gcp-periodics
+    description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
+  labels:
+    preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-gcp
+    base_ref: master
+    path_alias: k8s.io/cloud-provider-gcp
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      resources:
+        limits:
+          cpu: 4
+          memory: 14Gi
+        requests:
+          cpu: 4
+          memory: 14Gi
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      command:
+      - runner.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      # TODO: Use published release tars for cloud-provider-gcp if/once they exist
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
+        cd;
+        export GO111MODULE=on;
+        export BAZEL_VERSION=5.3.0;
+        /workspace/test-infra/images/kubekins-e2e/install-bazel.sh;
+        go install sigs.k8s.io/kubetest2@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+          export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env");
+          echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}";
+        else
+          export TEST_PACKAGE_VERSION="v1.25.0";
+          echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
+        fi;
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size n1-standard-2  -- --test-package-version="${TEST_PACKAGE_VERSION}" --focus-regex='\[Conformance\]' --test-args=--enabled-volume-drivers=gcepd
+- interval: 24h
+  cluster: k8s-infra-prow-build
+  name: ci-cloud-provider-gcp-e2e-latest-with-gcepd
+  decorate: true
+  decoration_config:
+    timeout: 80m
+  annotations:
+    testgrid-tab-name: E2E Full - Cloud Provider GCP with GCE-PD - master
+    testgrid-dashboards: provider-gcp-periodics
+    description: Runs e2e-full tests using kubetest2 against cloud-provider-gcp master on GCE
+  labels:
+    preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-gcp
+    base_ref: master
+    path_alias: k8s.io/cloud-provider-gcp
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      resources:
+        limits:
+          cpu: 4
+          memory: 14Gi
+        requests:
+          cpu: 4
+          memory: 14Gi
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      command:
+      - runner.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      # TODO: Use published release tars for cloud-provider-gcp if/once they exist
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
+        cd;
+        export GO111MODULE=on;
+        export BAZEL_VERSION=5.3.0;
+        /workspace/test-infra/images/kubekins-e2e/install-bazel.sh;
+        go install sigs.k8s.io/kubetest2@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+          export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env");
+          echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}";
+        else
+          export TEST_PACKAGE_VERSION="v1.25.0";
+          echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
+        fi;
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3 --enabled-volume-drivers=gcepd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/109541. Since cloud-provider-gcp installs the pd csi driver, it's safe to enable this now.

Tested manually, the best I could and it seemed to pass.

/assign @leiyiz 