### PR TITLE
Refactor inrepoconfig cache logic to be centralized

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -138,7 +138,7 @@ func main() {
 
 	cacheGetter, err := config.NewInRepoConfigCacheGetter(ca, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheDirBase, prowflagutil.GitHubOptions{}, o.cookiefilePath, o.dryRun)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error createing InRepoConfigCacheGetter.")
+		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}
 	c := adapter.NewController(ctx, prowJobClient, op, ca, o.projects, o.projectsOptOutHelp, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback, o.changeWorkerPoolSize, cacheGetter)
 

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 
@@ -135,7 +136,11 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating opener")
 	}
 
-	c := adapter.NewController(ctx, prowJobClient, op, ca, o.projects, o.projectsOptOutHelp, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback, o.config.InRepoConfigCacheDirBase, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.changeWorkerPoolSize)
+	cacheGetter, err := config.NewInRepoConfigCacheGetter(ca, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheDirBase, prowflagutil.GitHubOptions{}, o.cookiefilePath, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error createing InRepoConfigCacheGetter.")
+	}
+	c := adapter.NewController(ctx, prowJobClient, op, ca, o.projects, o.projectsOptOutHelp, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback, o.changeWorkerPoolSize, cacheGetter)
 
 	logrus.Infof("Starting gerrit fetcher")
 

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -135,7 +135,7 @@ func main() {
 
 	cacheGetter, err := config.NewInRepoConfigCacheGetter(configAgent, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheDirBase, o.github, o.cookiefilePath, o.dryRun)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error createing InRepoConfigCacheGetter.")
+		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}
 
 	s := &subscriber.Subscriber{

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/test-infra/pkg/flagutil"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/crier/reporters/pubsub"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	configflagutil "k8s.io/test-infra/prow/flagutil/config"
@@ -132,12 +133,9 @@ func main() {
 		}
 	}
 
