### PR TITLE
integration tests: stop bumping test data

### DIFF
--- a/prow/test/integration/test/testdata/invalid_prowjob.yaml
+++ b/prow/test/integration/test/testdata/invalid_prowjob.yaml
@@ -51,10 +51,10 @@ spec:
           cpu: 100m
     timeout: 2h0m0s
     utility_images:
-      clonerefs: 'gcr.io/k8s-prow/clonerefs:v20220902-41e9ad5a3e'
-      entrypoint: 'gcr.io/k8s-prow/entrypoint:v20220902-41e9ad5a3e'
-      initupload: 'gcr.io/k8s-prow/initupload:v20220902-41e9ad5a3e'
-      sidecar: 'gcr.io/k8s-prow/sidecar:v20220902-41e9ad5a3e'
+      clonerefs: localhost:5001/clonerefs-ssl-disabled:latest
+      initupload: localhost:5001/initupload:latest
+      entrypoint: localhost:5001/entrypoint:latest
+      sidecar: localhost:5001/sidecar:latest
   extra_refs:
     - base_ref: master
       org: kubernetes

--- a/prow/test/integration/test/testdata/valid_prowjob.yaml
+++ b/prow/test/integration/test/testdata/valid_prowjob.yaml
@@ -51,10 +51,10 @@ spec:
           cpu: 100m
     timeout: 2h0m0s
     utility_images:
-      clonerefs: 'gcr.io/k8s-prow/clonerefs:v20220902-41e9ad5a3e'
-      entrypoint: 'gcr.io/k8s-prow/entrypoint:v20220902-41e9ad5a3e'
-      initupload: 'gcr.io/k8s-prow/initupload:v20220902-41e9ad5a3e'
-      sidecar: 'gcr.io/k8s-prow/sidecar:v20220902-41e9ad5a3e'
+      clonerefs: localhost:5001/clonerefs-ssl-disabled:latest
+      initupload: localhost:5001/initupload:latest
+      entrypoint: localhost:5001/entrypoint:latest
+      sidecar: localhost:5001/sidecar:latest
   extra_refs:
     - base_ref: master
       org: kubernetes


### PR DESCRIPTION
The configuration to use production images was introduced in
3aaa6c53d55387a1326af75069a6c62aaf923862, and since then there have been
many "Bumping Prow and Boskos" changes (example:
016ea692a3897bd0be88e81496f595d56adcd00c) for these configurations,
which do not even test these images, making the git history
unnecessarily messy.

This commit instead makes these configurations refer to images inside
the test (KIND) cluster. They are already built and used by other tests,
so using them here is a NOP (unlike before, where presumably we
downloaded these images over the network).

/cc @cjwagner @chaodaiG 