### PR TITLE
enable dind for ci-containerd-e2e-ubuntu-gce-1-6

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -152,6 +152,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
     preset-e2e-containerd: "true"
     preset-e2e-containerd-image-load: "true"
   spec:


### PR DESCRIPTION
`--build=quick` needs `preset-dind-enabled: "true"` 

diagnosed from the log here:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-containerd-e2e-ubuntu-gce-1-6/1553140712885719040/build-log.txt

Signed-off-by: Davanum Srinivas <davanum@gmail.com>