### PR TITLE
Add integration test for latest rerun

### DIFF
--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -317,6 +317,13 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 				}
 				return
 			}
+			var rerunDescription string
+			if len(user) > 0 {
+				rerunDescription = fmt.Sprintf("%v successfully reran %v.", user, name)
+			} else {
+				rerunDescription = fmt.Sprintf("Successfully reran %v.", name)
+			}
+			newPJ.Status.Description = rerunDescription
 			created, err := prowJobClient.Create(context.TODO(), &newPJ, metav1.CreateOptions{})
 			if err != nil {
 				l.WithError(err).Error("Error creating job.")

--- a/prow/test/integration/config/prow/cluster/deck_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/deck_deployment.yaml
@@ -46,15 +46,14 @@ spec:
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
-        - --oauth-url=/github-login
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --spyglass=true
+        - --allow-insecure
         - --rerun-creates-job
         - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://fakeghserver
         - --github-oauth-config-file=/etc/githuboauth/secret
-        - --cookie-secret=/etc/cookie/secret
         - --plugin-config=/etc/plugins/plugins.yaml
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -1,3 +1,8 @@
+deck:
+  rerun_auth_configs:
+    '*':
+      allow_anyone: true
+
 sinker:
   resync_period: 5s
   max_prowjob_age: 48h


### PR DESCRIPTION
This PR adds integration testing for the latest rerun. It is a very basic test of changing an existing configuration, updating it, and rerunning with the latest expecting a newly added custom label.

/cc @chaodaiG 