### PR TITLE
Mutating Webhook and Integration Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306
 	golang.org/x/tools v0.1.11
+	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/api v0.83.0
 	google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac
 	google.golang.org/grpc v1.47.0
@@ -202,7 +203,6 @@ require (
 	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/prow/cmd/webhook-server/helpers_test.go
+++ b/prow/cmd/webhook-server/helpers_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"k8s.io/test-infra/prow/flagutil"
+)
+
+func TestCreateSecret(t *testing.T) {
+	tests := []struct {
+		name     string
+		dnsNames []string
+		expiry   int
+		want     [3]string
+	}{
+		{
+			name:     "base",
+			dnsNames: []string{"bar"},
+			expiry:   10,
+			want:     [3]string{"bar10a", "bar10b", "bar10c"},
+		},
+		{
+			name:     "noDnsNames",
+			dnsNames: []string{},
+			expiry:   10,
+			want:     [3]string{"", "", ""},
+		},
+	}
+
+	oldGenCertFunc := genCertFunc
+	genCertFunc = func(expiry int, dnsNames []string) (string, string, string, error) {
+		if len(dnsNames) == 0 {
+			return "", "", "", errors.New("dnsNames was not configured")
+		}
+		baseName := dnsNames[0] + strconv.Itoa(expiry)
+		return fmt.Sprintf("%s%s", baseName, "a"), fmt.Sprintf("%s%s", baseName, "b"), fmt.Sprintf("%s%s", baseName, "c"), nil
+	}
+	t.Cleanup(func() {
+		genCertFunc = oldGenCertFunc
+	})
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Parallel()
+			ctx := context.Background()
+			clientoptions := clientOptions{
+				secretID:      secretID,
+				dnsNames:      flagutil.NewStrings(tc.dnsNames...),
+				expiryInYears: tc.expiry,
+			}
+			f := newFakeClient()
+
+			gotCert, gotPrivKey, gotCaPem, gotErr := createSecret(f, ctx, clientoptions)
+			if tc.name == "noDnsNames" && gotErr == nil {
+				t.Fatalf("unexpected error %v", gotErr)
+			} else if tc.name != "noDnsNames" && gotErr != nil {
+				t.Fatalf("unexpected error %v", gotErr)
+			}
+			if gotCert != tc.want[0] || gotPrivKey != tc.want[1] || gotCaPem != tc.want[2] {
+				t.Fatalf("cert values do not match")
+			}
+		})
+	}
+
+}
+
+func TestUpdateSecret(t *testing.T) {
+	f := newFakeClient()
+	expectedValue := "{\"caBundle.pem\":\"bar10c\",\"certFile.pem\":\"bar10a\",\"privKeyFile.pem\":\"bar10b\"}"
+	f.project.store = map[string]string{secretID: "hello"}
+	tests := []struct {
+		name     string
+		dnsNames []string
+		expiry   int
+		want     [3]string
+	}{
+		{
+			name:     "base",
+			dnsNames: []string{"bar"},
+			expiry:   10,
+			want:     [3]string{"bar10a", "bar10b", "bar10c"},
+		},
+		{
+			name:     "noDnsNames",
+			dnsNames: []string{},
+			expiry:   10,
+			want:     [3]string{"", "", ""},
+		},
+	}
+
+	oldGenCertFunc := genCertFunc
+	genCertFunc = func(expiry int, dnsNames []string) (string, string, string, error) {
+		if len(dnsNames) == 0 {
+			return "", "", "", errors.New("dnsNames was not configured")
+		}
+		baseName := dnsNames[0] + strconv.Itoa(expiry)
+		return fmt.Sprintf("%s%s", baseName, "a"), fmt.Sprintf("%s%s", baseName, "b"), fmt.Sprintf("%s%s", baseName, "c"), nil
+	}
+	t.Cleanup(func() {
+		genCertFunc = oldGenCertFunc
+	})
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			clientoptions := clientOptions{
+				secretID:      secretID,
+				dnsNames:      flagutil.NewStrings(tc.dnsNames...),
+				expiryInYears: tc.expiry,
+			}
+
+			gotCert, gotPrivKey, gotCaPem, gotErr := updateSecret(f, ctx, clientoptions)
+			if tc.name == "noDnsNames" && gotErr == nil {
+				t.Fatalf("unexpected error %v", gotErr)
+			} else if tc.name != "noDnsNames" && gotErr != nil {
+				t.Fatalf("unexpected error %v", gotErr)
+			}
+			if gotCert != tc.want[0] || gotPrivKey != tc.want[1] || gotCaPem != tc.want[2] {
+				t.Fatalf("cert values do not match")
+			}
+			if f.project.store[secretID] != expectedValue {
+				t.Fatalf("secret was not updated")
+			}
+		})
+	}
+
+}

