### PR TITLE
Remove excludeConfigPaths for govet-levee test image

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -12,9 +12,6 @@ headBranchName: "prowjobs-autobump"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 includedConfigPaths:
   - "config/jobs"
-# TODO: don't exclude govet-levee once issue.k8s.io/111452 has been fixed
-excludedConfigPaths:
-  - "config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml"
 extraFiles:
   - "config/jobs/image-pushing/k8s-staging-e2e-test-images.sh"
   - "config/jobs/image-pushing/k8s-staging-sig-storage.sh"


### PR DESCRIPTION
https://github.com/golang/go/issues/54086#issuecomment-1204589970 provides a fix for the govet-levee CI panics when used with Go 1.19 (tracking issue: https://github.com/kubernetes/kubernetes/issues/111452).

https://github.com/kubernetes/kubernetes/pull/111677 implements the fix in k/k, once this is merged, we shouldn't prevent auto-bumping the test image for govet-levee and test with the latest build in our CI.

/hold for https://github.com/kubernetes/kubernetes/pull/111677 to merge
/assign @dims @nikhita @palnabarun 
/cc @aojea 