### PR TITLE
Add descheduler 1.25 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.25.yaml
@@ -1,15 +1,15 @@
 # sigs.k8s.io/descheduler presubmits
 presubmits:
   kubernetes-sigs/descheduler:
-  - name: pull-descheduler-verify-master
+  - name: pull-descheduler-verify-release-1-25
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-master
+      testgrid-tab-name: pull-descheduler-verify-release-1.25
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.25$
     always_run: true
     spec:
       containers:
@@ -18,15 +18,15 @@ presubmits:
         - make
         args:
         - verify
-  - name: pull-descheduler-verify-build-master
+  - name: pull-descheduler-verify-build-release-1-25
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-build-master
+      testgrid-tab-name: pull-descheduler-verify-build-release-1.25
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.25$
     always_run: true
     spec:
       containers:
@@ -35,15 +35,15 @@ presubmits:
         - make
         args:
         - build
-  - name: pull-descheduler-unit-test-master-master
+  - name: pull-descheduler-unit-test-release-1-25
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-unit-test-master
+      testgrid-tab-name: pull-descheduler-unit-test-release-1.25
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.25$
     always_run: false
     run_if_changed: '\.go$'
     spec:
@@ -53,10 +53,10 @@ presubmits:
         - make
         args:
         - test-unit
-  - name: pull-descheduler-test-e2e-k8s-master-1-25
+  - name: pull-descheduler-test-e2e-k8s-release-1-25-1-25
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.25
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-25-1.25
     decorate: true
     decoration_config:
       timeout: 20m
@@ -65,10 +65,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
+    - release-1.25
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220902-cdfab4f336-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -83,10 +83,10 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-descheduler-test-e2e-k8s-master-1-24
+  - name: pull-descheduler-test-e2e-k8s-release-1-25-1-24
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.24
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-25-1.24
     decorate: true
     decoration_config:
       timeout: 20m
@@ -95,10 +95,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
+    - release-1.25
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220902-cdfab4f336-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -113,10 +113,10 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-descheduler-test-e2e-k8s-master-1-23
+  - name: pull-descheduler-test-e2e-k8s-release-1-25-1-23
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.23
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-25-1.23
     decorate: true
     decoration_config:
       timeout: 20m
@@ -125,10 +125,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
+    - release-1.25
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220902-cdfab4f336-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh


### PR DESCRIPTION
As part of this change, we are updating the descheduler repo for 1.25 presubmits testing. Previous update: https://github.com/kubernetes/test-infra/pull/25833

Related issue: https://github.com/kubernetes-sigs/descheduler/issues/844