### PR TITLE
Gerrit controller for tide, implement provider interface for Gerrit

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -2316,6 +2316,12 @@ func parseProwConfig(c *Config) error {
 		c.Gerrit.RateLimit = 5
 	}
 
+	if c.Tide.Gerrit != nil {
+		if c.Tide.Gerrit.RateLimit == 0 {
+			c.Tide.Gerrit.RateLimit = 5
+		}
+	}
+
 	if len(c.GitHubReporter.JobTypesToReport) == 0 {
 		c.GitHubReporter.JobTypesToReport = append(c.GitHubReporter.JobTypesToReport, prowapi.PresubmitJob, prowapi.PostsubmitJob)
 	}

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -1229,6 +1229,17 @@ tide:
     # creates. The default is to only mention the one to which we are closest (Calculated
     # by total number of requirements - fulfilled number of requirements).
     display_all_tide_queries_in_status: true
+    gerrit:
+        queries:
+          - filters:
+                branches:
+                  - ""
+                excluded_branches:
+                  - ""
+            opt_out_help: true
+            org: ' '
+            repos:
+              - ""
 
     # A key/value pair of an org/repo as the key and Go template to override
     # the default merge commit title and/or message. Template is passed the
@@ -1309,7 +1320,7 @@ tide:
     # Defaults to the value of SyncPeriod.
     status_update_period: 0s
 
