### PR TITLE
Revert "Override NODE_SCOPES for scalability tests"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -107,8 +107,6 @@ presets:
     value: true
   - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
     value: pd.csi.storage.gke.io
-  - name: NODE_SCOPES
-    value: "monitoring,logging-write,storage-rw"
 
 ### kubemark-gce-scale
 - labels:
@@ -257,8 +255,6 @@ presets:
     value: pd.csi.storage.gke.io
   - name: KUBE_APISERVER_GODEBUG
     value: gctrace=1
-  - name: NODE_SCOPES
-    value: "monitoring,logging-write,storage-rw"
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.


### PR DESCRIPTION
Reverts kubernetes/test-infra#27322.

Reason: this override is actually not needed anywhere in the scalability tests.

/assign @jkaniuk 