### PR TITLE
Add branch protection and 1.26 milestone applier

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -495,6 +495,11 @@ branch-protection:
               protect: true
             release-1.22:
               protect: true
+            release-1.23:
+              protect: true
+            release-1.24:
+              protect: true
+            
     kubernetes-client:
       protect: true
       required_status_checks:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -499,7 +499,6 @@ branch-protection:
               protect: true
             release-1.24:
               protect: true
-            
     kubernetes-client:
       protect: true
       required_status_checks:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -447,7 +447,7 @@ milestone_applier:
     release-0.6: v0.6.x
     release-0.5: v0.5.x
   kubernetes/website:
-    dev-1.24: 1.24
+    dev-1.26: 1.26
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
- Add branch protection to missing release branches (1.23 and 1.24)
- Add milestone applier configuration for dev-1.26

/cc https://github.com/orgs/kubernetes/teams/sig-docs-leads

/assign @sftim @jimangel @reylejano 