### PR TITLE
kompose: remove travis-ci from branch protection

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -342,9 +342,6 @@ branch-protection:
             gh-pages:
               protect: false
         kompose:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
           required_pull_request_reviews:
             required_approving_review_count: 1
         kops:


### PR DESCRIPTION
We no longer use travis-ci for testing Kompose.