### PR TITLE
`label_sync`: use `FindIssuesWithOrg` to find issues

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -656,7 +656,7 @@ func (ru RepoUpdates) DoUpdates(org string, gc client) error {
 						errChan <- err
 					}
 				case "migrate":
-					issues, err := gc.FindIssues(fmt.Sprintf("is:open repo:%s/%s label:\"%s\" -label:\"%s\"", org, repo, update.Current.Name, update.Wanted.Name), "", false)
+					issues, err := gc.FindIssuesWithOrg(org, fmt.Sprintf("is:open repo:%s/%s label:\"%s\" -label:\"%s\"", org, repo, update.Current.Name, update.Wanted.Name), "", false)
 					if err != nil {
 						errChan <- err
 					}
@@ -702,7 +702,7 @@ type client interface {
 	DeleteRepoLabel(org, repo, label string) error
 	AddLabel(org, repo string, number int, label string) error
 	RemoveLabel(org, repo string, number int, label string) error
-	FindIssues(query, order string, ascending bool) ([]github.Issue, error)
+	FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	GetRepoLabels(string, string) ([]github.Label, error)
 	SetMax404Retries(int)


### PR DESCRIPTION
Since `label_sync` was updated to allow throttling by org in: https://github.com/kubernetes/test-infra/pull/26918 we received the following error when running with apps auth:
```
{"client":"github","component":"label_sync","error":"Get \"http://ghproxy/search/issues?per_page=100\u0026q=is%3Aopen+repo%3Aopenshift%2Froute-controller-manager+label%3A%22wontfix%22+-label%3A%22triage%2Funresolved%22\": BUG apps auth requested but empty org, please report this to the test-infra repo.
```

This is due to `FindIssues` not using the org. Since we have the org in scope it is no trouble to use `FindIssuesWithOrg` directly instead even if apps auth is not utilized.