### PR TITLE
CAPG: use 1.24 image with go 1.18 for main tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -57,7 +57,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220729-07f065e00e-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220729-07f065e00e-1.24
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"


### PR DESCRIPTION
Signed-off-by: Prajyot-Parab <prajyot.parab2@ibm.com>