### PR TITLE
gcsweb directory download instructions

### DIFF
--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -510,7 +510,7 @@ func (dir *gcsDir) Render(out http.ResponseWriter, inPath string) {
 		htmlNextButton(out, gcsPath+inPath, dir.NextMarker)
 	}
 
-	htmlContentFooter(out)
+	htmlContentFooter(out, strings.TrimPrefix(inPath, "/"))
 
 	htmlPageFooter(out)
 }

--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -401,7 +401,15 @@ func TestHandleDirectory(t *testing.T) {
 	    <div class="pure-u-1-5">0</div>
 	    <div class="pure-u-2-5">Sat, 01 Jan 2000 23:00:00 UTC</div>
 	</li>
-</ul></body></html>`,
+</ul>
+<details>
+	<summary style="display: list-item; padding-left: 1em">Download</summary>
+	<div style="padding: 1em">
+		You can download this directory by running the following <a href="https://cloud.google.com/storage/docs/gsutil">gsutil</a> command:
+		<pre>gsutil -m cp -r gs://test-bucket/pr-logs/12345/ .</pre>
+	</div>
+</details>
+</body></html>`,
 		},
 	}
 

--- a/gcsweb/cmd/gcsweb/templates.go
+++ b/gcsweb/cmd/gcsweb/templates.go
@@ -105,12 +105,25 @@ func htmlContentHeader(out io.Writer, dirname, path string) error {
 	return tmplContentHeader.Execute(out, args)
 }
 
-const tmplContentFooterText = `</ul>`
+const tmplContentFooterText = `</ul>
+<details>
+	<summary style="display: list-item; padding-left: 1em">Download</summary>
+	<div style="padding: 1em">
+		You can download this directory by running the following <a href="https://cloud.google.com/storage/docs/gsutil">gsutil</a> command:
+		<pre>gsutil -m cp -r gs://{{.Path}} .</pre>
+	</div>
+</details>
+`
 
 var tmplContentFooter = template.Must(template.New("content-footer").Parse(tmplContentFooterText))
 
-func htmlContentFooter(out io.Writer) error {
-	return tmplContentFooter.Execute(out, struct{}{})
+func htmlContentFooter(out io.Writer, path string) error {
+	args := struct {
+		Path    string
+	}{
+		Path:    path,
+	}
+	return tmplContentFooter.Execute(out, args)
 }
 
 const tmplNextButtonText = `


### PR DESCRIPTION
Adds a new collapsed "Download" button to the gcsweb directory listing
pages. When clicked it gives the user a shell command that they can run
to download the current directory being displayed.

Here is a video demonstrating what it looks like:

https://user-images.githubusercontent.com/10882062/181906942-1cd0f469-d35d-47dd-9e8e-fc1f4a8acb3e.mp4

