### PR TITLE
chore: do not use master image for capa jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -58,7 +58,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
       command:
         - "runner.sh"
         - "./scripts/ci-e2e-eks.sh"
@@ -96,7 +96,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -146,7 +146,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"
@@ -189,7 +189,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
           - runner.sh
           - bash

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -57,7 +57,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
             command:
               - "runner.sh"
               - "./scripts/ci-e2e-eks.sh"
@@ -97,7 +97,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
             command:
               - "runner.sh"
               - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -31,7 +31,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-apidiff-main
@@ -42,7 +42,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -58,7 +58,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
         command:
         - "runner.sh"
         - "make"
@@ -100,7 +100,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -142,7 +142,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -183,7 +183,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -226,7 +226,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -264,7 +264,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-1.24
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"


### PR DESCRIPTION
Change the CAPA jobs so that that they aren't using a `-master` kubekins
image and instead they use a specific version (i.e. `1.24`).

We where encountering issues with using the `-master` image as it uses a
RC version of go 1.19 which then causes problems with out linter.

Signed-off-by: Richard Case <richard.case@outlook.com>