### PR TITLE
Don't autobump govet-levee test image

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -12,6 +12,9 @@ headBranchName: "prowjobs-autobump"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 includedConfigPaths:
   - "config/jobs"
+# TODO: don't exclude govet-levee once issue.k8s.io/111452 has been fixed
+excludedConfigPaths:
+  - "config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml"
 extraFiles:
   - "config/jobs/image-pushing/k8s-staging-e2e-test-images.sh"
   - "config/jobs/image-pushing/k8s-staging-sig-storage.sh"


### PR DESCRIPTION
govet-levee with go1.19rc2 causes a lot of failures due to https://github.com/kubernetes/kubernetes/issues/111452. 

https://github.com/kubernetes/test-infra/pull/26931 reverts the test image bump for the job, and this PR ensures that the job stays at go1.18 until the core issue is fixed by the Go team.

cc @MadhavJivrajani @dims @palnabarun 