### PR TITLE
Tide configuration divided into shared vs. GitHub specific

### DIFF
--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -741,9 +741,11 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "no conflict: no strict config",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Orgs: []string{"kubernetes"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Orgs: []string{"kubernetes"},
+							},
 						},
 					},
 				},
@@ -774,10 +776,12 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "no conflict: tide repo exclusion",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Orgs:          []string{"kubernetes"},
-							ExcludedRepos: []string{"kubernetes/test-infra"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Orgs:          []string{"kubernetes"},
+								ExcludedRepos: []string{"kubernetes/test-infra"},
+							},
 						},
 					},
 				},
@@ -808,9 +812,11 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "no conflict: protection repo exclusion",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Repos: []string{"kubernetes/test-infra"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Repos: []string{"kubernetes/test-infra"},
+							},
 						},
 					},
 				},
@@ -841,9 +847,11 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "conflict: tide more general",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Orgs: []string{"kubernetes"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Orgs: []string{"kubernetes"},
+							},
 						},
 					},
 				},
@@ -874,9 +882,11 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "conflict: tide more specific",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Repos: []string{"kubernetes/test-infra"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Repos: []string{"kubernetes/test-infra"},
+							},
 						},
 					},
 				},
@@ -902,9 +912,11 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "conflict: org level",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Orgs: []string{"kubernetes", "k8s"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Orgs: []string{"kubernetes", "k8s"},
+							},
 						},
 					},
 				},
@@ -930,12 +942,14 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "conflict: repo level",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Repos: []string{"kubernetes/kubernetes"},
-						},
-						{
-							Repos: []string{"kubernetes/test-infra"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Repos: []string{"kubernetes/kubernetes"},
+							},
+							{
+								Repos: []string{"kubernetes/test-infra"},
+							},
 						},
 					},
 				},
@@ -965,13 +979,15 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "conflict: branch level",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Repos:            []string{"kubernetes/test-infra"},
-							IncludedBranches: []string{"master"},
-						},
-						{
-							Repos: []string{"kubernetes/kubernetes"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Repos:            []string{"kubernetes/test-infra"},
+								IncludedBranches: []string{"master"},
+							},
+							{
+								Repos: []string{"kubernetes/kubernetes"},
+							},
 						},
 					},
 				},
