### PR TITLE
Bump verify and verify-govet-levee presubmits to new kubekins-e2e with 1.19 golang GA

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220722-16ae0286c2-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220804-4fa19ea91a-master
         imagePullPolicy: IfNotPresent
         command:
         - make

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220729-07f065e00e-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220804-4fa19ea91a-master
         imagePullPolicy: Always
         command:
         - runner.sh


### PR DESCRIPTION
Let's bump a couple of CI jobs to see if it holds up (before the automated image bumps kicks in)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>