### PR TITLE
Fix rerun with original bug.

### DIFF
--- a/prow/cmd/deck/static/common/rerun.ts
+++ b/prow/cmd/deck/static/common/rerun.ts
@@ -25,7 +25,7 @@ export function createRerunProwJobIcon(modal: HTMLElement, parentEl: HTMLElement
   const getJobURL = (mode: string): string => {
     return `${location.protocol}//${location.host}/rerun?mode=${mode}&prowjob=${prowjob}`;
   };
-  let commandURL = getJobURL(LATEST_JOB);
+  let commandURL = getJobURL(ORIGINAL_JOB);
   const getCommandDescription = (mode: string): string => {
     return `The command is for the ${mode} configuration. Admin permissions are required to rerun via kubectl.`;
   };


### PR DESCRIPTION
This PR fixes a bug where rerunning a job using the original configuration will rerun with the latest configuration if the user does not click anything on the modal.

/cc @chaodaiG 