### PR TITLE
chore: move chewong to emeritus_approvers

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/OWNERS
@@ -3,10 +3,10 @@
 reviewers:
 - andyzhangx
 - feiskyer
-- chewong
 approvers:
 - andyzhangx
 - feiskyer
+emeritus_approvers:
 - chewong
 
 labels:

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/OWNERS
@@ -3,10 +3,10 @@
 reviewers:
 - andyzhangx
 - feiskyer
-- chewong
 approvers:
 - andyzhangx
 - feiskyer
+emeritus_approvers:
 - chewong
 
 labels:

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/OWNERS
@@ -3,10 +3,10 @@
 reviewers:
 - andyzhangx
 - feiskyer
-- chewong
 approvers:
 - andyzhangx
 - feiskyer
+emeritus_approvers:
 - chewong
 
 labels:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
 - andyzhangx
 - brendandburns
-- chewong
 - feiskyer
 - karataliu
 - khenidak
@@ -14,13 +13,15 @@ reviewers:
 approvers:
 - andyzhangx
 - brendandburns
-- chewong
 - feiskyer
 - karataliu
 - khenidak
 - lzhecheng
 - MartinForReal
 - nilo19
+
+emeritus_approvers:
+- chewong
 
 labels:
 - area/provider/azure

--- a/config/jobs/kubernetes-sigs/sig-windows/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-windows/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
 - adelina-t
 - andyzhangx
-- chewong
 - claudiubelu
 - ddebroy
 - feiskyer
@@ -14,13 +13,14 @@ approvers:
 - adelina-t
 - andyzhangx
 - benmoss
-- chewong
 - claudiubelu
 - ddebroy
 - feiskyer
 - jayunit100
 - jsturtevant
 - marosset
+emeritus_approvers:
+- chewong
 
 labels:
 - sig/windows

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -4,17 +4,17 @@ reviewers:
 - andyzhangx
 - brendandburns
 - CecileRobertMichon
-- chewong
 - feiskyer
 - karataliu
 - khenidak
 approvers:
 - andyzhangx
 - brendandburns
-- chewong
 - feiskyer
 - karataliu
 - khenidak
+emeritus_approvers:
+- chewong
 
 labels:
 - area/provider/azure

--- a/config/jobs/kubernetes/sig-windows/OWNERS
+++ b/config/jobs/kubernetes/sig-windows/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-- chewong
 - ddebroy
 - ibabou
 - jayunit100
@@ -7,13 +6,14 @@ reviewers:
 - marosset
 - pjh
 approvers:
-- chewong
 - ddebroy
 - ibabou
 - jayunit100
 - jsturtevant
 - marosset
 - pjh
+emeritus_approvers:
+- chewong
 
 labels:
 - sig/windows

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -4,17 +4,17 @@ reviewers:
 - andyzhangx
 - brendandburns
 - CecileRobertMichon
-- chewong
 - feiskyer
 - karataliu
 - khenidak
 approvers:
 - andyzhangx
 - brendandburns
-- chewong
 - feiskyer
 - karataliu
 - khenidak
+emeritus_approvers:
+- chewong
 
 labels:
 - area/provider/azure

--- a/config/testgrids/kubernetes/sig-windows/OWNERS
+++ b/config/testgrids/kubernetes/sig-windows/OWNERS
@@ -1,13 +1,11 @@
 reviewers:
 - adelina-t
-- chewong
 - claudiubelu
-- jsturtevant 
+- jsturtevant
 - marosset
 - pjh
 approvers:
 - adelina-t
-- chewong
 - claudiubelu
 - jsturtevant
 - marosset
@@ -15,6 +13,7 @@ approvers:
 
 emeritus_approvers:
 - benmoss
+- chewong
 - ddebroy
 - jeremyje
 - michmike


### PR DESCRIPTION
Moving myself to `emeritus_approvers` in various `OWNERS` files as per [kubernetes/community@master/contributors/guide/owners.md#emeritus](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md?rgh-link-date=2022-07-25T23%3A47%3A49Z#emeritus) guidance.