### PR TITLE
Inrepoconfig cache client supports concurrently processing multiple r…

### DIFF
--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -94,10 +94,11 @@ func TestFlags(t *testing.T) {
 					ConfigPath:                            "yo",
 					SupplementalProwConfigsFileNameSuffix: "_prowconfig.yaml",
 				},
-				dryRun:                 false,
-				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
-				inRepoConfigCacheSize:  100,
-				changeWorkerPoolSize:   1,
+				dryRun:                  false,
+				instrumentationOptions:  flagutil.DefaultInstrumentationOptions(),
+				inRepoConfigCacheSize:   100,
+				inRepoConfigCacheCopies: 1,
+				changeWorkerPoolSize:    1,
 			}
 			expected.projects.Set("foo=bar,baz")
 			expected.projectsOptOutHelp.Set("foo=bar")

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -45,11 +45,12 @@ var (
 )
 
 type options struct {
-	client                flagutil.KubernetesOptions
-	github                flagutil.GitHubOptions
-	port                  int
-	inRepoConfigCacheSize int
-	cookiefilePath        string
+	client                  flagutil.KubernetesOptions
+	github                  flagutil.GitHubOptions
+	port                    int
+	inRepoConfigCacheSize   int
+	inRepoConfigCacheCopies int
+	cookiefilePath          string
 
 	config configflagutil.ConfigOptions
 
@@ -79,6 +80,7 @@ func init() {
 	fs.BoolVar(&flagOptions.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	fs.DurationVar(&flagOptions.gracePeriod, "grace-period", 180*time.Second, "On shutdown, try to handle remaining events for the specified duration. ")
 	fs.IntVar(&flagOptions.inRepoConfigCacheSize, "in-repo-config-cache-size", 1000, "Cache size for ProwYAMLs read from in-repo configs.")
+	fs.IntVar(&flagOptions.inRepoConfigCacheCopies, "in-repo-config-cache-copies", 1, "Copy of caches for ProwYAMLs read from in-repo configs.")
 	fs.StringVar(&flagOptions.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile, leave empty for github or anonymous")
 	flagOptions.config.AddFlags(fs)
 	flagOptions.client.AddFlags(fs)
@@ -124,6 +126,7 @@ func main() {
 
 	cacheGetter := subscriber.InRepoConfigCacheGetter{
 		CacheSize:     flagOptions.inRepoConfigCacheSize,
+		CacheCopies:   flagOptions.inRepoConfigCacheCopies,
 		Agent:         configAgent,
 		GitHubOptions: flagOptions.github,
 		DryRun:        flagOptions.dryRun,

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -484,7 +484,7 @@ func TestFailedJobs(t *testing.T) {
 	}
 }
 
-func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCache, error) {
+func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCacheHandler, error) {
 	// processChange takes a ClientFactory. If provided a nil clientFactory it will skip inRepoConfig
 	// otherwise it will get the prow yaml using the client provided. We are mocking ProwYamlGetter
 	// so we are creating a localClientFactory but leaving it unpopulated.
@@ -505,10 +505,11 @@ func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCache, erro
 
 	// Initialize cache for fetching Presubmit and Postsubmit information. If
 	// the cache cannot be initialized, exit with an error.
-	cache, err := config.NewInRepoConfigCache(
+	cache, err := config.NewInRepoConfigCacheHandler(
 		10,
 		ca,
-		config.NewInRepoConfigGitCache(cf))
+		config.NewInRepoConfigGitCache(cf),
+		1)
 	if err != nil {
 		t.Errorf("error creating cache: %v", err)
 	}
@@ -1359,7 +1360,7 @@ func TestProcessChange(t *testing.T) {
 				prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
 				gc:            &gc,
 				tracker:       &fakeSync{val: fakeLastSync},
-				repoCacheMap:  map[string]*config.InRepoConfigCache{},
+				repoCacheMap:  map[string]*config.InRepoConfigCacheHandler{},
 			}
 			cloneURI, err := makeCloneURI(tc.instance, tc.change.Project)
 			if err != nil {

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -308,6 +308,7 @@ func TestHandleMessage(t *testing.T) {
 				Reporter:      &fr,
 				InRepoConfigCacheGetter: &InRepoConfigCacheGetter{
 					CacheSize:     100,
+					CacheCopies:   1,
 					Agent:         ca,
 					GitHubOptions: flagutil.GitHubOptions{},
 					DryRun:        true,


### PR DESCRIPTION
…equests

Inrepoconfig cache is meant to boost the performance of inrepoconfig processing, by:
- read from memory when there is a cache hit
- reuse already cloned and fetch repo to avoid repeated cloning large repos

This works well when the first one is hit, and the second one is not hit heavily. Otherwise the cache client will become process inrepoconfig request serially, and result in high latency.