### PR TITLE
[openshift/stackrox] Add new/renamed operator jobs and rename the qa one.

### DIFF
--- a/config/testgrids/openshift/redhat-stackrox-merge.yaml
+++ b/config/testgrids/openshift/redhat-stackrox-merge.yaml
@@ -113,19 +113,26 @@ dashboards:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: branch-ci-stackrox-stackrox-master-merge-mitre-bundles-checks
   - base_options: width=10
-    name: branch-ci-stackrox-stackrox-master-merge-openshift-4-operator-e2e-tests
+    name: branch-ci-stackrox-stackrox-master-merge-openshift-oldest-operator-e2e-tests
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: branch-ci-stackrox-stackrox-master-merge-openshift-4-operator-e2e-tests
+    test_group_name: branch-ci-stackrox-stackrox-master-merge-openshift-oldest-operator-e2e-tests
   - base_options: width=10
-    name: branch-ci-stackrox-stackrox-master-merge-openshift-4-qa-e2e-tests
+    name: branch-ci-stackrox-stackrox-master-merge-openshift-newest-operator-e2e-tests
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: branch-ci-stackrox-stackrox-master-merge-openshift-4-qa-e2e-tests
+    test_group_name: branch-ci-stackrox-stackrox-master-merge-openshift-newest-operator-e2e-tests
+  - base_options: width=10
+    name: branch-ci-stackrox-stackrox-master-merge-openshift-newest-qa-e2e-tests
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: branch-ci-stackrox-stackrox-master-merge-openshift-newest-qa-e2e-tests
   - base_options: width=10
     name: branch-ci-stackrox-stackrox-master-merge-policy-checks
     open_test_template:
@@ -195,10 +202,12 @@ test_groups:
   name: branch-ci-stackrox-stackrox-master-merge-local-roxctl-tests
 - gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-mitre-bundles-checks
   name: branch-ci-stackrox-stackrox-master-merge-mitre-bundles-checks
-- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-openshift-4-operator-e2e-tests
-  name: branch-ci-stackrox-stackrox-master-merge-openshift-4-operator-e2e-tests
-- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-openshift-4-qa-e2e-tests
-  name: branch-ci-stackrox-stackrox-master-merge-openshift-4-qa-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-openshift-oldest-operator-e2e-tests
+  name: branch-ci-stackrox-stackrox-master-merge-openshift-oldest-operator-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-openshift-newest-operator-e2e-tests
+  name: branch-ci-stackrox-stackrox-master-merge-openshift-newest-operator-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-openshift-newest-qa-e2e-tests
+  name: branch-ci-stackrox-stackrox-master-merge-openshift-newest-qa-e2e-tests
 - gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-policy-checks
   name: branch-ci-stackrox-stackrox-master-merge-policy-checks
 - gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-push-and-release

--- a/config/testgrids/openshift/redhat-stackrox-nightly.yaml
+++ b/config/testgrids/openshift/redhat-stackrox-nightly.yaml
@@ -127,19 +127,33 @@ dashboards:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: branch-ci-stackrox-stackrox-nightlies-nightly-tag
   - base_options: width=10
-    name: branch-ci-stackrox-stackrox-nightlies-openshift-4-operator-e2e-tests
+    name: branch-ci-stackrox-stackrox-nightlies-openshift-oldest-operator-e2e-tests
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: branch-ci-stackrox-stackrox-nightlies-openshift-4-operator-e2e-tests
+    test_group_name: branch-ci-stackrox-stackrox-nightlies-openshift-oldest-operator-e2e-tests
   - base_options: width=10
-    name: branch-ci-stackrox-stackrox-nightlies-openshift-4-qa-e2e-tests
+    name: branch-ci-stackrox-stackrox-nightlies-openshift-newest-operator-e2e-tests
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: branch-ci-stackrox-stackrox-nightlies-openshift-4-qa-e2e-tests
+    test_group_name: branch-ci-stackrox-stackrox-nightlies-openshift-newest-operator-e2e-tests
+  - base_options: width=10
+    name: branch-ci-stackrox-stackrox-nightlies-openshift-penultimate-operator-e2e-tests
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: branch-ci-stackrox-stackrox-nightlies-openshift-penultimate-operator-e2e-tests
+  - base_options: width=10
+    name: branch-ci-stackrox-stackrox-nightlies-openshift-newest-qa-e2e-tests
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: branch-ci-stackrox-stackrox-nightlies-openshift-newest-qa-e2e-tests
   - base_options: width=10
     name: branch-ci-stackrox-stackrox-nightlies-osd-gcp-qa-e2e-tests
     open_test_template:
@@ -220,10 +234,14 @@ test_groups:
   name: branch-ci-stackrox-stackrox-nightlies-mitre-bundles-checks
 - gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-nightly-tag
   name: branch-ci-stackrox-stackrox-nightlies-nightly-tag
-- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-4-operator-e2e-tests
-  name: branch-ci-stackrox-stackrox-nightlies-openshift-4-operator-e2e-tests
-- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-4-qa-e2e-tests
-  name: branch-ci-stackrox-stackrox-nightlies-openshift-4-qa-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-oldest-operator-e2e-tests
+  name: branch-ci-stackrox-stackrox-nightlies-openshift-oldest-operator-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-newest-operator-e2e-tests
+  name: branch-ci-stackrox-stackrox-nightlies-openshift-newest-operator-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-penultimate-operator-e2e-tests
+  name: branch-ci-stackrox-stackrox-nightlies-openshift-penultimate-operator-e2e-tests
+- gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-newest-qa-e2e-tests
+  name: branch-ci-stackrox-stackrox-nightlies-openshift-newest-qa-e2e-tests
 - gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-osd-gcp-qa-e2e-tests
   name: branch-ci-stackrox-stackrox-nightlies-osd-gcp-qa-e2e-tests
 - gcs_prefix: origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-policy-checks


### PR DESCRIPTION
This reflects the changes in:
- https://github.com/openshift/release/pull/31587
- https://github.com/openshift/release/pull/31489

/cc @gavin-stackrox 
/hold until both PRs mentioned above are merged