### PR TITLE
Updates to fix k8s-cve-feed prow job failures

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -99,14 +99,17 @@ periodics:
   - org: kubernetes
     repo: sig-security
     base_ref: main
+    workdir: true
   labels:
     preset-service-account: "true"
   spec:
     serviceAccountName: k8s-cve-feed
     containers:
-    - image: python:3.7
+    - image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20220607-33951ed1ed
       command:
-      - cd sig-security-tooling/cve-feed/hack/ && ./fetch-cve-feed.sh
+      - sh
+      - "-c"
+      - "cd sig-security-tooling/cve-feed/hack/ && ./fetch-cve-feed.sh"
       env:
       - name: CVE_GCS_PATH
         value: "gs://k8s-cve-feed"


### PR DESCRIPTION
🤞🏼🤞🏼🤞🏼
- Switched image that has python and gsutil installed
- Divided up the command line to be executed into shell
args
- Made k/sig-security the default working directory

/sig security testing k8s-infra

Previous attempts to make it work: https://github.com/kubernetes/test-infra/pull/26896 and https://github.com/kubernetes/test-infra/pull/26988

Inspired from https://github.com/kubernetes/test-infra/pull/26928

/cc @palnabarun @nehaLohia27 @ameukam 