### PR TITLE
Service account key used for default build cluster stored in GCP secr…

### DIFF
--- a/config/prow/cluster/build/build_kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/build/build_kubernetes_external_secrets.yaml
@@ -1,0 +1,15 @@
+# This is a place holder for adding kubernetes external secrets, please add the
+# ExternalSecret CR here, separated by `---`.
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow-builds
+  data:
+  - key: default-k8s-build-cluster-service-account-key
+    name: service-account.json
+    version: latest

--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -4,6 +4,19 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow-builds
+  data:
+  - key: default-k8s-build-cluster-service-account-key
+    name: service-account.json
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: prometheus-alert-slack-post-prow-alerts-secret-url
   namespace: prow-monitoring
 spec:


### PR DESCRIPTION
…et manager

The Prow team advocates for workload identity instead of relying on physical json keys for authenticating with GCS in Prow jobs. Learned from https://github.com/kubernetes/test-infra/issues/27157#issuecomment-1220982143 that there are use cases where service account keys are required.

This means that the key will need to be rotated every 90 days, which is currently done by me running kubectl commands, this is scary.

I have already stored the most up-to-date key in GCP secret manager as configured in this PR, and the IAMs for these two as well.

/cc @dims @spiffxp 