### PR TITLE
Change CAPZ presubmit main to use workload identity instead of preset-service-account

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -374,8 +374,6 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     always_run: true
     optional: true
-    labels:
-      preset-service-account: "true"
     branches:
     - ^main$
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -371,12 +371,15 @@ presubmits:
       testgrid-tab-name: capz-pr-upstream-k8s-ci-windows-containerd-serial-slow-main
   - name: pull-cluster-api-provider-azure-apidiff
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     always_run: true
     optional: true
     branches:
     - ^main$
     spec:
+      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220812-a0f1ed2b84-1.24
         command:


### PR DESCRIPTION
This PR removes the deprecated label `preset-service-account` from CAPZ apidiff job in favor of workload identity.