### PR TITLE
trusted cluster: use prowjob-default-sa KSA by default

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -38,6 +38,10 @@ plank:
     config:
       gcs_credentials_secret: ""
       default_service_account_name: "prowjob-default-sa"
+  - cluster: gke_k8s-prow_us-central1-f_prow
+    config:
+      gcs_credentials_secret: ""
+      default_service_account_name: "prowjob-default-sa"
 
 sinker:
   resync_period: 1m

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -38,7 +38,7 @@ plank:
     config:
       gcs_credentials_secret: ""
       default_service_account_name: "prowjob-default-sa"
-  - cluster: gke_k8s-prow_us-central1-f_prow
+  - cluster: test-infra-trusted
     config:
       gcs_credentials_secret: ""
       default_service_account_name: "prowjob-default-sa"


### PR DESCRIPTION
This way we can remove at least the

     config:
       gcs_credentials_secret: ""

lines from the jobs in
config/jobs/kubernetes/test-infra/test-infra-trusted.yaml.

NOTE: I guessed at the cluster name for this. I grepped through `~/.kube/config` to see a list of valid strings.

This is a follow-up to https://github.com/kubernetes/test-infra/pull/27204.

/cc @chaodaiG