### PR TITLE
Fixing alias path typo on windows op tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
@@ -7,7 +7,7 @@ presubmits:
     optional: true
     decoration_config:
       timeout: 8h
-    path_alias: sig.sk8s.io/windows-operational-readiness
+    path_alias: sigs.k8s.io/windows-operational-readiness
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure


### PR DESCRIPTION
job failing with
```
bash: line 0: cd: /home/prow/go/src/sigs.k8s.io/windows-operational-readiness/: No such file or directory
```