### PR TITLE
Fix generated release branch presubmit names

### DIFF
--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -86,7 +86,6 @@ func generatePresubmits(c config.JobConfig, version string) (map[string][]config
 			p.SkipBranches = nil
 			p.Branches = []string{"release-" + version}
 			p.Context = generatePresubmitContextVariant(p.Name, p.Context, version)
-			p.Name = generatePresubmitNameVariant(p.Name, version)
 			if p.Spec != nil {
 				for i := range p.Spec.Containers {
 					c := &p.Spec.Containers[i]
@@ -361,14 +360,6 @@ func generateNameVariant(name, version string, generic bool) string {
 	if !generic {
 		suffix = "-" + strings.ReplaceAll(version, ".", "-")
 	}
-	if !strings.HasSuffix(name, masterSuffix) {
-		return name + suffix
-	}
-	return replaceAllMaster(name, suffix)
-}
-
-func generatePresubmitNameVariant(name, version string) string {
-	suffix := "-" + version
 	if !strings.HasSuffix(name, masterSuffix) {
 		return name + suffix
 	}

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -559,7 +559,7 @@ func TestGeneratePresubmits(t *testing.T) {
 		"kubernetes/kubernetes": {
 			{
 				JobBase: config.JobBase{
-					Name:        "pull-kubernetes-e2e-1.15",
+					Name:        "pull-kubernetes-e2e",
 					Annotations: map[string]string{},
 				},
 				Brancher: config.Brancher{
@@ -571,7 +571,7 @@ func TestGeneratePresubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
-					Name:        "pull-kubernetes-e2e-branch-in-name-1.15",
+					Name:        "pull-kubernetes-e2e-branch-in-name-master",
 					Annotations: map[string]string{},
 				},
 				Brancher: config.Brancher{
@@ -583,7 +583,7 @@ func TestGeneratePresubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
-					Name:        "pull-kubernetes-e2e-keep-context-1.15",
+					Name:        "pull-kubernetes-e2e-keep-context",
 					Annotations: map[string]string{},
 				},
 				Brancher: config.Brancher{
@@ -595,7 +595,7 @@ func TestGeneratePresubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
-					Name:        "pull-kubernetes-e2e-replace-context-1.15",
+					Name:        "pull-kubernetes-e2e-replace-context",
 					Annotations: map[string]string{},
 				},
 				Brancher: config.Brancher{
@@ -607,7 +607,7 @@ func TestGeneratePresubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
-					Name: "pull-replace-some-things-1.15",
+					Name: "pull-replace-some-things",
 					Annotations: map[string]string{
 						"some-annotation": "yup",
 					},


### PR DESCRIPTION
This PR fixes the generated branch jobs so that presubmit names do not get the version number appended. When committing new branch jobs, the presubmits were breaking because of the version suffix, ie:

  `pull-kubernetes-e2e-kops-aws-1.25` now becomes →
  `pull-kubernetes-e2e-kops-aws`

/fixes  #27098

/cc @chaodaiG @Verolop @jeremyrickard 
/cc @kubernetes/release-engineering 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>