### PR TITLE
Redhat OSDe2e Testgrid Updates

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -1,213 +1,56 @@
 test_groups:
-- name: osde2e-stage-aws-conformance-default
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-conformance-default
+- name: osde2e-main-aws-stage-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aws-stage-e2e-default
   column_header:
   - configuration_value: cluster-version
-- name: osde2e-int-aws-e2e-upgrade-to-latest-z
-  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-upgrade-to-latest-z
+- name: osde2e-main-aws-prod-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aws-prod-e2e-default
   column_header:
   - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
-  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-osd-default-plus-one-nightly
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-int-aws-e2e-upgrade-to-latest-y
-  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-upgrade-to-latest-y
+- name: osde2e-main-aws-stage-e2e-upgrade-to-latest
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aws-stage-e2e-upgrade-to-latest
   column_header:
   - configuration_value: cluster-version
   - configuration_value: upgrade-version
-- name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
-  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-osd-default-plus-two-nightly
+- name: osde2e-main-aws-prod-informing-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aws-prod-informing-default
   column_header:
   - configuration_value: cluster-version
-- name: osde2e-prod-aws-e2e-default
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-default
+- name: osde2e-main-aws-prod-cleanup
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aws-prod-cleanup
   column_header:
   - configuration_value: cluster-version
-- name: osde2e-prod-aws-informing-default
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-informing-default
+- name: osde2e-main-rosa-stage-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-rosa-stage-e2e-default
   column_header:
   - configuration_value: cluster-version
-- name: osde2e-stage-aws-informing-default
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-informing-default
+- name: osde2e-main-rosa-prod-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-rosa-prod-e2e-default
   column_header:
   - configuration_value: cluster-version
-- name: osde2e-prod-aws-e2e-upgrade-to-latest
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-to-latest
+- name: osde2e-main-gcp-stage-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-gcp-stage-e2e-default
   column_header:
   - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-aws-e2e-upgrade-prod-minus-one-to-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-prod-minus-one-to-next
+- name: osde2e-main-gcp-prod-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-gcp-prod-e2e-default
   column_header:
   - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-aws-e2e-upgrade-prod-minus-two-to-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-prod-minus-two-to-next
+- name: osde2e-main-aro-e2e-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aro-e2e-default
   column_header:
   - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-aws-e2e-upgrade-prod-minus-three-to-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-prod-minus-three-to-next
+- name: osde2e-main-aro-nightly-cleanup
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-main-aro-nightly-cleanup
   column_header:
   - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-aws-e2e-upgrade-prod-minus-four-to-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-prod-minus-four-to-next
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-aws-e2e-upgrade-prod-plus-one-to-latest
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-prod-plus-one-to-latest
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-aws-e2e-middle-imageset
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-middle-imageset
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-aws-e2e-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-next
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-aws-informing-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-informing-next
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-aws-informing-next
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-informing-next
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-aws-e2e-oldest-imageset
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-oldest-imageset
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-aws-e2e-default
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-default
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-aws-e2e-upgrade-to-latest-z
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-upgrade-to-latest-z
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-stage-aws-e2e-upgrade-to-latest
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-upgrade-to-latest
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-stage-aws-e2e-middle-imageset
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-middle-imageset
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-aws-e2e-next-z
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-next-z
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-aws-e2e-next-y
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-next-y
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-aws-e2e-oldest-imageset
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-oldest-imageset
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-int-gcp-e2e-upgrade-to-latest-z
-  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-upgrade-to-latest-z
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-int-gcp-e2e-osd-default-plus-one-nightly
-  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-osd-default-plus-one-nightly
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-int-gcp-e2e-upgrade-to-latest-y
-  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-upgrade-to-latest-y
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
-  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-osd-default-plus-two-nightly
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-int-moa-e2e-osd-default-plus-one-nightly
-  gcs_prefix: origin-ci-test/logs/osde2e-int-moa-e2e-osd-default-plus-one-nightly
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-int-moa-e2e-osd-default-plus-two-nightly
-  gcs_prefix: origin-ci-test/logs/osde2e-int-moa-e2e-osd-default-plus-two-nightly
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-gcp-e2e-default
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-default
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-gcp-e2e-upgrade-to-latest
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-to-latest
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-stage-gcp-e2e-upgrade-to-latest-z
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-to-latest-z
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-stage-gcp-e2e-next-y
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-next-y
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-gcp-e2e-next-z
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-next-z
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-moa-e2e-default
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-moa-e2e-default
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-moa-e2e-next-y
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-moa-e2e-next-y
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-stage-moa-e2e-next-z
-  gcs_prefix: origin-ci-test/logs/osde2e-stage-moa-e2e-next-z
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-gcp-e2e-default
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-gcp-e2e-default
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-gcp-e2e-upgrade-to-next-y
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-gcp-e2e-upgrade-to-next-y
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-gcp-e2e-upgrade-to-next-z
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-gcp-e2e-upgrade-to-next-z
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osde2e-prod-gcp-e2e-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-gcp-e2e-next
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-moa-e2e-default
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-moa-e2e-default
-  column_header:
-  - configuration_value: cluster-version
-- name: osde2e-prod-moa-e2e-next
-  gcs_prefix: origin-ci-test/logs/osde2e-prod-moa-e2e-next
-  column_header:
-  - configuration_value: cluster-version
-
-
 
 dashboards:
 - name: redhat-osd
   dashboard_tab:
