### PR TITLE
Swap test fixes

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -95,7 +95,6 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --deployment=node
-          - --env=KUBE_SSH_USER=core
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
           - '--node-test-args=--feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
@@ -179,7 +178,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --env=KUBE_SSH_USER=core
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
       - '--node-test-args=--feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'

--- a/jobs/e2e_node/swap/crio_swap1g.ign
+++ b/jobs/e2e_node/swap/crio_swap1g.ign
@@ -28,7 +28,7 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/core/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh && chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys && chown -R prow:prow /home/prow/.ssh && chmod 0600 /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
@@ -46,6 +46,15 @@
         "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/74583d26406963ba150004f343bc36c16a861164/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
+      }
+    ]
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "prow",
+        "system": true,
+        "groups": ["sudo"]
       }
     ]
   }


### PR DESCRIPTION
These two changes move the swap jobs to be closer to the other jobs in this file that are passing: https://testgrid.k8s.io/sig-node-cri-o#node-kubelet-serial-crio. The files I based these changes on are [ign](https://github.com/kubernetes/test-infra/blob/deb9627c139c0d191651dd77610648368ff1aa2c/jobs/e2e_node/crio/crio_serial.ign#L1-L56) and [config](https://github.com/kubernetes/test-infra/blob/deb9627c139c0d191651dd77610648368ff1aa2c/config/jobs/kubernetes/sig-node/node-kubelet.yaml#L41-L80)

