### PR TITLE
Revert "drop preset-service-account from containerd presubmit jobs"

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -12,6 +12,7 @@ presubmits:
       testgrid-tab-name: pull-containerd-build
       description: build artifacts
     labels:
+      preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -48,6 +49,7 @@ presubmits:
       testgrid-tab-name: pull-containerd-node-e2e
       description: run node e2e tests
     labels:
+      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
@@ -98,6 +100,7 @@ presubmits:
       testgrid-tab-name: pull-containerd-sandboxed-node-e2e
       description: run node e2e tests sandboxed
     labels:
+      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:


### PR DESCRIPTION
This reverts commit 33b366c158b46b43d459cd7c813af50fd0a50881.

Made the problem worse, things are failing consistently

Signed-off-by: Davanum Srinivas <davanum@gmail.com>