### PR TITLE
Setting the default PR merge policy to 'squash'.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -753,6 +753,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/ibm-vpc-block-csi-driver: squash
+    kubernetes-sigs/kernel-module-management: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
     kubernetes-sigs/kubespray: squash


### PR DESCRIPTION
It means that every PR will be squashed to a single commit before
merging regardless of the number of commits in the PR pre-merging.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>