### PR TITLE
`label_sync`: validate gh options in order to populate throttle by org

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -777,7 +777,10 @@ func main() {
 		if deprecated {
 			githubClient, err = newClient(o.token, o.tokens, o.tokenBurst, !o.confirm, o.graphqlEndpoint, o.endpoint.Strings()...)
 		} else {
-			githubClient, err = o.github.GitHubClient(!o.confirm)
+			err = o.github.Validate(!o.confirm)
+			if err == nil {
+				githubClient, err = o.github.GitHubClient(!o.confirm)
+			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
While attempting to configure OpenShift's label_sync job for throttling by org I noticed that the `--github-throttle-org` params weren't being honored. I discovered this was due to not calling `github.Validate` which doesn't just contain validation code, but also has side effects like setting `parsedOrgThrottlers`.

It seems that we only need this when not using the `deprecated` client, so I only added it there.