### PR TITLE
ci-kubernetes-coverage-unit: increase resources

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -199,10 +199,10 @@ periodics:
         exit $result
       resources:
         limits:
-          cpu: 2
-          memory: 4Gi
+          cpu: 4
+          memory: 8Gi
         requests:
-          cpu: 2
-          memory: 4Gi
+          cpu: 4
+          memory: 8Gi
       securityContext:
         privileged: true


### PR DESCRIPTION
Follow-up of: https://github.com/kubernetes/test-infra/pull/27197

Job is failing since the migration to k8s-infra: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-coverage-unit/1561615414813790208
The only possibility I can think of is a lack of compute resources.