### PR TITLE
Remove preset-service-account label from CAPI presubmit main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -2,8 +2,6 @@ periodics:
 - name: periodic-cluster-api-test-main
   interval: 1h
   decorate: true
-  labels:
-    preset-service-account: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
@@ -25,8 +23,6 @@ periodics:
 - name: periodic-cluster-api-test-mink8s-main
   interval: 1h
   decorate: true
-  labels:
-    preset-service-account: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Remove the deprecated usages of preset-service-account from the CAPI presubmits main file.