### PR TITLE
Fetch CAPV CI secret from GCP project

### DIFF
--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -53,7 +53,7 @@ metadata:
   namespace: test-pods
 spec:
   backendType: gcpSecretsManager
-  projectId: cf-pks-golf
+  projectId: cluster-api-provider-vsphere
   data:
     - key: CAPV_IPAM_kubeconfig
       name: capv-services.conf
@@ -66,7 +66,7 @@ metadata:
   namespace: test-pods
 spec:
   backendType: gcpSecretsManager
-  projectId: eminent-nation-87317
+  projectId: cluster-api-provider-vsphere
   data:
     - key: cluster-api-provider-vsphere-vcenter-url
       name: vsphere-server


### PR DESCRIPTION
This patch fetches the updated secrets from the GCP project `cluster-api-provider-vsphere` for the CAPV project. This has the secrets used by the CI jobs. 