### PR TITLE
Tide: move refsForJob out of interface

### DIFF
--- a/prow/tide/codereview.go
+++ b/prow/tide/codereview.go
@@ -135,6 +135,27 @@ func (crc *CodeReviewCommon) GitHubCommits() *Commits {
 	return &crc.GitHub.Commits
 }
 
+func refsForJob(sp subpool, prs []CodeReviewCommon) prowapi.Refs {
+	refs := prowapi.Refs{
+		Org:     sp.org,
+		Repo:    sp.repo,
+		BaseRef: sp.branch,
+		BaseSHA: sp.sha,
+	}
+	for _, pr := range prs {
+		refs.Pulls = append(
+			refs.Pulls,
+			prowapi.Pull{
+				Number: pr.Number,
+				Title:  pr.Title,
+				Author: string(pr.AuthorLogin),
+				SHA:    pr.HeadRefOID,
+			},
+		)
+	}
+	return refs
+}
+
 // CodeReviewCommonFromPullRequest derives CodeReviewCommon struct from GitHub
 // PullRequest struct, by extracting shared fields among different code review
 // providers.
@@ -184,6 +205,5 @@ type provider interface {
 	headContexts(pr *CodeReviewCommon) ([]Context, error)
 	mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdateStatus *threadSafePRSet) error
 	GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, headSHA string) (contextChecker, error)
-	refsForJob(sp subpool, prs []CodeReviewCommon) prowapi.Refs
 	prMergeMethod(crc *CodeReviewCommon) (types.PullRequestMergeType, error)
 }

--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/git/v2"
@@ -150,27 +149,6 @@ func (gi *GitHubProvider) GetRef(org, repo, ref string) (string, error) {
 
 func (gi *GitHubProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, headSHA string) (contextChecker, error) {
 	return gi.cfg().GetTideContextPolicy(gitClient, org, repo, branch, baseSHAGetter, headSHA)
-}
-
-func (gi *GitHubProvider) refsForJob(sp subpool, prs []CodeReviewCommon) prowapi.Refs {
-	refs := prowapi.Refs{
-		Org:     sp.org,
-		Repo:    sp.repo,
-		BaseRef: sp.branch,
-		BaseSHA: sp.sha,
-	}
-	for _, pr := range prs {
-		refs.Pulls = append(
-			refs.Pulls,
-			prowapi.Pull{
-				Number: pr.Number,
-				Title:  pr.Title,
-				Author: string(pr.AuthorLogin),
-				SHA:    pr.HeadRefOID,
-			},
-		)
-	}
-	return refs
 }
 
 func (gi *GitHubProvider) prMergeMethod(crc *CodeReviewCommon) (types.PullRequestMergeType, error) {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1308,7 +1308,7 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 }
 
 func (c *syncController) trigger(sp subpool, presubmits []config.Presubmit, prs []CodeReviewCommon) error {
-	refs := c.provider.refsForJob(sp, prs)
+	refs := refsForJob(sp, prs)
 
 	// If PRs require the same job, we only want to trigger it once.
 	// If multiple required jobs have the same context, we assume the


### PR DESCRIPTION
The method doesn't use any field or method from the provider, there is no need to define it under interface

/cc @cjwagner @alvaroaleman 