### PR TITLE
Deck logs gcs path when warning about error

### DIFF
--- a/prow/spyglass/artifacts.go
+++ b/prow/spyglass/artifacts.go
@@ -56,9 +56,9 @@ func (s *Spyglass) ListArtifacts(ctx context.Context, src string) ([]string, err
 	// context cancelled error due to user cancelled request.
 	if err != nil && err != context.Canceled {
 		if config.IsNotAllowedBucketError(err) {
-			logrus.WithError(err).Debug("error retrieving artifact names from gcs storage")
+			logrus.WithError(err).WithField("gcs-key", gcsKey).Debug("error retrieving artifact names from gcs storage")
 		} else {
-			logrus.WithError(err).Warn("error retrieving artifact names from gcs storage")
+			logrus.WithError(err).WithField("gcs-key", gcsKey).Warn("error retrieving artifact names from gcs storage")
 		}
 	}
 


### PR DESCRIPTION
The warning without gcs path doesn't help that much rootcausing the problem