### PR TITLE
Switch containerd config back to original

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -7,8 +7,6 @@ presubmits:
     - release/1.5
     - release/1.6
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     annotations:
       testgrid-dashboards: sig-node-containerd
       testgrid-tab-name: pull-containerd-build
@@ -16,7 +14,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220812-a0f1ed2b84-master
         command:
@@ -37,7 +34,6 @@ presubmits:
     - release/1.6
     decoration_config:
       timeout: 100m
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -54,7 +50,6 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - name: pull-containerd-node-e2e
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220812-a0f1ed2b84-master
@@ -89,7 +84,6 @@ presubmits:
     - main
     decoration_config:
       timeout: 100m
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -106,7 +100,6 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - name: pull-containerd-node-e2e
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220812-a0f1ed2b84-master

--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -12,6 +12,7 @@ presubmits:
       testgrid-tab-name: pull-containerd-build
       description: build artifacts
     labels:
+      preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -48,6 +49,7 @@ presubmits:
       testgrid-tab-name: pull-containerd-node-e2e
       description: run node e2e tests
     labels:
+      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
@@ -98,6 +100,7 @@ presubmits:
       testgrid-tab-name: pull-containerd-sandboxed-node-e2e
       description: run node e2e tests sandboxed
     labels:
+      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:


### PR DESCRIPTION
we tried a few things, didn't work out. In the mean time, @chaodaiG was able to get the keys rotated https://github.com/kubernetes/test-infra/issues/27157#issuecomment-1218486575 

So let's go back to what we had before.

NOTE: for the future we have to either find a owner for `cri-c8d-pr-node-e2e` or get the containerd team to request new GCP projects (i'd prefer the latter)

Slack Context: please see https://kubernetes.slack.com/archives/C7J9RP96G/p1660758182628529