### PR TITLE
Enable new mode in oss periodics

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -334,3 +334,7 @@ presets:
 - labels:
     preset-e2e-scalability-periodics-master: "true"
   env:
+  - name: CL2_WAIT_FOR_CONTROLLED_PODS_USE_EXACT_OPERATION_TIMEOUT
+    value: true
+  - name: CL2_RATE_LIMIT_POD_CREATION
+    value: false


### PR DESCRIPTION
Following procedure in https://github.com/kubernetes/test-infra/pull/19710

This enables changes in https://github.com/kubernetes/perf-tests/pull/2134

This has been tested in presubmit for 100 and 5k tests many times.

/assign @marseel 