### PR TITLE
[DigitalOcean] Add kops e2e test for in FQDN mode

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -137,3 +137,4 @@ periodics:
     testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
     testgrid-tab-name: e2e-kops-do-calico-fqdn
+    

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -24,7 +24,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, kops-presubmits
     testgrid-tab-name: kops-build
     testgrid-alert-email: release-team@kubernetes.io
-- name: e2e-kops-do-calico
+- name: e2e-kops-do-calico-gossip
   cron: '54 4-23/8 * * *'
   labels:
     preset-service-account: "true"
@@ -79,4 +79,61 @@ periodics:
     test.kops.k8s.io/networking: 'calico'
     testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
-    testgrid-tab-name: e2e-kops-do-calico
+    testgrid-tab-name: e2e-kops-do-calico-gossip
+- name: e2e-kops-do-calico-fqdn
+  cron: '54 2-20/8 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-do-credential: "true"
+    preset-do-spaces-credential: "true"
+    preset-do-ssh: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-experimental
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+          make test-e2e-install
+          kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=digitalocean \
+          --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+          --create-args "--networking=calico --node-count=3 --master-count=3" \
+          --cluster-name=e2e-b284d3e83b-4c997.test-cncf-do.k8s.io \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-package-marker=stable.txt \
+          --parallel 15 \
+      resources:
+        limits:
+          memory: "3Gi"
+        requests:
+          cpu: "2"
+          memory: "3Gi"
+  annotations:
+    test.kops.k8s.io/cloud: digitalocean
+    test.kops.k8s.io/k8s_version: 'stable'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: 'calico'
+    testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: e2e-kops-do-calico-fqdn

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -137,4 +137,3 @@ periodics:
     testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
     testgrid-tab-name: e2e-kops-do-calico-fqdn
-    


### PR DESCRIPTION
Adding another e2e test that covers kops cluster lifecycle for Digital Ocean cloud provider that uses a non-gossip mode. We already have an e2e test for gossip mode here - https://testgrid.k8s.io/google-aws#e2e-kops-do-calico

FYI - @rifelpet @timoreimann 