### PR TITLE
Fix Gerrit queries

### DIFF
--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -183,7 +183,7 @@ func TestQueryStringsFromQueryFilter(t *testing.T) {
 			filters: &config.GerritQueryFilter{
 				Branches: []string{"foo1", "foo2", "foo3"},
 			},
-			expected: []string{"(branch:'foo1' OR branch:'foo2' OR branch:'foo3')"},
+			expected: []string{"(branch:'foo1'+OR+branch:'foo2'+OR+branch:'foo3')"},
 		},
 		{
 			name: "branches-and-excluded",
@@ -192,8 +192,8 @@ func TestQueryStringsFromQueryFilter(t *testing.T) {
 				ExcludedBranches: []string{"bar1", "bar2", "bar3"},
 			},
 			expected: []string{
-				"(branch:'foo1' OR branch:'foo2' OR branch:'foo3')",
-				"(-branch:'bar1' AND -branch:'bar2' AND -branch:'bar3')",
+				"(branch:'foo1'+OR+branch:'foo2'+OR+branch:'foo3')",
+				"(-branch:'bar1'+AND+-branch:'bar2'+AND+-branch:'bar3')",
 			},
 		},
 	}

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -50,11 +50,11 @@ const (
 	// ref:
 	// https://gerrit-review.googlesource.com/Documentation/user-search.html#_search_operators.
 	// Also good to know: `(repo:repo-A OR repo:repo-B)`
-	gerritDefaultQueryParam = "status:open -is:wip is:submittable is:mergeable"
+	gerritDefaultQueryParam = "status:open+-is:wip+is:submittable+is:mergeable"
 )
 
 type gerritClient interface {
-	QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters []string) ([]gerrit.ChangeInfo, error)
+	QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters ...string) ([]gerrit.ChangeInfo, error)
 	GetChange(instance, id string) (*gerrit.ChangeInfo, error)
 	GetBranchRevision(instance, project, branch string) (string, error)
 }
@@ -167,7 +167,7 @@ func (p *GerritProvider) Query() (map[string]CodeReviewCommon, error) {
 		for projName := range projs {
 			wg.Add(1)
 			go func(projName string) {
-				changes, err := p.gc.QueryChangesForProject(instance, projName, lastUpdate, p.cfg().Gerrit.RateLimit, []string{gerritDefaultQueryParam})
+				changes, err := p.gc.QueryChangesForProject(instance, projName, lastUpdate, p.cfg().Gerrit.RateLimit, gerritDefaultQueryParam)
 				if err != nil {
 					p.logger.WithFields(logrus.Fields{"instance": instance, "project": projName}).WithError(err).Warn("Querying gerrit project for changes.")
 					errChan <- fmt.Errorf("failed querying project '%s' from instance '%s': %v", projName, instance, err)

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -51,7 +51,7 @@ func newFakeGerritClient() *fakeGerritClient {
 	}
 }
 
-func (f *fakeGerritClient) QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters []string) ([]gerrit.ChangeInfo, error) {
+func (f *fakeGerritClient) QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters ...string) ([]gerrit.ChangeInfo, error) {
 	if f.changes == nil || f.changes[instance] == nil || f.changes[instance][project] == nil {
 		return nil, errors.New("queries project doesn't exist")
 	}


### PR DESCRIPTION
Gerrit client sends query parameters as part of URL instead of payload, the previous implementation used space as separators which didn't work well with http Client. Inspected Gerrit UI by looking at the request URLs and figured that plus signs are expected.

/cc @cjwagner @listx 