### PR TITLE
Fix typo for image:tag on k8s-cve-feed job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -104,7 +104,7 @@ periodics:
   spec:
     serviceAccountName: k8s-cve-feed
     containers:
-    - image: python3.7
+    - image: python:3.7
       command:
       - cd sig-security-tooling/cve-feed/hack/ && ./fetch-cve-feed.sh
       env:


### PR DESCRIPTION
Job is failing: https://testgrid.k8s.io/sig-security-cve-feed#auto-refreshing-official-cve-feed because it can not pull image
/sig security k8s-infra
/area security