### PR TITLE
Deck disallows unknows storage buckets by default

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -172,6 +172,9 @@ deck:
       github_team_ids:
       - 2009231 # test-infra-admins
       - 2460384 # milestone-maintainers
+  # additional_allowed_buckets is used only when skip_storage_path_validation is
+  # false
+  skip_storage_path_validation: false
   additional_allowed_buckets:
     - k8s-ovn
     - containerd-integration

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -195,6 +195,12 @@ state and no claims of backwards compatibility are made for any external API.
 Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
+ - *August 24th, 2022* Deck by default validating storage buckets, can still opt
+   out by setting `deck.skip_storage_path_validation: true` in your Prow config.
+   Buckets specified in job configs (`<job>.gcs_configuration.bucket`) and plank
+   configs (`plank.default_decoration_configs[*].gcs_configuration.bucket`) are
+   automatically allowed access. Additional buckets can be allowed by adding
+   them to the `deck.additional_allowed_buckets` list.
  - *May 27th, 2022* Crier flags `--gcs-workers` and `--kubernetes-gcs-workers` are
    removed in favor of `--blob-storage-workers` and `--kubernetes-blob-storage-workers`.
  - *May 27th, 2022* The `owners_dir_blacklist` field in prow config is removed

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1134,7 +1134,7 @@ type Deck struct {
 	// SkipStoragePathValidation skips validation that restricts artifact requests to specific buckets.
 	// By default, buckets listed in the GCSConfiguration are automatically allowed.
 	// Additional locations can be allowed via `AdditionalAllowedBuckets` fields.
-	// When unspecified (nil), it defaults to true (until ~Jan 2021).
+	// When unspecified (nil), it defaults to false
 	SkipStoragePathValidation *bool `json:"skip_storage_path_validation,omitempty"`
 	// AdditionalAllowedBuckets is a list of storage buckets to allow in artifact requests
 	// (in addition to those listed in the GCSConfiguration).
@@ -1202,7 +1202,7 @@ func (c *Config) ValidateStorageBucket(bucketName string) error {
 // Validation could be either enabled by default or explicitly turned off.
 func (d *Deck) shouldValidateStorageBuckets() bool {
 	if d.SkipStoragePathValidation == nil {
-		return true
+		return false
 	}
 	return !*d.SkipStoragePathValidation
 }

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1965,9 +1965,9 @@ func TestValidateDeck(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name:        "AdditionalAllowedBuckets has items, SkipStoragePathValidation is default value => no error",
+			name:        "AdditionalAllowedBuckets has items, SkipStoragePathValidation is default value => error",
 			deck:        Deck{AdditionalAllowedBuckets: []string{"hello", "world"}},
-			expectedErr: "",
+			expectedErr: "skip_storage_path_validation is enabled",
 		},
 		{
 			name:        "AdditionalAllowedBuckets has items, SkipStoragePathValidation is true => error",
@@ -7973,10 +7973,10 @@ func TestValidateStorageBucket(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name:        "unspecified config means validation",
+			name:        "unspecified config means no validation",
 			yaml:        ``,
 			bucket:      "who-knows",
-			expectedErr: "bucket \"who-knows\" not in allowed list",
+			expectedErr: "",
 		},
 		{
 			name: "validation disabled",

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -396,7 +396,7 @@ deck:
     # SkipStoragePathValidation skips validation that restricts artifact requests to specific buckets.
     # By default, buckets listed in the GCSConfiguration are automatically allowed.
     # Additional locations can be allowed via `AdditionalAllowedBuckets` fields.
-    # When unspecified (nil), it defaults to true (until ~Jan 2021).
+    # When unspecified (nil), it defaults to false
     skip_storage_path_validation: false
 
     # Spyglass specifies which viewers will be used for which artifacts when viewing a job in Deck.

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -57,6 +57,12 @@ blunderbuss:
     # approvers will never be considered as reviewers.
     exclude_approvers: true
 
+    # IgnoreAuthors skips requesting reviewers for specified users.
+    # This is useful when a bot user or admin opens a PR that will be
+    # merged regardless of approvals.
+    ignore_authors:
+      - ""
+
     # IgnoreDrafts instructs the plugin to ignore assigning reviewers
     # to the PR that is in Draft state. Default it's false.
     ignore_drafts: true


### PR DESCRIPTION
This was announced to be changed in Jan 2021

/cc @cjwagner @alvaroaleman @stevekuznetsov 