### PR TITLE
kOps: Rename main AWS pre-submit to be more explicit

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1026,9 +1026,9 @@ def generate_presubmits_e2e():
         presubmit_test(
             k8s_version='stable',
             kops_channel='alpha',
-            name='pull-kops-e2e-kubernetes-aws',
+            name='pull-kops-e2e-k8s-aws-calico',
             networking='calico',
-            tab_name='e2e-containerd',
+            tab_name='e2e-aws-calico',
             always_run=True,
         ),
         presubmit_test(

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -205,7 +205,7 @@ presubmits:
       testgrid-tab-name: e2e-docker
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-e2e-kubernetes-aws
+  - name: pull-kops-e2e-k8s-aws-calico
     branches:
     - master
     always_run: true
@@ -267,7 +267,7 @@ presubmits:
       test.kops.k8s.io/networking: calico
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: e2e-containerd
+      testgrid-tab-name: e2e-aws-calico
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-k8s-gce-cilium


### PR DESCRIPTION
This will make the job similar to the new GCE one named `pull-kops-e2e-k8s-gce-cilium`.

/cc @olemarkus @rifelpet 