### PR TITLE
sig node: add presubmit test for Dynamic Resource Allocation

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1270,3 +1270,56 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+
+  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha).
+  # crio >= 1.23.0 has the necessary support for Container Device Interface (CDI).
+  - name: pull-kubernetes-node-crio-dra
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-crio-dra
+    # Not relevant for most PRs.
+    always_run: false
+    # This covers most of the code related to dynamic resource allocation.
+    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/
+    # The tests might still be flaky or this job might get triggered accidentally for
+    # an unrelated PR.
+    optional: true
+    max_concurrency: 12
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220804-4fa19ea91a-master
+        args:
+        - --root=/go/src
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=240"
+        - --scenario=kubernetes_e2e
+        - -- # end bootstrap args, scenario args below
+        - --deployment=node
+        - --env=KUBE_SSH_USER=core
+        - --env=KUBE_FEATURE_GATES=DynamicResourceAllocation=true
+        - --gcp-zone=us-west1-b
+        - '--test_args=--nodes=4 --focus="\[Feature:DynamicResourceAllocation\]"'
+        - --provider=gce
+        - --timeout=180m
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -126,6 +126,11 @@ dashboards:
   - name: pull-kubernetes-node-e2e-containerd-features-kubetest2
     test_group_name: pull-kubernetes-node-e2e-containerd-features-kubetest2
     base_options: width=10
+  - name: pull-kubernetes-node-crio-dra
+    test_group_name: pull-kubernetes-node-crio-dra
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: patrick.ohly@intel.com
 - name: presubmits-kubernetes-scalability
 - name: presubmits-misc
 - name: presubmits-node-problem-detector


### PR DESCRIPTION
No code has been merged yet, but
https://github.com/kubernetes/kubernetes/pull/111023 will add it and contains
E2E tests that need to pass before merging.

The job is configured so that it only runs if relevant code is getting modified
by a PR.