### PR TITLE
kubernetes-csi: don't override snapshotter version for csi-test

### DIFF
--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -68,8 +68,6 @@ presubmits:
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-test
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
   - name: pull-kubernetes-csi-release-tools-external-provisioner
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
@@ -106,8 +104,6 @@ presubmits:
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.22.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
@@ -116,6 +112,8 @@ presubmits:
           value: "v1.8.0"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
   - name: pull-kubernetes-csi-release-tools-external-snapshotter
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
@@ -152,8 +150,6 @@ presubmits:
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.22.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
@@ -162,6 +158,8 @@ presubmits:
           value: "v1.8.0"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
   - name: pull-kubernetes-csi-release-tools-csi-driver-host-path
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
@@ -198,8 +196,6 @@ presubmits:
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.22.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
@@ -208,3 +204,5 @@ presubmits:
           value: "v1.8.0"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -761,18 +761,11 @@ $(resources_for_kubernetes "$latest_stable_k8s_version")
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/$repo
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: $(snapshotter_version "$latest_stable_k8s_version" "")
 EOF
 
     # The environment must mirror the corresponding pull jobs for those repos,
     # otherwise our pre-merge testing will not match what those jobs will do
     # after updating csi-release-tools.
-    #
-    # CSI_SNAPSHOTTER_VERSION above is common to all jobs. csi-test only
-    # has one job which uses the default Kubernetes defined in prow.sh.
-    # We should therefore not override these settings. For the other
-    # repos we mimick testing on the latest stable K8S.
     if [ "${repo}" != "csi-test" ]; then
         cat >>"$base/csi-release-tools/csi-release-tools-config.yaml" <<EOF
         - name: CSI_PROW_KUBERNETES_VERSION
@@ -783,6 +776,8 @@ EOF
           value: "$hostpath_driver_version"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: $(snapshotter_version "$latest_stable_k8s_version" "")
 EOF
     fi
 done


### PR DESCRIPTION
The csi-test pull job uses the snapshotter version defined in prow.sh,
therefore the pull job for csi-test should not override it either to detect
a mismatched version in the prow.sh file.