### PR TITLE
ci-kubernetes-coverage-unit: increase memory

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -200,9 +200,9 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 8Gi
+          memory: 16Gi
         requests:
           cpu: 4
-          memory: 8Gi
+          memory: 16Gi
       securityContext:
         privileged: true


### PR DESCRIPTION
Follow-up of : https://github.com/kubernetes/test-infra/pull/27208#issuecomment-1222319560

Looks like we need more memory. 