### PR TITLE
Remove traige/needed label from PRs in CAPA

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -767,13 +767,13 @@ require_matching_label:
   org: kubernetes-sigs
   repo: cluster-api-provider-aws
   issues: true
-  prs: false
+  prs: true
   regexp: ^priority/
 - missing_label: needs-triage
   org: kubernetes-sigs
   repo: cluster-api
   issues: true
-  prs: true
+  prs: false
   regexp: ^triage/accepted$
   missing_comment: |
     This issue is currently awaiting triage.


### PR DESCRIPTION
Disable applying the needs-triage label to PRs on the Cluster API Provider for AWS repo.