### PR TITLE
Drop ci-containerd-e2e-ubuntu-gce-1-6

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -147,41 +147,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
-- interval: 1h
-  name: ci-containerd-e2e-ubuntu-gce-1-6
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-      - args:
-          - --root=/go/src
-          - --repo=k8s.io/kubernetes=release-1.24
-          - --repo=github.com/containerd/containerd=release/1.6
-          - --timeout=70
-          - --scenario=kubernetes_e2e
-          - --
-          - --check-leaked-resources
-          - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env
-          - --env=KUBE_NODE_EXTRA_METADATA=user-data=/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env
-          - --build=quick
-          - --extract=local
-          - --gcp-master-image=ubuntu
-          - --gcp-node-image=ubuntu
-          - --gcp-zone=us-west1-b
-          - --ginkgo-parallel=30
-          - --image-family=ubuntu-2004-lts
-          - --image-project=ubuntu-os-cloud
-          - --provider=gce
-          - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-          - --timeout=50m
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220729-07f065e00e-master
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-e2e-ubuntu-1-6
 - name: ci-cos-cgroupv1-containerd-node-e2e
   interval: 1h
   labels:


### PR DESCRIPTION
ok, i haven't managed to get this on it feet yet. Let's remove it for now and work on this later if we still think we need it.

https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu-1-6

/assign @palnabarun @nikhita @endocrimes 

Signed-off-by: Davanum Srinivas <davanum@gmail.com>