### PR TITLE
Enabling Windows operational readiness tests on CAPZ

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
@@ -1,0 +1,75 @@
+---
+presubmits:
+  kubernetes-sigs/windows-operational-readiness:
+  - name: operational-tests-capz-windows-2019
+    decorate: true
+    always_run: false
+    optional: true
+    decoration_config:
+      timeout: 8h
+    path_alias: sig.sk8s.io/windows-operational-readiness
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.4
+        path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+        workdir: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220822-9f275332ba-master
+          command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+          args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/windows-operational-readiness/ &&
+              ./hack/run-tests.sh
+          securityContext:
+            privileged: true
+          env:
+            # CAPZ variables
+            - name: NODE_MACHINE_TYPE
+              value: "Standard_D4s_v3"
+            - name: TEST_WINDOWS
+              value: "true"
+            - name: KUBERNETES_VERSION
+              value: "latest"
+            - name: WINDOWS_WORKER_MACHINE_COUNT
+              value: "1"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create linux worker nodes
+            - name: CL2_POD_COUNT
+              value: "10"
+            # clusterloader2 variables
+            - name: ENABLE_PROMETHEUS_SERVER
+              value: "true"
+            - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+              value: "true"
+            - name: PROMETHEUS_APISERVER_SCRAPE_PORT
+              value: "6443"
+            - name: PROMETHEUS_SCRAPE_WINDOWS_NODE_EXPORTER
+              value: "true"
+            - name: CL2_PROMETHEUS_TOLERATE_MASTER
+              value: "true"
+            # azuredisk variables - required for Prometheus PVC
+            - name: DEPLOY_AZURE_CSI_DRIVER
+              value: "true"
+            - name: AZUREDISK_CSI_DRIVER_VERSION
+              value: "master"
+            - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
+              value: "kubernetes.io/azure-disk"
+            - name: PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE
+              value: "StandardSSD_LRS"
+    annotations:
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: operational-tests-capz-windows-2019
+      description: "Run Windows Operational tests on a CAPZ Windows 2019 cluster"
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
In order to use the tests in the repo, this PR intends to enable the custom Windows test validation on a CAPZ cluster.