### PR TITLE
releng 1.25: Add 1.25 and remove 1.21 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -387,10 +387,10 @@ milestone_applier:
     master: v1.25
   kubernetes/kubernetes:
     master: v1.25
+    release-1.25: v1.25
     release-1.24: v1.24
     release-1.23: v1.23
     release-1.22: v1.22
-    release-1.21: v1.21
   kubernetes/org:
     main: v1.25
   kubernetes/release:


### PR DESCRIPTION
releng: Add 1.25 and remove 1.21 milestone_applier rules
Pending branch cut:
/hold

/sig release
/area release-eng
/assign @Verolop @puerco 
cc: https://github.com/orgs/kubernetes/teams/release-engineering

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>