### PR TITLE
Check specific app installation path in app_auth_roundtripper

### DIFF
--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -91,10 +92,12 @@ func (arr *appsRoundTripper) canonicalizedPath(url *url.URL) string {
 	return strings.TrimPrefix(url.Path, arr.hostPrefixMapping[url.Host])
 }
 
+var installationPath = regexp.MustCompile("^/repos/(\\w*)/(\\w*)/installation$")
+
 func (arr *appsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	path := arr.canonicalizedPath(r.URL)
 	// We need to use a JWT when we are getting /app/* endpoints or installation information for a particular repo
-	if strings.HasPrefix(path, "/app") || strings.HasSuffix(path, "/installation") {
+	if strings.HasPrefix(path, "/app") || installationPath.MatchString(path) {
 		if err := arr.addAppAuth(r); err != nil {
 			return nil, err
 		}

--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -92,7 +92,7 @@ func (arr *appsRoundTripper) canonicalizedPath(url *url.URL) string {
 	return strings.TrimPrefix(url.Path, arr.hostPrefixMapping[url.Host])
 }
 
-var installationPath = regexp.MustCompile("^/repos/(\\w*)/(\\w*)/installation$")
+var installationPath = regexp.MustCompile(`^/repos/(\w*)/(\w*)/installation$`)
 
 func (arr *appsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	path := arr.canonicalizedPath(r.URL)


### PR DESCRIPTION
Since https://github.com/kubernetes/test-infra/pull/27181 was merged adding the JWT to the `/repos/org/repo/installation` path we have noticed an error when accessing the `getRepo` endpoint with a repo named `integr8ly/installation`. It seems that simply checking for the `installation` suffix will not suffice since that can be a repo name. If we use a specific regex instead we won't hit false positives.