### PR TITLE
Update minikube prow job to point to v0.0.3 image

### DIFF
--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-minikube/prow-test:v0.0.2
+      - image: gcr.io/k8s-minikube/prow-test:v0.0.3
         # we add --force since minikube is running as root
         command:
         - wrapper.sh


### PR DESCRIPTION
Pointing the prow job to v0.0.3, which has an updated Go version to support generics.