### PR TITLE
update release jobs to use go1.19

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -46,7 +46,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -63,7 +63,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -80,7 +80,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
go1.19 upgrade here https://github.com/kubernetes/release/pull/2649 and need to update the jobs

/assign @saschagrunert @Verolop @xmudrii @palnabarun
cc @kubernetes/release-managers 