### PR TITLE
Revert "Revert "drop preset-service-account from containerd presubmit jobs

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -12,7 +12,6 @@ presubmits:
       testgrid-tab-name: pull-containerd-build
       description: build artifacts
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -49,7 +48,6 @@ presubmits:
       testgrid-tab-name: pull-containerd-node-e2e
       description: run node e2e tests
     labels:
-      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
@@ -100,7 +98,6 @@ presubmits:
       testgrid-tab-name: pull-containerd-sandboxed-node-e2e
       description: run node e2e tests sandboxed
     labels:
-      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:


### PR DESCRIPTION
Let's try this again! we landed https://github.com/containerd/containerd/pull/7306 already

This reverts commit 383d0881ec95943512bf348710db76f64ba925e8.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>