### PR TITLE
Move some tests to k8s-infra

### DIFF
--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -42,6 +42,7 @@ periodics:
     testgrid-dashboards: sig-api-machinery-structured-merge-diff
     testgrid-tab-name: ci-gofmt
 - name: ci-structured-merge-diff-benchmark
+  cluster: k8s-infra-prow-build
   interval: 1h
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -1,6 +1,7 @@
 periodics:
   - interval: 6h
     name: check-dependency-stats-periodical
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 5m
@@ -28,6 +29,13 @@ periodics:
           popd
 
           depstat stats -m "k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')" --json | tee "${WORKDIR}/stats-base.json";
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-testing-misc

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -168,6 +168,7 @@ periodics:
 
 - interval: 1h
   name: ci-kubernetes-coverage-unit
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -196,5 +197,12 @@ periodics:
         ./gopherage filter --exclude-path="zz_generated,generated\.pb\.go"  "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
         ./gopherage junit --threshold 0.05 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
         exit $result
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
       securityContext:
         privileged: true


### PR DESCRIPTION
Move:

- ci-kubernetes-coverage-unit
- ci-structured-merge-diff-benchmark
- check-dependency-stats-periodical

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>