### PR TITLE
Add another timeout for another kubectl delete command

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -804,7 +804,9 @@ function dump_nodes_with_logexporter() {
 
   # Delete the logexporter resources and dump logs for the failed nodes (if any) through SSH.
   kubectl get pods --namespace "${logexporter_namespace}" || true
-  kubectl delete namespace "${logexporter_namespace}" || true
+  # Timeout prevents the test waiting too long to delete resources and
+  # never uploading logs, as happened in https://github.com/kubernetes/kubernetes/issues/111111
+  kubectl delete namespace "${logexporter_namespace}" --timeout 15m || true
   if [[ "${#failed_nodes[@]}" != 0 ]]; then
     echo -e "Dumping logs through SSH for the following nodes:\n${failed_nodes[*]}"
     dump_nodes "${failed_nodes[@]}"


### PR DESCRIPTION
Turns out we run this command in two places, depending on whether logexporter succeeds on all nodes. Follow-up to #26787. 