### PR TITLE
Patch to AWS IAM Authenticator e2e test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
@@ -42,6 +42,7 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
+      preset-dind-enabled: "true"
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
@@ -51,6 +52,8 @@ presubmits:
         args:
         - make
         - e2e
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: provider-aws-iam-authenticator
       testgrid-tab-name: pull-e2e


### PR DESCRIPTION
Enable privileged container as docker needs to be used