### PR TITLE
Bump kubekins image build/push to 30 mins

### DIFF
--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -49,6 +49,7 @@ substitutions:
   _KIND_VERSION: ''
   _KUBETEST2_VERSION: ''
   _YQ_VERSION: v4.23.1
+timeout: 1800s  
 options:
   substitution_option: ALLOW_LOOSE
 images:


### PR DESCRIPTION
Last few runs failed:
https://testgrid.k8s.io/sig-k8s-infra-gcb#kubekins-e2e

with the following error:
```
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build 2bd1615b-4dc4-4750-948d-0b28d0249bac completed with status "TIMEOUT"
```

Since default cloudbuild times out at 10 mins, let's give it some more time (30 mins)