### PR TITLE
pin kubekins-e2e image to v1.24 for secrets-store-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -12,7 +12,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -37,7 +37,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -90,7 +90,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
           command:
             - runner.sh
           args:
@@ -129,7 +129,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -162,7 +162,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -199,7 +199,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -242,7 +242,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
           - kubetest
@@ -293,7 +293,7 @@ presubmits:
     spec:
       serviceAccountName: secrets-store-csi-driver-gcp
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -331,7 +331,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -362,7 +362,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -395,7 +395,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -435,7 +435,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -475,7 +475,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -516,7 +516,7 @@ presubmits:
       preset-akeyless-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -557,7 +557,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -597,7 +597,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -638,7 +638,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -678,7 +678,7 @@ presubmits:
     spec:
       serviceAccountName: secrets-store-csi-driver-gcp
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -718,7 +718,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -758,7 +758,7 @@ postsubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -797,7 +797,7 @@ postsubmits:
     spec:
       serviceAccountName: secrets-store-csi-driver-gcp
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -838,7 +838,7 @@ postsubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -877,7 +877,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -913,7 +913,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:
@@ -947,7 +947,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.1-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.1-config.yaml
@@ -18,7 +18,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.2-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.2-config.yaml
@@ -18,7 +18,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
         args:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

The go version for `-master` image has been bumped to `go version go1.19rc2 linux/amd64` which causes lint failures. Pinning the kubekins-e2e image to `-1.24` as we are using go1.18.

/assign @tam7t 