### PR TITLE
sig-node: fix resources for containerd-performance-test

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1272,11 +1272,11 @@ periodics:
             value: /go
         resources:
           limits:
-            cpu: 15000m
-            memory: 16Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 15000m
-            memory: 16Gi
+            cpu: 4
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-performance-test


### PR DESCRIPTION
Reducing the resources requested to ensure the test can run on community
infrastruture.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>