### PR TITLE
Use kubekins-e2e in kwok CI

### DIFF
--- a/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
@@ -76,8 +76,12 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220804-4fa19ea91a-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - e2e-test
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true


### PR DESCRIPTION

Use the same image as the other CIs

https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/Dockerfile

/cc @Huang-Wei
