### PR TITLE
Bump go version to 1.18 in kwok CI

### DIFF
--- a/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
@@ -12,7 +12,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.18
         command:
         - make
         args:
@@ -28,7 +28,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.18
         command:
         - make
         args:
@@ -44,7 +44,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.18
         command:
         - make
         args:
@@ -60,7 +60,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.18
         command:
         - make
         args:
@@ -76,7 +76,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.18
         command:
         - make
         args:


### PR DESCRIPTION
The kwok `main` is vendoring k8s v1.24, which is using go 1.18, so we should bump the go version to 1.18 as well.