### PR TITLE
enable require matching label plugin in CAPI

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1155,6 +1155,7 @@ plugins:
     plugins:
     - milestone
     - override
+    - require-matching-label
 
   kubernetes-sigs/cluster-api-provider-aws:
     plugins:


### PR DESCRIPTION
Completing the work started in https://github.com/kubernetes/test-infra/pull/26970

/cc @dims 
/cc @vincepri 