### PR TITLE
prow: Add support for closing issues as Not Planned

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -114,6 +114,7 @@ type IssueClient interface {
 	AssignIssue(org, repo string, number int, logins []string) error
 	UnassignIssue(org, repo string, number int, logins []string) error
 	CloseIssue(org, repo string, number int) error
+	CloseIssueAsNotPlanned(org, repo string, number int) error
 	ReopenIssue(org, repo string, number int) error
 	FindIssues(query, sort string, asc bool) ([]Issue, error)
 	FindIssuesWithOrg(org, query, sort string, asc bool) ([]Issue, error)
@@ -3233,19 +3234,38 @@ func (c *client) UnrequestReview(org, repo string, number int, logins []string) 
 }
 
 // CloseIssue closes the existing, open issue provided
+// CloseIssue also closes the issue with the reason being
+// "completed" - default value for the state_reason attribute.
 //
 // See https://developer.github.com/v3/issues/#edit-an-issue
 func (c *client) CloseIssue(org, repo string, number int) error {
 	durationLogger := c.log("CloseIssue", org, repo, number)
 	defer durationLogger()
 
+	return c.closeIssue(org, repo, number, "completed")
+}
+
+// CloseIssueAsNotPlanned closes the existing, open issue provided
+// CloseIssueAsNotPlanned also closes the issue with the reason being
+// "not_planned" - value passed for the state_reason attribute.
+//
+// See https://developer.github.com/v3/issues/#edit-an-issue
+func (c *client) CloseIssueAsNotPlanned(org, repo string, number int) error {
+	durationLogger := c.log("CloseIssueAsNotPlanned", org, repo, number)
+	defer durationLogger()
+
+	return c.closeIssue(org, repo, number, "not_planned")
+}
+
+func (c *client) closeIssue(org, repo string, number int, reason string) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, number),
 		org:         org,
-		requestBody: map[string]string{"state": "closed"},
+		requestBody: map[string]string{"state": "closed", "state_reason": reason},
 		exitCodes:   []int{200},
 	}, nil)
+
 	return err
 }
 

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -453,6 +453,22 @@ func (f *FakeClient) CloseIssue(org, repo string, number int) error {
 	}
 
 	f.Issues[number].State = "closed"
