### PR TITLE
chore: Update Windows CAPZ jobs to use containerd v1.6.8

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -30,7 +30,7 @@ presets:
     preset-capz-containerd-latest: "true"
   env:
   - name: WINDOWS_CONTAINERD_URL
-    value: "https://github.com/containerd/containerd/releases/download/v1.6.6/containerd-1.6.6-windows-amd64.tar.gz"
+    value: "https://github.com/containerd/containerd/releases/download/v1.6.8/containerd-1.6.8-windows-amd64.tar.gz"
 - labels:
     preset-capz-serial-slow: "true"
   env:


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Containerd v1.6.8 has a fix for stats not being filled out for host-process containers on Windows.