--- a/prow/cmd/webhook-server/main_test.go
+++ b/prow/cmd/webhook-server/main_test.go
@@ -31,6 +31,13 @@ type fakeClient struct {
 	project secretStore
 }
 
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		project: secretStore{
+			store: make(map[string]string),
+		},
+	}
+}
 func (f *fakeClient) CreateSecret(ctx context.Context, secretID string) error {
 	f.project.store[secretID] = ""
 	return nil
@@ -67,19 +74,14 @@ func (f *fakeClient) CheckSecret(ctx context.Context, secretName string) (bool, 
 	}
 }
 
-var (
-	store = make(map[string]string)
-	f     = &fakeClient{
-		project: secretStore{
-			store: store,
-		},
-	}
-	ctx      = context.Background()
+const (
 	secretID = "prowjob-webhook-secrets"
 	payload  = "xxx123"
 )
 
 func TestCreateSecrets(t *testing.T) {
+	ctx := context.Background()
+	f := newFakeClient()
 	f.CreateSecret(ctx, secretID)
 	if len(f.project.store) == 0 {
 		t.Errorf("secret was not created successfully")
@@ -87,6 +89,8 @@ func TestCreateSecrets(t *testing.T) {
 }
 
 func TestGetSecretValue(t *testing.T) {
+	ctx := context.Background()
+	f := newFakeClient()
 	f.AddSecretVersion(ctx, secretID, []byte(payload))
 	res, exist, err := f.GetSecretValue(ctx, secretID, "")
 	if err != nil {

--- a/prow/cmd/webhook-server/mutation.go
+++ b/prow/cmd/webhook-server/mutation.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/api/admission/v1beta1"
+	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+func (wa *webhookAgent) serveMutate(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		logrus.WithError(err).Info("unable to read request")
+		http.Error(w, fmt.Sprintf("bad request %v", err), http.StatusBadRequest)
+		return
+	}
+	admissionReview := &v1beta1.AdmissionReview{}
+	err = json.Unmarshal(body, admissionReview)
+	if err != nil {
+		logrus.WithError(err).Info("unable to unmarshal admission review request")
+		http.Error(w, fmt.Sprintf("unable to unmarshal admission review request %v", err), http.StatusBadRequest)
+		return
+	}
+	admissionRequest := admissionReview.Request
+	var prowJob v1.ProwJob
+	err = json.Unmarshal(admissionRequest.Object.Raw, &prowJob)
+	if err != nil {
+		logrus.WithError(err).Info("unable to prowjob from request")
+		http.Error(w, fmt.Sprintf("unable to unmarshal prowjob %v", err), http.StatusBadRequest)
+		return
+	}
+	var mutatedProwJobPatch []byte
+	if admissionRequest.Operation == "CREATE" {
+		mutatedProwJobPatch, err = generateMutatingPatch(&prowJob, wa.plank)
+		if err != nil {
+			logrus.WithError(err).Info("unable to return mutated prowjob patch")
+			http.Error(w, fmt.Sprintf("unable to return mutated prowjob patch %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+	admissionReview.Response = createMutatingAdmissionResponse(admissionRequest.UID, mutatedProwJobPatch)
+	resp, err := json.Marshal(admissionReview)
+	if err != nil {
+		logrus.WithError(err).Info("unable to marshal response")
+		http.Error(w, fmt.Sprintf("unable to marshal mutated prowjob patch %v", err), http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(resp); err != nil {
+		logrus.WithError(err).Info("unable to write response")
+		http.Error(w, fmt.Sprintf("unable to write response: %v", err), http.StatusInternalServerError)
+		return
+	}
+}
+
+func createMutatingAdmissionResponse(uid types.UID, patch []byte) *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		UID:     uid,
+		Allowed: true,
+		Result: &apiv1.Status{
+			Message: accepted,
+		},
+		Patch: patch,
+		PatchType: func() *v1beta1.PatchType {
+			pt := v1beta1.PatchTypeJSONPatch
+			return &pt
+		}(),
+	}
+}
+
+func generateMutatingPatch(prowJob *v1.ProwJob, plank config.Plank) ([]byte, error) {
+	var defDecorationConfig *v1.DecorationConfig
+	var patchBytes []byte
+	if prowJob.Spec.Type == v1.PeriodicJob {
+		var repo string
+		if len(prowJob.Spec.ExtraRefs) > 0 {
+			repo = fmt.Sprintf("%s/%s", prowJob.Spec.ExtraRefs[0].Org, prowJob.Spec.ExtraRefs[0].Repo)
+		}
+		defDecorationConfig = plank.GuessDefaultDecorationConfigWithJobDC(repo, prowJob.Spec.Cluster, prowJob.Spec.DecorationConfig)
+	} else {
+		defDecorationConfig = plank.GuessDefaultDecorationConfig(prowJob.Spec.Refs.Repo, prowJob.Spec.Cluster)
+	}
+	prowJobCopy := prowJob.DeepCopy()
+	prowJobCopy.Spec.DecorationConfig = prowJobCopy.Spec.DecorationConfig.ApplyDefault(defDecorationConfig)
+	originalProwJobJSON, err := json.Marshal(prowJob)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal prowjob %v", err)
+	}
+	mutatedProwJobJSON, err := json.Marshal(prowJobCopy)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal prowjob %v", err)
+	}
+	patch, err := jsonpatch.CreatePatch(originalProwJobJSON, mutatedProwJobJSON)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create json patch")
+	}
+	patchBytes, err = json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal patch")
+	}
+
+	return patchBytes, nil
+}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -763,6 +763,13 @@ func (p *Plank) GuessDefaultDecorationConfig(repo, cluster string) *prowapi.Deco
 	return p.mergeDefaultDecorationConfig(repo, cluster, nil)
 }
 
+// GuessDefaultDecorationConfig attempts to find the resolved default decoration
+// config for a given repo, cluster and job DecorationConfig. It is primarily used for best effort
+// guesses about GCS configuration for undecorated jobs.
+func (p *Plank) GuessDefaultDecorationConfigWithJobDC(repo, cluster string, jobDC *prowapi.DecorationConfig) *prowapi.DecorationConfig {
+	return p.mergeDefaultDecorationConfig(repo, cluster, jobDC)
+}
+
 // defaultDecorationMapToSlice converts the old format
 // (map[string]*prowapi.DecorationConfig) to the new format
 // ([]*DefaultDecorationConfigEntry).

--- a/prow/test/integration/config/prow/cluster/webhook_server_rbac.yaml
+++ b/prow/test/integration/config/prow/cluster/webhook_server_rbac.yaml
@@ -27,6 +27,7 @@ rules:
       - "admissionregistration.k8s.io"
     resources:
       - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
     verbs:
       - create
       - list

--- a/prow/test/integration/config/prow/cluster/webhook_server_service.yaml
+++ b/prow/test/integration/config/prow/cluster/webhook_server_service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: webhook-server
   namespace: default
-  name: prowjob-validation-webhook
+  name: prowjob-admission-webhook
 spec:
   selector:
     app: webhook-server
@@ -31,3 +31,4 @@ spec:
     port: 9090
     protocol: TCP
   type: ClusterIP
+

--- a/prow/test/integration/test/testdata/valid_bare_prowjob.yaml
+++ b/prow/test/integration/test/testdata/valid_bare_prowjob.yaml
@@ -1,0 +1,60 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  annotations:
+    prow.k8s.io/context: ''
+    prow.k8s.io/job: ci-k8s-infra-build-cluster-prow-build
+    testgrid-alert-email: 'k8s-infra-alerts@kubernetes.io, k8s-infra-prow-oncall@kubernetes.io'
+    testgrid-dashboards: sig-k8s-infra-prow
+    testgrid-num-failures-to-alert: '6'
+    testgrid-tab-name: gke-prow-build-heartbeat
+  creationTimestamp: '2022-07-18T20:30:22Z'
+  generation: 7
+  labels:
+    prow.k8s.io/build-id: '1549129474832863232'
+    prow.k8s.io/context: ''
+    prow.k8s.io/id: test-mutate-job
+    prow.k8s.io/job: ci-k8s-infra-build-cluster-prow-build
+    prow.k8s.io/refs.base_ref: master
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
+    prow.k8s.io/type: periodic
+    foo: bar
+    default-me: enabled
+    admission-webhook: enabled
+  name: test-mutate-job
+  namespace: default
+  resourceVersion: '1085091611'
+  uid: 35197a85-9518-41a9-bc60-66ec48cfcf5f
+spec:
+  agent: tekton-pipeline
+  cluster: k8s-infra-prow-build
+  extra_refs:
+    - base_ref: master
+      org: kubernetes
+      repo: test-infra
+  job: ci-k8s-infra-build-cluster-prow-build
+  max_concurrency: 1
+  namespace: test-pods
+  pod_spec:
+    containers:
+      - args:
+          - Everything is fine!
+        command:
+          - echo
+        env:
+          - name: GOPROXY
+            value: 'https://proxy.golang.org'
+        image: 'gcr.io/k8s-staging-infra-tools/k8s-infra:latest'
+        name: ''
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+  prowjob_defaults:
+    tenant_id: GlobalDefaultID
+  report: true
+  type: periodic


### PR DESCRIPTION
next PR will mount a volume to store the filesystem secrets for use in integration testing. It will also explore the use of a flag to set the serviceName and Namespace for the admission webhook. 