### PR TITLE
node-e2e-serial-crio: extend ginkgo timeout to 4h

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -59,7 +59,7 @@ periodics:
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]"
+          - --test_args=--nodes=1 --timeout=4h --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]"
           - --timeout=240m
       env:
       - name: GOPATH


### PR DESCRIPTION
In ginkgo v1 there was a large default timeout for ginkgo tests, in v2
it became 1 hour. This updates the timeout to be 4h to allow tests to
complete (same timeout as containerd).

/sig node
/priority important-soon
/assign @dims 