### PR TITLE
[ci-containerd-e2e-ubuntu-gce-1-6] build 1.24.x locally and switch main image to ubuntu

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -147,7 +147,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
-- interval: 4h
+- interval: 1h
   name: ci-containerd-e2e-ubuntu-gce-1-6
   labels:
     preset-service-account: "true"
@@ -166,7 +166,9 @@ periodics:
           - --check-leaked-resources
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=user-data=/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env
-          - --extract=ci/latest
+          - --build=quick
+          - --extract=local
+          - --gcp-master-image=ubuntu
           - --gcp-node-image=ubuntu
           - --gcp-zone=us-west1-b
           - --ginkgo-parallel=30


### PR DESCRIPTION
CI job still not on its feet
- forgot to ensure that we build locally
- run this job every hour 
- switch main image to ubuntu as well

Signed-off-by: Davanum Srinivas <davanum@gmail.com>