### PR TITLE
Gerrit CommondFilter prints both the first 70 and last 70 chars from a comment

### DIFF
--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -108,10 +108,14 @@ func (af *ArbitraryFilter) Name() string {
 // CommandFilter builds a filter for `/test foo`
 type CommandFilter struct {
 	body string
+	// half is used by `.Name`. For large body only the first and last "half"
+	// chars are part of `.Name`. The default is 70, define here for easier unit
+	// test purpose.
+	half int
 }
 
 func NewCommandFilter(body string) *CommandFilter {
-	return &CommandFilter{body: body}
+	return &CommandFilter{body: body, half: 70}
 }
 
 func (cf *CommandFilter) ShouldRun(p config.Presubmit) (bool, bool, bool) {
@@ -119,12 +123,13 @@ func (cf *CommandFilter) ShouldRun(p config.Presubmit) (bool, bool, bool) {
 }
 
 func (cf *CommandFilter) Name() string {
-	// Arbitrarily grabbing the first 50 chars for debugging purpose
-	end := 50
-	if len(cf.body) < 50 {
-		end = len(cf.body)
+	var body string
+	if len(cf.body) <= cf.half*2 {
+		body = cf.body
+	} else {
+		body = cf.body[:cf.half] + "\n...\n" + cf.body[len(cf.body)-cf.half:]
 	}
-	return "command-filter: " + cf.body[:end]
+	return "command-filter: " + body
 }
 
 // TestAllFilter builds a filter for the automatic behavior of `/test all`.


### PR DESCRIPTION
Initially it only prints the first 50 chars, which includes only general messages from Prow, such as , which is not very helpful.