### PR TITLE
Gerrit client accepts org/repo from different sources

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -223,7 +223,10 @@ func main() {
 	}
 
 	if o.gerritWorkers > 0 {
-		gerritReporter, err := gerritreporter.NewReporter(cfg, o.cookiefilePath, o.gerritProjects, mgr.GetClient())
+		orgRepoConfigGetter := func() *config.GerritOrgRepoConfigs {
+			return cfg().Gerrit.OrgReposConfig
+		}
+		gerritReporter, err := gerritreporter.NewReporter(orgRepoConfigGetter, o.cookiefilePath, o.gerritProjects, mgr.GetClient())
 		if err != nil {
 			logrus.WithError(err).Fatal("Error starting gerrit reporter")
 		}

--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -130,7 +130,7 @@ type JobReport struct {
 }
 
 // NewReporter returns a reporter client
-func NewReporter(cfg config.Getter, cookiefilePath string, projects map[string][]string, pjclientset ctrlruntimeclient.Client) (*Client, error) {
+func NewReporter(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, cookiefilePath string, projects map[string][]string, pjclientset ctrlruntimeclient.Client) (*Client, error) {
 	gc, err := client.NewClient(client.ProjectsFlagToConfig(projects))
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func NewReporter(cfg config.Getter, cookiefilePath string, projects map[string][
 	// applyGlobalConfig reads gerrit configurations from global gerrit config,
 	// it will completely override previously configured gerrit hosts and projects.
 	// it will also by the way authenticate gerrit
-	gc.ApplyGlobalConfig(cfg, nil, cookiefilePath, "", func() {})
+	gc.ApplyGlobalConfig(orgRepoConfigGetter, nil, cookiefilePath, "", func() {})
 
 	// Authenticate creates a goroutine for rotating token secrets when called the first
 	// time, afterwards it only authenticate once.

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -70,7 +70,7 @@ type fgc struct {
 	instanceMap map[string]*gerrit.AccountInfo
 }
 
-func (f *fgc) ApplyGlobalConfig(cfg config.Getter, lastSyncTracker *client.SyncTime, cookiefilePath, tokenPathOverride string, additionalFunc func()) {
+func (f *fgc) ApplyGlobalConfig(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, lastSyncTracker *client.SyncTime, cookiefilePath, tokenPathOverride string, additionalFunc func()) {
 
 }
 


### PR DESCRIPTION
This was overlooked in previous PR, that the Gerrit org/repo configuration is actually defined at different places in prow configuration. Make it flexible so that it'll work with tide in the future.

Also fixing a bug that when LastSyncTracker is supplied as nil, it won't panic(Crier would panic without this fix)

/cc @listx @mpherman2 