### PR TITLE
hook: reduce log level for unrecognized PR actions

### DIFF
--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -219,7 +219,7 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 	action := genericCommentAction(string(pr.Action))
 	if action == "" {
 		if !nonCommentPullRequestActions[pr.Action] {
-			l.Errorf(failedCommentCoerceFmt, "pull_request", string(pr.Action))
+			l.Infof(failedCommentCoerceFmt, "pull_request", string(pr.Action))
 		}
 		return
 	}


### PR DESCRIPTION
This is spamming our logs due to a "milestoned" event. Example error
message:

    Could not coerce pull_request event to a GenericCommentEvent. Unknown 'action': "milestoned".

This shouldn't be an error anyway because hook should never attempt to
handle actions that it does not recognize/support.

/cc @chaodaiG @cjwagner 