### PR TITLE
GCR to AR Sync Job Typo Fix 3

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
@@ -24,6 +24,7 @@ periodics:
           args:
             - -c
             - |
+              export PATH=$PATH:$GOPATH/bin
               apt update && apt install parallel -qqy
               go install github.com/google/go-containerregistry/cmd/gcrane@latest
               parallel "gcrane cp --recursive --allow-nondistributable-artifacts eu.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west4 europe-west8 europe-west9
@@ -52,6 +53,7 @@ periodics:
           args:
             - -c
             - |
+              export PATH=$PATH:$GOPATH/bin
               apt update && apt install parallel -qqy
               go install github.com/google/go-containerregistry/cmd/gcrane@latest
               parallel "gcrane cp --recursive --allow-nondistributable-artifacts asia.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: asia-east1 asia-south1 asia-northeast1 asia-northeast2 australia-southeast1
@@ -80,6 +82,7 @@ periodics:
           args:
             - -c
             - |
+              export PATH=$PATH:$GOPATH/bin
               apt update && apt install parallel -qqy
               go install github.com/google/go-containerregistry/cmd/gcrane@latest
               parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: southamerica-west1 us-central1 us-east1 us-east4 us-east5 us-south1 us-west1 us-west2


### PR DESCRIPTION
Final fix #26916 

Prow sets GOPATH for all jobs which doesn't match the GOPATH + PATH set by the golang image.