### PR TITLE
Deflake podutils integration test with 90 seconds timeout

### DIFF
--- a/prow/test/integration/test/pod-utils_test.go
+++ b/prow/test/integration/test/pod-utils_test.go
@@ -567,8 +567,11 @@ ls-tree (submodule):
 				return true, nil
 			}
 
-			// Wait up to 60 seconds to observe that this test passed.
-			timeout := 60 * time.Second
+			// Wait up to 90 seconds to observe that this test passed.
+			// These 90 seconds are spent waiting on serial execution of
+			// clonerefs, initupload, sidecar, place-entrypoint then test. Based
+			// on observation from kind logs these could take ~60 seconds.
+			timeout := 90 * time.Second
 			pollInterval := 500 * time.Millisecond
 			if waitErr := wait.Poll(pollInterval, timeout, expectJobSuccess); waitErr != nil {
 				if lastErr != nil {


### PR DESCRIPTION
Inspected a failed run https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/27152/pull-test-infra-integration/1560370485592592384 that timed out waiting for a prow job to finish. The logs indicated that it is a serial event as  clonerefs, initupload, sidecar, place-entrypoint then test. Based on observation from kind logs these could take ~60 seconds.