### PR TITLE
post-test-infra-push-prow: explicitly disable GCS credentials secret

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -192,6 +192,8 @@ postsubmits:
     # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
     run_if_changed: '^(\.ko\.yaml|hack/(make-rules|prowimagebuilder)|gencred|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     labels:
       # Building deck requires docker for typescript compilation.
       preset-dind-enabled: "true"


### PR DESCRIPTION
post-test-infra-push-prow: explicitly disable GCS credentials secret

Slack thread: https://kubernetes.slack.com/archives/C09QZ4DQB/p1660866377880809?thread_ts=1660813165.240589&cid=C09QZ4DQB

Let's see if this fixes the increasing flakiness of this job that
started a couple days ago, which coincides with the discussion (and
remedy) here: https://github.com/kubernetes/test-infra/issues/27157.

/cc @chaodaiG @mpherman2 
