### PR TITLE
Add preset-dind-enabled for kwok CI

### DIFF
--- a/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
@@ -71,6 +71,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kwok-e2e-test-main
+    labels:
+      preset-dind-enabled: "true"
     branches:
     - ^main$
     always_run: true


### PR DESCRIPTION
xref #27100
/cc @Huang-Wei

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kwok/11/pull-kwok-e2e-test-main/1557414558119759872
The label `preset-dind-enabled` is required to mount `unix:///var/run/docker.sock`
