### PR TITLE
flaky test fix: moving prow job to a different build cluster 

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1242,6 +1242,7 @@ periodics:
     testgrid-alert-email: ehashman@redhat.com, mkmir@google.com
     description: Executes E2E suite with swap enabled on Ubuntu
 - name: ci-kubernetes-node-kubelet-containerd-performance-test
+  cluster: k8s-infra-prow-build
   interval: 12h
   labels:
     preset-service-account: "true"
@@ -1268,6 +1269,13 @@ periodics:
         env:
           - name: GOPATH
             value: /go
+        resources:
+          limits:
+            cpu: 15000m
+            memory: 16Gi
+          requests:
+            cpu: 15000m
+            memory: 16Gi
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-performance-test


### PR DESCRIPTION
moving prow job ci-kubernetes-node-kubelet-container-performance-test to a different build cluster

e2e_node test [node-kubelet-containerd-performance-test](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-containerd-performance-test/1552135743453794304) has been failing due to an inaccessible test asset.

After some discussion we are moving this test to try to facilitate moving the test asset into a controlled resource.

Tracking ticket: https://github.com/kubernetes/kubernetes/issues/109295