### PR TITLE
Remove go.mod replace for client-go by extracting required parts of boskos

### DIFF
--- a/config/prow/cluster/build/boskos-resources/boskos_test.go
+++ b/config/prow/cluster/build/boskos-resources/boskos_test.go
@@ -19,7 +19,7 @@ package cluster
 import (
 	"testing"
 
-	"sigs.k8s.io/boskos/common"
+	"k8s.io/test-infra/kubetest/boskos/common"
 )
 
 func TestConfig(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,6 @@ module k8s.io/test-infra
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f
 
-// Pin all k8s.io staging repositories to kubernetes v0.18.6
-// When bumping Kubernetes dependencies, you should update each of these lines
-// to point to the same kubernetes v0.KubernetesMinor.KubernetesPatch version
-// before running update-deps.sh.
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 
@@ -18,7 +14,6 @@ replace (
 
 	golang.org/x/lint => golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22
-	k8s.io/client-go => k8s.io/client-go v0.24.2
 )
 
 require (
@@ -64,6 +59,7 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/klauspost/pgzip v1.2.1
@@ -102,13 +98,12 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
-	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
+	k8s.io/client-go v0.24.2
 	k8s.io/code-generator v0.24.2
 	k8s.io/klog/v2 v2.70.0
 	k8s.io/utils v0.0.0-20220725171434-9bab9ef40391
 	knative.dev/pkg v0.0.0-20220329144915-0a1ec2e0d46c
 	mvdan.cc/xurls/v2 v2.0.0
-	sigs.k8s.io/boskos v0.0.0-20220725190635-b0ffc2fcc06a
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/controller-tools v0.9.2
 	sigs.k8s.io/yaml v1.3.0
@@ -153,6 +148,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
+	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gobuffalo/flect v0.2.5 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -173,7 +169,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,7 @@ github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/e
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
+github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobuffalo/flect v0.2.5 h1:H6vvsv2an0lalEaCDRThvtBfmg44W/QHXBCYUXf/6S4=
@@ -1483,8 +1484,6 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/boskos v0.0.0-20220725190635-b0ffc2fcc06a h1:9db2GyAD64pp7HCeXRL2SOrsXrV7PFvtjxDtHkKoAvo=
-sigs.k8s.io/boskos v0.0.0-20220725190635-b0ffc2fcc06a/go.mod h1:0WpgO6LPSKTpy+RxOjihwWNSouVatRalWe+uauJVt68=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/controller-tools v0.9.2 h1:AkTE3QAdz9LS4iD3EJvHyYxBkg/g9fTbgiYsrcsFCcM=

--- a/kubetest/boskos/README.md
+++ b/kubetest/boskos/README.md
@@ -1,0 +1,10 @@
+# Boskos client package
+
+**If you are building something outside test-infra that relies on the Boskos client library, do not use this package! Use `sigs.k8s.io/boskos` directly instead.**
+
+This package has been copied across from https://github.com/kubernetes-sigs/boskos to avoid a dependency cycle between this repository and the Boskos repository.
+This is a temporary stop-gap measure until Boskos has moved it's `k8s.io/client-go` dependency off of the old `v11` version.
+
+More details on this problem can be read in the issue [#20421](https://github.com/kubernetes/test-infra/issues/20421).
+
+Once Boskos no longer requires client-go@v11, we can delete this whole directory and once again depend directly on `sigs.k8s.io/boskos/*`.

--- a/kubetest/boskos/client/README.md
+++ b/kubetest/boskos/client/README.md
@@ -1,0 +1,69 @@
+# Boskos Client Library
+
+Boskos client is a go client library interfaces [boskos server](../README.md).
+
+Users of boskos need to use boskos client to communicate with the deployed boskos service.
+
+# Initialize
+
+A boskos client instance is initialized with the URL of target boskos server accompanied with owner of the client.
+
+The client object looks like:
+
+```
+type Client struct {
+	// RetryCount is the number of times an HTTP request issued by this client
+	// is retried when the initial request fails due an inaccessible endpoint.
+	RetryCount uint
+
+	// RetryDuration is the interval to wait before retrying an HTTP operation
+	// that failed due to an inaccessible endpoint.
+	RetryWait time.Duration
+
+	url       string
+	resources []string
+	owner     string
+}
+```
+
+To create a boskos client, use `NewClient` and specify the Boskos endpoint URL and resource owner.
+The `NewClient` function also sets the client's `RetryCount` to `3` and `RetryWait` interval to `10s`.
+```
+func NewClient(url string, owner string) *Client
+```
+
+
+# API Reference
+
+```
+// Acquire asks boskos for a resource of certain type in certain state, and set the resource to dest state.
+func (c *Client) Acquire(rtype string, state string, dest string) (string, error)
+
+// AcquireWait blocks until Acquire returns the specified resource or the
+// provided context is cancelled or its deadline exceeded.
+func (c *Client) AcquireWait(rtype string, state string, dest string) (string, error)
+
+// AcquireByState asks boskos for a resources of certain type, and set the resource to dest state.
+// Returns a list of resources on success.
+func (c *Client) AcquireByState(state, dest string, names []string) ([]common.Resource, error)
+
+// AcquireByStateWait blocks until AcquireByState returns the specified
+// resource(s) or the provided context is cancelled or its deadline exceeded.
+func (c *Client) AcquireByStateWait(ctx context.Context, state, dest string, names []string) ([]common.Resource, error)
+
+// ReleaseAll returns all resources hold by the client back to boskos and set them to dest state.
+func (c *Client) ReleaseAll(dest string) error
+
+// ReleaseOne returns one of owned resources back to boskos and set it to dest state.
+func (c *Client) ReleaseOne(name string, dest string) error
+
+// UpdateAll signals update for all resources hold by the client.
+func (c *Client) UpdateAll(state string) error
+
+// UpdateOne signals update for one of the resources hold by the client.
+func (c *Client) UpdateOne(name string, state string) error
+
+// Reset will scan all boskos resources of type, in state, last updated before expire, and set them to dest state.
+// Returns a map of {resourceName:owner} for further actions.
+func (c *Client) Reset(rtype string, state string, expire time.Duration, dest string) (map[string]string, error)
+```

--- a/kubetest/boskos/client/client.go
+++ b/kubetest/boskos/client/client.go
@@ -1,0 +1,740 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"k8s.io/test-infra/kubetest/boskos/common"
+	"k8s.io/test-infra/kubetest/boskos/storage"
+	"k8s.io/test-infra/prow/config/secret"
+)
+
+var (
+	// ErrNotFound is returned by Acquire() when no resources are available.
+	ErrNotFound = errors.New("resources not found")
+	// ErrAlreadyInUse is returned by Acquire when resources are already being requested.
+	ErrAlreadyInUse = errors.New("resources already used by another user")
+	// ErrContextRequired is returned by AcquireWait and AcquireByStateWait when
+	// they are invoked with a nil context.
+	ErrContextRequired = errors.New("context required")
+	// ErrTypeNotFound is returned when the requested resource type (rtype) does not exist.
+	// For this error to be returned, you must set DistinguishNotFoundVsTypeNotFound to true.
+	ErrTypeNotFound = errors.New("resource type not found")
+)
+
+// Client defines the public Boskos client object
+type Client struct {
+	// Dialer is the net.Dialer used to establish connections to the remote
+	// boskos endpoint.
+	Dialer DialerWithRetry
+	// DistinguishNotFoundVsTypeNotFound, if set, will make it possible to distinguish between
+	// ErrNotFound and ErrTypeNotFound. For backwards-compatibility, this flag is off by
+	// default.
+	DistinguishNotFoundVsTypeNotFound bool
+
+	// http is the http.Client used to interact with the boskos REST API
+	http http.Client
+
+	owner       string
+	url         string
+	username    string
+	getPassword func() []byte
+	lock        sync.Mutex
+
+	storage storage.PersistenceLayer
+}
+
+// NewClient creates a Boskos client for the specified URL and resource owner.
+//
+// Clients created with this function default to retrying failed connection
+// attempts three times with a ten second pause between each attempt.
+func NewClient(owner string, urlString, username, passwordFile string) (*Client, error) {
+
+	if (username == "") != (passwordFile == "") {
+		return nil, fmt.Errorf("username and passwordFile must be specified together")
+	}
+
+	var getPassword func() []byte
+	if passwordFile != "" {
+		u, err := url.Parse(urlString)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != "https" {
+			// returning error here would make the tests hard
+			// we print out a warning message here instead
+			fmt.Printf("[WARNING] should NOT use password without enabling TLS: '%s'\n", urlString)
+		}
+
+		if err := secret.Add(passwordFile); err != nil {
+			logrus.WithError(err).Fatal("Failed to start secrets agent")
+		}
+		getPassword = secret.GetTokenGenerator(passwordFile)
+	}
+
+	return NewClientWithPasswordGetter(owner, urlString, username, getPassword)
+}
+
+// NewClientWithPasswordGetter creates a Boskos client for the specified URL and resource owner.
+//
+// Clients created with this function default to retrying failed connection
+// attempts three times with a ten second pause between each attempt.
+func NewClientWithPasswordGetter(owner string, urlString, username string, passwordGetter func() []byte) (*Client, error) {
+	client := &Client{
+		url:         urlString,
+		username:    username,
+		getPassword: passwordGetter,
+		owner:       owner,
+		storage:     storage.NewMemoryStorage(),
+	}
+
+	// Configure the dialer to attempt three additional times to establish
+	// a connection after a failed dial attempt. The dialer should wait 10
+	// seconds between each attempt.
+	client.Dialer.RetryCount = 3
+	client.Dialer.RetrySleep = time.Second * 10
+
+	// Configure the dialer and HTTP client transport to mimic the configuration
+	// of the http.DefaultTransport with the exception that the Dialer's Dial
+	// and DialContext functions are assigned to the client transport.
+	//
+	// See https://golang.org/pkg/net/http/#RoundTripper for the values
+	// values used for the http.DefaultTransport.
+	client.Dialer.Timeout = 30 * time.Second
+	client.Dialer.KeepAlive = 30 * time.Second
+	client.Dialer.DualStack = true
+	client.http.Transport = &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		Dial:                  client.Dialer.Dial,
+		DialContext:           client.Dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return client, nil
+}
+
+// public method
+
+// Acquire asks boskos for a resource of certain type in certain state, and set the resource to dest state.
+// Returns the resource on success.
+func (c *Client) Acquire(rtype, state, dest string) (*common.Resource, error) {
+	return c.AcquireWithPriority(rtype, state, dest, "")
+}
+
+// AcquireWithPriority asks boskos for a resource of certain type in certain state, and set the resource to dest state.
+// Returns the resource on success.
+// Boskos Priority are FIFO.
+func (c *Client) AcquireWithPriority(rtype, state, dest, requestID string) (*common.Resource, error) {
+	r, err := c.acquire(rtype, state, dest, requestID)
+	if err != nil {
+		return nil, err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if r != nil {
+		c.storage.Add(*r)
+	}
+
+	return r, nil
+}
+
+// AcquireWait blocks until Acquire returns the specified resource or the
+// provided context is cancelled or its deadline exceeded.
+func (c *Client) AcquireWait(ctx context.Context, rtype, state, dest string) (*common.Resource, error) {
+	// request with FIFO priority
+	requestID := uuid.New().String()
+	return c.AcquireWaitWithPriority(ctx, rtype, state, dest, requestID)
+}
+
+// AcquireWaitWithPriority blocks until Acquire returns the specified resource or the
+// provided context is cancelled or its deadline exceeded. This allows you to pass in a request priority.
+// Boskos Priority are FIFO.
+func (c *Client) AcquireWaitWithPriority(ctx context.Context, rtype, state, dest, requestID string) (*common.Resource, error) {
+	if ctx == nil {
+		return nil, ErrContextRequired
+	}
+	// Try to acquire the resource until available or the context is
+	// cancelled or its deadline exceeded.
+	for {
+		r, err := c.AcquireWithPriority(rtype, state, dest, requestID)
+		if err != nil {
+			if err == ErrAlreadyInUse || err == ErrNotFound {
+				select {
+				case <-ctx.Done():
+					return nil, err
+				case <-time.After(3 * time.Second):
+					continue
+				}
+			}
+			return nil, err
+		}
+		return r, nil
+	}
+}
+
+// AcquireByState asks boskos for a resources of certain type, and set the resource to dest state.
+// Returns a list of resources on success.
+func (c *Client) AcquireByState(state, dest string, names []string) ([]common.Resource, error) {
+	resources, err := c.acquireByState(state, dest, names)
+	if err != nil {
+		return nil, err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for _, r := range resources {
+		c.storage.Add(r)
+	}
+	return resources, nil
+}
+
+// AcquireByStateWait blocks until AcquireByState returns the specified
+// resource(s) or the provided context is cancelled or its deadline
+// exceeded.
+func (c *Client) AcquireByStateWait(ctx context.Context, state, dest string, names []string) ([]common.Resource, error) {
+	if ctx == nil {
+		return nil, ErrContextRequired
+	}
+	// Try to acquire the resource(s) until available or the context is
+	// cancelled or its deadline exceeded.
+	for {
+		r, err := c.AcquireByState(state, dest, names)
+		if err != nil {
+			if err == ErrAlreadyInUse || err == ErrNotFound {
+				select {
+				case <-ctx.Done():
+					return nil, err
+				case <-time.After(3 * time.Second):
+					continue
+				}
+			}
+			return nil, err
+		}
+		return r, nil
+	}
+}
+
+// ReleaseAll returns all resources hold by the client back to boskos and set them to dest state.
+func (c *Client) ReleaseAll(dest string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	resources, err := c.storage.List()
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		return fmt.Errorf("no holding resource")
+	}
+	var allErrors error
+	for _, r := range resources {
+		c.storage.Delete(r.Name)
+		err := c.Release(r.Name, dest)
+		if err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+	}
+	return allErrors
+}
+
+// ReleaseOne returns one of owned resources back to boskos and set it to dest state.
+func (c *Client) ReleaseOne(name, dest string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if _, err := c.storage.Get(name); err != nil {
+		return fmt.Errorf("no resource name %v", name)
+	}
+	c.storage.Delete(name)
+	if err := c.Release(name, dest); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateAll signals update for all resources hold by the client.
+func (c *Client) UpdateAll(state string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	resources, err := c.storage.List()
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		return fmt.Errorf("no holding resource")
+	}
+	var allErrors error
+	for _, r := range resources {
+		if err := c.Update(r.Name, state, nil); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+			continue
+		}
+		if err := c.updateLocalResource(r, state, nil); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+	}
+	return allErrors
+}
+
+// SyncAll signals update for all resources hold by the client.
+func (c *Client) SyncAll() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	resources, err := c.storage.List()
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		logrus.Info("no resource to sync")
+		return nil
+	}
+	var allErrors error
+	for _, r := range resources {
+		if err := c.Update(r.Name, r.State, nil); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+			continue
+		}
+		if _, err := c.storage.Update(r); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+	}
+	return allErrors
+}
+
+// UpdateOne signals update for one of the resources hold by the client.
+func (c *Client) UpdateOne(name, state string, userData *common.UserData) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	r, err := c.storage.Get(name)
+	if err != nil {
+		return fmt.Errorf("no resource name %v", name)
+	}
+	if err := c.Update(r.Name, state, userData); err != nil {
+		return err
+	}
+	return c.updateLocalResource(r, state, userData)
+}
+
+// Reset will scan all boskos resources of type, in state, last updated before expire, and set them to dest state.
+// Returns a map of {resourceName:owner} for further actions.
+func (c *Client) Reset(rtype, state string, expire time.Duration, dest string) (map[string]string, error) {
+	return c.reset(rtype, state, expire, dest)
+}
+
+// Metric will query current metric for target resource type.
+// Return a common.Metric object on success.
+func (c *Client) Metric(rtype string) (common.Metric, error) {
+	return c.metric(rtype)
+}
+
+// HasResource tells if current client holds any resources
+func (c *Client) HasResource() bool {
+	resources, _ := c.storage.List()
+	return len(resources) > 0
+}
+
+// private methods
+
+func (c *Client) updateLocalResource(res common.Resource, state string, data *common.UserData) error {
+	res.State = state
+	if res.UserData == nil {
+		res.UserData = data
+	} else {
+		res.UserData.Update(data)
+	}
+	_, err := c.storage.Update(res)
+	return err
+}
+
+func (c *Client) acquire(rtype, state, dest, requestID string) (*common.Resource, error) {
+	values := url.Values{}
+	values.Set("type", rtype)
+	values.Set("state", state)
+	values.Set("owner", c.owner)
+	values.Set("dest", dest)
+	if requestID != "" {
+		values.Set("request_id", requestID)
+	}
+
+	res := common.Resource{}
+
+	work := func(retriedErrs *[]error) (bool, error) {
+		resp, err := c.httpPost("/acquire", values, "", nil)
+		if err != nil {
+			// Swallow the error so we can retry
+			*retriedErrs = append(*retriedErrs, err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return false, err
+			}
+
+			err = json.Unmarshal(body, &res)
+			if err != nil {
+				return false, err
+			}
+			if res.Name == "" {
+				return false, fmt.Errorf("unable to parse resource")
+			}
+			return true, nil
+		case http.StatusUnauthorized:
+			return false, ErrAlreadyInUse
+		case http.StatusNotFound:
+			// The only way to distinguish between all reasources being busy and a request for a non-existent
+			// resource type is to check the text of the accompanying error message.
+			if c.DistinguishNotFoundVsTypeNotFound {
+				if bytes, err := io.ReadAll(resp.Body); err == nil {
+					errorMsg := string(bytes)
+					if strings.Contains(errorMsg, common.ResourceTypeNotFoundMessage(rtype)) {
+						return false, ErrTypeNotFound
+					}
+				}
+			}
+			return false, ErrNotFound
+		default:
+			*retriedErrs = append(*retriedErrs, fmt.Errorf("status %s, status code %v", resp.Status, resp.StatusCode))
+			// Swallow it so we can retry
+			return false, nil
+		}
+	}
+
+	return &res, retry(work)
+}
+
+func (c *Client) acquireByState(state, dest string, names []string) ([]common.Resource, error) {
+	values := url.Values{}
+	values.Set("state", state)
+	values.Set("dest", dest)
+	values.Set("names", strings.Join(names, ","))
+	values.Set("owner", c.owner)
+	var resources []common.Resource
+
+	work := func(retriedErrs *[]error) (bool, error) {
+		resp, err := c.httpPost("/acquirebystate", values, "", nil)
+		if err != nil {
+			*retriedErrs = append(*retriedErrs, err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			if err := json.NewDecoder(resp.Body).Decode(&resources); err != nil {
+				return false, err
+			}
+			return true, nil
+		case http.StatusUnauthorized:
+			return false, ErrAlreadyInUse
+		case http.StatusNotFound:
+			return false, ErrNotFound
+		default:
+			*retriedErrs = append(*retriedErrs, fmt.Errorf("status %s, status code %v", resp.Status, resp.StatusCode))
+			return false, nil
+		}
+	}
+
+	return resources, retry(work)
+}
+
+// Release a lease for a resource and set its state to the destination state
+func (c *Client) Release(name, dest string) error {
+	values := url.Values{}
+	values.Set("name", name)
+	values.Set("dest", dest)
+	values.Set("owner", c.owner)
+
+	work := func(retriedErrs *[]error) (bool, error) {
+		resp, err := c.httpPost("/release", values, "", nil)
+		if err != nil {
+			*retriedErrs = append(*retriedErrs, err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			*retriedErrs = append(*retriedErrs, fmt.Errorf("status %s, statusCode %v releasing %s", resp.Status, resp.StatusCode, name))
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return retry(work)
+}
+
+// Update a resource on the server, setting the state and user data
+func (c *Client) Update(name, state string, userData *common.UserData) error {
+	var bodyData *bytes.Buffer
+	if userData != nil {
+		bodyData = new(bytes.Buffer)
+		err := json.NewEncoder(bodyData).Encode(userData)
+		if err != nil {
+			return err
+		}
+	}
+	values := url.Values{}
+	values.Set("name", name)
+	values.Set("owner", c.owner)
+	values.Set("state", state)
+
+	work := func(retriedErrs *[]error) (bool, error) {
+		// As the body is an io.Reader and hence its content
+		// can only be read once, we have to copy it for every request we make
+		var body io.Reader
+		if bodyData != nil {
+			body = bytes.NewReader(bodyData.Bytes())
+		}
+		resp, err := c.httpPost("/update", values, "application/json", body)
+		if err != nil {
+			*retriedErrs = append(*retriedErrs, err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			*retriedErrs = append(*retriedErrs, fmt.Errorf("status %s, status code %v updating %s", resp.Status, resp.StatusCode, name))
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return retry(work)
+}
+
+func (c *Client) reset(rtype, state string, expire time.Duration, dest string) (map[string]string, error) {
+	rmap := make(map[string]string)
+	values := url.Values{}
+	values.Set("type", rtype)
+	values.Set("state", state)
+	values.Set("expire", expire.String())
+	values.Set("dest", dest)
+
+	work := func(retriedErrs *[]error) (bool, error) {
+		resp, err := c.httpPost("/reset", values, "", nil)
+		if err != nil {
+			*retriedErrs = append(*retriedErrs, err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return false, err
+			}
+
+			err = json.Unmarshal(body, &rmap)
+			return true, err
+		}
+		*retriedErrs = append(*retriedErrs, fmt.Errorf("status %s, status code %v", resp.Status, resp.StatusCode))
+		return false, nil
+
+	}
+
+	return rmap, retry(work)
+}
+
+func (c *Client) metric(rtype string) (common.Metric, error) {
+	var metric common.Metric
+	values := url.Values{}
+	values.Set("type", rtype)
+
+	work := func(retriedErrs *[]error) (bool, error) {
+		resp, err := c.httpGet("/metric", values)
+		if err != nil {
+			*retriedErrs = append(*retriedErrs, err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			*retriedErrs = append(*retriedErrs, fmt.Errorf("status %s, status code %v", resp.Status, resp.StatusCode))
+			return false, nil
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		return true, json.Unmarshal(body, &metric)
+	}
+
+	return metric, retry(work)
+}
+
+func (c *Client) httpGet(action string, values url.Values) (*http.Response, error) {
+	u, _ := url.ParseRequestURI(c.url)
+	u.Path = action
+	u.RawQuery = values.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.username != "" && c.getPassword != nil {
+		req.SetBasicAuth(c.username, string(c.getPassword()))
+	}
+	return c.http.Do(req)
+}
+
+func (c *Client) httpPost(action string, values url.Values, contentType string, body io.Reader) (*http.Response, error) {
+	u, _ := url.ParseRequestURI(c.url)
+	u.Path = action
+	u.RawQuery = values.Encode()
+	req, err := http.NewRequest(http.MethodPost, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	if c.username != "" && c.getPassword != nil {
+		req.SetBasicAuth(c.username, string(c.getPassword()))
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return c.http.Do(req)
+}
+
+// DialerWithRetry is a composite version of the net.Dialer that retries
+// connection attempts.
+type DialerWithRetry struct {
+	net.Dialer
+
+	// RetryCount is the number of times to retry a connection attempt.
+	RetryCount uint
+
+	// RetrySleep is the length of time to pause between retry attempts.
+	RetrySleep time.Duration
+}
+
+// Dial connects to the address on the named network.
+func (d *DialerWithRetry) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+// DialContext connects to the address on the named network using the provided context.
+func (d *DialerWithRetry) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	// Always bump the retry count by 1 in order to equal the actual number of
+	// attempts. For example, if a retry count of 2 is specified, the intent
+	// is for three attempts -- the initial attempt with two retries in case
+	// the initial attempt times out.
+	count := d.RetryCount + 1
+	sleep := d.RetrySleep
+	i := uint(0)
+	for {
+		conn, err := d.Dialer.DialContext(ctx, network, address)
+		if err != nil {
+			if isDialErrorRetriable(err) {
+				if i < count-1 {
+					select {
+					case <-time.After(sleep):
+						i++
+						continue
+					case <-ctx.Done():
+						return nil, err
+					}
+				}
+			}
+			return nil, err
+		}
+		return conn, nil
+	}
+}
+
+// isDialErrorRetriable determines whether or not a dialer should retry
+// a failed connection attempt by examining the connection error to see
+// if it is one of the following error types:
+//   - Timeout
+//   - Temporary
+//   - ECONNREFUSED
+//   - ECONNRESET
+func isDialErrorRetriable(err error) bool {
+	opErr, isOpErr := err.(*net.OpError)
+	if !isOpErr {
+		return false
+	}
+	if opErr.Timeout() || opErr.Temporary() {
+		return true
+	}
+	sysErr, isSysErr := opErr.Err.(*os.SyscallError)
+	if !isSysErr {
+		return false
+	}
+	switch sysErr.Err {
+	case syscall.ECONNREFUSED, syscall.ECONNRESET:
+		return true
+	}
+	return false
+}
+
+// workFunc describes retrieable work. It should
+// * Return an error for non-recoverable errors
+// * Write retriable errors into `retriedErrs` and return with false, nil
+// * Return with true, nil on success
+type workFunc func(retriedErrs *[]error) (bool, error)
+
+// SleepFunc is called when requests are retried. This may be replaced in tests.
+var SleepFunc = time.Sleep
+
+func retry(work workFunc) error {
+	var retriedErrs []error
+
+	maxAttempts := 4
+	for i := 1; i <= maxAttempts; i++ {
+		success, err := work(&retriedErrs)
+		if err != nil {
+			return err
+		}
+		if success {
+			return nil
+		}
+		if i == maxAttempts {
+			break
+		}
+
+		SleepFunc(time.Duration(i*i) * time.Second)
+	}
+
+	return utilerrors.NewAggregate(retriedErrs)
+}

--- a/kubetest/boskos/common/common.go
+++ b/kubetest/boskos/common/common.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// Busy state defines a resource being used.
+	Busy = "busy"
+	// Cleaning state defines a resource being cleaned
+	Cleaning = "cleaning"
+	// Dirty state defines a resource that needs cleaning
+	Dirty = "dirty"
+	// Free state defines a resource that is usable
+	Free = "free"
+	// Leased state defines a resource being leased in order to make a new resource
+	Leased = "leased"
+	// ToBeDeleted is used for resources about to be deleted, they will be verified by a cleaner which mark them as tombstone
+	ToBeDeleted = "toBeDeleted"
+	// Tombstone is the state in which a resource can safely be deleted
+	Tombstone = "tombstone"
+	// Other is used to agglomerate unspecified states for metrics reporting
+	Other = "other"
+)
+
+var (
+	// KnownStates is the set of all known states, excluding "other".
+	KnownStates = []string{
+		Busy,
+		Cleaning,
+		Dirty,
+		Free,
+		Leased,
+		ToBeDeleted,
+		Tombstone,
+	}
+)
+
+// UserData is a map of Name to user defined interface, serialized into a string
+type UserData struct {
+	sync.Map
+}
+
+// UserDataMap is the standard Map version of UserMap, it is used to ease UserMap creation.
+type UserDataMap map[string]string
+
+// LeasedResources is a list of resources name that used in order to create another resource by Mason
+type LeasedResources []string
+
+// Duration is a wrapper around time.Duration that parses times in either
+// 'integer number of nanoseconds' or 'duration string' formats and serializes
+// to 'duration string' format.
+type Duration struct {
+	*time.Duration
+}
+
+// UnmarshalJSON implement the JSON Unmarshaler interface in order to be able parse string to time.Duration.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &d.Duration); err == nil {
+		// b was an integer number of nanoseconds.
+		return nil
+	}
+	// b was not an integer. Assume that it is a duration string.
+
+	var str string
+	err := json.Unmarshal(b, &str)
+	if err != nil {
+		return err
+	}
+
+	pd, err := time.ParseDuration(str)
+	if err != nil {
+		return err
+	}
+	d.Duration = &pd
+	return nil
+}
+
+// Resource abstracts any resource type that can be tracked by boskos
+type Resource struct {
+	Type       string    `json:"type"`
+	Name       string    `json:"name"`
+	State      string    `json:"state"`
+	Owner      string    `json:"owner"`
+	LastUpdate time.Time `json:"lastupdate"`
+	// Customized UserData
+	UserData *UserData `json:"userdata"`
+	// Used to clean up dynamic resources
+	ExpirationDate *time.Time `json:"expiration-date,omitempty"`
+}
+
+// ResourceEntry is resource config format defined from config.yaml
+type ResourceEntry struct {
+	Type     string        `json:"type"`
+	State    string        `json:"state"`
+	Names    []string      `json:"names,flow"`
+	MaxCount int           `json:"max-count,omitempty"`
+	MinCount int           `json:"min-count,omitempty"`
+	LifeSpan *Duration     `json:"lifespan,omitempty"`
+	Config   ConfigType    `json:"config,omitempty"`
+	Needs    ResourceNeeds `json:"needs,omitempty"`
+}
+
+func (re *ResourceEntry) IsDRLC() bool {
+	return len(re.Names) == 0
+}
+
+// BoskosConfig defines config used by boskos server
+type BoskosConfig struct {
+	Resources []ResourceEntry `json:"resources,flow"`
+}
+
+// Metric contains analytics about a specific resource type
+type Metric struct {
+	Type    string         `json:"type"`
+	Current map[string]int `json:"current"`
+	Owners  map[string]int `json:"owner"`
+	// TODO: implements state transition metrics
+}
+
+// NewMetric returns a new Metric struct.
+func NewMetric(rtype string) Metric {
+	return Metric{
+		Type:    rtype,
+		Current: map[string]int{},
+		Owners:  map[string]int{},
+	}
+}
+
+// NewResource creates a new Boskos Resource.
+func NewResource(name, rtype, state, owner string, t time.Time) Resource {
+	// If no state defined, mark as Free
+	if state == "" {
+		state = Free
+	}
+	return Resource{
+		Name:       name,
+		Type:       rtype,
+		State:      state,
+		Owner:      owner,
+		LastUpdate: t,
+	}
+}
+
+// NewResourcesFromConfig parse the a ResourceEntry into a list of resources
+func NewResourcesFromConfig(e ResourceEntry) []Resource {
+	var resources []Resource
+	for _, name := range e.Names {
+		resources = append(resources, NewResource(name, e.Type, e.State, "", time.Time{}))
+	}
+	return resources
+}
+
+// UserDataFromMap returns a UserData from a map
+func UserDataFromMap(m UserDataMap) *UserData {
+	ud := &UserData{}
+	for k, v := range m {
+		ud.Store(k, v)
+	}
+	return ud
+}
+
+// UserDataNotFound will be returned if requested resource does not exist.
+type UserDataNotFound struct {
+	ID string
+}
+
+func (ud *UserDataNotFound) Error() string {
+	return fmt.Sprintf("user data ID %s does not exist", ud.ID)
+}
+
+// ResourceByName helps sorting resources by name
+type ResourceByName []Resource
+
+func (ut ResourceByName) Len() int           { return len(ut) }
+func (ut ResourceByName) Swap(i, j int)      { ut[i], ut[j] = ut[j], ut[i] }
+func (ut ResourceByName) Less(i, j int) bool { return ut[i].Name < ut[j].Name }
+
+// CommaSeparatedStrings is used to parse comma separated string flag into a list of strings
+type CommaSeparatedStrings []string
+
+func (r *CommaSeparatedStrings) String() string {
+	return fmt.Sprint(*r)
+}
+
+// Set parses the flag value into a CommaSeparatedStrings
+func (r *CommaSeparatedStrings) Set(value string) error {
+	if len(*r) > 0 {
+		return errors.New("resTypes flag already set")
+	}
+	for _, rtype := range strings.Split(value, ",") {
+		*r = append(*r, rtype)
+	}
+	return nil
+}
+
+func (r *CommaSeparatedStrings) Type() string {
+	return "commaSeparatedStrings"
+}
+
+// UnmarshalJSON implements JSON Unmarshaler interface
+func (ud *UserData) UnmarshalJSON(data []byte) error {
+	tmpMap := UserDataMap{}
+	if err := json.Unmarshal(data, &tmpMap); err != nil {
+		return err
+	}
+	ud.FromMap(tmpMap)
+	return nil
+}
+
+// MarshalJSON implements JSON Marshaler interface
+func (ud *UserData) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ud.ToMap())
+}
+
+// Extract unmarshalls a string a given struct if it exists
+func (ud *UserData) Extract(id string, out interface{}) error {
+	content, ok := ud.Load(id)
+	if !ok {
+		return &UserDataNotFound{id}
+	}
+	return yaml.Unmarshal([]byte(content.(string)), out)
+}
+
+// User Data are used to store custom information mainly by Mason and Masonable implementation.
+// Mason used a LeasedResource keys to store information about other resources that used to
+// create the given resource.
+
+// Set marshalls a struct to a string into the UserData
+func (ud *UserData) Set(id string, in interface{}) error {
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		return err
+	}
+	ud.Store(id, string(b))
+	return nil
+}
+
+// Update updates existing UserData with new UserData.
+// If a key as an empty string, the key will be deleted
+func (ud *UserData) Update(new *UserData) *UserData {
+	if new == nil {
+		return ud
+	}
+	new.Range(func(key, value interface{}) bool {
+		if value.(string) != "" {
+			ud.Store(key, value)
+		} else {
+			ud.Delete(key)
+		}
+		return true
+	})
+	return ud
+}
+
+// ToMap converts a UserData to UserDataMap
+func (ud *UserData) ToMap() UserDataMap {
+	if ud == nil {
+		return nil
+	}
+	m := UserDataMap{}
+	ud.Range(func(key, value interface{}) bool {
+		m[key.(string)] = value.(string)
+		return true
+	})
+	return m
+}
+
+// FromMap feels updates user data from a map
+func (ud *UserData) FromMap(m UserDataMap) {
+	for key, value := range m {
+		ud.Store(key, value)
+	}
+}
+
+func ResourceTypeNotFoundMessage(rType string) string {
+	return fmt.Sprintf("resource type %q does not exist", rType)
+}

--- a/kubetest/boskos/common/common.go
+++ b/kubetest/boskos/common/common.go
@@ -116,7 +116,7 @@ type Resource struct {
 type ResourceEntry struct {
 	Type     string        `json:"type"`
 	State    string        `json:"state"`
-	Names    []string      `json:"names,flow"`
+	Names    []string      `json:"names"`
 	MaxCount int           `json:"max-count,omitempty"`
 	MinCount int           `json:"min-count,omitempty"`
 	LifeSpan *Duration     `json:"lifespan,omitempty"`
@@ -130,7 +130,7 @@ func (re *ResourceEntry) IsDRLC() bool {
 
 // BoskosConfig defines config used by boskos server
 type BoskosConfig struct {
-	Resources []ResourceEntry `json:"resources,flow"`
+	Resources []ResourceEntry `json:"resources"`
 }
 
 // Metric contains analytics about a specific resource type

--- a/kubetest/boskos/common/config.go
+++ b/kubetest/boskos/common/config.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
+)
+
+// ValidateConfig validates config with existing resources
+// In: boskosConfig - a boskos config defining resources
+// Out: nil on success, error on failure
+func ValidateConfig(config *BoskosConfig) error {
+	if len(config.Resources) == 0 {
+		return errors.New("empty config")
+	}
+	resourceNames := map[string]bool{}
+	resourceTypes := map[string]bool{}
+	resourcesNeeds := map[string]int{}
+	actualResources := map[string]int{}
+
+	var errs []error
+	for idx, e := range config.Resources {
+		if e.Type == "" {
+			errs = append(errs, fmt.Errorf(".%d.type: must be set", idx))
+		}
+
+		if resourceTypes[e.Type] {
+			errs = append(errs, fmt.Errorf(".%d.type.%s already exists", idx, e.Type))
+		}
+
+		names := e.Names
+		if e.IsDRLC() {
+			// Dynamic Resource
+			if e.MaxCount == 0 {
+				errs = append(errs, fmt.Errorf(".%d.max-count: must be >0", idx))
+			}
+			if e.MinCount > e.MaxCount {
+				errs = append(errs, fmt.Errorf(".%d.min-count: must be <= .%d.max-count", idx, idx))
+			}
+			for i := 0; i < e.MaxCount; i++ {
+				name := GenerateDynamicResourceName()
+				names = append(names, name)
+			}
+
+			// Updating resourceNeeds
+			for k, v := range e.Needs {
+				resourcesNeeds[k] += v * e.MaxCount
+			}
+
+		} else {
+			if e.MinCount != 0 {
+				errs = append(errs, fmt.Errorf(".%d.min-count must be unset when the names property is set", idx))
+			}
+			if e.MaxCount != 0 {
+				errs = append(errs, fmt.Errorf(".%d.max-count must be unset when the names property is set", idx))
+			}
+		}
+		actualResources[e.Type] += len(names)
+		for nameIdx, name := range names {
+			validationErrs := validation.IsDNS1123Subdomain(name)
+			if len(validationErrs) != 0 {
+				errs = append(errs, fmt.Errorf(".%d.names.%d(%s) is invalid: %v", idx, nameIdx, name, validationErrs))
+			}
+
+			if _, ok := resourceNames[name]; ok {
+				errs = append(errs, fmt.Errorf(".%d.names.%d(%s) is a duplicate", idx, nameIdx, name))
+				continue
+			}
+			resourceNames[name] = true
+		}
+	}
+
+	for rType, needs := range resourcesNeeds {
+		actual, ok := actualResources[rType]
+		if !ok {
+			errs = append(errs, fmt.Errorf("need for resource %s that does not exist", rType))
+		}
+		if needs > actual {
+			errs = append(errs, fmt.Errorf("not enough resource of type %s for provisioning", rType))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// ParseConfig reads in configPath and returns a list of resource objects
+// on success.
+func ParseConfig(configPath string) (*BoskosConfig, error) {
+	file, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var data BoskosConfig
+	if err := yaml.Unmarshal(file, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}

--- a/kubetest/boskos/common/mason_config.go
+++ b/kubetest/boskos/common/mason_config.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ResourceNeeds maps the type to count of resources types needed
+type ResourceNeeds map[string]int
+
+// TypeToResources stores all the leased resources with the same type f
+type TypeToResources map[string][]Resource
+
+// ConfigType gather the type of config to be applied by Mason in order to construct the resource
+type ConfigType struct {
+	// Identifier of the struct this maps back to
+	Type string `json:"type,omitempty"`
+	// Marshaled JSON content
+	Content string `json:"content,omitempty"`
+}
+
+// DynamicResourceLifeCycle defines the life cycle of a dynamic resource.
+// All Resource of a given type will be constructed using the same configuration
+type DynamicResourceLifeCycle struct {
+	Type string `json:"type"`
+	// Initial state to be created as
+	InitialState string `json:"state"`
+	// Minimum number of resources to be use as a buffer.
+	// Resources in the process of being deleted and cleaned up are included in this count.
+	MinCount int `json:"min-count"`
+	// Maximum number of resources expected. This maximum may be temporarily
+	// exceeded while resources are in the process of being deleted, though this
+	// is only expected when MaxCount is lowered.
+	MaxCount int `json:"max-count"`
+	// Lifespan of a resource, time after which the resource should be reset.
+	LifeSpan *time.Duration `json:"lifespan,omitempty"`
+	// Config information about how to create the object
+	Config ConfigType `json:"config,omitempty"`
+	// Needs define the resource needs to create the object
+	Needs ResourceNeeds `json:"needs,omitempty"`
+}
+
+// DRLCByName helps sorting ResourcesConfig by name
+type DRLCByName []DynamicResourceLifeCycle
+
+func (ut DRLCByName) Len() int           { return len(ut) }
+func (ut DRLCByName) Swap(i, j int)      { ut[i], ut[j] = ut[j], ut[i] }
+func (ut DRLCByName) Less(i, j int) bool { return ut[i].Type < ut[j].Type }
+
+// NewDynamicResourceLifeCycleFromConfig parse the a ResourceEntry into a DynamicResourceLifeCycle
+func NewDynamicResourceLifeCycleFromConfig(e ResourceEntry) DynamicResourceLifeCycle {
+	var dur *time.Duration
+	if e.LifeSpan != nil {
+		dur = e.LifeSpan.Duration
+	}
+	return DynamicResourceLifeCycle{
+		Type:         e.Type,
+		MaxCount:     e.MaxCount,
+		MinCount:     e.MinCount,
+		LifeSpan:     dur,
+		InitialState: e.State,
+		Config:       e.Config,
+		Needs:        e.Needs,
+	}
+}
+
+// Copy returns a copy of the TypeToResources
+func (t TypeToResources) Copy() TypeToResources {
+	n := TypeToResources{}
+	for k, v := range t {
+		n[k] = v
+	}
+	return n
+}
+
+// GenerateDynamicResourceName generates a unique name for dynamic resources
+func GenerateDynamicResourceName() string {
+	return uuid.New().String()
+}

--- a/kubetest/boskos/storage/storage.go
+++ b/kubetest/boskos/storage/storage.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"sync"
+
+	"fmt"
+
+	"k8s.io/test-infra/kubetest/boskos/common"
+)
+
+// PersistenceLayer defines a simple interface to persists Boskos Information
+type PersistenceLayer interface {
+	Add(r common.Resource) error
+	Delete(name string) error
+	Update(r common.Resource) (common.Resource, error)
+	Get(name string) (common.Resource, error)
+	List() ([]common.Resource, error)
+}
+
+type inMemoryStore struct {
+	resources map[string]common.Resource
+	lock      sync.RWMutex
+}
+
+// NewMemoryStorage creates an in memory persistence layer
+func NewMemoryStorage() PersistenceLayer {
+	return &inMemoryStore{
+		resources: map[string]common.Resource{},
+	}
+}
+
+func (im *inMemoryStore) Add(r common.Resource) error {
+	im.lock.Lock()
+	defer im.lock.Unlock()
+	_, ok := im.resources[r.Name]
+	if ok {
+		return fmt.Errorf("resource %s already exists", r.Name)
+	}
+	im.resources[r.Name] = r
+	return nil
+}
+
+func (im *inMemoryStore) Delete(name string) error {
+	im.lock.Lock()
+	defer im.lock.Unlock()
+	_, ok := im.resources[name]
+	if !ok {
+		return fmt.Errorf("cannot find item %s", name)
+	}
+	delete(im.resources, name)
+	return nil
+}
+
+func (im *inMemoryStore) Update(r common.Resource) (common.Resource, error) {
+	im.lock.Lock()
+	defer im.lock.Unlock()
+	_, ok := im.resources[r.Name]
+	if !ok {
+		return common.Resource{}, fmt.Errorf("cannot find item %s", r.Name)
+	}
+	im.resources[r.Name] = r
+	return r, nil
+}
+
+func (im *inMemoryStore) Get(name string) (common.Resource, error) {
+	im.lock.RLock()
+	defer im.lock.RUnlock()
+	r, ok := im.resources[name]
+	if !ok {
+		return common.Resource{}, fmt.Errorf("cannot find item %s", name)
+	}
+	return r, nil
+}
+
+func (im *inMemoryStore) List() ([]common.Resource, error) {
+	im.lock.RLock()
+	defer im.lock.RUnlock()
+	var resources []common.Resource
+	for _, r := range im.resources {
+		resources = append(resources, r)
+	}
+	return resources, nil
+}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	"sigs.k8s.io/boskos/client"
+	"k8s.io/test-infra/kubetest/boskos/client"
 
 	"k8s.io/test-infra/kubetest/conformance"
 	"k8s.io/test-infra/kubetest/kind"


### PR DESCRIPTION
Extracts the parts of boskos that this repository actually uses into a `third_party` directory.

This allows us to remove the `replace` directive, which will in turn allow for a PR against the boskos repository to do the same (after bumping to `main` of k8s.io/test-infra).

Once that's been done, I can create a PR to basically revert this PR and bump our dependency on boskos 😅

Closes #20421
