### PR TITLE
Enable overriding multiple contexts inline

### DIFF
--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -580,6 +580,33 @@ func TestHandle(t *testing.T) {
 			checkComments: []string{fmt.Sprintf("%s: broken-test, hung-test", adminUser)},
 		},
 		{
+			name:    "override multiple contexts inline",
+			comment: "/override broken-test hung-test",
+			contexts: []github.Status{
+				{
+					Context: "broken-test",
+					State:   github.StatusFailure,
+				},
+				{
+					Context: "hung-test",
+					State:   github.StatusPending,
+				},
+			},
+			expected: []github.Status{
+				{
+					Context:     "broken-test",
+					Description: description(adminUser),
+					State:       github.StatusSuccess,
+				},
+				{
+					Context:     "hung-test",
+					Description: description(adminUser),
+					State:       github.StatusSuccess,
+				},
+			},
+			checkComments: []string{fmt.Sprintf("%s: broken-test, hung-test", adminUser)},
+		},
+		{
 			name: "override with extra whitespace",
 			// Note two spaces here to start, and trailing whitespace
 			comment: "/override  broken-test \n",


### PR DESCRIPTION
Let the user give more than one context/job names to override, e.g.:
```
/override this-job that-other-job
```

This should make it similar to the ``/test`` command that is able to trigger multiple jobs at once, and should be more intuitive to users.