### PR TITLE
Add needs-triage message to Cluster API

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -770,6 +770,18 @@ require_matching_label:
   regexp: ^priority/
 - missing_label: needs-triage
   org: kubernetes-sigs
+  repo: cluster-api
+  issues: true
+  prs: true
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If CAPI contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-triage
+  org: kubernetes-sigs
   repo: cluster-api-provider-aws
   issues: true
   prs: true


### PR DESCRIPTION
We are starting to use triage labels in CAPI....