### PR TITLE
cloud-provider-vsphere will trigger e2e tests when the e2e script is changed.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -262,7 +262,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
     always_run: false
-    run_if_changed: '\.go$|go.mod'
+    run_if_changed: '\.go$|go.mod|hack/e2e\.sh'
     skip_report: false
     optional: true
     spec:


### PR DESCRIPTION
For the presubmit job `pull-cloud-provider-vsphere-e2e-test` of cloud-provider-vsphere, we want it to be triggered if the e2e script itself is modified.
