### PR TITLE
Check for Jira issues in Markdown links

### DIFF
--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	issueNameRegex = regexp.MustCompile(`\b([a-zA-Z]+-[0-9]+)(\s|:|$)`)
+	issueNameRegex = regexp.MustCompile(`\b([a-zA-Z]+-[0-9]+)(\s|:|$|]|\))`)
 	projectCache   = &threadsafeSet{data: sets.String{}}
 )
 

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -324,6 +324,18 @@ func TestHandle(t *testing.T) {
 			existingIssues: []jira.Issue{{ID: "ENTERPRISE-4"}},
 		},
 		{
+			name: "Valid issue in disabled project, multiple references, with markdown link, case insensitive matching, nothing to do",
+			event: github.GenericCommentEvent{
+				HTMLURL:    "https://github.com/org/repo/issues/3",
+				IssueTitle: "ABC-123: Fixes Some issue",
+				Body:       "Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)",
+				Repo:       github.Repo{FullName: "org/repo"},
+				Number:     3,
+			},
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			cfg:          &plugins.Jira{DisabledJiraProjects: []string{"abc"}},
+		},
+		{
 			name: "Project 404 gets served from cache, nothing happens",
 			event: github.GenericCommentEvent{
 				HTMLURL:    "https://github.com/org/repo/issues/3",

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -276,7 +276,7 @@ func TestHandle(t *testing.T) {
 			},
 			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
 			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			existingLinks:  map[string][]jira.RemoteLink{"ABC-123": {{Object: &jira.RemoteLinkObject{URL: "https://github.com/org/repo/issues/3", Title: "Some issue"}}}},
+			existingLinks:  map[string][]jira.RemoteLink{"ABC-123": {{Object: &jira.RemoteLinkObject{URL: "https://github.com/org/repo/issues/3", Title: "org/repo#3: Some issue"}}}},
 		},
 		{
 			name: "Link exists but title is different, replacing it",

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -89,6 +89,11 @@ func TestRegex(t *testing.T) {
 			name:  "Trailing special characters, no match",
 			input: "rehearse-15676-pull",
 		},
+		{
+			name:     "Included in markdown link",
+			input:    "[Jira Bug ABC-123](https://my-jira.com/browse/ABC-123)",
+			expected: []string{"ABC-123", "ABC-123"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We have observed that the Jira plugin cannot properly determine a jira issue when the issue is included inside of a Markdown link.  This PR adds support to detect the cases where the Jira issue is the last word inside with the link text:
`[ABC-123](https://my-jira.com/browse/ABC-123)`
or the URL:
`[here](https://my-jira.com/browse/ABC-123)`