### PR TITLE
Enable GODEBUG=gctrace=1 in kube-apiserver in scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -253,6 +253,8 @@ presets:
     value: true
   - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
     value: pd.csi.storage.gke.io
+  - name: KUBE_APISERVER_GODEBUG
+    value: gctrace=1
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.


### PR DESCRIPTION
Currently a no-op until https://github.com/kubernetes/kubernetes/pull/111906 gets submitted.

/sig scalability
/assign @mborsz