### PR TITLE
gcs upload: log full bucket and dest path

### DIFF
--- a/prow/pod-utils/gcs/upload_test.go
+++ b/prow/pod-utils/gcs/upload_test.go
@@ -236,3 +236,33 @@ func Test_openerObjectWriter_Write(t *testing.T) {
 		})
 	}
 }
+
+func Test_openerObjectWriter_fullUploadPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		bucket string
+		dest   string
+		want   string
+	}{
+		{
+			name:   "simple path",
+			bucket: "bucket-A",
+			dest:   "path/to/some/file.json",
+			want:   "gs://bucket-A/path/to/some/file.json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &openerObjectWriter{
+				Bucket: fmt.Sprintf("gs://%s", tt.bucket),
+				Dest:   tt.dest,
+			}
+			got := w.fullUploadPath()
+
+			if got != tt.want {
+				t.Errorf("fullUploadPath(): got %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously we only logged the dest path, without the bucket name.
Example:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-prow/1560484749049335808
where we logged:

      Init container initupload not ready: (state: terminated, reason: "Error", message: "unc1\",\"level\":\"info\",\"msg\":\"Failed upload\",\"severity\":\"info\",\"time\":\"2022-08-19T04:33:21Z\"}\n{\"component\":\"initupload\",\"dest\":\"logs/post-test-infra-push-prow/1560484749049335808/clone-records.json\",\"file\":\"k8s.io/test-infra/prow/pod-utils/gcs/upload.go:112\",\"func\":\"k8s.io/test-infra/prow/pod-utils/gcs.upload.func1\",\"level\":\"info\",\"msg\":\"Failed upload\",\"severity\":\"info\",\"time\":\"2022-08-19T04:33:21Z\"}\n{\"component\":\"initupload\",\"dest\":\"logs/post-test-infra-push-prow/1560484749049335808/started.json\",\"file\":\"k8s.io/test-infra/prow/pod-utils/gcs/upload.go:112\",\"func\":\"k8s.io/test-infra/prow/pod-utils/gcs.upload.func1\",\"level\":\"info\",\"msg\":\"Failed upload\",\"severity\":\"info\",\"time\":\"2022-08-19T04:33:21Z\"}\n{\"component\":\"initupload\",\"error\":\"failed to upload to blob storage: encountered errors during upload: [writer close error: googleapi: Error 403: pusher@k8s-prow.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage bucket., forbidden upload error: writer close error: googleapi: Error 403: pusher@k8s-prow.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage bucket., forbidden writer close error: googleapi: Error 403: pusher@k8s-prow.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage bucket., forbidden]\",\"file\":\"k8s.io/test-infra/prow/gcsupload/run.go:59\",\"func\":\"k8s.io/test-infra/prow/gcsupload.Options.Run\",\"level\":\"info\",\"msg\":\"Also failed to upload extra targets\",\"severity\":\"info\",\"time\":\"2022-08-19T04:33:21Z\"}\n{\"component\":\"initupload\",\"error\":\"failed to upload to blob storage: failed to upload to blob storage: encountered errors during upload: [writer close error: googleapi: Error 403: pusher@k8s-prow.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage bucket., forbidden]\",\"file\":\"k8s.io/test-infra/prow/cmd/initupload/main.go:45\",\"func\":\"main.main\",\"level\":\"fatal\",\"msg\":\"Failed to initialize job\",\"severity\":\"fatal\",\"time\":\"2022-08-19T04:33:21Z\"}\n") Init container place-entrypoint not ready: (state: waiting, reason: "PodInitializing", message: "")

Notice that the bucket information is missing and that we only log the
"dest", which in this case was
`logs/post-test-infra-push-prow/1560484749049335808/clone-records.json`.

/cc @chaodaiG @cjwagner