### PR TITLE
Temporarily run windows conformance tests every 3h and set parallel nodes to 3

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -554,7 +554,7 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-conformance-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-- cron: "0 4/2 * * *"  # Temporarily run every 2h
+- cron: "0 5/3 * * *"  # Temporarily run every 3h
   name: cloud-provider-azure-conformance-windows-capz
   decorate: true
   decoration_config:
@@ -615,7 +615,7 @@ periodics:
       - name: CLUSTER_PROVISIONING_TOOL
         value: "capz"
       - name: GINKGO_PARALLEL_NODES
-        value: "5"
+        value: "3"
       - name: GINKGO_TOLERATE_FLAKES
         value: "y"
   annotations:


### PR DESCRIPTION
Temporarily run windows conformance tests every 3h and set parallel nodes to 3