### PR TITLE
clonerefs: include duration of cloning in logs

### DIFF
--- a/prow/pod-utils/clone/format.go
+++ b/prow/pod-utils/clone/format.go
@@ -48,12 +48,18 @@ func FormatRecord(record Record) string {
 		}
 	}
 	for _, command := range record.Commands {
-		fmt.Fprintf(&output, "$ %s\n", command.Command)
+		runtime := ""
+		if command.Duration != 0 {
+			runtime = fmt.Sprintf(" (runtime: %v)", command.Duration)
+		}
+		fmt.Fprintf(&output, "$ %s%s\n", command.Command, runtime)
 		fmt.Fprint(&output, command.Output)
 		if command.Error != "" {
 			fmt.Fprintf(&output, "# Error: %s\n", command.Error)
 		}
 	}
+	fmt.Fprintf(&output, "# Final SHA: %v\n", record.FinalSHA)
+	fmt.Fprintf(&output, "# Total runtime: %v\n", record.Duration)
 
 	return output.String()
 }

--- a/prow/pod-utils/clone/format_test.go
+++ b/prow/pod-utils/clone/format_test.go
@@ -19,6 +19,7 @@ package clone
 import (
 	"strings"
 	"testing"
+	"time"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
@@ -110,6 +111,20 @@ func TestFormatRecord(t *testing.T) {
 				},
 			},
 			require: []string{"42", "food", "13"},
+		},
+		{
+			name: "include durations when present",
+			r: Record{
+				Commands: []Command{
+					{
+						Command:  "rm /something",
+						Output:   "barf",
+						Duration: time.Second * 23,
+					},
+				},
+				Duration: time.Second * 12,
+			},
+			require: []string{"12s", "23s"},
 		},
 	}
 

--- a/prow/pod-utils/clone/types.go
+++ b/prow/pod-utils/clone/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clone
 
 import (
+	"time"
+
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
@@ -32,6 +34,9 @@ type Record struct {
 	// FinalSHA is the SHA from ultimate state of a cloned ref
 	// This is used to populate RepoCommit in started.json properly
 	FinalSHA string `json:"final_sha,omitempty"`
+
+	// Duration is the total runtime for the clone.
+	Duration time.Duration `json:"duration,omitempty"`
 }
 
 // Command is a trace of a command executed
@@ -40,4 +45,6 @@ type Command struct {
 	Command string `json:"command"`
 	Output  string `json:"output,omitempty"`
 	Error   string `json:"error,omitempty"`
+	// Duration is the runtime for the command.
+	Duration time.Duration `json:"duration,omitempty"`
 }


### PR DESCRIPTION
This helps to debug slow cloning. When cloning large repos like k/k the
clone time can be substantial; seeing this duration is helpful for
understanding and debugging