-  - name: osde2e-stage-aws-conformance-default
+  - name: osde2e-main-aws-stage-e2e-default
     description: OpenShift conformance tests on OSD
-    test_group_name: osde2e-stage-aws-conformance-default
+    test_group_name: osde2e-main-aws-stage-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -225,9 +68,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-aws-e2e-upgrade-to-latest-z
-    description: OSD test
-    test_group_name: osde2e-int-aws-e2e-upgrade-to-latest-z
+  - name: osde2e-main-aws-prod-e2e-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-aws-prod-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -245,9 +88,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
-    description: Runs an a test on Default-Y+1 nightly in integration on AWS
-    test_group_name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
+  - name: osde2e-main-aws-stage-e2e-upgrade-to-latest
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-aws-stage-e2e-upgrade-to-latest
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -265,9 +108,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-aws-e2e-upgrade-to-latest-y
-    description: OSD test
-    test_group_name: osde2e-int-aws-e2e-upgrade-to-latest-y
+  - name: osde2e-main-aws-prod-informing-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-aws-prod-informing-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -285,9 +128,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
-    description: OSD test
-    test_group_name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
+  - name: osde2e-main-aws-prod-cleanup
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-aws-prod-cleanup
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -305,9 +148,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-default
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-default
+  - name: osde2e-main-rosa-stage-e2e-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-rosa-stage-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -325,9 +168,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-informing-default
-    description: OSD test
-    test_group_name: osde2e-prod-aws-informing-default
+  - name: osde2e-main-rosa-prod-e2e-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-rosa-prod-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -345,9 +188,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-informing-default
-    description: OSD test
-    test_group_name: osde2e-stage-aws-informing-default
+  - name: osde2e-main-gcp-stage-e2e-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-gcp-stage-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -365,9 +208,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-upgrade-to-latest
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-upgrade-to-latest
+  - name: osde2e-main-gcp-prod-e2e-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-gcp-prod-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -385,9 +228,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-upgrade-prod-minus-one-to-next
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-one-to-next
+  - name: osde2e-main-aro-e2e-default
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-aro-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -405,709 +248,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-upgrade-prod-minus-two-to-next
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-two-to-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-upgrade-prod-minus-three-to-next
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-three-to-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-upgrade-prod-minus-four-to-next
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-four-to-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-upgrade-prod-plus-one-to-latest
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-upgrade-prod-plus-one-to-latest
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-middle-imageset
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-middle-imageset
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-next
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-informing-next
-    description: OSD test
-    test_group_name: osde2e-prod-aws-informing-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-informing-next
-    description: OSD test
-    test_group_name: osde2e-stage-aws-informing-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-aws-e2e-oldest-imageset
-    description: OSD test
-    test_group_name: osde2e-prod-aws-e2e-oldest-imageset
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-default
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-default
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-upgrade-to-latest-z
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-upgrade-to-latest-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-upgrade-to-latest
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-upgrade-to-latest
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-middle-imageset
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-middle-imageset
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-next-z
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-next-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-next-y
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-next-y
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-aws-e2e-oldest-imageset
-    description: OSD test
-    test_group_name: osde2e-stage-aws-e2e-oldest-imageset
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-gcp-e2e-upgrade-to-latest-z
-    description: OSD test
-    test_group_name: osde2e-int-gcp-e2e-upgrade-to-latest-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-gcp-e2e-osd-default-plus-one-nightly
-    description: OSD test
-    test_group_name: osde2e-int-gcp-e2e-osd-default-plus-one-nightly
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-gcp-e2e-upgrade-to-latest-y
-    description: OSD test
-    test_group_name: osde2e-int-gcp-e2e-upgrade-to-latest-y
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
-    description: OSD test
-    test_group_name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-moa-e2e-osd-default-plus-one-nightly
-    description: OSD test
-    test_group_name: osde2e-int-moa-e2e-osd-default-plus-one-nightly
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-int-moa-e2e-osd-default-plus-two-nightly
-    description: OSD test
-    test_group_name: osde2e-int-moa-e2e-osd-default-plus-two-nightly
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-gcp-e2e-default
-    description: Runs a test using the default version on GCP
-    test_group_name: osde2e-stage-gcp-e2e-default
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-gcp-e2e-upgrade-to-latest
-    description: Runa a test on GCP that upgrades to the latest version
-    test_group_name: osde2e-stage-gcp-e2e-upgrade-to-latest
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-gcp-e2e-upgrade-to-latest-z
-    description: Runs a test on GCP that upgrades to the latest-z
-    test_group_name: osde2e-stage-gcp-e2e-upgrade-to-latest-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-gcp-e2e-next-y
-    description: Runs a test using the next-y version on GCP
-    test_group_name: osde2e-stage-gcp-e2e-next-y
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-gcp-e2e-next-z
-    description: Runs a test using the next-z version on GCP
-    test_group_name: osde2e-stage-gcp-e2e-next-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-moa-e2e-default
-    description: Runs a test using the default version on ROSA
-    test_group_name: osde2e-stage-moa-e2e-default
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-moa-e2e-next-y
-    description: Runs a test using the next-y version on ROSA
-    test_group_name: osde2e-stage-moa-e2e-next-y
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-stage-moa-e2e-next-z
-    description: Runs a test using the next-z version on ROSA
-    test_group_name: osde2e-stage-moa-e2e-next-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-gcp-e2e-default
-    description: Runs a test using the default version in GCP 
-    test_group_name: osde2e-prod-gcp-e2e-default
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-gcp-e2e-upgrade-to-next-y
-    description: Runs a test using the next-y version on GCP
-    test_group_name: osde2e-prod-gcp-e2e-upgrade-to-next-y
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-gcp-e2e-upgrade-to-next-z
-    description: Runs a test using the next-z version on GCP
-    test_group_name: osde2e-prod-gcp-e2e-upgrade-to-next-z
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-gcp-e2e-next
-    description: Runs a test using the next version on GCP
-    test_group_name: osde2e-prod-gcp-e2e-next
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-moa-e2e-default
-    description: Runs a test using default version on ROSA
-    test_group_name: osde2e-prod-moa-e2e-default
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osde2e-prod-moa-e2e-next
-    description: Runs an a test using the next available version in ROSA
-    test_group_name: osde2e-prod-moa-e2e-next
+  - name: osde2e-main-aro-nightly-cleanup
+    description: OpenShift conformance tests on OSD
+    test_group_name: osde2e-main-aro-nightly-cleanup
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
We are updating the OSDe2e pipelines to include the base e2e scenario in order to clear up signal. 
This PR is a continuation of the Prow pipelines that been updated in order to focus the signal for different flavors of Openshift. 