### PR TITLE
Update all variants from 1.19rc2 -> 1.19 golang

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.19rc2
+    GO_VERSION: 1.19
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,19 +22,19 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.19rc2
+    GO_VERSION: 1.19
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.19rc2
+    GO_VERSION: 1.19
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: 1.18.5
+    GO_VERSION: 1.19
     K8S_RELEASE: latest-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
update kubekins/krte to 1.19 GA

xref: https://github.com/kubernetes/release/issues/2575

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

/assign @saschagrunert @puerco @justaugustus @BenTheElder @palnabarun 
cc https://github.com/orgs/kubernetes/teams/release-engineering