### PR TITLE
Started.json populated by the same code path between pod-utils and Crier

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/sirupsen/logrus"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -350,13 +351,13 @@ func getBuildData(ctx context.Context, bucket storageBucket, dir string) (buildD
 		Result:     "Unknown",
 		commitHash: "Unknown",
 	}
-	started := gcs.Started{}
+	started := metadata.Started{}
 	err := readJSON(ctx, bucket, path.Join(dir, prowv1.StartedStatusFile), &started)
 	if err != nil {
 		return b, fmt.Errorf("failed to read started.json: %w", err)
 	}
 	b.Started = time.Unix(started.Timestamp, 0)
-	finished := gcs.Finished{}
+	finished := metadata.Finished{}
 	err = readJSON(ctx, bucket, path.Join(dir, prowv1.FinishedStatusFile), &finished)
 	if err != nil {
 		b.Result = "Pending"

--- a/prow/crier/reporters/gcs/reporter.go
+++ b/prow/crier/reporters/gcs/reporter.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/crier/reporters/gcs/util"
 	"k8s.io/test-infra/prow/io"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 )
 
 const reporterName = "gcsreporter"
@@ -71,10 +72,9 @@ func (gr *gcsReporter) reportJobState(ctx context.Context, log *logrus.Entry, pj
 // happen before the pod itself gets to upload one, at which point the pod will
 // upload its own. If for some reason one already exists, it will not be overwritten.
 func (gr *gcsReporter) reportStartedJob(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) error {
-	s := metadata.Started{
-		Timestamp: pj.Status.StartTime.Unix(),
-		Metadata:  metadata.Metadata{"uploader": "crier"},
-	}
+	s := downwardapi.PjToStarted(pj, nil)
+	s.Metadata = metadata.Metadata{"uploader": "crier"}
+
 	output, err := json.MarshalIndent(s, "", "\t")
 	if err != nil {
 		return fmt.Errorf("failed to marshal started metadata: %w", err)

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -23,63 +23,14 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"reflect"
-	"strconv"
 	"time"
 
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/clone"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
 )
-
-// specToStarted translate a jobspec into a started struct
-// optionally overwrite RepoVersion with provided cloneRecords
-func specToStarted(spec *downwardapi.JobSpec, cloneRecords []clone.Record) gcs.Started {
-	var version string
-
-	started := gcs.Started{
-		Timestamp: time.Now().Unix(),
-	}
-
-	if mainRefs := spec.MainRefs(); mainRefs != nil {
-		version = shaForRefs(*mainRefs, cloneRecords)
-	}
-
-	if version == "" {
-		version = downwardapi.GetRevisionFromSpec(spec)
-	}
-
-	started.DeprecatedRepoVersion = version
-	started.RepoCommit = version
-
-	// TODO(fejta): VM name
-
-	if spec.Refs != nil && len(spec.Refs.Pulls) > 0 {
-		started.Pull = strconv.Itoa(spec.Refs.Pulls[0].Number)
-	}
-
-	started.Repos = map[string]string{}
-
-	if spec.Refs != nil {
-		started.Repos[spec.Refs.Org+"/"+spec.Refs.Repo] = spec.Refs.String()
-	}
-	for _, ref := range spec.ExtraRefs {
-		started.Repos[ref.Org+"/"+ref.Repo] = ref.String()
-	}
-
-	return started
-}
-
-// shaForRefs finds the resolved SHA after cloning and merging for the given refs
-func shaForRefs(refs prowv1.Refs, cloneRecords []clone.Record) string {
-	for _, record := range cloneRecords {
-		if reflect.DeepEqual(refs, record.Refs) {
-			return record.FinalSHA
-		}
-	}
-	return ""
-}
 
 // Run will start the initupload job to upload the artifacts, logs and clone status.
 func (o Options) Run() error {
@@ -98,7 +49,7 @@ func (o Options) Run() error {
 		}
 	}
 
-	started := specToStarted(spec, cloneRecords)
+	started := downwardapi.SpecToStarted(spec, cloneRecords)
 
 	startedData, err := json.Marshal(&started)
 	if err != nil {
@@ -150,7 +101,7 @@ func processCloneLog(logfile string, uploadTargets map[string]gcs.UploadFunc) (b
 
 		passed := !failed
 		now := time.Now().Unix()
-		finished := gcs.Finished{
+		finished := metadata.Finished{
 			Timestamp: &now,
 			Passed:    &passed,
 			Result:    "FAILURE",

--- a/prow/initupload/run_test.go
+++ b/prow/initupload/run_test.go
@@ -20,10 +20,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/clone"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
-	"k8s.io/test-infra/prow/pod-utils/gcs"
 )
 
 func TestSpecToStarted(t *testing.T) {
@@ -31,7 +31,7 @@ func TestSpecToStarted(t *testing.T) {
 		name         string
 		spec         downwardapi.JobSpec
 		cloneRecords []clone.Record
-		expected     gcs.Started
+		expected     metadata.Started
 	}{
 		{
 			name: "Refs with Pull",
@@ -49,7 +49,7 @@ func TestSpecToStarted(t *testing.T) {
 					},
 				},
 			},
-			expected: gcs.Started{
+			expected: metadata.Started{
 				Pull:                  "123",
 				DeprecatedRepoVersion: "abcd1234",
 				RepoCommit:            "abcd1234",
@@ -67,7 +67,7 @@ func TestSpecToStarted(t *testing.T) {
 					BaseRef: "master",
 				},
 			},
-			expected: gcs.Started{
+			expected: metadata.Started{
 				DeprecatedRepoVersion: "master",
 				RepoCommit:            "master",
 				Repos: map[string]string{
@@ -92,7 +92,7 @@ func TestSpecToStarted(t *testing.T) {
 					},
 				},
 			},
-			expected: gcs.Started{
+			expected: metadata.Started{
 				DeprecatedRepoVersion: "deadbeef",
 				RepoCommit:            "deadbeef",
 				Repos: map[string]string{
@@ -125,7 +125,7 @@ func TestSpecToStarted(t *testing.T) {
 				},
 				FinalSHA: "aaaaaaaa",
 			}},
-			expected: gcs.Started{
+			expected: metadata.Started{
 				DeprecatedRepoVersion: "aaaaaaaa",
 				RepoCommit:            "aaaaaaaa",
 				Repos: map[string]string{
@@ -153,7 +153,7 @@ func TestSpecToStarted(t *testing.T) {
 				},
 				FinalSHA: "aaaaaaaa",
 			}},
-			expected: gcs.Started{
+			expected: metadata.Started{
 				DeprecatedRepoVersion: "aaaaaaaa",
 				RepoCommit:            "aaaaaaaa",
 				Repos: map[string]string{
@@ -164,7 +164,7 @@ func TestSpecToStarted(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, expected := specToStarted(&test.spec, test.cloneRecords), test.expected
+		actual, expected := downwardapi.SpecToStarted(&test.spec, test.cloneRecords), test.expected
 		expected.Timestamp = actual.Timestamp
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("%s: got started: %#v, but expected: %#v", test.name, actual, expected)

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -20,9 +20,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
+	"time"
 
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/pod-utils/clone"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 // JobSpec is the full downward API that we expose to
@@ -164,6 +170,9 @@ func EnvForType(jobType prowapi.ProwJobType) []string {
 
 // getRevisionFromRef returns a ref or sha from a refs object
 func getRevisionFromRef(refs *prowapi.Refs) string {
+	if refs == nil {
+		return ""
+	}
 	if len(refs.Pulls) > 0 {
 		return refs.Pulls[0].SHA
 	}
@@ -175,23 +184,75 @@ func getRevisionFromRef(refs *prowapi.Refs) string {
 	return refs.BaseRef
 }
 
-// GetRevisionFromSpec returns a main ref or sha from a spec object
-func GetRevisionFromSpec(spec *JobSpec) string {
-	if spec.Refs != nil {
-		return getRevisionFromRef(spec.Refs)
-	} else if len(spec.ExtraRefs) > 0 {
-		return getRevisionFromRef(&spec.ExtraRefs[0])
-	}
-	return ""
+func GetRevisionFromSpec(jobSpec *JobSpec) string {
+	return getRevisionFromRefs(jobSpec.Refs, jobSpec.ExtraRefs)
 }
 
-// MainRefs determines the main refs under test, if there are any
-func (s *JobSpec) MainRefs() *prowapi.Refs {
-	if s.Refs != nil {
-		return s.Refs
+// GetRevisionFromSpec returns a main ref or sha from a spec object
+func getRevisionFromRefs(refs *prowapi.Refs, extra []prowapi.Refs) string {
+	return getRevisionFromRef(mainRefs(refs, extra))
+}
+
+func mainRefs(refs *prowapi.Refs, extra []prowapi.Refs) *prowapi.Refs {
+	if refs != nil {
+		return refs
 	}
-	if len(s.ExtraRefs) > 0 {
-		return &s.ExtraRefs[0]
+	if len(extra) > 0 {
+		return &extra[0]
 	}
 	return nil
+}
+
+func PjToStarted(pj *prowv1.ProwJob, cloneRecords []clone.Record) metadata.Started {
+	return refsToStarted(pj.Spec.Refs, pj.Spec.ExtraRefs, cloneRecords, pj.Status.StartTime.Unix())
+}
+
+func SpecToStarted(spec *JobSpec, cloneRecords []clone.Record) metadata.Started {
+	return refsToStarted(spec.Refs, spec.ExtraRefs, cloneRecords, time.Now().Unix())
+}
+
+// refsToStarted translate a jobspec into a started struct
+// optionally overwrite RepoVersion with provided cloneRecords
+func refsToStarted(refs *prowapi.Refs, extraRefs []prowapi.Refs, cloneRecords []clone.Record, startTime int64) metadata.Started {
+	var version string
+
+	started := metadata.Started{
+		Timestamp: startTime,
+	}
+
+	if mainRefs := mainRefs(refs, extraRefs); mainRefs != nil {
+		version = shaForRefs(*mainRefs, cloneRecords)
+	}
+
+	if version == "" {
+		version = getRevisionFromRefs(refs, extraRefs)
+	}
+
+	started.DeprecatedRepoVersion = version
+	started.RepoCommit = version
+
+	if refs != nil && len(refs.Pulls) > 0 {
+		started.Pull = strconv.Itoa(refs.Pulls[0].Number)
+	}
+
+	started.Repos = map[string]string{}
+
+	if refs != nil {
+		started.Repos[refs.Org+"/"+refs.Repo] = refs.String()
+	}
+	for _, ref := range extraRefs {
+		started.Repos[ref.Org+"/"+ref.Repo] = ref.String()
+	}
+
+	return started
+}
+
+// shaForRefs finds the resolved SHA after cloning and merging for the given refs
+func shaForRefs(refs prowv1.Refs, cloneRecords []clone.Record) string {
+	for _, record := range cloneRecords {
+		if reflect.DeepEqual(refs, record.Refs) {
+			return record.FinalSHA
+		}
+	}
+	return ""
 }

--- a/prow/pod-utils/gcs/metadata.go
+++ b/prow/pod-utils/gcs/metadata.go
@@ -20,19 +20,9 @@ import (
 	"mime"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/testgrid/metadata"
-
 	"k8s.io/test-infra/prow/io"
 	utilpointer "k8s.io/utils/pointer"
 )
-
-// TODO(fejta): migrate usage off type alias.
-
-// Started holds started.json data
-type Started = metadata.Started
-
-// Finished holds finished.json data
-type Finished = metadata.Finished
 
 // WriterOptionsFromFileName guesses file attributes from the filename
 // and returns the writerOptions and a simplified filename.  For example,

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
+
+	testgridmetadata "github.com/GoogleCloudPlatform/testgrid/metadata"
 )
 
 const LogFileName = "sidecar-logs.json"
@@ -264,7 +266,7 @@ func (o Options) doUpload(ctx context.Context, spec *downwardapi.JobSpec, passed
 	}
 
 	now := time.Now().Unix()
-	finished := gcs.Finished{
+	finished := testgridmetadata.Finished{
 		Timestamp: &now,
 		Passed:    &passed,
 		Result:    result,

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -36,7 +36,6 @@ import (
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	k8sreporter "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes"
-	"k8s.io/test-infra/prow/pod-utils/gcs"
 	"k8s.io/test-infra/prow/spyglass/api"
 	"k8s.io/test-infra/prow/spyglass/lenses"
 )
@@ -96,8 +95,8 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 		Metadata     map[string]interface{}
 	}
 	metadataViewData := MetadataViewData{}
-	started := gcs.Started{}
-	finished := gcs.Finished{}
+	started := metadata.Started{}
+	finished := metadata.Finished{}
 	for _, a := range artifacts {
 		read, err := a.ReadAll()
 		if err != nil {


### PR DESCRIPTION
This will make `started.json` uploaded by Crier be more close to the ones uploaded by pod-utils. As far as I can tell the only thing missing here is the `clone-record`, which is not readily available when prowjob was just started, so `RepoCommit` will still be missing.

/cc @alvaroaleman @cjwagner @listx 