### PR TITLE
Fix typo in minimum_interval

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -243,7 +243,7 @@ type Periodic struct {
 	Interval string `json:"interval,omitempty"`
 	// MinimumInterval to wait between two runs of the job.
 	// Consecutive jobs are run at `interval` + `duration of previous job` apart.
-	MinimumInterval string `json:"minimun_interval,omitempty"`
+	MinimumInterval string `json:"minimum_interval,omitempty"`
 	// Cron representation of job trigger time
 	Cron string `json:"cron,omitempty"`
 	// Tags for config entries


### PR DESCRIPTION
The Periodic.MinimumInterval json tag was misspelled: `minimun_interval`
instead of `minimum_interval`.

A follow-up to https://github.com/kubernetes/test-infra/pull/26743