### PR TITLE
crate new default KSA prowjob-default-sa for the trusted cluster

### DIFF
--- a/config/prow/cluster/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/trusted_serviceaccounts.yaml
@@ -54,6 +54,14 @@ metadata:
     iam.gke.io/gcp-service-account: kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com
   name: kubernetes-external-secrets-sa
   namespace: default
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-default-sa@k8s-prow.iam.gserviceaccount.com
+  name: prowjob-default-sa
+  namespace: test-pods
 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/15806
 # * Run experiment/workload-identity/bind-service-accounts.sh on the above
 # * Config service account on job


### PR DESCRIPTION
This also adds the annotation on the KSA such that it will attempt to
impersonate prowjob-default-sa@k8s-prow.iam.gserviceaccount.com.

See
https://github.com/kubernetes/test-infra/issues/27191#issuecomment-1222609488
for context.

/cc @chaodaiG