-    # SyncPeriod specifies how often Tide will sync jobs with provider. Defaults to 1m.
+    # SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
     sync_period: 0s
 
     # URL for tide status contexts.

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -81,7 +81,8 @@ type TidePriority struct {
 
 // Tide is config for the tide pool.
 type Tide struct {
-	// SyncPeriod specifies how often Tide will sync jobs with provider. Defaults to 1m.
+	Gerrit *TideGerritConfig `json:"gerrit,omitempty"`
+	// SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
 	SyncPeriod *metav1.Duration `json:"sync_period,omitempty"`
 	// MaxGoroutines is the maximum number of goroutines spawned inside the
 	// controller to handle org/repo:branch pools. Defaults to 20. Needs to be a
@@ -183,6 +184,14 @@ type TideGitHubConfig struct {
 	// creates. The default is to only mention the one to which we are closest (Calculated
 	// by total number of requirements - fulfilled number of requirements).
 	DisplayAllQueriesInStatus bool `json:"display_all_tide_queries_in_status,omitempty"`
+}
+
+// TideGerritConfig contains all Gerrit related configurations for tide.
+type TideGerritConfig struct {
+	Queries GerritOrgRepoConfigs `json:"queries"`
+	// RateLimit defines how many changes to query per gerrit API call
+	// default is 5.
+	RateLimit int `json:"ratelimit,omitempty"`
 }
 
 func (t *Tide) mergeFrom(additional *Tide) error {

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/gerrit/client"
+	"k8s.io/test-infra/prow/git/types"
+	"k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/tide/blockers"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/andygrunwald/go-gerrit"
+	githubql "github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// ref:
+	// https://gerrit-review.googlesource.com/Documentation/user-search.html#_search_operators.
+	// Also good to know: `(repo:repo-A OR repo:repo-B)`
+	gerritDefaultQueryParam = "status:open -is:wip is:submittable is:mergeable"
+)
+
+type gerritClient interface {
+	QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters []string) ([]gerrit.ChangeInfo, error)
+	GetBranchRevision(instance, project, branch string) (string, error)
+}
+
+// Enforcing interface implementation check at compile time
+var _ provider = (*GerritProvider)(nil)
+
+// GerritProvider implements provider, used by tide Controller for
+// interacting directly with Gerrit.
+//
+// Tide Controller should only use GerritProvider for communicating with Gerrit.
+type GerritProvider struct {
+	cfg config.Getter
+	gc  gerritClient
+
+	pjclientset ctrlruntimeclient.Client
+
+	cookiefilePath    string
+	tokenPathOverride string
+
+	*mergeChecker
+	logger *logrus.Entry
+}
+
+func newGerritProvider(
+	logger *logrus.Entry,
+	cfg config.Getter,
+	pjclientset ctrlruntimeclient.Client,
+	mergeChecker *mergeChecker,
+	cookiefilePath string,
+	tokenPathOverride string,
+) *GerritProvider {
+	gerritClient, err := client.NewClient(nil)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating gerrit client.")
+	}
+
+	gp := &GerritProvider{
+		logger:            logger,
+		cfg:               cfg,
+		pjclientset:       pjclientset,
+		gc:                gerritClient,
+		cookiefilePath:    cookiefilePath,
+		tokenPathOverride: tokenPathOverride,
+		mergeChecker:      mergeChecker,
+	}
+
+	gp.applyGlobalConfig(cfg, gerritClient, cookiefilePath, tokenPathOverride)
+
+	return gp
+}
+
+func (p *GerritProvider) applyGlobalConfig(cfg config.Getter, gerritClient *client.Client, cookiefilePath, tokenPathOverride string) {
+	p.applyGlobalConfigOnce(cfg, gerritClient, cookiefilePath, tokenPathOverride)
+
+	go func() {
+		for {
+			p.applyGlobalConfigOnce(cfg, gerritClient, cookiefilePath, tokenPathOverride)
+			// No need to spin constantly, give it a break. It's ok that config change has one second delay.
+			time.Sleep(time.Second)
+		}
+	}()
+}
+
+func (p *GerritProvider) applyGlobalConfigOnce(cfg config.Getter, gerritClient *client.Client, cookiefilePath, tokenPathOverride string) {
+	gerritCfg := cfg().Tide.Gerrit
+	if gerritCfg == nil {
+		return
+	}
+
+	if err := gerritClient.UpdateClients(gerritCfg.Queries.AllRepos()); err != nil {
+		logrus.WithError(err).Error("Updating clients.")
+	}
+	// Authenticate creates a goroutine for rotating token secrets when called the first
+	// time, afterwards it only authenticate once.
+	gerritClient.Authenticate(cookiefilePath, tokenPathOverride)
+}
+
+// Query returns all PRs from configured gerrit org/repos.
+func (p *GerritProvider) Query() (map[string]CodeReviewCommon, error) {
+	// lastUpdate is used by gerrit adapter for achieving incremental query. In
+	// tide case we want to get everything so use default time.Time, which
+	// should be 1970,1,1.
+	var lastUpdate time.Time
+
+	res := make(map[string]CodeReviewCommon)
+	// This is querying serially, which would safely guard against quota issues.
+	// TODO(chaodai): parallize this to boot the performance.
+	for instance, projs := range p.cfg().Tide.Gerrit.Queries.AllRepos() {
+		for projName := range projs {
+			changes, err := p.gc.QueryChangesForProject(instance, projName, lastUpdate, p.cfg().Gerrit.RateLimit, []string{gerritDefaultQueryParam})
+			if err != nil {
+				p.logger.WithFields(logrus.Fields{"instance": instance, "project": projName}).WithError(err).Error("Querying gerrit project for changes.")
+				continue
+			}
+			for _, pr := range changes {
+				crc := CodeReviewCommonFromGerrit(&pr, instance)
+				res[prKey(crc)] = *crc
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func (p *GerritProvider) blockers() (blockers.Blockers, error) {
+	// This is not supported yet, so return an empty blocker for now.
+	return blockers.Blockers{}, nil
+}
+
+func (p *GerritProvider) isAllowedToMerge(crc *CodeReviewCommon) (string, error) {
+	if crc.Mergeable == string(githubql.MergeableStateConflicting) {
+		return "PR has a merge conflict.", nil
+	}
+	return "", nil
+}
+
+// GetRef gets the latest revision from org/repo/branch.
+func (p *GerritProvider) GetRef(org, repo, ref string) (string, error) {
+	return p.gc.GetBranchRevision(org, repo, ref)
+}
+
+// headContexts gets the status contexts for the commit with OID ==
+// pr.HeadRefOID
+//
+// Assuming all submission requirements are already met as the PRs queried are
+// already submittable. So the focus here is to ensure that all prowjobs were
+// tested against latest baseSHA.
+// Prow parses baseSHA from the `Description` field of a context, will make sure
+// that all Prow jobs that vote to required labels are represented here.
+func (p *GerritProvider) headContexts(crc *CodeReviewCommon) ([]Context, error) {
+	var res []Context
+
+	selector := map[string]string{
+		kube.GerritRevision:   crc.HeadRefOID,
+		kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+		kube.OrgLabel:         crc.Org,
+		kube.RepoLabel:        crc.Repo,
+		kube.PullLabel:        strconv.Itoa(crc.Number),
+	}
+	var pjs v1.ProwJobList
+	if err := p.pjclientset.List(context.Background(), &pjs, ctrlruntimeclient.MatchingLabels(selector)); err != nil {
+		return nil, fmt.Errorf("Cannot list prowjob with selector %v", selector)
+	}
+
+	// keep track of latest prowjobs only
+	latestPjs := make(map[string]*prowapi.ProwJob)
+	for _, pj := range pjs.Items {
+		pj := pj
+		if exist, ok := latestPjs[pj.Spec.Context]; ok && exist.CreationTimestamp.After(pj.CreationTimestamp.Time) {
+			continue
+		}
+		latestPjs[pj.Spec.Context] = &pj
+	}
+
+	for _, pj := range latestPjs {
+		res = append(res, Context{
+			Context:     githubql.String(pj.Spec.Context),
+			Description: githubql.String(config.ContextDescriptionWithBaseSha(pj.Status.Description, pj.Spec.Refs.BaseSHA)),
+			State:       githubql.StatusState(pj.Status.State),
+		})
+	}
+
+	return res, nil
+}
+
+func (p *GerritProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdateStatus *threadSafePRSet) error {
+	p.logger.Info("The merge function hasn't been implemented yet, just logging for now.")
+	return nil
+}
+
+// GetTideContextPolicy gets context policy defined by users + requirements from
+// prow jobs.
+func (p *GerritProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, crc *CodeReviewCommon) (contextChecker, error) {
+	pr := crc.Gerrit
+	if pr == nil {
+		return nil, errors.New("programmer error: crc.Gerrit cannot be nil for GerritProvider")
+	}
+
+	required := sets.NewString()
+	requiredIfPresent := sets.NewString()
+	optional := sets.NewString()
+
+	headSHAGetter := func() (string, error) {
+		return crc.HeadRefOID, nil
+	}
+	presubmits, err := p.cfg().GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get presubmits: %w", err)
+	}
+
+	requireLabels := sets.NewString()
+	for l, info := range pr.Labels {
+		if !info.Optional {
+			requireLabels.Insert(l)
+		}
+	}
+
+	// generate required and optional entries for Prow Jobs
+	for _, pj := range presubmits {
+		if !pj.CouldRun(branch) {
+			continue
+		}
+
+		var isJobRequired bool
+		if val, ok := pj.Labels[kube.GerritReportLabel]; ok && requireLabels.Has(val) {
+			isJobRequired = true
+		}
+
+		if isJobRequired {
+			if pj.TriggersConditionally() {
+				// jobs that trigger conditionally are required if present.
+				requiredIfPresent.Insert(pj.Context)
+			} else {
+				// jobs that produce required contexts and will
+				// always run should be required at all times
+				required.Insert(pj.Context)
+			}
+		} else {
+			optional.Insert(pj.Context)
+		}
+	}
+
+	t := &config.TideContextPolicy{
+		RequiredContexts:          required.List(),
+		RequiredIfPresentContexts: requiredIfPresent.List(),
+		OptionalContexts:          optional.List(),
+	}
+	if err := t.Validate(); err != nil {
+		return t, err
+	}
+	return t, nil
+}
+
+func (p *GerritProvider) prMergeMethod(crc *CodeReviewCommon) (types.PullRequestMergeType, error) {
+	var res types.PullRequestMergeType
+	pr := crc.Gerrit
+	if pr == nil {
+		return res, errors.New("programmer error: crc.Gerrit cannot be nil for GerritProvider")
+	}
+
+	// Translate merge methods to types that git could understand. The merge
+	// methods for gerrit are documented at
+	// https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#repository.
+	// Git can only understand MergeIfNecessary, MergeMerge, MergeRebase, MergeSquash.
+	switch pr.SubmitType {
+	case "MERGE_IF_NECESSARY":
+		res = types.MergeIfNecessary
+	case "FAST_FORWARD_ONLY":
+		res = types.MergeMerge
+	case "REBASE_IF_NECESSARY":
+		res = types.MergeRebase
+	case "REBASE_ALWAYS":
+		res = types.MergeRebase
+	case "MERGE_ALWAYS":
+		res = types.MergeMerge
+	default:
+		res = types.MergeMerge
+	}
+
+	return res, nil
+}

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -1,0 +1,733 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/andygrunwald/go-gerrit"
+	"github.com/google/go-cmp/cmp"
+	githubql "github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git/types"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/tide/blockers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ gerritClient = (*fakeGerritClient)(nil)
+
+type fakeGerritClient struct {
+	reviews int
+	changes map[string]map[string][]gerrit.ChangeInfo
+}
+
+func newFakeGerritClient() *fakeGerritClient {
+	return &fakeGerritClient{
+		changes: make(map[string]map[string][]gerrit.ChangeInfo),
+	}
+}
+
+func (f *fakeGerritClient) QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters []string) ([]gerrit.ChangeInfo, error) {
+	if f.changes == nil || f.changes[instance] == nil || f.changes[instance][project] == nil {
+		return nil, errors.New("queries project doesn't exist")
+	}
+
+	return f.changes[instance][project], nil
+}
+
+func (f *fakeGerritClient) GetBranchRevision(instance, project, branch string) (string, error) {
+	return "abc", nil
+}
+
+func (f *fakeGerritClient) addChange(instance, project string, change gerrit.ChangeInfo) {
+	if _, ok := f.changes[instance]; !ok {
+		f.changes[instance] = make(map[string][]gerrit.ChangeInfo)
+	}
+	if _, ok := f.changes[instance][project]; !ok {
+		f.changes[instance][project] = []gerrit.ChangeInfo{}
+	}
+	f.changes[instance][project] = append(f.changes[instance][project], change)
+}
+
+func TestQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		queries config.GerritOrgRepoConfigs
+		prs     map[string]map[string][]gerrit.ChangeInfo
+		expect  map[string]CodeReviewCommon
+	}{
+		{
+			name: "single",
+			queries: config.GerritOrgRepoConfigs{
+				{
+					Org:   "foo1",
+					Repos: []string{"bar1"},
+				},
+			},
+			prs: map[string]map[string][]gerrit.ChangeInfo{
+				"foo1": {
+					"bar1": {
+						gerrit.ChangeInfo{
+							Number:  1,
+							Project: "bar1",
+						},
+					},
+				},
+			},
+			expect: map[string]CodeReviewCommon{
+				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar1"}, "foo1"),
+			},
+		},
+		{
+			name: "multiple",
+			queries: config.GerritOrgRepoConfigs{
+				{
+					Org:   "foo1",
+					Repos: []string{"bar1", "bar2"},
+				},
+				{
+					Org:   "foo2",
+					Repos: []string{"bar3", "bar4"},
+				},
+			},
+			prs: map[string]map[string][]gerrit.ChangeInfo{
+				"foo1": {
+					"bar1": {
+						gerrit.ChangeInfo{
+							Number:  1,
+							Project: "bar1",
+						},
+					},
+					"bar2": {
+						gerrit.ChangeInfo{
+							Number:  2,
+							Project: "bar2",
+						},
+					},
+				},
+				"foo2": {
+					"bar3": {
+						gerrit.ChangeInfo{
+							Number:  1,
+							Project: "bar3",
+						},
+					},
+					"bar4": {
+						gerrit.ChangeInfo{
+							Number:  2,
+							Project: "bar4",
+						},
+					},
+				},
+			},
+			expect: map[string]CodeReviewCommon{
+				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar1"}, "foo1"),
+				"foo1/bar2#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 2, Project: "bar2"}, "foo1"),
+				"foo2/bar3#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar3"}, "foo2"),
+				"foo2/bar4#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 2, Project: "bar4"}, "foo2"),
+			},
+		},
+		{
+			name: "not-configured",
+			queries: config.GerritOrgRepoConfigs{
+				{
+					Org:   "foo5",
+					Repos: []string{"bar1", "bar2"},
+				},
+				{
+					Org:   "foo6",
+					Repos: []string{"bar3", "bar4"},
+				},
+			},
+			prs: map[string]map[string][]gerrit.ChangeInfo{
+				"foo1": {
+					"bar1": {
+						gerrit.ChangeInfo{
+							Number:  1,
+							Project: "bar1",
+						},
+					},
+					"bar2": {
+						gerrit.ChangeInfo{
+							Number:  2,
+							Project: "bar2",
+						},
+					},
+				},
+				"foo2": {
+					"bar3": {
+						gerrit.ChangeInfo{
+							Number:  1,
+							Project: "bar3",
+						},
+					},
+					"bar4": {
+						gerrit.ChangeInfo{
+							Number:  2,
+							Project: "bar4",
+						},
+					},
+				},
+			},
+			expect: map[string]CodeReviewCommon{},
+		},
+		{
+			name: "no-pr",
+			queries: config.GerritOrgRepoConfigs{
+				{
+					Org:   "foo1",
+					Repos: []string{"bar1"},
+				},
+			},
+			prs:    map[string]map[string][]gerrit.ChangeInfo{},
+			expect: map[string]CodeReviewCommon{},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{
+				ProwConfig: config.ProwConfig{
+					Tide: config.Tide{
+						Gerrit: &config.TideGerritConfig{
+							Queries: tc.queries,
+						},
+					},
+				},
+			}
+
+			fc := newGerritProvider(logrus.WithContext(context.Background()), func() *config.Config { return &cfg }, nil, nil, "", "")
+			fgc := newFakeGerritClient()
+
+			for instance, projs := range tc.prs {
+				for project, changes := range projs {
+					for _, change := range changes {
+						fgc.addChange(instance, project, change)
+					}
+				}
+			}
+			fc.gc = fgc
+
+			got, err := fc.Query()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expect, got); diff != "" {
+				t.Fatalf("Query result mismatch. Want(-), got(+):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBlocker(t *testing.T) {
+	fc := &GerritProvider{}
+	want := blockers.Blockers{}
+	var wantErr error
+	got, gotErr := fc.blockers()
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)
+	}
+	if wantErr != gotErr {
+		t.Errorf("Error mismatch. Want: %v, got: %v", wantErr, gotErr)
+	}
+}
+
+func TestIsAllowedToMerge(t *testing.T) {
+	tests := []struct {
+		name      string
+		mergeable string
+		want      string
+		wantErr   error
+	}{
+		{
+			name:      "conflict",
+			mergeable: string(githubql.MergeableStateConflicting),
+			want:      "PR has a merge conflict.",
+		},
+		{
+			name:      "normal",
+			mergeable: string(githubql.MergeableStateMergeable),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &GerritProvider{}
+			got, gotErr := fc.isAllowedToMerge(&CodeReviewCommon{Mergeable: tc.mergeable})
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)
+			}
+			if tc.wantErr != gotErr {
+				t.Errorf("Error mismatch. Want: %v, got: %v", tc.wantErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestGetRef(t *testing.T) {
+	fgc := newFakeGerritClient()
+	fc := &GerritProvider{gc: fgc}
+	got, _ := fc.GetRef("", "", "")
+
+	want := "abc"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)
+	}
+}
+
+func TestGerritHeadContexts(t *testing.T) {
+	tests := []struct {
+		name    string
+		jobs    []prowapi.ProwJob
+		want    []Context
+		wantErr error
+	}{
+		{
+			name: "normal",
+			jobs: []prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-important-1",
+						Namespace: "prowjobs",
+						Labels: map[string]string{
+							kube.GerritRevision:   "abc123",
+							kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+							kube.OrgLabel:         "foo1",
+							kube.RepoLabel:        "bar1",
+							kube.PullLabel:        "1",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type:    prowapi.PresubmitJob,
+						Job:     "job-1",
+						Context: "job-1",
+						Refs: &prowapi.Refs{
+							BaseSHA: "def123",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:       prowapi.SuccessState,
+						Description: "desc",
+					},
+				},
+			},
+			want: []Context{
+				{
+					Context:     "job-1",
+					Description: "desc\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\xe2\x80\x81\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001\u2001 BaseSHA:def123",
+					State:       "success",
+				},
+			},
+		},
+		{
+			name: "periodic",
+			jobs: []prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-important-1",
+						Namespace: "prowjobs",
+						Labels: map[string]string{
+							kube.GerritRevision:   "abc123",
+							kube.ProwJobTypeLabel: string(prowapi.PeriodicJob),
+							kube.OrgLabel:         "foo1",
+							kube.RepoLabel:        "bar1",
+							kube.PullLabel:        "1",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type:    prowapi.PeriodicJob,
+						Job:     "job-1",
+						Context: "job-1",
+						Refs: &prowapi.Refs{
+							BaseSHA: "def123",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:       prowapi.SuccessState,
+						Description: "desc",
+					},
+				},
+			},
+		},
+		{
+			name: "wrong-org",
+			jobs: []prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-important-1",
+						Namespace: "prowjobs",
+						Labels: map[string]string{
+							kube.GerritRevision:   "abc123",
+							kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+							kube.OrgLabel:         "foo2",
+							kube.RepoLabel:        "bar1",
+							kube.PullLabel:        "1",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type:    prowapi.PresubmitJob,
+						Job:     "job-1",
+						Context: "job-1",
+						Refs: &prowapi.Refs{
+							BaseSHA: "def123",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:       prowapi.SuccessState,
+						Description: "desc",
+					},
+				},
+			},
+		},
+		{
+			name: "wrong-repo",
+			jobs: []prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-important-1",
+						Namespace: "prowjobs",
+						Labels: map[string]string{
+							kube.GerritRevision:   "abc123",
+							kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+							kube.OrgLabel:         "foo1",
+							kube.RepoLabel:        "bar2",
+							kube.PullLabel:        "1",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type:    prowapi.PresubmitJob,
+						Job:     "job-1",
+						Context: "job-1",
+						Refs: &prowapi.Refs{
+							BaseSHA: "def123",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:       prowapi.SuccessState,
+						Description: "desc",
+					},
+				},
+			},
+		},
+		{
+			name: "wrong-revision",
+			jobs: []prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-important-1",
+						Namespace: "prowjobs",
+						Labels: map[string]string{
+							kube.GerritRevision:   "abc456",
+							kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+							kube.OrgLabel:         "foo1",
+							kube.RepoLabel:        "bar1",
+							kube.PullLabel:        "1",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type:    prowapi.PresubmitJob,
+						Job:     "job-1",
+						Context: "job-1",
+						Refs: &prowapi.Refs{
+							BaseSHA: "def123",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:       prowapi.SuccessState,
+						Description: "desc",
+					},
+				},
+			},
+		},
+		{
+			name: "wrong-pull",
+			jobs: []prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-important-1",
+						Namespace: "prowjobs",
+						Labels: map[string]string{
+							kube.GerritRevision:   "abc123",
+							kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+							kube.OrgLabel:         "foo1",
+							kube.RepoLabel:        "bar1",
+							kube.PullLabel:        "2",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type:    prowapi.PresubmitJob,
+						Job:     "job-1",
+						Context: "job-1",
+						Refs: &prowapi.Refs{
+							BaseSHA: "def123",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:       prowapi.SuccessState,
+						Description: "desc",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var jobs []runtime.Object
+			for _, job := range tc.jobs {
+				job := job
+				complete := metav1.NewTime(time.Now().Add(-time.Millisecond))
+				if job.Status.State != prowapi.PendingState && job.Status.State != prowapi.TriggeredState {
+					job.Status.CompletionTime = &complete
+				}
+				jobs = append(jobs, &job)
+			}
+
+			fpjc := fakectrlruntimeclient.NewFakeClient(jobs...)
+			fc := &GerritProvider{pjclientset: fpjc}
+
+			got, gotErr := fc.headContexts(&CodeReviewCommon{
+				HeadRefOID: "abc123",
+				Org:        "foo1",
+				Repo:       "bar1",
+				Number:     1,
+			})
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)
+			}
+			if tc.wantErr != gotErr {
+				t.Errorf("Error mismatch. Want: %v, got: %v", tc.wantErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestMergePR(t *testing.T) {
+	testLogger, hook := test.NewNullLogger()
+	fc := &GerritProvider{logger: testLogger.WithContext(context.Background())}
+	var wantErr error
+	if gotErr := fc.mergePRs(subpool{}, nil, nil); wantErr != gotErr {
+		t.Fatalf("Error not matching. Want: %v, got: %v", wantErr, gotErr)
+	}
+	wantLog := "The merge function hasn't been implemented yet, just logging for now."
+	if gotLog := hook.LastEntry().Message; wantLog != gotLog {
+		t.Fatalf("Log mismatch. Want: %q, got: %q", wantErr, gotLog)
+	}
+}
+
+func TestGetTideContextPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		pr         gerrit.ChangeInfo
+		presubmits map[string][]config.Presubmit
+		want       contextChecker
+		wantErr    error
+	}{
+		{
+			name: "normal",
+			pr: gerrit.ChangeInfo{
+				Project:         "bar1",
+				Branch:          "main",
+				CurrentRevision: "abc123",
+				Labels: map[string]gerrit.LabelInfo{
+					"Verified": {
+						Optional: false,
+					},
+				},
+			},
+			presubmits: map[string][]config.Presubmit{
+				"foo1/bar1": {
+					{
+						Reporter: config.Reporter{Context: "job-1"},
+						JobBase: config.JobBase{
+							Labels: map[string]string{
+								"prow.k8s.io/gerrit-report-label": "Verified",
+							},
+						},
+					},
+				},
+			},
+			want: &config.TideContextPolicy{
+				RequiredContexts:          []string{},
+				RequiredIfPresentContexts: []string{"job-1"},
+				OptionalContexts:          []string{},
+			},
+		},
+		{
+			name: "required",
+			pr: gerrit.ChangeInfo{
+				Project:         "bar1",
+				Branch:          "main",
+				CurrentRevision: "abc123",
+				Labels: map[string]gerrit.LabelInfo{
+					"Verified": {
+						Optional: false,
+					},
+				},
+			},
+			presubmits: map[string][]config.Presubmit{
+				"foo1/bar1": {
+					{
+						Reporter: config.Reporter{Context: "job-1"},
+						JobBase: config.JobBase{
+							Labels: map[string]string{
+								"prow.k8s.io/gerrit-report-label": "Verified",
+							},
+						},
+						AlwaysRun: true,
+					},
+				},
+			},
+			want: &config.TideContextPolicy{
+				RequiredContexts:          []string{"job-1"},
+				RequiredIfPresentContexts: []string{},
+				OptionalContexts:          []string{},
+			},
+		},
+		{
+			name: "optional",
+			pr: gerrit.ChangeInfo{
+				Project:         "bar1",
+				Branch:          "main",
+				CurrentRevision: "abc123",
+				Labels: map[string]gerrit.LabelInfo{
+					"Verified": {
+						Optional: false,
+					},
+				},
+			},
+			presubmits: map[string][]config.Presubmit{
+				"foo1/bar1": {
+					{
+						Reporter: config.Reporter{Context: "job-1"},
+						JobBase: config.JobBase{
+							Labels: map[string]string{
+								"prow.k8s.io/gerrit-report-label": "Optional",
+							},
+						},
+						AlwaysRun: true,
+					},
+				},
+			},
+			want: &config.TideContextPolicy{
+				RequiredContexts:          []string{},
+				RequiredIfPresentContexts: []string{},
+				OptionalContexts:          []string{"job-1"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{JobConfig: config.JobConfig{PresubmitsStatic: tc.presubmits}}
+			fc := &GerritProvider{cfg: func() *config.Config { return &cfg }}
+
+			got, gotErr := fc.GetTideContextPolicy(nil, "foo1", tc.pr.Project, tc.pr.Branch, nil, CodeReviewCommonFromGerrit(&tc.pr, "foo1"))
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)
+			}
+			if tc.wantErr != gotErr {
+				t.Errorf("Error mismatch. Want: %v, got: %v", tc.wantErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestPrMergeMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		pr      gerrit.ChangeInfo
+		want    types.PullRequestMergeType
+		wantErr error
+	}{
+		{
+			name: "MERGE_IF_NECESSARY",
+			pr: gerrit.ChangeInfo{
+				SubmitType: "MERGE_IF_NECESSARY",
+			},
+			want: types.MergeIfNecessary,
+		},
+		{
+			name: "FAST_FORWARD_ONLY",
+			pr: gerrit.ChangeInfo{
+				SubmitType: "FAST_FORWARD_ONLY",
+			},
+			want: types.MergeMerge,
+		},
+		{
+			name: "REBASE_IF_NECESSARY",
+			pr: gerrit.ChangeInfo{
+				SubmitType: "REBASE_IF_NECESSARY",
+			},
+			want: types.MergeRebase,
+		},
+		{
+			name: "REBASE_ALWAYS",
+			pr: gerrit.ChangeInfo{
+				SubmitType: "REBASE_ALWAYS",
+			},
+			want: types.MergeRebase,
+		},
+		{
+			name: "MERGE_ALWAYS",
+			pr: gerrit.ChangeInfo{
+				SubmitType: "MERGE_ALWAYS",
+			},
+			want: types.MergeMerge,
+		},
+		{
+			name: "NOT_EXIST",
+			pr: gerrit.ChangeInfo{
+				SubmitType: "NOT_EXIST",
+			},
+			want: types.MergeMerge,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &GerritProvider{}
+
+			got, gotErr := fc.prMergeMethod(CodeReviewCommonFromGerrit(&tc.pr, "foo1"))
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)
+			}
+			if tc.wantErr != gotErr {
+				t.Errorf("Error mismatch. Want: %v, got: %v", tc.wantErr, gotErr)
+			}
+		})
+	}
+}

--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -147,8 +147,8 @@ func (gi *GitHubProvider) GetRef(org, repo, ref string) (string, error) {
 	return gi.ghc.GetRef(org, repo, ref)
 }
 
-func (gi *GitHubProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, headSHA string) (contextChecker, error) {
-	return gi.cfg().GetTideContextPolicy(gitClient, org, repo, branch, baseSHAGetter, headSHA)
+func (gi *GitHubProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, pr *CodeReviewCommon) (contextChecker, error) {
+	return gi.cfg().GetTideContextPolicy(gitClient, org, repo, branch, baseSHAGetter, pr.HeadRefOID)
 }
 
 func (gi *GitHubProvider) prMergeMethod(crc *CodeReviewCommon) (types.PullRequestMergeType, error) {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -621,7 +621,7 @@ func (c *syncController) initSubpoolData(sp *subpool) error {
 	}
 	sp.cc = make(map[int]contextChecker, len(sp.prs))
 	for _, pr := range sp.prs {
-		sp.cc[pr.Number], err = c.provider.GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), pr.HeadRefOID)
+		sp.cc[pr.Number], err = c.provider.GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), &pr)
 		if err != nil {
 			return fmt.Errorf("error setting up context checker for pr %d: %w", pr.Number, err)
 		}
@@ -1852,9 +1852,14 @@ type CheckRun struct {
 
 // Context holds graphql response data for github contexts.
 type Context struct {
-	Context     githubql.String
+	// Context is the name of the context, it's identical to the full name of a
+	// prowjob if the context is for a prowjob.
+	Context githubql.String
+	// Description is the description for a context, it's formed by
+	// config.ContextDescriptionWithBaseSha for a prowjob.
 	Description githubql.String
-	State       githubql.StatusState
+	// State is the state for a prowjob: EXPECTED, ERROR, FAILURE, PENDING, SUCCESS.
+	State githubql.StatusState
 }
 
 type PRNode struct {


### PR DESCRIPTION
This PR implements the provider interface, but not hooked up yet. Intentionally left `mergePRs` method unimplemented as I would expect it to start with dry-run for a bit. Foreseeable remaining works:
- Hook up inrepoconfig for Gerrit.
- Parallelize query.
- Figuring out how to report back to Gerrit.
These will be addressed in following PRs.

/cc @cjwagner @mpherman2 @listx 
cc @alvaroaleman 