### PR TITLE
Using 1.24 variant of kubekins image

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220831-bcf0c264ed-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220831-bcf0c264ed-1.24
         command:
         - "runner.sh"
         args:


### PR DESCRIPTION
Switching the repo and the job to go v1.18, hence the variant change to
1.24 which uses go v1.18.5

Signed-off-by: Imran Pochi <imran@kinvolk.io>