### PR TITLE
Add IgnoreAuthors option to Blunderbuss plugin

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -68,6 +68,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 			MaxReviewerCount:      3,
 			ExcludeApprovers:      true,
 			UseStatusAvailability: true,
+			IgnoreAuthors:         []string{},
 		},
 	})
 	if err != nil {
@@ -150,6 +151,12 @@ func handlePullRequest(ghc githubClient, roc repoownersClient, log *logrus.Entry
 	if pr.Draft && config.IgnoreDrafts {
 		// ignore Draft PR when IgnoreDrafts is true
 		return nil
+	}
+	// Ignore PRs submitted by users matching logins set in IgnoreAuthors
+	for _, user := range config.IgnoreAuthors {
+		if user == pr.User.Login {
+			return nil
+		}
 	}
 	return handle(
 		ghc,

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -576,6 +576,7 @@ func TestHandlePullRequest(t *testing.T) {
 		expectedRequested []string
 		draft             bool
 		ignoreDrafts      bool
+		ignoreAuthors     []string
 	}{
 		{
 			name:              "PR opened",
@@ -622,6 +623,12 @@ func TestHandlePullRequest(t *testing.T) {
 			reviewerCount:     1,
 			expectedRequested: []string{"al"},
 		},
+		{
+			name:          "PR opened by ignored author, do not assign review to PR",
+			action:        github.PullRequestActionOpened,
+			filesChanged:  []string{"a.go"},
+			ignoreAuthors: []string{"author"},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -633,6 +640,7 @@ func TestHandlePullRequest(t *testing.T) {
 				MaxReviewerCount: 0,
 				ExcludeApprovers: false,
 				IgnoreDrafts:     tc.ignoreDrafts,
+				IgnoreAuthors:    tc.ignoreAuthors,
 			}
 
 			if err := handlePullRequest(

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -163,6 +163,10 @@ type Blunderbuss struct {
 	// IgnoreDrafts instructs the plugin to ignore assigning reviewers
 	// to the PR that is in Draft state. Default it's false.
 	IgnoreDrafts bool `json:"ignore_drafts,omitempty"`
+	// IgnoreAuthors skips requesting reviewers for specified users.
+	// This is useful when a bot user or admin opens a PR that will be
+	// merged regardless of approvals.
+	IgnoreAuthors []string `json:"ignore_authors,omitempty"`
 }
 
 // Owners contains configuration related to handling OWNERS files.


### PR DESCRIPTION
Ignoring assigning to particular authors is useful in cases where a bot
or admin opens a PR that will be merged without reviews.