### PR TITLE
Add S3 sync jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcs-to-aws-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcs-to-aws-sync.yaml
@@ -1,0 +1,49 @@
+periodics:
+  - name: gcs-to-s3-sync
+    interval: 2h
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    max_concurrency: 1
+    annotations:
+      testgrid-dashboards: sig-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+    extra_refs:
+      - org: kubernetes
+        repo: k8s.io
+        base_ref: main
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes
+          slug: sig-k8s-infra-leads
+        - org: kubernetes
+          slug: release-managers
+    spec:
+      serviceAccountName: s3-sync
+      containers:
+        - name: aws-cli
+          image: amazon/aws-cli:latest
+          command:
+            - /bin/bash
+            - -c
+            - "aws sts get-caller-identity"
+          env:
+            - name: AWS_ROLE_ARN
+              value: arn:aws:iam::513428760722:role/registry.k8s.io_s3writer
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/aws-iam-token/serviceaccount/token
+            - name: AWS_REGION
+              value: us-east-1
+          volumeMounts:
+            - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
+              name: aws-iam-token
+              readOnly: true
+      volumes:
+        - name: aws-iam-token
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                audience: sts.amazonaws.com
+                expirationSeconds: 86400
+                path: token


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/k8s.io/issues/3807

Adding a Prow Job to write blobs to S3.

The script isn't ready yet so for now it is just going to authenticate to AWS to test that it works. @BobyMCbobs will raise a PR later with the scripts.

AWS Infra Change: https://github.com/cncf-infra/aws-infra/pull/15
Prow Infra Change: https://github.com/kubernetes/k8s.io/pull/4170
We will be using an AWS service to replicate the blobs from the primary bucket to all the other S3 buckets. https://github.com/kubernetes/k8s.io/pull/4118
