### PR TITLE
Update controller runtime and tools jobs to support go 1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-master.yaml
@@ -8,7 +8,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: golang:1.18
+    - image: golang:1.19
       command:
       - ./hack/ci-check-everything.sh
       resources:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.18
+      - image: golang:1.19
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.18
+      - image: golang:1.19
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.18.1
+      - image: golang:1.19
         command:
         - make
         - test-all


### PR DESCRIPTION
Update controller runtime and tools jobs to support go 1.19

This change will update the jobs for the `controller-runtime` and `controller-tools` jobs to support go 1.19