### PR TITLE
use workload identity for various trusted jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -114,6 +114,8 @@ postsubmits:
     cluster: test-infra-trusted
     run_if_changed: '^(config/prow/cluster/|config/prow/Makefile$|Makefile.base.mk$)'
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     branches:
     - ^master$
     max_concurrency: 1

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -148,10 +148,13 @@ postsubmits:
     cluster: test-infra-trusted
     run_if_changed: 'config/prow/config.yaml'
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     branches:
     - ^master$
     max_concurrency: 1
     spec:
+      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-prow/hmac:v20220818-6dcd812eb2
         command:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -589,11 +589,14 @@ periodics:
   name: ci-test-infra-autobump-prow-for-auto-deploy
   cluster: test-infra-trusted
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   extra_refs:
   - org: kubernetes
     repo: test-infra
     base_ref: master
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220818-6dcd812eb2
       command:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -619,11 +619,14 @@ periodics:
   name: ci-test-infra-autobump-prow
   cluster: test-infra-trusted
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   extra_refs:
   - org: kubernetes
     repo: test-infra
     base_ref: master
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220818-6dcd812eb2
       command:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -442,6 +442,8 @@ postsubmits:
     max_concurrency: 1
     run_if_changed: '^config/(jobs|testgrids)/.*$'
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     spec:
       serviceAccountName: testgrid-config-updater
       containers:


### PR DESCRIPTION
(Hopefully) fixes https://github.com/kubernetes/test-infra/issues/27191

For those jobs that did not already have a k8s service account bound, I used `prowjob-default-sa`. For the jobs that did have them defined already, I left them as-is.

For `post-test-infra-upload-testgrid-config`, I see that k8s SA is called `testgrid-config-updater` but I'm not sure how to find which GCP SA it is bound to. I need this information to check that the this GCP SA has write permissions to `gs://kubernetes-jenkins` because otherwise we'll continue to get the same errors with 0 byte-sized `finished.json` artifacts.

It appears some of these permissions are a bit messy (e.g., gs://kubernetes-jenkins gives broad permissions to a certain `prow-build-trusted@k8s-infra-prow-build-trusted.iam.gserviceaccount.com` but I don't seem to have access to the `k8s-infra-prow-build-trusted` project (I assume that's the owner of this account). The reason I say this is because I am unable to verify how `deployer@k8s-prow.iam.gserviceaccount.com` is able to write to `gs://kubernetes-jenkins`.

/cc @chaodaiG @chases2 