### PR TITLE
Add git client method to determine if the utilized app is installed in a repo

### DIFF
--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -92,7 +92,9 @@ func (arr *appsRoundTripper) canonicalizedPath(url *url.URL) string {
 }
 
 func (arr *appsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	if strings.HasPrefix(arr.canonicalizedPath(r.URL), "/app") {
+	path := arr.canonicalizedPath(r.URL)
+	// We need to use a JWT when we are getting /app/* endpoints or installation information for a particular repo
+	if strings.HasPrefix(path, "/app") || strings.HasSuffix(path, "/installation") {
 		if err := arr.addAppAuth(r); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The github API exposes a method to determine if an app is installed in a particular repo when you are accessing with app auth: https://docs.github.com/en/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app.

We want to use this method downstream in OpenShift to create a presubmit to check that our app is installed when onboarding a new repo.