### PR TITLE
Bump Go version for cli-utils build

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.19
         command:
         - make
         args:


### PR DESCRIPTION
Trying to fix build for https://github.com/kubernetes-sigs/cli-utils/pull/606.

/assign @mortent