+	f.Issues[number].StateReason = "completed"
+
+	return nil
+}
+
+func (f *FakeClient) CloseIssueAsNotPlanned(org, repo string, number int) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if _, ok := f.Issues[number]; !ok {
+		return fmt.Errorf("issue number %d does not exist", number)
+	}
+
+	f.Issues[number].State = "closed"
+	f.Issues[number].StateReason = "not_planned"
+
 	return nil
 }
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -756,19 +756,20 @@ type IssueCommentEvent struct {
 
 // Issue represents general info about an issue.
 type Issue struct {
-	ID        int       `json:"id"`
-	NodeID    string    `json:"node_id"`
-	User      User      `json:"user"`
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	State     string    `json:"state"`
-	HTMLURL   string    `json:"html_url"`
-	Labels    []Label   `json:"labels"`
-	Assignees []User    `json:"assignees"`
-	Body      string    `json:"body"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	Milestone Milestone `json:"milestone"`
+	ID          int       `json:"id"`
+	NodeID      string    `json:"node_id"`
+	User        User      `json:"user"`
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	State       string    `json:"state"`
+	HTMLURL     string    `json:"html_url"`
+	Labels      []Label   `json:"labels"`
+	Assignees   []User    `json:"assignees"`
+	Body        string    `json:"body"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Milestone   Milestone `json:"milestone"`
+	StateReason string    `json:"state_reason"`
 
 	// This will be non-nil if it is a pull request.
 	PullRequest *struct{} `json:"pull_request,omitempty"`

--- a/prow/plugins/lifecycle/close.go
+++ b/prow/plugins/lifecycle/close.go
@@ -26,12 +26,16 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
-var closeRe = regexp.MustCompile(`(?mi)^/close\s*$`)
+var (
+	closeRe           = regexp.MustCompile(`(?mi)^/close\s*$`)
+	closeNotPlannedRe = regexp.MustCompile(`(?mi)^/close not-planned\s*$`)
+)
 
 type closeClient interface {
 	IsCollaborator(owner, repo, login string) (bool, error)
 	CreateComment(owner, repo string, number int, comment string) error
 	CloseIssue(owner, repo string, number int) error
+	CloseIssueAsNotPlanned(org, repo string, number int) error
 	ClosePR(owner, repo string, number int) error
 	GetIssueLabels(owner, repo string, number int) ([]github.Label, error)
 }
@@ -55,7 +59,7 @@ func handleClose(gc closeClient, log *logrus.Entry, e *github.GenericCommentEven
 		return nil
 	}
 
-	if !closeRe.MatchString(e.Body) {
+	if !closeRe.MatchString(e.Body) && !closeNotPlannedRe.MatchString(e.Body) {
 		return nil
 	}
 
@@ -101,9 +105,19 @@ func handleClose(gc closeClient, log *logrus.Entry, e *github.GenericCommentEven
 	}
 
 	log.Info("Closing issue.")
-	if err := gc.CloseIssue(org, repo, number); err != nil {
-		return fmt.Errorf("Error closing issue: %w", err)
+	var reply string
+	if closeNotPlannedRe.MatchString(e.Body) {
+		if err := gc.CloseIssueAsNotPlanned(org, repo, number); err != nil {
+			return fmt.Errorf("Error closing issue as \"Not Planned\": %w", err)
+		}
+		reply = "Closing this issue, marking it as \"Not Planned\"."
+	} else {
+		if err := gc.CloseIssue(org, repo, number); err != nil {
+			return fmt.Errorf("Error closing issue: %w", err)
+		}
+		reply = "Closing this issue."
 	}
-	response := plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, "Closing this issue.")
+
+	response := plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, reply)
 	return gc.CreateComment(org, repo, number, response)
 }

--- a/prow/plugins/lifecycle/close_test.go
+++ b/prow/plugins/lifecycle/close_test.go
@@ -28,6 +28,7 @@ import (
 type fakeClientClose struct {
 	commented      bool
 	closed         bool
+	stateReason    string
 	AssigneesAdded []string
 	labels         []string
 }
@@ -39,6 +40,13 @@ func (c *fakeClientClose) CreateComment(owner, repo string, number int, comment 
 
 func (c *fakeClientClose) CloseIssue(owner, repo string, number int) error {
 	c.closed = true
+	c.stateReason = "completed"
+	return nil
+}
+
+func (c *fakeClientClose) CloseIssueAsNotPlanned(org, repo string, number int) error {
+	c.closed = true
+	c.stateReason = "not_planned"
 	return nil
 }
 
@@ -70,6 +78,7 @@ func TestCloseComment(t *testing.T) {
 		name          string
 		action        github.GenericCommentEventAction
 		state         string
+		stateReason   string
 		body          string
 		commenter     string
 		labels        []string
@@ -89,6 +98,7 @@ func TestCloseComment(t *testing.T) {
 			name:          "close by author",
 			action:        github.GenericCommentActionCreated,
 			state:         "open",
+			stateReason:   "completed",
 			body:          "/close",
 			commenter:     "author",
 			shouldClose:   true,
@@ -98,6 +108,7 @@ func TestCloseComment(t *testing.T) {
 			name:          "close by author, trailing space.",
 			action:        github.GenericCommentActionCreated,
 			state:         "open",
+			stateReason:   "completed",
 			body:          "/close \r",
 			commenter:     "author",
 			shouldClose:   true,
@@ -107,6 +118,7 @@ func TestCloseComment(t *testing.T) {
 			name:          "close by collaborator",
 			action:        github.GenericCommentActionCreated,
 			state:         "open",
+			stateReason:   "completed",
 			body:          "/close",
 			commenter:     "collaborator",
 			shouldClose:   true,
@@ -143,6 +155,7 @@ func TestCloseComment(t *testing.T) {
 			name:          "close by non-collaborator on stale issue",
 			action:        github.GenericCommentActionCreated,
 			state:         "open",
+			stateReason:   "completed",
 			body:          "/close",
 			commenter:     "non-collaborator",
 			labels:        []string{"lifecycle/stale"},
@@ -153,6 +166,7 @@ func TestCloseComment(t *testing.T) {
 			name:          "close by non-collaborator on rotten issue",
 			action:        github.GenericCommentActionCreated,
 			state:         "open",
+			stateReason:   "completed",
 			body:          "/close",
 			commenter:     "non-collaborator",
 			labels:        []string{"lifecycle/rotten"},
@@ -164,6 +178,77 @@ func TestCloseComment(t *testing.T) {
 			action:        github.GenericCommentActionCreated,
 			state:         "open",
 			body:          "/close",
+			commenter:     "non-collaborator",
+			labels:        []string{"error"},
+			shouldClose:   false,
+			shouldComment: true,
+		},
+		{
+			name:          "close by author as not planned",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			stateReason:   "not_planned",
+			body:          "/close not-planned",
+			commenter:     "author",
+			shouldClose:   true,
+			shouldComment: true,
+		},
+		{
+			name:          "close by author as not planned, trailing space.",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			stateReason:   "not_planned",
+			body:          "/close not-planned \r",
+			commenter:     "author",
+			shouldClose:   true,
+			shouldComment: true,
+		},
+		{
+			name:          "close by author, multiple spaces in between.",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			stateReason:   "not_planned",
+			body:          "/close not-planned",
+			commenter:     "author",
+			shouldClose:   true,
+			shouldComment: true,
+		},
+		{
+			name:          "close as not planned by non-collaborator on active issue, cannot close",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			body:          "/close not-planned",
+			commenter:     "non-collaborator",
+			shouldClose:   false,
+			shouldComment: true,
+		},
+		{
+			name:          "close as not planned by non-collaborator on stale issue",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			stateReason:   "not_planned",
+			body:          "/close not-planned",
+			commenter:     "non-collaborator",
+			labels:        []string{"lifecycle/stale"},
+			shouldClose:   true,
+			shouldComment: true,
+		},
+		{
+			name:          "close as not planned by non-collaborator on rotten issue",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			stateReason:   "not_planned",
+			body:          "/close not-planned",
+			commenter:     "non-collaborator",
+			labels:        []string{"lifecycle/rotten"},
+			shouldClose:   true,
+			shouldComment: true,
+		},
+		{
+			name:          "cannot close stale issue as not planned by non-collaborator when list issue fails",
+			action:        github.GenericCommentActionCreated,
+			state:         "open",
+			body:          "/close not-planned",
 			commenter:     "non-collaborator",
 			labels:        []string{"error"},
 			shouldClose:   false,
@@ -193,6 +278,9 @@ func TestCloseComment(t *testing.T) {
 			t.Errorf("For case %s, should have commented but didn't.", tc.name)
 		} else if !tc.shouldComment && fc.commented {
 			t.Errorf("For case %s, should not have commented but did.", tc.name)
+		}
+		if fc.stateReason != tc.stateReason {
+			t.Errorf("For case %s, unexpected state_reason value, expected %s, but got %s", tc.name, tc.stateReason, fc.stateReason)
 		}
 	}
 }

--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -43,11 +43,11 @@ func help(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.Plugin
 		Description: "Close, reopen, flag and/or unflag an issue or PR as frozen/stale/rotten",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/close",
+		Usage:       "/close [not-planned]",
 		Description: "Closes an issue or PR.",
 		Featured:    false,
 		WhoCanUse:   "Authors and collaborators on the repository can trigger this command.",
-		Examples:    []string{"/close"},
+		Examples:    []string{"/close", "/close not-planned"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/reopen",


### PR DESCRIPTION
This commit adds support for closing issues as Not Planned
by utilising the new `state_reason` attribute of the GH API.
The default value of this attribute, if not set, is `completed`
which is the current behaviour.

Changes to the github client:
* The `IssueClient` interface is modified to include a method
  called `CloseIssueAsNotPlanned` which sets the `state_reason`
  attribute to `not_planned`
* The Issue type is also modified to now have the `StateReason`
  field.
* Subsequent changes to the fake client are made to set the
  `StateReason` field to `completed` or `not_planned` depending
  on the method invoked.

Changes to lifecycle plugin:
* The `/close` command is extended to be used as `/close not-planned`
  if an issue is to be closed as Not Planned.

Ref #26380 

---

/assign @nikhita @cblecker 
/cc @mrbobbytables @jberkus