### PR TITLE
Update Cluster-API-Provider Cloudstack prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -104,7 +104,7 @@ presubmits:
           - bash
           - -c
           - >
-            cp /secrets/cloud-config ./cloud-config && cat ./cloud-config && mv /mybin ./bin && make test
+            mv /mybin ./bin && make test
           resources:
             requests:
               memory: "8Gi"
@@ -112,12 +112,3 @@ presubmits:
             limits:
               memory: "8Gi"
               cpu: "1024m"
-          volumeMounts:
-          - mountPath: /secrets
-            name: secrets
-            readOnly: true
-        volumes:
-        - name: secrets
-          secret:
-            defaultMode: 256
-            secretName: cloudstack-token


### PR DESCRIPTION
These changes remove a requirement for Kubernetes secrets to successfully execute CI jobs for the CAP-C special interest group repository. These changes will unblock their development efforts for a required successful test. 