### PR TITLE
crio_serial: Symlink runc before installing crio

### DIFF
--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -38,7 +38,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/40cdd9c2d97384eb5601c1af28e7092cdda3815e/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/40cdd9c2d97384eb5601c1af28e7092cdda3815e/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }


### PR DESCRIPTION
Same change as #26998 but for serial jobs, now that non serial jobs are running (even if not all passing yet)

---

It appears that runc is now installed by default on fedora nodes. This
conflicts with crio installer, that only installs runc to /usr/local/bin
if not already installed
(https://github.com/cri-o/cri-o/blob/a91b943496f87a1d34a6118d035195be69557842/scripts/get#L236-L238).

However, the runc path is then required to be /usr/local/bin/runc for
the script to complete
(https://github.com/cri-o/cri-o/blob/a91b943496f87a1d34a6118d035195be69557842/scripts/get#L247-L250).

/usr/local/bin/runc is also the required runc for the nodee2e installer:
https://raw.githubusercontent.com/cri-o/cri-o/40cdd9c2d97384eb5601c1af28e7092cdda3815e/scripts/node_e2e_installer
