### PR TITLE
verify-govet-levee: revert test image bump to use go1.18.3

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220726-61b7bafca6-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220722-16ae0286c2-master
         imagePullPolicy: IfNotPresent
         command:
         - make


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/111452

This PR reverts the test image bump to go back to using go1.18.3. Using the go1.19rc2 image leads to test failures which is now blocking master.

See https://github.com/kubernetes/test-infra/commit/8b92c5c79a4c62d3b700a1180acd727cf18f8207#diff-d1fbb791428748a3ac059cce6d068e946557499654010d24494baf1a24bc2b05 for the details of the revert.

https://github.com/kubernetes/test-infra/pull/26932 avoids autobumping the job until the Go team fixes the core issue.

cc @MadhavJivrajani @dims @palnabarun 