### PR TITLE
Use ubuntu for ci-containerd-e2e-ubuntu-gce

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -135,6 +135,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
+      - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30


### PR DESCRIPTION
We should see if using a ubuntu image helps with the flakiness in:
https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu

Signed-off-by: Davanum Srinivas <davanum@gmail.com>