### PR TITLE
Remove traige/needed label from PRs in CAPA

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -767,7 +767,7 @@ require_matching_label:
   org: kubernetes-sigs
   repo: cluster-api-provider-aws
   issues: true
-  prs: true
+  prs: false
   regexp: ^priority/
 - missing_label: needs-triage
   org: kubernetes-sigs


### PR DESCRIPTION
Disable applying the needs-triage label to PRs on the Cluster API Provider for AWS repo.