### PR TITLE
Revert "Use ubuntu for ci-containerd-e2e-ubuntu-gce"

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -135,7 +135,6 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
-      - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30


### PR DESCRIPTION
This reverts commit f9eb91327ee96a1dafa06d93b656f7205b5a76ef.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>