### PR TITLE
config/prow: fix boskos dashboard

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -25,7 +25,7 @@ dashboard.new(
         aliasColors={'busy': '#ff0000', 'cleaning': '#00eeff', 'dirty': '#ff8000', 'free': '#00ff00', 'leased': '#ee00ff', 'other': '#aaaaff', 'toBeDeleted': '#fafa00', 'tombstone': '#cccccc'}
     )
     .addTarget(prometheus.target(
-        std.format('sum(boskos_resources{type="%s",job="%s"} or boskos_resources{type="%s",instance="%s"}) by (state)', [resource.type, resource.job, resource.type, resource.instance]),
+        std.format('sum(boskos_resources{type="%s",job="%s"}) by (state)', [resource.type, resource.job]),
         legendFormat='{{state}}',
     ))
     {gridPos: {


### PR DESCRIPTION
The dashboard has been failing to generate with:
```
Generating boskos.json from boskos.jsonnet ...
RUNTIME ERROR: Field does not exist: instance
	grafana_dashboards/boskos.jsonnet:28:166-183	thunk from <thunk from <thunk from <thunk from <thunk from <thunk from <$>>>>>>
	<std>:708:15-22	thunk <val> from <function <format_codes_arr>>
	<std>:715:27-30	thunk from <thunk <s> from <function <format_codes_arr>>>
	<std>:585:22-25	thunk from <function <format_code>>
	<std>:585:9-26	function <format_code>
...
```

We missed this in https://github.com/kubernetes/test-infra/pull/26302

Not sure why the prow deploy job was continuing to pass despite this failure