### PR TITLE
kubekins: fix go build ldflags in cloudbuild.yaml

### DIFF
--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     - go
     - build
     - -o=/workspace/images/kubekins-e2e/kubetest
-    - -ldflags="-X=main.gitTag=$_GIT_TAG"
+    - -ldflags=-X=main.gitTag=$_GIT_TAG
     - ./kubetest/
     env:
     - CGO_ENABLED=0


### PR DESCRIPTION
`go build` now complains if value passed to -ldflags starts with a quote
ref: https://go-review.googlesource.com/c/go/+/339289

Thanks @dims for the above ref! ❤️ 

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

/assign @dims @BenTheElder 
/cc @kubernetes/release-engineering 
/priority critical-urgent
/sig release
/sig testing