@@ -1005,9 +1021,11 @@ func TestValidateStrictBranches(t *testing.T) {
 			name: "conflict: global strict",
 			config: config.ProwConfig{
 				Tide: config.Tide{
-					Queries: []config.TideQuery{
-						{
-							Repos: []string{"kubernetes/test-infra"},
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: []config.TideQuery{
+							{
+								Repos: []string{"kubernetes/test-infra"},
+							},
 						},
 					},
 				},

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -431,8 +431,10 @@ func TestTide(t *testing.T) {
 	ca.Set(&config.Config{
 		ProwConfig: config.ProwConfig{
 			Tide: config.Tide{
-				Queries: []config.TideQuery{
-					{Repos: []string{"prowapi.netes/test-infra"}},
+				TideGitHubConfig: config.TideGitHubConfig{
+					Queries: []config.TideQuery{
+						{Repos: []string{"prowapi.netes/test-infra"}},
+					},
 				},
 			},
 		},
@@ -756,8 +758,10 @@ func TestHandleConfig(t *testing.T) {
 				},
 			},
 			Tide: config.Tide{
-				Queries: []config.TideQuery{
-					{Repos: []string{"prowapi.netes/test-infra"}},
+				TideGitHubConfig: config.TideGitHubConfig{
+					Queries: []config.TideQuery{
+						{Repos: []string{"prowapi.netes/test-infra"}},
+					},
 				},
 			},
 		},

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -3082,7 +3082,7 @@ func StringsToOrgRepos(vs []string) []OrgRepo {
 func (pc *ProwConfig) mergeFrom(additional *ProwConfig) error {
 	emptyReference := &ProwConfig{
 		BranchProtection: additional.BranchProtection,
-		Tide:             Tide{MergeType: additional.Tide.MergeType, Queries: additional.Tide.Queries},
+		Tide:             Tide{TideGitHubConfig: TideGitHubConfig{MergeType: additional.Tide.MergeType, Queries: additional.Tide.Queries}},
 	}
 
 	var errs []error
@@ -3189,7 +3189,7 @@ func (pc *ProwConfig) hasGlobalConfig() bool {
 	}
 	emptyReference := &ProwConfig{
 		BranchProtection: pc.BranchProtection,
-		Tide:             Tide{MergeType: pc.Tide.MergeType, Queries: pc.Tide.Queries},
+		Tide:             Tide{TideGitHubConfig: TideGitHubConfig{MergeType: pc.Tide.MergeType, Queries: pc.Tide.Queries}},
 	}
 	return cmp.Diff(pc, emptyReference) != ""
 }

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -8520,7 +8520,7 @@ func TestHasConfigFor(t *testing.T) {
 			name: "Any config that is empty except for tide.merge_method is considered to be for those orgs or repos",
 			resultGenerator: func(fuzzedConfig *ProwConfig) (toCheck *ProwConfig, exceptGlobal bool, expectOrgs sets.String, expectRepos sets.String) {
 				expectOrgs, expectRepos = sets.String{}, sets.String{}
-				result := &ProwConfig{Tide: Tide{MergeType: fuzzedConfig.Tide.MergeType}}
+				result := &ProwConfig{Tide: Tide{TideGitHubConfig: TideGitHubConfig{MergeType: fuzzedConfig.Tide.MergeType}}}
 				for orgOrRepo := range result.Tide.MergeType {
 					if strings.Contains(orgOrRepo, "/") {
 						expectRepos.Insert(orgOrRepo)
@@ -8536,7 +8536,7 @@ func TestHasConfigFor(t *testing.T) {
 			name: "Any config that is empty except for tide.queries is considered to be for those orgs or repos",
 			resultGenerator: func(fuzzedConfig *ProwConfig) (toCheck *ProwConfig, exceptGlobal bool, expectOrgs sets.String, expectRepos sets.String) {
 				expectOrgs, expectRepos = sets.String{}, sets.String{}
-				result := &ProwConfig{Tide: Tide{Queries: fuzzedConfig.Tide.Queries}}
+				result := &ProwConfig{Tide: Tide{TideGitHubConfig: TideGitHubConfig{Queries: fuzzedConfig.Tide.Queries}}}
 				for _, query := range result.Tide.Queries {
 					expectOrgs.Insert(query.Orgs...)
 					expectRepos.Insert(query.Repos...)
@@ -8664,13 +8664,13 @@ func TestProwConfigMergingProperties(t *testing.T) {
 		{
 			name: "Tide merge method",
 			makeMergeable: func(pc *ProwConfig) {
-				*pc = ProwConfig{Tide: Tide{MergeType: pc.Tide.MergeType}}
+				*pc = ProwConfig{Tide: Tide{TideGitHubConfig: TideGitHubConfig{MergeType: pc.Tide.MergeType}}}
 			},
 		},
 		{
 			name: "Tide queries",
 			makeMergeable: func(pc *ProwConfig) {
-				*pc = ProwConfig{Tide: Tide{Queries: pc.Tide.Queries}}
+				*pc = ProwConfig{Tide: Tide{TideGitHubConfig: TideGitHubConfig{Queries: pc.Tide.Queries}}}
 			},
 		},
 	}

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -1158,8 +1158,6 @@ tide:
     # Special values:
     # 0 => unlimited batch size
     # -1 => batch merging disabled :(
-
-    # This is suitable for any source code provider, so keep it global.
     batch_size_limit:
         "": 0
 
@@ -1266,8 +1264,6 @@ tide:
     # eligible. Continuing on an old batch allows to re-use all existing test results whereas
     # starting a new one requires to start new instances of all tests.
     # Use '*' as key to set this globally. Defaults to true.
-
-    # This is suitable for any source code provider, so keep it global.
     prioritize_existing_batches:
         "": false
 
@@ -1313,7 +1309,7 @@ tide:
     # Defaults to the value of SyncPeriod.
     status_update_period: 0s
 
-    # SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
+    # SyncPeriod specifies how often Tide will sync jobs with provider. Defaults to 1m.
     sync_period: 0s
 
     # URL for tide status contexts.

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -81,8 +81,30 @@ type TidePriority struct {
 
 // Tide is config for the tide pool.
 type Tide struct {
-	// SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
+	// SyncPeriod specifies how often Tide will sync jobs with provider. Defaults to 1m.
 	SyncPeriod *metav1.Duration `json:"sync_period,omitempty"`
+	// MaxGoroutines is the maximum number of goroutines spawned inside the
+	// controller to handle org/repo:branch pools. Defaults to 20. Needs to be a
+	// positive number.
+	MaxGoroutines int `json:"max_goroutines,omitempty"`
+	// BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
+	// integer batch size limit as the value. Use "*" as key to set a global default.
+	// Special values:
+	//  0 => unlimited batch size
+	// -1 => batch merging disabled :(
+	BatchSizeLimitMap map[string]int `json:"batch_size_limit,omitempty"`
+	// PrioritizeExistingBatches configures on org or org/repo level if Tide should continue
+	// testing pre-existing batches instead of immediately including new PRs as they become
+	// eligible. Continuing on an old batch allows to re-use all existing test results whereas
+	// starting a new one requires to start new instances of all tests.
+	// Use '*' as key to set this globally. Defaults to true.
+	PrioritizeExistingBatchesMap map[string]bool `json:"prioritize_existing_batches,omitempty"`
+
+	TideGitHubConfig `json:",inline"`
+}
+
+// TideGitHubConfig is the tide config for GitHub.
+type TideGitHubConfig struct {
 	// StatusUpdatePeriod specifies how often Tide will update GitHub status contexts.
 	// Defaults to the value of SyncPeriod.
 	StatusUpdatePeriod *metav1.Duration `json:"status_update_period,omitempty"`
@@ -139,11 +161,6 @@ type Tide struct {
 	// Leave this blank to disable this feature.
 	MergeLabel string `json:"merge_label,omitempty"`
 
-	// MaxGoroutines is the maximum number of goroutines spawned inside the
-	// controller to handle org/repo:branch pools. Defaults to 20. Needs to be a
-	// positive number.
-	MaxGoroutines int `json:"max_goroutines,omitempty"`
-
 	// TideContextPolicyOptions defines merge options for context. If not set it will infer
 	// the required and optional contexts from the prow jobs configured and use the github
 	// combined status; otherwise it may apply the branch protection setting or let user
@@ -155,23 +172,12 @@ type Tide struct {
 	// Special values:
 	//  0 => unlimited batch size
 	// -1 => batch merging disabled :(
-	//
-	// This is suitable for any source code provider, so keep it global.
 	BatchSizeLimitMap map[string]int `json:"batch_size_limit,omitempty"`
 
 	// Priority is an ordered list of sets of labels that would be prioritized before other PRs
 	// PRs should match all labels contained in a set to be prioritized. The first entry has
 	// the highest priority.
 	Priority []TidePriority `json:"priority,omitempty"`
-
-	// PrioritizeExistingBatches configures on org or org/repo level if Tide should continue
-	// testing pre-existing batches instead of immediately including new PRs as they become
-	// eligible. Continuing on an old batch allows to re-use all existing test results whereas
-	// starting a new one requires to start new instances of all tests.
-	// Use '*' as key to set this globally. Defaults to true.
-	//
-	// This is suitable for any source code provider, so keep it global.
-	PrioritizeExistingBatchesMap map[string]bool `json:"prioritize_existing_batches,omitempty"`
 
 	// DisplayAllQueriesInStatus controls if Tide should mention all queries in the status it
 	// creates. The default is to only mention the one to which we are closest (Calculated

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -175,10 +175,12 @@ func TestOrgExceptionsAndRepos(t *testing.T) {
 
 func TestMergeMethod(t *testing.T) {
 	ti := &Tide{
-		MergeType: map[string]types.PullRequestMergeType{
-			"kubernetes/kops":             types.MergeRebase,
-			"kubernetes-helm":             types.MergeSquash,
-			"kubernetes-helm/chartmuseum": types.MergeMerge,
+		TideGitHubConfig: TideGitHubConfig{
+			MergeType: map[string]types.PullRequestMergeType{
+				"kubernetes/kops":             types.MergeRebase,
+				"kubernetes-helm":             types.MergeSquash,
+				"kubernetes-helm/chartmuseum": types.MergeMerge,
+			},
 		},
 	}
 
@@ -218,14 +220,16 @@ func TestMergeMethod(t *testing.T) {
 }
 func TestMergeTemplate(t *testing.T) {
 	ti := &Tide{
-		MergeTemplate: map[string]TideMergeCommitTemplate{
-			"kubernetes/kops": {
-				TitleTemplate: "",
-				BodyTemplate:  "",
-			},
-			"kubernetes-helm": {
-				TitleTemplate: "{{ .Title }}",
-				BodyTemplate:  "{{ .Body }}",
+		TideGitHubConfig: TideGitHubConfig{
+			MergeTemplate: map[string]TideMergeCommitTemplate{
+				"kubernetes/kops": {
+					TitleTemplate: "",
+					BodyTemplate:  "",
+				},
+				"kubernetes-helm": {
+					TitleTemplate: "{{ .Title }}",
+					BodyTemplate:  "{{ .Body }}",
+				},
 			},
 		},
 	}
@@ -476,9 +480,11 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 			config: Config{
 				ProwConfig: ProwConfig{
 					Tide: Tide{
-						ContextOptions: TideContextPolicyOptions{
-							TideContextPolicy: TideContextPolicy{
-								FromBranchProtection: &yes,
+						TideGitHubConfig: TideGitHubConfig{
+							ContextOptions: TideContextPolicyOptions{
+								TideContextPolicy: TideContextPolicy{
+									FromBranchProtection: &yes,
+								},
 							},
 						},
 					},
@@ -504,9 +510,11 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 						},
 					},
 					Tide: Tide{
-						ContextOptions: TideContextPolicyOptions{
-							TideContextPolicy: TideContextPolicy{
-								FromBranchProtection: &yes,
+						TideGitHubConfig: TideGitHubConfig{
+							ContextOptions: TideContextPolicyOptions{
+								TideContextPolicy: TideContextPolicy{
+									FromBranchProtection: &yes,
+								},
 							},
 						},
 					},
@@ -523,12 +531,14 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 			config: Config{
 				ProwConfig: ProwConfig{
 					Tide: Tide{
-						ContextOptions: TideContextPolicyOptions{
-							TideContextPolicy: TideContextPolicy{
-								RequiredContexts:          []string{"r1"},
-								RequiredIfPresentContexts: []string{},
-								OptionalContexts:          []string{"o1"},
-								SkipUnknownContexts:       &yes,
+						TideGitHubConfig: TideGitHubConfig{
+							ContextOptions: TideContextPolicyOptions{
+								TideContextPolicy: TideContextPolicy{
+									RequiredContexts:          []string{"r1"},
+									RequiredIfPresentContexts: []string{},
+									OptionalContexts:          []string{"o1"},
+									SkipUnknownContexts:       &yes,
+								},
 							},
 						},
 					},

--- a/prow/plugins/merge-method-comment/merge-method-comment_test.go
+++ b/prow/plugins/merge-method-comment/merge-method-comment_test.go
@@ -282,11 +282,13 @@ func TestHandlePR(t *testing.T) {
 
 			c.event.Number = 101
 			config := config.Tide{
-				MergeType: map[string]types.PullRequestMergeType{
-					"kubernetes/kubernetes": c.defaultMergeMethod,
+				TideGitHubConfig: config.TideGitHubConfig{
+					MergeType: map[string]types.PullRequestMergeType{
+						"kubernetes/kubernetes": c.defaultMergeMethod,
+					},
+					SquashLabel: c.squashLabel,
+					MergeLabel:  c.mergeLabel,
 				},
-				SquashLabel: c.squashLabel,
-				MergeLabel:  c.mergeLabel,
 			}
 			err := handlePR(c.client, config, c.event)
 

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -814,7 +814,8 @@ func TestExpectedStatus(t *testing.T) {
 			blocks.Repo[blockers.OrgRepo{Org: "", Repo: ""}] = items
 
 			ca := &config.Agent{}
-			ca.Set(&config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{DisplayAllQueriesInStatus: tc.displayAllTideQueries}}})
+			ca.Set(&config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{
+				TideGitHubConfig: config.TideGitHubConfig{DisplayAllQueriesInStatus: tc.displayAllTideQueries}}}})
 			mmc := newMergeChecker(ca.Config, &fgc{})
 
 			sc, err := newStatusController(
@@ -1028,13 +1029,13 @@ func TestTargetUrl(t *testing.T) {
 		{
 			name:        "tide overview config",
 			pr:          &PullRequest{},
-			config:      config.Tide{TargetURLs: map[string]string{"*": "tide.com"}},
+			config:      config.Tide{TideGitHubConfig: config.TideGitHubConfig{TargetURLs: map[string]string{"*": "tide.com"}}},
 			expectedURL: "tide.com",
 		},
 		{
 			name:        "PR dashboard config and overview config",
 			pr:          &PullRequest{},
-			config:      config.Tide{TargetURLs: map[string]string{"*": "tide.com"}, PRStatusBaseURLs: map[string]string{"*": "pr.status.com"}},
+			config:      config.Tide{TideGitHubConfig: config.TideGitHubConfig{TargetURLs: map[string]string{"*": "tide.com"}, PRStatusBaseURLs: map[string]string{"*": "pr.status.com"}}},
 			expectedURL: "tide.com",
 		},
 		{
@@ -1052,7 +1053,7 @@ func TestTargetUrl(t *testing.T) {
 				}{NameWithOwner: githubql.String("org/repo")},
 				HeadRefName: "head",
 			},
-			config:      config.Tide{PRStatusBaseURLs: map[string]string{"*": "pr.status.com"}},
+			config:      config.Tide{TideGitHubConfig: config.TideGitHubConfig{PRStatusBaseURLs: map[string]string{"*": "pr.status.com"}}},
 			expectedURL: "pr.status.com?query=is%3Apr+repo%3Aorg%2Frepo+author%3Aauthor+head%3Ahead",
 		},
 		{
@@ -1074,7 +1075,7 @@ func TestTargetUrl(t *testing.T) {
 				},
 				HeadRefName: "head",
 			},
-			config:      config.Tide{PRStatusBaseURLs: map[string]string{"*": "default.pr.status.com"}},
+			config:      config.Tide{TideGitHubConfig: config.TideGitHubConfig{PRStatusBaseURLs: map[string]string{"*": "default.pr.status.com"}}},
 			expectedURL: "default.pr.status.com?query=is%3Apr+repo%3AtestOrg%2FtestRepo+author%3Aauthor+head%3Ahead",
 		},
 		{
@@ -1096,10 +1097,10 @@ func TestTargetUrl(t *testing.T) {
 				},
 				HeadRefName: "head",
 			},
-			config: config.Tide{PRStatusBaseURLs: map[string]string{
+			config: config.Tide{TideGitHubConfig: config.TideGitHubConfig{PRStatusBaseURLs: map[string]string{
 				"*":       "default.pr.status.com",
 				"testOrg": "byorg.pr.status.com"},
-			},
+			}},
 			expectedURL: "byorg.pr.status.com?query=is%3Apr+repo%3AtestOrg%2FtestRepo+author%3Aauthor+head%3Ahead",
 		},
 		{
@@ -1121,11 +1122,11 @@ func TestTargetUrl(t *testing.T) {
 				},
 				HeadRefName: "head",
 			},
-			config: config.Tide{PRStatusBaseURLs: map[string]string{
+			config: config.Tide{TideGitHubConfig: config.TideGitHubConfig{PRStatusBaseURLs: map[string]string{
 				"*":                "default.pr.status.com",
 				"testOrg":          "byorg.pr.status.com",
 				"testOrg/testRepo": "byrepo.pr.status.com"},
-			},
+			}},
 			expectedURL: "byrepo.pr.status.com?query=is%3Apr+repo%3AtestOrg%2FtestRepo+author%3Aauthor+head%3Ahead",
 		},
 	}
@@ -1344,7 +1345,8 @@ func TestStatusControllerSearch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ghc := &fgc{prs: tc.prs}
 			cfg := func() *config.Config {
-				return &config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{Queries: config.TideQueries{{Orgs: []string{"org-a", "org-b"}}}}}}
+				return &config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{
+					TideGitHubConfig: config.TideGitHubConfig{Queries: config.TideQueries{{Orgs: []string{"org-a", "org-b"}}}}}}}
 			}
 			sc, err := newStatusController(
 				context.Background(),

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1181,14 +1181,16 @@ func TestMergeMethodCheckerAndPRMergeMethod(t *testing.T) {
 	rebaseLabel := "tide/rebase"
 
 	tideConfig := config.Tide{
-		SquashLabel: squashLabel,
-		MergeLabel:  mergeLabel,
-		RebaseLabel: rebaseLabel,
+		TideGitHubConfig: config.TideGitHubConfig{
+			SquashLabel: squashLabel,
+			MergeLabel:  mergeLabel,
+			RebaseLabel: rebaseLabel,
 
-		MergeType: map[string]types.PullRequestMergeType{
-			"o/configured-rebase":              types.MergeRebase, // GH client allows merge, rebase
-			"o/configured-squash-allow-rebase": types.MergeSquash, // GH client allows merge, squash, rebase
-			"o/configure-re-base":              types.MergeRebase, // GH client allows merge
+			MergeType: map[string]types.PullRequestMergeType{
+				"o/configured-rebase":              types.MergeRebase, // GH client allows merge, rebase
+				"o/configured-squash-allow-rebase": types.MergeSquash, // GH client allows merge, squash, rebase
+				"o/configure-re-base":              types.MergeRebase, // GH client allows merge
+			},
 		},
 	}
 	cfg := func() *config.Config { return &config.Config{ProwConfig: config.ProwConfig{Tide: tideConfig}} }
@@ -1338,8 +1340,10 @@ func TestRebaseMergeMethodIsAllowed(t *testing.T) {
 	orgName := "fake-org"
 	repoName := "fake-repo"
 	tideConfig := config.Tide{
-		MergeType: map[string]types.PullRequestMergeType{
-			fmt.Sprintf("%s/%s", orgName, repoName): types.MergeRebase,
+		TideGitHubConfig: config.TideGitHubConfig{
+			MergeType: map[string]types.PullRequestMergeType{
+				fmt.Sprintf("%s/%s", orgName, repoName): types.MergeRebase,
+			},
 		},
 	}
 	cfg := func() *config.Config { return &config.Config{ProwConfig: config.ProwConfig{Tide: tideConfig}} }
@@ -2297,9 +2301,11 @@ func TestSync(t *testing.T) {
 			ca.Set(&config.Config{
 				ProwConfig: config.ProwConfig{
 					Tide: config.Tide{
-						Queries:            []config.TideQuery{{}},
-						MaxGoroutines:      4,
-						StatusUpdatePeriod: &metav1.Duration{Duration: time.Second * 0},
+						MaxGoroutines: 4,
+						TideGitHubConfig: config.TideGitHubConfig{
+							Queries:            []config.TideQuery{{}},
+							StatusUpdatePeriod: &metav1.Duration{Duration: time.Second * 0},
+						},
 					},
 				},
 			})
@@ -4457,7 +4463,8 @@ func TestQueryShardsByOrgWhenAppsAuthIsEnabledOnly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			provider := &GitHubProvider{
 				cfg: func() *config.Config {
-					return &config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{Queries: []config.TideQuery{{Orgs: []string{"org", "other-org"}}}}}}
+					return &config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{
+						TideGitHubConfig: config.TideGitHubConfig{Queries: []config.TideQuery{{Orgs: []string{"org", "other-org"}}}}}}}
 				},
 				ghc:                &fgc{prs: tc.prs},
 				usesGitHubAppsAuth: tc.usesGitHubAppsAuth,
@@ -4756,8 +4763,7 @@ func TestPickBatchPrefersBatchesWithPreexistingJobs(t *testing.T) {
 					*CodeReviewCommonFromPullRequest(&PullRequest{Number: 99, HeadRefOID: "pr-from-new-batch-func"})}, nil
 			}
 
-			logger := logrus.WithField("test", tc.name)
-			config := func() *config.Config {
+			cfg := func() *config.Config {
 				return &config.Config{ProwConfig: config.ProwConfig{
 					Tide: config.Tide{
 						BatchSizeLimitMap:            map[string]int{"*": tc.maxBatchSize},
@@ -4765,13 +4771,14 @@ func TestPickBatchPrefersBatchesWithPreexistingJobs(t *testing.T) {
 					}},
 				}
 			}
-			ghc := &fgc{skipExpectedShaCheck: true}
 
+			logger := logrus.WithField("test", tc.name)
+			ghc := &fgc{skipExpectedShaCheck: true}
 			c := &syncController{
-				logger: logger,
-				config: config,
+				logger: logrus.WithField("test", tc.name),
+				config: cfg,
 				provider: &GitHubProvider{
-					cfg:    config,
+					cfg:    cfg,
 					logger: logger,
 					ghc:    ghc,
 				},
@@ -4956,10 +4963,14 @@ func TestBatchPickingConsidersPRThatIsCurrentlyBeingSeriallyRetested(t *testing.
 	t.Parallel()
 	configGetter := func() *config.Config {
 		return &config.Config{
-			ProwConfig: config.ProwConfig{Tide: config.Tide{
-				Queries:       config.TideQueries{{}},
-				MaxGoroutines: 1,
-			}},
+			ProwConfig: config.ProwConfig{
+				Tide: config.Tide{
+					MaxGoroutines: 1,
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: config.TideQueries{{}},
+					},
+				},
+			},
 			JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
 				"/": {{AlwaysRun: true, Reporter: config.Reporter{Context: "mandatory-job"}}},
 			}},
@@ -5234,10 +5245,14 @@ func TestSerialRetestingConsidersPRThatIsCurrentlyBeingSRetested(t *testing.T) {
 	t.Parallel()
 	configGetter := func() *config.Config {
 		return &config.Config{
-			ProwConfig: config.ProwConfig{Tide: config.Tide{
-				Queries:       config.TideQueries{{}},
-				MaxGoroutines: 1,
-			}},
+			ProwConfig: config.ProwConfig{
+				Tide: config.Tide{
+					MaxGoroutines: 1,
+					TideGitHubConfig: config.TideGitHubConfig{
+						Queries: config.TideQueries{{}},
+					},
+				},
+			},
 			JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
 				"/": {{AlwaysRun: true, Reporter: config.Reporter{Context: "mandatory-job"}}},
 			}},


### PR DESCRIPTION
The shared fields are the fields that meant to be consumed by any provider, and the GitHub specific ones are meant to be consumed for GitHub only. Other providers will be added later on

/cc @cjwagner @alvaroaleman 