-	cacheGetter := subscriber.InRepoConfigCacheGetter{
-		CacheSize:     o.config.InRepoConfigCacheSize,
-		CacheCopies:   o.config.InRepoConfigCacheCopies,
-		Agent:         configAgent,
-		GitHubOptions: o.github,
-		DryRun:        o.dryRun,
+	cacheGetter, err := config.NewInRepoConfigCacheGetter(configAgent, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheDirBase, o.github, o.cookiefilePath, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error createing InRepoConfigCacheGetter.")
 	}
 
 	s := &subscriber.Subscriber{
@@ -145,7 +143,7 @@ func main() {
 		Metrics:                 promMetrics,
 		ProwJobClient:           kubeClient,
 		Reporter:                pubsub.NewReporter(configAgent.Config), // reuse crier reporter
-		InRepoConfigCacheGetter: &cacheGetter,
+		InRepoConfigCacheGetter: cacheGetter,
 	}
 
 	subMux := http.NewServeMux()

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -68,7 +68,7 @@ type options struct {
 	// b) the default acls do not expose any private info
 	statusURI string
 
-	// Gerit related options
+	// Gerrit-related options
 	cookiefilePath string
 }
 
@@ -95,8 +95,8 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.IntVar(&o.maxRecordsPerPool, "max-records-per-pool", 1000, "The maximum number of history records stored for an individual Tide pool.")
 	fs.StringVar(&o.historyURI, "history-uri", "", "The /local/path,gs://path/to/object or s3://path/to/object to store tide action history. GCS writes will use the default object ACL for the bucket")
 	fs.StringVar(&o.statusURI, "status-path", "", "The /local/path, gs://path/to/object or s3://path/to/object to store status controller state. GCS writes will use the default object ACL for the bucket.")
-	// Gerrit related flags
-	fs.StringVar(&o.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile, leave empty for github or anonymous")
+	// Gerrit-related flags
+	fs.StringVar(&o.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile; leave empty for anonymous access or if you are using GitHub")
 
 	fs.Parse(args)
 	return o

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -67,6 +67,9 @@ type options struct {
 	// a) the gcs credentials can write to this bucket
 	// b) the default acls do not expose any private info
 	statusURI string
+
+	// Gerit related options
+	cookiefilePath string
 }
 
 func (o *options) Validate() error {
@@ -92,6 +95,8 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.IntVar(&o.maxRecordsPerPool, "max-records-per-pool", 1000, "The maximum number of history records stored for an individual Tide pool.")
 	fs.StringVar(&o.historyURI, "history-uri", "", "The /local/path,gs://path/to/object or s3://path/to/object to store tide action history. GCS writes will use the default object ACL for the bucket")
 	fs.StringVar(&o.statusURI, "status-path", "", "The /local/path, gs://path/to/object or s3://path/to/object to store status controller state. GCS writes will use the default object ACL for the bucket.")
+	// Gerrit related flags
+	fs.StringVar(&o.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile, leave empty for github or anonymous")
 
 	fs.Parse(args)
 	return o

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -37,6 +37,7 @@ import (
 	prowfake "k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
 	reporter "k8s.io/test-infra/prow/crier/reporters/gerrit"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/git/v2"
@@ -1363,12 +1364,16 @@ func TestProcessChange(t *testing.T) {
 
 			var gc fgc
 			gc.instanceMap = tc.instancesMap
+			inRepoConfigCacheGetter, err := config.NewInRepoConfigCacheGetter(nil, 1, 1, "", flagutil.GitHubOptions{}, "", false)
+			if err != nil {
+				t.Fatalf("Failed creating cache getter: %v", err)
+			}
 			c := &Controller{
-				config:        fca.Config,
-				prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
-				gc:            &gc,
-				tracker:       &fakeSync{val: fakeLastSync},
-				repoCacheMap:  map[string]*config.InRepoConfigCacheHandler{},
+				config:                  fca.Config,
+				prowJobClient:           fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+				gc:                      &gc,
+				tracker:                 &fakeSync{val: fakeLastSync},
+				inRepoConfigCacheGetter: inRepoConfigCacheGetter,
 			}
 			cloneURI, err := makeCloneURI(tc.instance, tc.change.Project)
 			if err != nil {

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -306,7 +306,7 @@ func TestHandleMessage(t *testing.T) {
 				ProwJobClient: fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),
 				ConfigAgent:   ca,
 				Reporter:      &fr,
-				InRepoConfigCacheGetter: &InRepoConfigCacheGetter{
+				InRepoConfigCacheGetter: &config.InRepoConfigCacheGetter{
 					CacheSize:     100,
 					CacheCopies:   1,
 					Agent:         ca,

--- a/prow/tide/codereview.go
+++ b/prow/tide/codereview.go
@@ -256,6 +256,6 @@ type provider interface {
 	// into a context.
 	headContexts(pr *CodeReviewCommon) ([]Context, error)
 	mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdateStatus *threadSafePRSet) error
-	GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, pr *CodeReviewCommon) (contextChecker, error)
+	GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch, cloneURI string, baseSHAGetter config.RefGetter, pr *CodeReviewCommon) (contextChecker, error)
 	prMergeMethod(crc *CodeReviewCommon) (types.PullRequestMergeType, error)
 }

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -226,7 +226,7 @@ func TestQuery(t *testing.T) {
 				},
 			}
 
-			fc := newGerritProvider(logrus.WithContext(context.Background()), func() *config.Config { return &cfg }, nil, nil, "", "")
+			fc := newGerritProvider(logrus.WithContext(context.Background()), func() *config.Config { return &cfg }, nil, nil, nil, "", "")
 			fgc := newFakeGerritClient()
 
 			for instance, projs := range tc.prs {
@@ -551,6 +551,7 @@ func TestGetTideContextPolicy(t *testing.T) {
 	tests := []struct {
 		name       string
 		pr         gerrit.ChangeInfo
+		cloneURI   string
 		presubmits map[string][]config.Presubmit
 		want       contextChecker
 		wantErr    error
@@ -655,7 +656,7 @@ func TestGetTideContextPolicy(t *testing.T) {
 			cfg := config.Config{JobConfig: config.JobConfig{PresubmitsStatic: tc.presubmits}}
 			fc := &GerritProvider{cfg: func() *config.Config { return &cfg }}
 
-			got, gotErr := fc.GetTideContextPolicy(nil, "foo1", tc.pr.Project, tc.pr.Branch, nil, CodeReviewCommonFromGerrit(&tc.pr, "foo1"))
+			got, gotErr := fc.GetTideContextPolicy(nil, "foo1", tc.pr.Project, tc.pr.Branch, tc.cloneURI, nil, CodeReviewCommonFromGerrit(&tc.pr, "foo1"))
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Blocker mismatch. Want(-), got(+):\n%s", diff)

--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -147,7 +147,7 @@ func (gi *GitHubProvider) GetRef(org, repo, ref string) (string, error) {
 	return gi.ghc.GetRef(org, repo, ref)
 }
 
-func (gi *GitHubProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter config.RefGetter, pr *CodeReviewCommon) (contextChecker, error) {
+func (gi *GitHubProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch, cloneURI string, baseSHAGetter config.RefGetter, pr *CodeReviewCommon) (contextChecker, error) {
 	return gi.cfg().GetTideContextPolicy(gitClient, org, repo, branch, baseSHAGetter, pr.HeadRefOID)
 }
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -619,8 +619,10 @@ func (c *syncController) initSubpoolData(sp *subpool) error {
 	if err != nil {
 		return fmt.Errorf("error determining required presubmit prowjobs: %w", err)
 	}
-	// CloneURI is used for Gerrit to retrieve inrepoconfig, this is not used by
-	// GitHub at all. Blindly trust that it's identical among jobs.
+	// CloneURI is used by Gerrit to retrieve inrepoconfig; this is not used by
+	// GitHub at all.
+	// It's known that cloneURI is the only reliable way for Gerrit to correctly
+	// clone, so it should be safe to assume that cloneURI is identical among jobs.
 	var cloneURI string
 	for _, presubmits := range sp.presubmits {
 		for _, p := range presubmits {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -619,9 +619,21 @@ func (c *syncController) initSubpoolData(sp *subpool) error {
 	if err != nil {
 		return fmt.Errorf("error determining required presubmit prowjobs: %w", err)
 	}
+	// CloneURI is used for Gerrit to retrieve inrepoconfig, this is not used by
+	// GitHub at all. Blindly trust that it's identical among jobs.
+	var cloneURI string
+	for _, presubmits := range sp.presubmits {
+		for _, p := range presubmits {
+			if p.CloneURI != "" {
+				cloneURI = p.CloneURI
+				break
+			}
+		}
+	}
+
 	sp.cc = make(map[int]contextChecker, len(sp.prs))
 	for _, pr := range sp.prs {
-		sp.cc[pr.Number], err = c.provider.GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), &pr)
+		sp.cc[pr.Number], err = c.provider.GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, cloneURI, refGetterFactory(string(sp.sha)), &pr)
 		if err != nil {
 			return fmt.Errorf("error setting up context checker for pr %d: %w", pr.Number, err)
 		}


### PR DESCRIPTION
This was previously implemented differently in `gerrit` and `sub`, don't want to make a third one for tide, so refactoring here.

/cc @cjwagner @listx 
also 
/cc @alvaroaleman 
as the `GetTideContextPolicy` method signature is changed to also take `cloneURI`. There should be no functional change to GitHub side, so might just be a FYI