### PR TITLE
releng 1.25: Update kubekins-e2e variants

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -41,7 +41,7 @@ variants:
   '1.24':
     CONFIG: '1.24'
     GO_VERSION: 1.18.5
-    K8S_RELEASE: latest-1.24
+    K8S_RELEASE: stable-1.24
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':


### PR DESCRIPTION
* No change to 1.25 variant, it was already updated
* Update 1.24 kubekins-e2e variant to set K8S_RELEASE to stable-1.24

Pending branch cut:
/hold

/sig release
/area release-eng
/assign @puerco  @Verolop 
cc: https://github.com/orgs/kubernetes/teams/release-engineering

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>