### PR TITLE
klog flag deprecation

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -618,8 +618,7 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone, runtimeC
 		"run",
 		util.K8s("kubernetes", "test", "e2e_node", "runner", "remote", "run_remote.go"),
 		"--cleanup",
-		"--logtostderr",
-		"--vmodule=*=4",
+		"-vmodule=*=4", // This causes more runtime overhead than -v=4, but perhaps there is a reason for using it?
 		"--ssh-env=gce",
 		fmt.Sprintf("--results-dir=%s", artifactsDir),
 		fmt.Sprintf("--project=%s", project),

--- a/maintenance/migratestatus/migrate-many.sh
+++ b/maintenance/migratestatus/migrate-many.sh
@@ -25,7 +25,7 @@ migrate() {
     exit 1
   fi
   "${REPO_ROOT}/_bin/migratestatus" \
-    --dry-run=false --alsologtostderr \
+    --dry-run=false \
     --org=kubernetes \
     --repo=kubernetes \
     --tokenfile ~/github-token \


### PR DESCRIPTION
As describe in https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components, several klog flags will soon be removed from Kubernetes commands, in particular in the e2e test suites invoked by kubetest.

Right now that triggers a deprecation warning, for example in https://storage.googleapis.com/kubernetes-jenkins/logs/ci-crio-cgroupv1-node-e2e-conformance/1564520501156515840/build-log.txt

