### PR TITLE
Adds new key-value pair for CAPV jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -17,6 +17,11 @@ presets:
       secretKeyRef:
         name: capv-ci-overrides
         key: vsphere-password
+  - name: VSPHERE_TLS_THUMBPRINT
+    valueFrom:
+      secretKeyRef:
+        name: capv-ci-overrides
+        key: vsphere-server-thumbprint
   - name: VM_SSH_PUB_KEY
     valueFrom:
       secretKeyRef:

--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -77,3 +77,6 @@ spec:
     - key: cluster-api-provider-vsphere-vcenter-user
       name: vsphere-username
       version: latest
+    - key: cluster-api-provider-vsphere-vcenter-thumbprint
+      name: vsphere-server-thumbprint
+      version: latest


### PR DESCRIPTION
This PR adds a new secret ref to read the thumbprint for the vCenter instanced used for CAPV CI.