### PR TITLE
Fix a typo in `CreateCheckRun` method

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -4962,15 +4962,13 @@ func (c *client) ListCheckRuns(org, repo, ref string) (*CheckRunList, error) {
 func (c *client) CreateCheckRun(org, repo string, checkRun CheckRun) error {
 	durationLogger := c.log("CreateCheckRun", org, repo, checkRun)
 	defer durationLogger()
-
-	var retCheckRun CheckRun
 	_, err := c.request(&request{
 		method:      http.MethodPost,
-		path:        fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", org, repo, checkRun.HeadSHA),
+		path:        fmt.Sprintf("/repos/%s/%s/check-runs", org, repo),
 		org:         org,
 		requestBody: &checkRun,
 		exitCodes:   []int{201},
-	}, &retCheckRun)
+	}, nil)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -514,7 +514,7 @@ Successful checkruns are listed but can not be overridden.`, formatList(unknown.
 	// Checkruns have been converted to contexts and deduped
 	if oc.UsesAppAuth() {
 		for _, checkrun := range checkrunContexts {
-			if overrides.Has(checkrun.Context) && checkrun.State != "SUCCESS" {
+			if overrides.Has(checkrun.Context) && !done.Has(checkrun.Context) && checkrun.State != "SUCCESS" {
 				prowOverrideCR := github.CheckRun{
 					Name:       checkrun.Context,
 					HeadSHA:    sha,

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -533,7 +533,7 @@ Successful checkruns are listed but can not be overridden.`, formatList(unknown.
 				done.Insert(checkrun.Context)
 			} else if overrides.Has(checkrun.Context) && checkrun.State == "SUCCESS" {
 				// This is to prevent creating duplicate success checkrun by prow. Legacy contexts are updated in place but you cant update checkruns submitted by another github app
-				resp := fmt.Sprintf("The Check Run %s is already marked as successful, skipping override. If you specified another checkrun in the same comment that isn't successful, please reissue the override command for the failed checkrun.", checkrun.Context)
+				resp := fmt.Sprintf("The Check Run %s is already marked as successful, skipping override.", checkrun.Context)
 				log.Info(resp)
 				oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 			}

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -428,7 +428,7 @@ func TestHandle(t *testing.T) {
 			},
 			usesAppsAuth: true,
 			checkComments: []string{
-				"The Check Run success-checkrun is already marked as successful",
+				"The following unknown contexts/checkruns were given:", "`success-checkrun`",
 			},
 		},
 		{
@@ -513,7 +513,7 @@ func TestHandle(t *testing.T) {
 			},
 			checkComments: []string{
 				"The following unknown contexts/checkruns were given", "whatever-you-want",
-				"Only the following contexts/checkruns were expected", "hung-test", "hung-prow-job",
+				"Only the following failed contexts/checkruns were expected", "hung-test", "hung-prow-job",
 			},
 		},
 		{

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -411,6 +411,27 @@ func TestHandle(t *testing.T) {
 			usesAppsAuth: true,
 		},
 		{
+			name:    "override a successful unknown context derived from checkruns",
+			comment: "/override success-checkrun",
+			checkruns: &github.CheckRunList{
+				CheckRuns: []github.CheckRun{
+					{Name: "incomplete-checkrun"},
+					{Name: "success-checkrun", CompletedAt: "1800 BC", Conclusion: "success"},
+				},
+			},
+			expected: []github.Status{},
+			expectedCheckRuns: &github.CheckRunList{
+				CheckRuns: []github.CheckRun{
+					{Name: "incomplete-checkrun"},
+					{Name: "success-checkrun", CompletedAt: "1800 BC", Conclusion: "success"},
+				},
+			},
+			usesAppsAuth: true,
+			checkComments: []string{
+				"The Check Run success-checkrun is already marked as successful",
+			},
+		},
+		{
 			name:    "override failure-checkrun checkrun, usesAppsAuth is false",
 			comment: "/override failure-checkrun",
 			checkruns: &github.CheckRunList{
@@ -491,8 +512,8 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			checkComments: []string{
-				"The following unknown contexts were given", "whatever-you-want",
-				"Only the following contexts were expected", "hung-test", "hung-prow-job",
+				"The following unknown contexts/checkruns were given", "whatever-you-want",
+				"Only the following contexts/checkruns were expected", "hung-test", "hung-prow-job",
 			},
 		},
 		{
@@ -1138,7 +1159,6 @@ func TestHandle(t *testing.T) {
 				t.Errorf("expected checkruns differs from actual: %s", cmp.Diff(fc.checkruns, tc.expectedCheckRuns))
 
 			}
-
 			for _, expectedComment := range tc.checkComments {
 				if !strings.Contains(strings.Join(fc.comments, "\n"), expectedComment) {
 					t.Errorf("bad comments: expected %#v to be in %#v", expectedComment, fc.comments)


### PR DESCRIPTION
/cc @alvaroaleman 

- Fixed a typo in `CreateCheckRun` method
- Added some tests
- For some reason, an empty context was appearing on the list so I added check to remove it.
- Something I forgot earlier is to block creation of a duplicate checkrun for checkruns that are successful.

https://github.com/knative/serving/pull/13176#issuecomment-1210456459
Hook Log Entry:
```
{"author":"upodroid", "component":"hook", "error":"status code 404 not one of [201], body: {"message":"Not Found","documentation_url":"https://docs.github.com/rest"}", "event-GUID":"8d96cc50-1894-11ed-90ae-a156854ac635", "event-type":"issue_comment", "file":"k8s.io/test-infra/prow/plugins/override/override.go:526", "func":"k8s.io/test-infra/prow/plugins/override.handle", "level":"warning", "msg":"cannot create prow-override CheckRun {0  64485201bcd4dc322bfdfa5b4d65b2c334827d12     completed success   {Prow override - trailing whitespace Prow has received override command for the trailing whitespace checkrun.  0  [] []} trailing whitespace {0         <nil> <nil> [] <nil>} {0   {   0  {false false false false false} }       <nil> []} []}", "org":"knative", "plugin":"override", "pr":13176, "repo":"serving", "url":"https://github.com/knative/serving/pull/13176#issuecomment-1210457420"}
```