### PR TITLE
Fix deck image build flakiness unique intermittent filename

### DIFF
--- a/hack/ts-rollup/main.go
+++ b/hack/ts-rollup/main.go
@@ -135,7 +135,7 @@ func rollupOne(pi *packageInfo, cleanupOnly bool) error {
 	// Intermediate output files, stored under `_output` dir
 	jsOutputFile := path.Join(defaultOutputDir, pi.Dir, entrypointFileBasename+".js")
 	bundleOutputDir := path.Join(defaultOutputDir, pi.Dir)
-	rollupOutputFile := path.Join(bundleOutputDir, "bundle.js")
+	rollupOutputFile := path.Join(bundleOutputDir, fmt.Sprintf("%s_bundle.js", entrypointFileBasename))
 	// terserOutputFile is the minified bundle, which is placed next to all
 	// other static files in the source tree
 	terserOutputFile := path.Join(pi.Dir, pi.Dst)


### PR DESCRIPTION
Fixes: #26345

The problem is that the intermittent rollup output file name is based off of the original directory name, for example for `prow/cmd/deck/static/spyglass/spyglass.ts`, the intermittent file path is `_output/js/prow/cmd/deck/static/spyglass/bundle.js`, this works only when there is only a single bundle expected from each directory, this is not necessarily true all the time, for example there is also a `prow/cmd/deck/static/spyglass/lens.ts`. And since these happen concurrently, the output could be wrong when race condition is hit, which totally explains why the deck image failed once per month

See https://github.com/kubernetes/test-infra/issues/26345#issuecomment-1192963472 for a bit more info.

/cc @cjwagner @alvaroaleman 