### PR TITLE
plugins/jira: fix disabled project filtering

### DIFF
--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -325,17 +325,16 @@ func filterOutDisabledJiraProjects(candidateNames []string, cfg *plugins.Jira) [
 		return candidateNames
 	}
 
-	var result []string
+	candidateSet := sets.NewString(candidateNames...)
 	for _, excludedProject := range cfg.DisabledJiraProjects {
 		for _, candidate := range candidateNames {
 			if strings.HasPrefix(strings.ToLower(candidate), strings.ToLower(excludedProject)) {
-				continue
+				candidateSet.Delete(candidate)
 			}
-			result = append(result, candidate)
 		}
 	}
 
-	return result
+	return candidateSet.UnsortedList()
 }
 
 // projectCachingJiraClient caches 404 for projects and uses them to introduce


### PR DESCRIPTION
Fix behavior of `filterDisabledJiraProjects` when multiple disabled
projects are listed and add corresponding unit test.

/cc @stevekuznetsov 