### PR TITLE
Add cloud-provider-azure basic lb job due to security problem

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -80,6 +80,66 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
+  # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb runs Azure specific e2e tests with VMSS and basic loadbalancer.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+      - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+      preset-dind-enabled: "true"
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: release-1.24
+        path_alias: k8s.io/kubernetes
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220804-4fa19ea91a-master
+          command:
+            - runner.sh
+            - kubetest
+          args:
+            # Generic e2e test args
+            - --test
+            - --up
+            - --down
+            - --build=quick
+            - --dump=$(ARTIFACTS)
+            # Azure-specific test args
+            - --provider=skeleton
+            - --deployment=aksengine
+            - --aksengine-agentpoolcount=2
+            - --aksengine-admin-username=azureuser
+            - --aksengine-creds=$(AZURE_CREDENTIALS)
+            - --aksengine-orchestratorRelease=1.24
+            - --aksengine-mastervmsize=Standard_DS2_v2
+            - --aksengine-agentvmsize=Standard_D4s_v3
+            - --aksengine-ccm
+            - --aksengine-cnm
+            - --aksengine-deploy-custom-k8s
+            - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+            - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
+            - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
+            # Specific test args
+            - --test-ccm
+            - --ginkgo-parallel=30
+          securityContext:
+            privileged: true
+          env:
+            - name: AZURE_LOADBALANCER_SKU
+              value: "basic"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb
+      description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure master (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+      testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-capz runs kubernetes conformance tests.
   - name: pull-cloud-provider-azure-e2e-capz
     skip_if_only_changed: "^docs/|^site/|^helm/|^tests/e2e/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -28,6 +28,66 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-22
         description: "Run lint check tests for cloud-provider-azure release-1.1."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-22 runs Azure specific e2e tests with VMSS and basic loadbalancer.
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-22
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.1
+      labels:
+        preset-service-account: "true"
+        preset-azure-cred: "true"
+        preset-dind-enabled: "true"
+      extra_refs:
+        - org: kubernetes
+          repo: kubernetes
+          base_ref: release-1.22
+          path_alias: k8s.io/kubernetes
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220822-9f275332ba-1.22
+            command:
+              - runner.sh
+              - kubetest
+            args:
+              # Generic e2e test args
+              - --test
+              - --up
+              - --down
+              - --build=quick
+              - --dump=$(ARTIFACTS)
+              # Azure-specific test args
+              - --provider=skeleton
+              - --deployment=aksengine
+              - --aksengine-agentpoolcount=2
+              - --aksengine-admin-username=azureuser
+              - --aksengine-creds=$(AZURE_CREDENTIALS)
+              - --aksengine-orchestratorRelease=1.22
+              - --aksengine-mastervmsize=Standard_DS2_v2
+              - --aksengine-agentvmsize=Standard_D4s_v3
+              - --aksengine-ccm
+              - --aksengine-cnm
+              - --aksengine-deploy-custom-k8s
+              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
+              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
+              # Specific test args
+              - --test-ccm
+              - --ginkgo-parallel=30
+            securityContext:
+              privileged: true
+            env:
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-22
+        description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-22
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -28,6 +28,66 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-23
         description: "Run lint check tests for cloud-provider-azure release-1.23."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-23 runs Azure specific e2e tests with VMSS and basic loadbalancer.
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-23
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.23
+      labels:
+        preset-service-account: "true"
+        preset-azure-cred: "true"
+        preset-dind-enabled: "true"
+      extra_refs:
+        - org: kubernetes
+          repo: kubernetes
+          base_ref: release-1.23
+          path_alias: k8s.io/kubernetes
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220822-9f275332ba-1.23
+            command:
+              - runner.sh
+              - kubetest
+            args:
+              # Generic e2e test args
+              - --test
+              - --up
+              - --down
+              - --build=quick
+              - --dump=$(ARTIFACTS)
+              # Azure-specific test args
+              - --provider=skeleton
+              - --deployment=aksengine
+              - --aksengine-agentpoolcount=2
+              - --aksengine-admin-username=azureuser
+              - --aksengine-creds=$(AZURE_CREDENTIALS)
+              - --aksengine-orchestratorRelease=1.23
+              - --aksengine-mastervmsize=Standard_DS2_v2
+              - --aksengine-agentvmsize=Standard_D4s_v3
+              - --aksengine-ccm
+              - --aksengine-cnm
+              - --aksengine-deploy-custom-k8s
+              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
+              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
+              # Specific test args
+              - --test-ccm
+              - --ginkgo-parallel=30
+            securityContext:
+              privileged: true
+            env:
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-23
+        description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -203,3 +203,63 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-24
         description: "Run unit tests for cloud-provider-azure release-1.24."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-24 runs Azure specific e2e tests with VMSS and basic loadbalancer.
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-24
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.24
+      labels:
+        preset-service-account: "true"
+        preset-azure-cred: "true"
+        preset-dind-enabled: "true"
+      extra_refs:
+        - org: kubernetes
+          repo: kubernetes
+          base_ref: release-1.24
+          path_alias: k8s.io/kubernetes
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220822-9f275332ba-master
+            command:
+              - runner.sh
+              - kubetest
+            args:
+              # Generic e2e test args
+              - --test
+              - --up
+              - --down
+              - --build=quick
+              - --dump=$(ARTIFACTS)
+              # Azure-specific test args
+              - --provider=skeleton
+              - --deployment=aksengine
+              - --aksengine-agentpoolcount=2
+              - --aksengine-admin-username=azureuser
+              - --aksengine-creds=$(AZURE_CREDENTIALS)
+              - --aksengine-orchestratorRelease=1.24
+              - --aksengine-mastervmsize=Standard_DS2_v2
+              - --aksengine-agentvmsize=Standard_D4s_v3
+              - --aksengine-ccm
+              - --aksengine-cnm
+              - --aksengine-deploy-custom-k8s
+              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
+              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
+              # Specific test args
+              - --test-ccm
+              - --ginkgo-parallel=30
+            securityContext:
+              privileged: true
+            env:
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-24-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-24
+        description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.24 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+        testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Add cloud-provider-azure basic lb job due to security problem.
In current sub for aks cluster, custom config is not allowed. So aks-engine basic-lb jobs should be temporarily re-added until the problem is solved.