### PR TITLE
capz: add v1beta1 presubmit workload-upgrade test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -422,6 +422,8 @@ presubmits:
     decorate: true
     optional: true
     always_run: false
+    decoration_config:
+      timeout: 4h
     branches:
     - ^main$
     path_alias: sigs.k8s.io/cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -372,3 +372,40 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-k8s-ci-v1beta1
+  - name: pull-cluster-api-provider-azure-e2e-workload-upgrade-v1beta1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    branches:
+    - ^release-1.*
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-1.25
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: capz-pr-e2e-upgrade-v1beta1


### PR DESCRIPTION
This PR adds a presubmit workload-upgrade test equivalent to the existing `pull-cluster-api-provider-azure-e2e-workload-upgrade` test.

This allows us to run such tests against the active v1beta1 release branch prior to merging changes.

Also set an appropriate timeout to the existing presubmit test against main.