### PR TITLE
Add cloud-provider-gcp-e2e-full-next for GCP cloud provider

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -80,3 +80,40 @@ presubmits:
           go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
           go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
           kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version=v1.24.2 --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+  - name: cloud-provider-gcp-e2e-full-next
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 80m
+    path_alias: k8s.io/cloud-provider-gcp
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    annotations:
+      testgrid-dashboards: provider-gcp-presubmits
+      description: End to end test of kubernetes/cloud-provider-gcp for bumping to next version
+      testgrid-num-columns-recent: '30'
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220829-d5650c79bf-master
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        command:
+        - runner.sh
+        args:
+        - "/bin/bash"
+        - "-c"
+        - set -o errexit;
+          set -o nounset;
+          set -o pipefail;
+          set -o xtrace;
+          REPO_ROOT=$(git rev-parse --show-toplevel);
+          cd;
+          export GO111MODULE=on;
+          go install sigs.k8s.io/kubetest2@latest;
+          go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+          go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version=v1.25.0 --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
Required to bump cloud-provider-gcp repository to newer version.