### PR TITLE
Increase HPA cpu e2e test timeout

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -283,7 +283,7 @@ periodics:
     containers:
     - args:
       - --bare
-      - --timeout=120
+      - --timeout=260
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
@@ -293,7 +293,7 @@ periodics:
       # Enable HPAContainerMetrics. Required for container metrics tests.
       - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
       - --extract=ci/latest
-      - --timeout=100m
+      - --timeout=240m
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=1


### PR DESCRIPTION
sig-autoscaling-hpa tests are failing due to timeout 100m: https://k8s-testgrid.appspot.com/sig-autoscaling-hpa#gce-cos-autoscaling-hpa-cpu

Also, the number of tests has increased recently.

We need to increase current timeout, chose 300m similarly to the timeouts in other HPA suits.