### PR TITLE
`app_auth_roundtripper`: repos can have: '-', '_', and '.'

### DIFF
--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -92,7 +92,7 @@ func (arr *appsRoundTripper) canonicalizedPath(url *url.URL) string {
 	return strings.TrimPrefix(url.Path, arr.hostPrefixMapping[url.Host])
 }
 
-var installationPath = regexp.MustCompile(`^/repos/(\w*)/(\w*)/installation$`)
+var installationPath = regexp.MustCompile(`^/repos/[^/]+/[^/]+/installation$`)
 
 func (arr *appsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	path := arr.canonicalizedPath(r.URL)

--- a/prow/github/app_auth_roundtripper_test.go
+++ b/prow/github/app_auth_roundtripper_test.go
@@ -378,10 +378,10 @@ func TestAppsAuth(t *testing.T) {
 			cachedTokens:        map[int64]*AppInstallationToken{1: {Token: "the-token", ExpiresAt: time.Now().Add(time.Hour)}},
 			cachedInstallations: map[string]AppInstallation{"kuber": {ID: 1}},
 			doRequest: func(c Client) error {
-				_, err := c.IsAppInstalled("kuber", "k8s")
+				_, err := c.IsAppInstalled("kuber", "k8.s-repo")
 				return err
 			},
-			responses: map[string]*http.Response{"/repos/kuber/k8s/installation": {
+			responses: map[string]*http.Response{"/repos/kuber/k8.s-repo/installation": {
 				StatusCode: 200,
 				Body:       serializeOrDie(AppInstallation{}),
 			}},


### PR DESCRIPTION
Updating the regex for some cases that were missed. I referenced: https://stackoverflow.com/questions/21262997/what-is-the-format-for-valid-git-repo-names#:~:text=Git%20repository%20name%20can%20be,can%20differ%20from%20the%20name., and also attempted to make some repos of my own to get the char set that is allowed. We need to allow the `-`, `_`, and `.`.