### PR TITLE
apiserver-network-proxy-presubmits: use Go 1.18

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - make
         args:


### PR DESCRIPTION
Signed-off-by: Imran Pochi <imran@kinvolk.io>