### PR TITLE
kubernetes-csi: more realistic pre-merge testing of csi-release-tools

### DIFF
--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -59,25 +59,15 @@ presubmits:
         - runner.sh
         args:
         - ./pull-test.sh # provided by csi-release-tools
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.22.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.22"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.8.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "unit sanity parallel"
-        - name: PULL_TEST_REPO_DIR
-          value: /home/prow/go/src/github.com/kubernetes-csi/csi-test
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: 2000m
+        env:
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
   - name: pull-kubernetes-csi-release-tools-external-provisioner
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
@@ -105,25 +95,25 @@ presubmits:
         - runner.sh
         args:
         - ./pull-test.sh # provided by csi-release-tools
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.22.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.22"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.8.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "unit sanity parallel"
-        - name: PULL_TEST_REPO_DIR
-          value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: 2000m
+        env:
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.8.0"
+        - name: CSI_PROW_TESTS
+          value: "unit sanity parallel"
+        - name: PULL_TEST_REPO_DIR
+          value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
   - name: pull-kubernetes-csi-release-tools-external-snapshotter
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
@@ -151,25 +141,25 @@ presubmits:
         - runner.sh
         args:
         - ./pull-test.sh # provided by csi-release-tools
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.22.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.22"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.8.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "unit sanity parallel"
-        - name: PULL_TEST_REPO_DIR
-          value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: 2000m
+        env:
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.8.0"
+        - name: CSI_PROW_TESTS
+          value: "unit sanity parallel"
+        - name: PULL_TEST_REPO_DIR
+          value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
   - name: pull-kubernetes-csi-release-tools-csi-driver-host-path
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
@@ -197,22 +187,22 @@ presubmits:
         - runner.sh
         args:
         - ./pull-test.sh # provided by csi-release-tools
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.22.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.22"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.8.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "unit sanity parallel"
-        - name: PULL_TEST_REPO_DIR
-          value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: 2000m
+        env:
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.8.0"
+        - name: CSI_PROW_TESTS
+          value: "unit sanity parallel"
+        - name: PULL_TEST_REPO_DIR
+          value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -754,22 +754,35 @@ for repo in $csi_release_tools_repos; do
         - runner.sh
         args:
         - ./pull-test.sh # provided by csi-release-tools
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+$(resources_for_kubernetes "$latest_stable_k8s_version")
         env:
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: $(snapshotter_version "$latest_stable_k8s_version" "")
+EOF
+
+    # The environment must mirror the corresponding pull jobs for those repos,
+    # otherwise our pre-merge testing will not match what those jobs will do
+    # after updating csi-release-tools.
+    #
+    # CSI_SNAPSHOTTER_VERSION above is common to all jobs. csi-test only
+    # has one job which uses the default Kubernetes defined in prow.sh.
+    # We should therefore not override these settings. For the other
+    # repos we mimick testing on the latest stable K8S.
+    if [ "${repo}" != "csi-test" ]; then
+        cat >>"$base/csi-release-tools/csi-release-tools-config.yaml" <<EOF
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "$latest_stable_k8s_version.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "$latest_stable_k8s_version"
         - name: CSI_PROW_DRIVER_VERSION
           value: "$hostpath_driver_version"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: $(snapshotter_version "$latest_stable_k8s_version" "")
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/$repo
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-$(resources_for_kubernetes "$latest_stable_k8s_version")
 EOF
+    fi
 done


### PR DESCRIPTION
In https://github.com/kubernetes-csi/csi-release-tools/pull/195, the
csi-driver-host-path version was bumped while keeping the default Kubernetes
version at the (ancient!) v1.17.0. When updating csi-release-tools later in
csi-test, pull-kubernetes-csi-csi-test failed because the new driver is not
supporting Kubernetes 1.17 anymore (no v1 CSIDriver API).

This wasn't detected by the csi-release-tools pre-submmit because it overwrote
the Kubernetes version. That's okay for other repos (they do the same in their
jobs) but not for csi-test.