### PR TITLE
Git client for inrepoconfig uses a single client for all repos

### DIFF
--- a/prow/cmd/deck/pr_history.go
+++ b/prow/cmd/deck/pr_history.go
@@ -209,7 +209,7 @@ func parsePullURL(u *url.URL) (org, repo string, pr int, err error) {
 }
 
 // getStorageDirsForPR returns a map from bucket names -> set of "directories" containing presubmit data
-func getStorageDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitClient git.ClientFactory, org, repo string, prNumber int) (map[string]sets.String, error) {
+func getStorageDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitClient git.ClientFactory, org, repo, cloneURI string, prNumber int) (map[string]sets.String, error) {
 	toSearch := make(map[string]sets.String)
 	fullRepo := org + "/" + repo
 
@@ -218,7 +218,7 @@ func getStorageDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitCli
 		return nil, nil
 	}
 	prRefGetter := config.NewRefGetterForGitHubPullRequest(gitHubClient, org, repo, prNumber)
-	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, prRefGetter.BaseSHA, prRefGetter.HeadSHA)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, cloneURI, prRefGetter.BaseSHA, prRefGetter.HeadSHA)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Presubmits for pull request %s/%s#%d: %w", org, repo, prNumber, err)
 	}
@@ -276,7 +276,12 @@ func getPRHistory(ctx context.Context, prHistoryURL *url.URL, config *config.Con
 	template.Name = fmt.Sprintf("%s/%s #%d", org, repo, pr)
 	template.Link = githubPRLink(githubHost, org, repo, pr) // TODO(ibzib) support Gerrit :/
 
-	toSearch, err := getStorageDirsForPR(config, gitHubClient, gitClient, org, repo, pr)
+	// cloneURI is used for cloning Gerrit repos, set it to empty for now as PR
+	// history doesn't work for Gerrit yet.
+	// TODO(chaodaiG): update once
+	// https://github.com/kubernetes/test-infra/issues/24130 is fixed.
+	cloneURI := ""
+	toSearch, err := getStorageDirsForPR(config, gitHubClient, gitClient, org, repo, cloneURI, pr)
 	if err != nil {
 		return template, fmt.Errorf("failed to list directories for PR %s: %w", template.Name, err)
 	}

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -483,7 +483,7 @@ func TestGetGCSDirsForPR(t *testing.T) {
 		gitHubClient.PullRequests = map[int]*github.PullRequest{
 			123: {Number: 123},
 		}
-		toSearch, err := getStorageDirsForPR(tc.config, gitHubClient, nil, tc.org, tc.repo, tc.pr)
+		toSearch, err := getStorageDirsForPR(tc.config, gitHubClient, nil, tc.org, tc.repo, "", tc.pr)
 		if (err != nil) != tc.expErr {
 			t.Errorf("%s: unexpected error %v", tc.name, err)
 		}

--- a/prow/config/cache_test.go
+++ b/prow/config/cache_test.go
@@ -142,7 +142,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 	// goodValConstructor mocks config.getProwYAML.
 	// This map pretends to be an expensive computation in order to generate a
 	// *ProwYAML value.
-	goodValConstructor := func(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+	goodValConstructor := func(gc git.ClientFactory, identifier, cloneURI string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 
 		baseSHA, headSHAs, err := GetAndCheckRefs(baseSHAGetter, headSHAGetters...)
 		if err != nil {
@@ -202,7 +202,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 		}
 	}
 
-	badValConstructor := func(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+	badValConstructor := func(gc git.ClientFactory, identifier, cloneURI string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 		return nil, fmt.Errorf("unable to construct *ProwYAML value")
 	}
 
@@ -214,7 +214,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 
 	for _, tc := range []struct {
 		name           string
-		valConstructor func(git.ClientFactory, string, RefGetter, ...RefGetter) (*ProwYAML, error)
+		valConstructor func(git.ClientFactory, string, string, RefGetter, ...RefGetter) (*ProwYAML, error)
 		// We use a slice of CacheKeysParts for simplicity.
 		cacheInitialState   []CacheKeyParts
 		cacheCorrupted      bool
@@ -441,7 +441,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 				}
 			}
 
-			prowYAML, err := cache.getProwYAML(tc.valConstructor, tc.identifier, tc.baseSHAGetter, tc.headSHAGetters...)
+			prowYAML, err := cache.getProwYAML(tc.valConstructor, tc.identifier, "", tc.baseSHAGetter, tc.headSHAGetters...)
 
 			if tc.expected.err == "" {
 				if err != nil {
@@ -838,7 +838,7 @@ func TestGetProwYAMLCachedAndDefaulted(t *testing.T) {
 			var errGroup errgroup.Group
 			for i := 0; i < 1000; i++ {
 				errGroup.Go(func() error {
-					presubmits, err := cache.GetPresubmits(identifier, baseSHAGetter, headSHAGetters...)
+					presubmits, err := cache.GetPresubmits(identifier, "", baseSHAGetter, headSHAGetters...)
 					if err != nil {
 						return fmt.Errorf("Expected error 'nil' got '%v'", err.Error())
 					}
@@ -849,7 +849,7 @@ func TestGetProwYAMLCachedAndDefaulted(t *testing.T) {
 				})
 
 				errGroup.Go(func() error {
-					postsubmits, err := cache.GetPostsubmits(identifier, baseSHAGetter, headSHAGetters...)
+					postsubmits, err := cache.GetPostsubmits(identifier, "", baseSHAGetter, headSHAGetters...)
 					if err != nil {
 						return fmt.Errorf("Expected error 'nil' got '%v'", err.Error())
 					}
@@ -868,11 +868,11 @@ func TestGetProwYAMLCachedAndDefaulted(t *testing.T) {
 			// Reload Config.
 			fca.c = tc.configAfter
 
-			presubmits, err := cache.GetPresubmits(identifier, baseSHAGetter, headSHAGetters...)
+			presubmits, err := cache.GetPresubmits(identifier, "", baseSHAGetter, headSHAGetters...)
 			if err != nil {
 				t1.Fatalf("Expected error 'nil' got '%v'", err.Error())
 			}
-			postsubmits, err := cache.GetPostsubmits(identifier, baseSHAGetter, headSHAGetters...)
+			postsubmits, err := cache.GetPostsubmits(identifier, "", baseSHAGetter, headSHAGetters...)
 			if err != nil {
 				t1.Fatalf("Expected error 'nil' got '%v'", err.Error())
 			}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -394,7 +394,7 @@ func GetAndCheckRefs(
 // does a call to GitHub and who also need the result of that GitHub call just
 // keep a pointer to its result, but must nilcheck that pointer before accessing
 // it.
-func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier, cloneURI string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 	if identifier == "" {
 		return nil, errors.New("no identifier for repo given")
 	}
@@ -407,7 +407,7 @@ func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier string
 		return nil, err
 	}
 
-	prowYAML, err := c.ProwYAMLGetterWithDefaults(c, gc, identifier, baseSHA, headSHAs...)
+	prowYAML, err := c.ProwYAMLGetterWithDefaults(c, gc, identifier, cloneURI, baseSHA, headSHAs...)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier string
 }
 
 // getProwYAML is like getProwYAMLWithDefaults, minus the defaulting logic.
-func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+func (c *Config) getProwYAML(gc git.ClientFactory, identifier, cloneURI string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 	if identifier == "" {
 		return nil, errors.New("no identifier for repo given")
 	}
@@ -429,7 +429,7 @@ func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGet
 		return nil, err
 	}
 
-	prowYAML, err := c.ProwYAMLGetter(c, gc, identifier, baseSHA, headSHAs...)
+	prowYAML, err := c.ProwYAMLGetter(c, gc, identifier, cloneURI, baseSHA, headSHAs...)
 	if err != nil {
 		return nil, err
 	}
@@ -443,8 +443,8 @@ func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGet
 // Consumers that pass in a RefGetter implementation that does a call to GitHub and who
 // also need the result of that GitHub call just keep a pointer to its result, but must
 // nilcheck that pointer before accessing it.
-func (c *Config) GetPresubmits(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
-	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, baseSHAGetter, headSHAGetters...)
+func (c *Config) GetPresubmits(gc git.ClientFactory, identifier, cloneURI string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
+	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, cloneURI, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -463,8 +463,8 @@ func (c *Config) GetPresubmitsStatic(identifier string) []Presubmit {
 // Consumers that pass in a RefGetter implementation that does a call to GitHub and who
 // also need the result of that GitHub call just keep a pointer to its result, but must
 // nilcheck that pointer before accessing it.
-func (c *Config) GetPostsubmits(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error) {
-	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, baseSHAGetter, headSHAGetters...)
+func (c *Config) GetPostsubmits(gc git.ClientFactory, identifier, cloneURI string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error) {
+	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, cloneURI, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -7391,7 +7391,7 @@ func TestGetProwYAMLDoesNotCallRefGettersWhenInrepoconfigIsDisabled(t *testing.T
 	}
 
 	c := &Config{}
-	if _, err := c.getProwYAMLWithDefaults(nil, "test", baseSHAGetter, headSHAGetter); err != nil {
+	if _, err := c.getProwYAMLWithDefaults(nil, "test", "", baseSHAGetter, headSHAGetter); err != nil {
 		t.Fatalf("error calling GetProwYAML: %v", err)
 	}
 	if baseSHAGetterCalled {
@@ -7428,7 +7428,7 @@ func TestGetPresubmitsReturnsStaticAndInrepoconfigPresubmits(t *testing.T) {
 		},
 	}
 
-	presubmits, err := c.GetPresubmits(nil, org+"/"+repo, func() (string, error) { return "", nil })
+	presubmits, err := c.GetPresubmits(nil, org+"/"+repo, "", func() (string, error) { return "", nil })
 	if err != nil {
 		t.Fatalf("Error calling GetPresubmits: %v", err)
 	}
@@ -7466,7 +7466,7 @@ func TestGetPostsubmitsReturnsStaticAndInrepoconfigPostsubmits(t *testing.T) {
 		},
 	}
 
-	postsubmits, err := c.GetPostsubmits(nil, org+"/"+repo, func() (string, error) { return "", nil })
+	postsubmits, err := c.GetPostsubmits(nil, org+"/"+repo, "", func() (string, error) { return "", nil })
 	if err != nil {
 		t.Fatalf("Error calling GetPostsubmits: %v", err)
 	}

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -56,7 +56,7 @@ type ProwYAML struct {
 
 // ProwYAMLGetter is used to retrieve a ProwYAML. Tests should provide
 // their own implementation and set that on the Config.
-type ProwYAMLGetter func(c *Config, gc git.ClientFactory, identifier, baseSHA string, headSHAs ...string) (*ProwYAML, error)
+type ProwYAMLGetter func(c *Config, gc git.ClientFactory, identifier, cloneURI, baseSHA string, headSHAs ...string) (*ProwYAML, error)
 
 // Verify prowYAMLGetterWithDefaults and prowYAMLGetter are both of type
 // ProwYAMLGetter.
@@ -73,6 +73,7 @@ func prowYAMLGetter(
 	c *Config,
 	gc git.ClientFactory,
 	identifier string,
+	cloneURI string,
 	baseSHA string,
 	headSHAs ...string) (*ProwYAML, error) {
 
@@ -87,7 +88,7 @@ func prowYAMLGetter(
 	if orgRepo.Repo == "" {
 		return nil, fmt.Errorf("didn't get two results when splitting repo identifier %q", identifier)
 	}
-	repo, err := gc.ClientFor(orgRepo.Org, orgRepo.Repo)
+	repo, err := gc.ClientFor(orgRepo.Org, orgRepo.Repo, cloneURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to clone repo for %q: %w", identifier, err)
 	}
@@ -217,10 +218,11 @@ func prowYAMLGetterWithDefaults(
 	c *Config,
 	gc git.ClientFactory,
 	identifier string,
+	cloneURI string,
 	baseSHA string,
 	headSHAs ...string) (*ProwYAML, error) {
 
-	prowYAML, err := prowYAMLGetter(c, gc, identifier, baseSHA, headSHAs...)
+	prowYAML, err := prowYAMLGetter(c, gc, identifier, cloneURI, baseSHA, headSHAs...)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +288,7 @@ func NewInRepoConfigGitCache(factory git.ClientFactory) git.ClientFactory {
 	}
 }
 
-func (c *InRepoConfigGitCache) ClientFor(org, repo string) (git.RepoClient, error) {
+func (c *InRepoConfigGitCache) ClientFor(org, repo, cloneURI string) (git.RepoClient, error) {
 	key := fmt.Sprintf("%s/%s", org, repo)
 	getCache := func(threadSafe bool) (git.RepoClient, error) {
 		if client, ok := c.cache[key]; ok {
@@ -337,7 +339,7 @@ func (c *InRepoConfigGitCache) ClientFor(org, repo string) (git.RepoClient, erro
 	if cached != nil || err != nil {
 		return cached, err
 	}
-	coreClient, err := c.ClientFactory.ClientFor(org, repo)
+	coreClient, err := c.ClientFactory.ClientFor(org, repo, cloneURI)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -616,10 +616,10 @@ postsubmits: [{"name": "oli", "spec": {"containers": [{}]}}]`),
 			var p, pCached *ProwYAML
 			var errCached error
 			if headSHA == baseSHA {
-				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, baseSHA)
-				pCached, errCached = prowYAMLGetterWithDefaults(tc.config, testGCCached, org+"/"+repo, baseSHA)
+				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, "", baseSHA)
+				pCached, errCached = prowYAMLGetterWithDefaults(tc.config, testGCCached, org+"/"+repo, "", baseSHA)
 			} else {
-				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, baseSHA, headSHA)
+				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, "", baseSHA, headSHA)
 				pCached, errCached = prowYAMLGetterWithDefaults(tc.config, testGCCached, org+"/"+repo, baseSHA, headSHA)
 			}
 
@@ -660,7 +660,7 @@ func testDefaultProwYAMLGetter_RejectsJustOrg(clients localgit.Clients, t *testi
 		t.Fatalf("Making fake repo: %v", err)
 	}
 	expectedErrMsg := `didn't get two results when splitting repo identifier "my-repo"`
-	if _, err := prowYAMLGetterWithDefaults(&Config{}, gc, identifier, ""); err == nil || err.Error() != expectedErrMsg {
+	if _, err := prowYAMLGetterWithDefaults(&Config{}, gc, identifier, "", ""); err == nil || err.Error() != expectedErrMsg {
 		t.Errorf("Error %v does not have expected message %s", err, expectedErrMsg)
 	}
 }
@@ -671,7 +671,7 @@ type testClientFactory struct {
 	clientsCreated    int
 }
 
-func (cf *testClientFactory) ClientFor(org, repo string) (git.RepoClient, error) {
+func (cf *testClientFactory) ClientFor(org, repo, cloneURI string) (git.RepoClient, error) {
 	cf.clientsCreated++
 	// Returning this RepoClient ensures that only Fetch() is called and that Close() is not.
 
@@ -704,7 +704,7 @@ func TestInRepoConfigGitCacheConcurrency(t *testing.T) {
 		if err := lg.MakeFakeRepo("org", repo); err != nil {
 			t.Fatal(err)
 		}
-		rc, err := c.ClientFor("org", repo)
+		rc, err := c.ClientFor("org", repo, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -726,7 +726,7 @@ func TestInRepoConfigGitCacheConcurrency(t *testing.T) {
 
 	// Thread 1: gets a client for repo1, signals on signal1, then blocks on block1 before Clean()ing the repo1 client.
 	go func() {
-		client, err := cache.ClientFor(org, repo1)
+		client, err := cache.ClientFor(org, repo1, "")
 		if err != nil {
 			t.Errorf("Unexpected error getting repo client for thread 1: %v.", err)
 			return
@@ -738,7 +738,7 @@ func TestInRepoConfigGitCacheConcurrency(t *testing.T) {
 
 	// Thread 2: gets a client for repo1, signals success on signal2, then Clean()s the repo1 client.
 	go func() {
-		client, err := cache.ClientFor(org, repo1)
+		client, err := cache.ClientFor(org, repo1, "")
 		if err != nil {
 			t.Errorf("Unexpected error getting repo client for thread 2: %v.", err)
 			return
@@ -750,7 +750,7 @@ func TestInRepoConfigGitCacheConcurrency(t *testing.T) {
 
 	// Thread 3: gets a client for repo2, signals success on signal3, then Clean()s the repo2 client.
 	go func() {
-		client, err := cache.ClientFor(org, repo2)
+		client, err := cache.ClientFor(org, repo2, "")
 		if err != nil {
 			t.Errorf("Unexpected error getting repo client for thread 3: %v.", err)
 			return
@@ -777,7 +777,7 @@ func TestInRepoConfigClean(t *testing.T) {
 	if err := lg.MakeFakeRepo(org, repo); err != nil {
 		t.Fatal(err)
 	}
-	rc, err := c.ClientFor(org, repo)
+	rc, err := c.ClientFor(org, repo, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +789,7 @@ func TestInRepoConfigClean(t *testing.T) {
 	cache := NewInRepoConfigGitCache(cf)
 
 	// First time clone should work
-	repoClient, err := cache.ClientFor(org, repo)
+	repoClient, err := cache.ClientFor(org, repo, "")
 	if err != nil {
 		t.Fatalf("Unexpected error getting repo client for thread 1: %v.", err)
 	}
@@ -805,7 +805,7 @@ func TestInRepoConfigClean(t *testing.T) {
 	}
 
 	// Second time should be none dirty
-	repoClient, err = cache.ClientFor(org, repo)
+	repoClient, err = cache.ClientFor(org, repo, "")
 	if err != nil {
 		t.Fatalf("Unexpected error getting repo client for thread 1: %v.", err)
 	}

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -682,7 +682,7 @@ func (c Config) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, bra
 	headSHAGetter := func() (string, error) {
 		return headSHA, nil
 	}
-	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, "", baseSHAGetter, headSHAGetter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get presubmits: %w", err)
 	}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -1092,7 +1092,7 @@ func TestTideContextPolicy_MissingRequiredContexts(t *testing.T) {
 }
 
 func fakeProwYAMLGetterFactory(presubmits []Presubmit, postsubmits []Postsubmit) ProwYAMLGetter {
-	return func(_ *Config, _ git.ClientFactory, _, _ string, _ ...string) (*ProwYAML, error) {
+	return func(_ *Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*ProwYAML, error) {
 		return &ProwYAML{
 			Presubmits:  presubmits,
 			Postsubmits: postsubmits,

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -405,7 +405,7 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 
 	// Clone the repo, checkout the target branch.
 	startClone := time.Now()
-	r, err := s.gc.ClientFor(org, repo)
+	r, err := s.gc.ClientFor(org, repo, "")
 	if err != nil {
 		return fmt.Errorf("failed to get git client for %s/%s: %w", org, forkName, err)
 	}

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -205,7 +205,7 @@ func (c *Controller) syncChange(latest client.LastSyncState, changeChan <-chan C
 			log.WithError(err).Error("makeCloneURI.")
 		}
 
-		cache, err := c.inRepoConfigCacheGetter.GetCache(cloneURI.String(), instance)
+		cache, err := c.inRepoConfigCacheGetter.GetCache()
 		if err != nil {
 			wg.Done()
 			log.WithError(err).Error("create repo cache.")
@@ -441,7 +441,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 	case client.Merged:
 		var postsubmits []config.Postsubmit
 		for attempt := 0; attempt < inRepoConfigRetries; attempt++ {
-			postsubmits, err = cache.GetPostsubmits(trimmedHostPath, func() (string, error) { return baseSHA, nil }, func() (string, error) { return change.CurrentRevision, nil })
+			postsubmits, err = cache.GetPostsubmits(trimmedHostPath, cloneURI.String(), func() (string, error) { return baseSHA, nil }, func() (string, error) { return change.CurrentRevision, nil })
 			// Break if there was no error, or if there was a merge conflict
 			if err == nil || strings.Contains(err.Error(), "Merge conflict in") {
 				break
@@ -467,7 +467,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 	case client.New:
 		var presubmits []config.Presubmit
 		for attempt := 0; attempt < inRepoConfigRetries; attempt++ {
-			presubmits, err = cache.GetPresubmits(trimmedHostPath, func() (string, error) { return baseSHA, nil }, func() (string, error) { return change.CurrentRevision, nil })
+			presubmits, err = cache.GetPresubmits(trimmedHostPath, cloneURI.String(), func() (string, error) { return baseSHA, nil }, func() (string, error) { return change.CurrentRevision, nil })
 			if err == nil {
 				break
 			}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -108,6 +108,7 @@ func fakeProwYAMLGetter(
 	c *config.Config,
 	gc git.ClientFactory,
 	identifier string,
+	cloneURI string,
 	baseSHA string,
 	headSHAs ...string) (*config.ProwYAML, error) {
 

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -64,7 +64,7 @@ func testClone(clients localgit.Clients, t *testing.T) {
 	}
 
 	// Fresh clone, will be a cache miss.
-	r1, err := c.ClientFor("foo", "bar")
+	r1, err := c.ClientFor("foo", "bar", "")
 	if err != nil {
 		t.Fatalf("Cloning the first time: %v", err)
 	}
@@ -75,7 +75,7 @@ func testClone(clients localgit.Clients, t *testing.T) {
 	}()
 
 	// Clone from the same org.
-	r2, err := c.ClientFor("foo", "baz")
+	r2, err := c.ClientFor("foo", "baz", "")
 	if err != nil {
 		t.Fatalf("Cloning another repo in the same org: %v", err)
 	}
@@ -89,7 +89,7 @@ func testClone(clients localgit.Clients, t *testing.T) {
 	if err := lg.AddCommit("foo", "bar", map[string][]byte{"second": {}}); err != nil {
 		t.Fatalf("Adding second commit: %v", err)
 	}
-	r3, err := c.ClientFor("foo", "bar")
+	r3, err := c.ClientFor("foo", "bar", "")
 	if err != nil {
 		t.Fatalf("Cloning a second time: %v", err)
 	}
@@ -134,7 +134,7 @@ func testCheckoutPR(clients localgit.Clients, t *testing.T) {
 	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	r, err := c.ClientFor("foo", "bar")
+	r, err := c.ClientFor("foo", "bar", "")
 	if err != nil {
 		t.Fatalf("Cloning: %v", err)
 	}
@@ -183,7 +183,7 @@ func testMergeCommitsExistBetween(clients localgit.Clients, t *testing.T) {
 	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	r, err := c.ClientFor("foo", "bar")
+	r, err := c.ClientFor("foo", "bar", "")
 	if err != nil {
 		t.Fatalf("Cloning: %v", err)
 	}
@@ -403,7 +403,7 @@ func testMergeAndCheckout(clients localgit.Clients, t *testing.T) {
 				}
 			}
 
-			clonedRepo, err := c.ClientFor(org, repo)
+			clonedRepo, err := c.ClientFor(org, repo, "")
 			if err != nil {
 				t.Fatalf("Cloning failed: %v", err)
 			}
@@ -517,7 +517,7 @@ func testMerging(clients localgit.Clients, t *testing.T) {
 				t.Fatalf("checkout baseSHA: %v", err)
 			}
 
-			r, err := c.ClientFor(org, repo)
+			r, err := c.ClientFor(org, repo, "")
 			if err != nil {
 				t.Fatalf("clone: %v", err)
 			}
@@ -570,7 +570,7 @@ func testShowRef(clients localgit.Clients, t *testing.T) {
 		t.Fatalf("lg.RevParse: %v", err)
 	}
 
-	client, err := c.ClientFor(org, repo)
+	client, err := c.ClientFor(org, repo, "")
 	if err != nil {
 		t.Fatalf("clientFor: %v", err)
 	}

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -44,12 +44,17 @@ type clientFactoryAdapter struct {
 
 // ClientFromDir creates a client that operates on a repo that has already
 // been cloned to the given directory.
-func (a *clientFactoryAdapter) ClientFromDir(org, repo, dir string) (RepoClient, error) {
+//
+// CloneURI is the third arg that's ignored here, it's currently only used for
+// cloning Gerrit repos. This client is not used for cloning Gerrit repos yet,
+// so leave it unimplemented.
+// (TODO: chaodaiG) Either implement or remove this struct.
+func (a *clientFactoryAdapter) ClientFromDir(org, repo, _, dir string) (RepoClient, error) {
 	return nil, errors.New("no ClientFromDir implementation exists in the v1 git client")
 }
 
 // Repo creates a client that operates on a new clone of the repo.
-func (a *clientFactoryAdapter) ClientFor(org, repo string) (RepoClient, error) {
+func (a *clientFactoryAdapter) ClientFor(org, repo, _ string) (RepoClient, error) {
 	r, err := a.Client.Clone(org, repo)
 	return &repoClientAdapter{Repo: r}, err
 }

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -161,7 +161,7 @@ func handle(ghc githubClient, gc git.ClientFactory, log *logrus.Entry, e *github
 
 	// Clone the repo, checkout the PR.
 	startClone := time.Now()
-	r, err := gc.ClientFor(org, repo)
+	r, err := gc.ClientFor(org, repo, "")
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -236,7 +236,7 @@ func handle(minimumConfidence float64, ghc githubClient, gc git.ClientFactory, l
 
 	// Clone the repo, checkout the PR.
 	startClone := time.Now()
-	r, err := gc.ClientFor(org, repo)
+	r, err := gc.ClientFor(org, repo, "")
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/mergecommitblocker/mergecommitblocker.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker.go
@@ -84,7 +84,7 @@ func handle(ghc githubClient, gc git.ClientFactory, cp pruneClient, log *logrus.
 	)
 
 	// Clone the repo, checkout the PR.
-	r, err := gc.ClientFor(org, repo)
+	r, err := gc.ClientFor(org, repo, "")
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -137,7 +137,7 @@ func (c client) presubmits(org, repo string, baseSHAGetter config.RefGetter, hea
 	headSHAGetter := func() (string, error) {
 		return headSHA, nil
 	}
-	presubmits, err := c.config.GetPresubmits(c.gc, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	presubmits, err := c.config.GetPresubmits(c.gc, org+"/"+repo, "", baseSHAGetter, headSHAGetter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get presubmits: %w", err)
 	}

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -98,7 +98,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 	headSHAGetter := func() (string, error) {
 		return pr.Head.SHA, nil
 	}
-	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, "", baseSHAGetter, headSHAGetter)
 	if err != nil {
 		return fmt.Errorf("failed to get presubmits: %w", err)
 	}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -329,7 +329,7 @@ func runRequested(c Client, pr *github.PullRequest, baseSHA string, requestedJob
 }
 
 func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, orgRepo string, baseSHAGetter, headSHAGetter config.RefGetter) []config.Presubmit {
-	presubmits, err := cfg.GetPresubmits(gc, orgRepo, baseSHAGetter, headSHAGetter)
+	presubmits, err := cfg.GetPresubmits(gc, orgRepo, "", baseSHAGetter, headSHAGetter)
 	if err != nil {
 		// Fall back to static presubmits to avoid deadlocking when a presubmit is used to verify
 		// inrepoconfig. Tide will still respect errors here and not merge.
@@ -340,7 +340,7 @@ func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, 
 }
 
 func getPostsubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, orgRepo string, baseSHAGetter config.RefGetter) []config.Postsubmit {
-	postsubmits, err := cfg.GetPostsubmits(gc, orgRepo, baseSHAGetter)
+	postsubmits, err := cfg.GetPostsubmits(gc, orgRepo, "", baseSHAGetter)
 	if err != nil {
 		// Fall back to static postsubmits, loading inrepoconfig returned an error.
 		log.WithError(err).Error("Failed to get postsubmits")

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -412,7 +412,7 @@ func TestGetPresubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-presubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Presubmits: []config.Presubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-presubmit"},
@@ -436,7 +436,7 @@ func TestGetPresubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-presubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Presubmits: []config.Presubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-presubmit"},
@@ -490,7 +490,7 @@ func TestGetPostsubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-postsubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Postsubmits: []config.Postsubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-postsubmit"},
@@ -514,7 +514,7 @@ func TestGetPostsubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-postsubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Postsubmits: []config.Postsubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-postsubmit"},

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -340,7 +340,7 @@ func handle(gc githubClient, gitClient git.ClientFactory, kc corev1.ConfigMapsGe
 		indent = "   " // three spaces for sub bullets
 	}
 
-	gitRepo, err := gitClient.ClientFor(org, repo)
+	gitRepo, err := gitClient.ClientFor(org, repo, "")
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -1790,7 +1790,7 @@ func testUpdate(clients localgit.Clients, t *testing.T) {
 		repo := "repo"
 		c := setupLocalGitRepo(clients, t, org, repo)
 
-		gitRepo, err := c.ClientFor(org, repo)
+		gitRepo, err := c.ClientFor(org, repo, "")
 		if err != nil {
 			t.Fatalf("Failed to clone: %v.", err)
 		}

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -249,7 +249,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 	}
 
 	// Clone the repo, checkout the PR.
-	r, err := gc.ClientFor(org, repo)
+	r, err := gc.ClientFor(org, repo, "")
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -649,7 +649,7 @@ func testParseOwnersFile(clients localgit.Clients, t *testing.T) {
 				Patch:    test.patch,
 			}
 
-			r, err := c.ClientFor("org", "repo")
+			r, err := c.ClientFor("org", "repo", "")
 			if err != nil {
 				t.Fatalf("error cloning the repo: %v", err)
 			}

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -231,7 +231,7 @@ func (prh *presubmitJobHandler) getProwJobSpec(cfg prowCfgClient, pc *config.InR
 		logger.Debug("Getting prow jobs.")
 		var presubmitsWithInrepoconfig []config.Presubmit
 		var err error
-		presubmitsWithInrepoconfig, err = pc.GetPresubmits(orgRepo, baseSHAGetter, headSHAGetters...)
+		presubmitsWithInrepoconfig, err = pc.GetPresubmits(orgRepo, refs.CloneURI, baseSHAGetter, headSHAGetters...)
 		if err != nil {
 			logger.WithError(err).Info("Failed to get presubmits")
 		} else {
@@ -307,7 +307,7 @@ func (poh *postsubmitJobHandler) getProwJobSpec(cfg prowCfgClient, pc *config.In
 		logger.Debug("Getting prow jobs.")
 		var postsubmitsWithInrepoconfig []config.Postsubmit
 		var err error
-		postsubmitsWithInrepoconfig, err = pc.GetPostsubmits(orgRepo, baseSHAGetter)
+		postsubmitsWithInrepoconfig, err = pc.GetPostsubmits(orgRepo, refs.CloneURI, baseSHAGetter)
 		if err != nil {
 			logger.WithError(err).Info("Failed to get postsubmits from inrepoconfig")
 		} else {
@@ -459,8 +459,7 @@ func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageIn
 	var cache *config.InRepoConfigCacheHandler
 	var err error
 	if eType != PeriodicProwJobEvent {
-		cloneURI, host := tryGetCloneURIAndHost(pe)
-		cache, err = s.InRepoConfigCacheGetter.GetCache(cloneURI, host)
+		cache, err = s.InRepoConfigCacheGetter.GetCache()
 		if err != nil {
 			return err
 		}

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -307,11 +307,12 @@ func TestHandleMessage(t *testing.T) {
 				ConfigAgent:   ca,
 				Reporter:      &fr,
 				InRepoConfigCacheGetter: &config.InRepoConfigCacheGetter{
-					CacheSize:     100,
-					CacheCopies:   1,
-					Agent:         ca,
-					GitHubOptions: flagutil.GitHubOptions{},
-					DryRun:        true,
+					CacheSize:      100,
+					CacheCopies:    1,
+					Agent:          ca,
+					GitHubOptions:  flagutil.GitHubOptions{},
+					CookieFilePath: "abc",
+					DryRun:         true,
 				},
 			}
 			if tc.pe != nil {
@@ -818,6 +819,7 @@ func fakeProwYAMLGetter(
 	c *config.Config,
 	gc git.ClientFactory,
 	identifier string,
+	cloneURI string,
 	baseSHA string,
 	headSHAs ...string) (*config.ProwYAML, error) {
 

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -349,7 +349,7 @@ func (c *Client) cacheEntryFor(org, repo, base, cloneRef, fullName, sha string, 
 	filenames := c.filenames(org, repo)
 	if !ok || entry.sha != sha || entry.owners == nil || !entry.matchesMDYAML(mdYaml) {
 		start := time.Now()
-		gitRepo, err := c.git.ClientFor(org, repo)
+		gitRepo, err := c.git.ClientFor(org, repo, "")
 		if err != nil {
 			return cacheEntry{}, fmt.Errorf("failed to clone %s: %w", cloneRef, err)
 		}

--- a/prow/test/integration/config/prow/cluster/101_secrets.yaml
+++ b/prow/test/integration/config/prow/cluster/101_secrets.yaml
@@ -6,6 +6,17 @@ metadata:
 stringData:
   hmac: abcde12345
 ---
+# Used by Gerrit integration tests, the value doesn't matter
+apiVersion: v1
+kind: Secret
+metadata:
+  name: http-cookiefile
+  namespace: default
+type: Opaque
+data:
+  # This is just "helloworld" in base64.
+  cookies: aGVsbG93b3JsZA==
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/prow/test/integration/config/prow/cluster/gerrit.yaml
+++ b/prow/test/integration/config/prow/cluster/gerrit.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,7 +27,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --last-sync-fallback=/etc/last-sync-fallback/last-sync-fallback
         - --cache-dir-base=/etc/cache
-        # --gerrit-projects defined as args are deprecated in favor of global prow config. Add/change/delete them at https://gke-internal.googlesource.com/test-infra/+/ea514f5acad2a0e4c0b985f34795dc27904d6a94/prow/gob/config.yaml#135 instead.
+        - --cookiefile=/etc/cookies/cookies
         ports:
         - name: metrics
           containerPort: 9090
@@ -36,11 +38,13 @@ spec:
         - name: config
           mountPath: /etc/config
           readOnly: true
-          readOnly: true
         - name: last-sync-fallback
           mountPath: /etc/last-sync-fallback
         - name: cache
           mountPath: /etc/cache
+        - name: cookies
+          mountPath: /etc/cookies
+          readOnly: true
         resources:
           requests:
             cpu: "1"
@@ -60,7 +64,10 @@ spec:
         emptyDir: {}
       - name: cache
         emptyDir: {}
-
+      - name: cookies
+        secret:
+          defaultMode: 420
+          secretName: http-cookiefile
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/test/integration/config/prow/cluster/sub.yaml
+++ b/prow/test/integration/config/prow/cluster/sub.yaml
@@ -125,13 +125,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: sub
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: http-cookiefile
-  namespace: default
-type: Opaque
-data:
-  # This is just "helloworld" in base64.
-  cookies: aGVsbG93b3JsZA==

--- a/prow/test/integration/test/sub_test.go
+++ b/prow/test/integration/test/sub_test.go
@@ -246,6 +246,7 @@ this-is-from-repo2
 						RepoLink: "https://fakegitserver.default/repo/repo3",
 						BaseSHA:  Repo3HEADsha,
 						BaseRef:  "master",
+						CloneURI: "https://fakegitserver.default/repo/repo3",
 						Pulls: []prowjobv1.Pull{
 							{
 								Number: 1,
@@ -291,6 +292,7 @@ this-is-from-repo3
 						RepoLink: "https://fakegitserver.default/repo/org1/repo4",
 						BaseSHA:  Repo4HEADsha,
 						BaseRef:  "master",
+						CloneURI: "https://fakegitserver.default/repo/org1/repo4",
 						Pulls: []prowjobv1.Pull{
 							{
 								Number: 1,
@@ -335,10 +337,11 @@ this-is-from-repo4
 						// clone_uri is set on the job definition itself (see
 						// ProwJobDecoratedCloneURI). However sub needs Org and
 						// Repo to retrieve (clone) this inrepo job config.
-						Org:     "https://fakegitserver.default/repo/org1",
-						Repo:    "repo5",
-						BaseSHA: Repo5HEADsha,
-						BaseRef: "master",
+						Org:      "https://fakegitserver.default/repo/org1",
+						Repo:     "repo5",
+						BaseSHA:  Repo5HEADsha,
+						BaseRef:  "master",
+						CloneURI: "https://fakegitserver.default/repo/org1/repo5",
 						Pulls: []prowjobv1.Pull{
 							{
 								Number: 1,

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -296,11 +296,11 @@ func (p *GerritProvider) GetTideContextPolicy(gitClient git.ClientFactory, org, 
 	// If InRepoConfigCache is provided, then it means that we also want to fetch
 	// from an inrepoconfig.
 	if p.inRepoConfigCacheGetter != nil {
-		handler, err := p.inRepoConfigCacheGetter.GetCache(cloneURI, org)
+		handler, err := p.inRepoConfigCacheGetter.GetCache()
 		if err != nil {
 			return nil, fmt.Errorf("faled to get inrepoconfig cache: %v", err)
 		}
-		presubmitsFromCache, err := handler.GetPresubmits(orgRepo, baseSHAGetter, headSHAGetter)
+		presubmitsFromCache, err := handler.GetPresubmits(orgRepo, cloneURI, baseSHAGetter, headSHAGetter)
 		if err != nil {
 			return nil, fmt.Errorf("faled to get presubmits from cache: %v", err)
 		}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3093,7 +3093,7 @@ func TestPresubmitsByPull(t *testing.T) {
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "always"},
 			}},
-			prowYAMLGetter: func(_ *config.Config, _ git.ClientFactory, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
+			prowYAMLGetter: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
 				if len(headRefs) == 1 && headRefs[0] == "1" {
 					return nil, errors.New("you shall not get jobs")
 				}
@@ -3673,7 +3673,7 @@ func TestPresubmitsForBatch(t *testing.T) {
 				logger: logrus.WithField("test", tc.name),
 			}
 
-			presubmits, err := c.presubmitsForBatch(tc.prs, "org", "repo", "baseSHA", defaultBranch)
+			presubmits, err := c.presubmitsForBatch(tc.prs, "org", "repo", "", "baseSHA", defaultBranch)
 			if err != nil {
 				t.Fatalf("failed to get presubmits for batch: %v", err)
 			}
@@ -3923,7 +3923,7 @@ func (c *indexingClient) List(ctx context.Context, list ctrlruntimeclient.Object
 }
 
 func prowYAMLGetterForHeadRefs(headRefsToLookFor []string, ps []config.Presubmit) config.ProwYAMLGetter {
-	return func(_ *config.Config, _ git.ClientFactory, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
+	return func(_ *config.Config, _ git.ClientFactory, _, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
 		if len(headRefsToLookFor) != len(headRefs) {
 			return nil, fmt.Errorf("expcted %d headrefs, got %d", len(headRefsToLookFor), len(headRefs))
 		}


### PR DESCRIPTION
The previous implementation resulted in one client for each Gerrit repo, which carries the CloneURI on the top level, and as a result the client method ClientFor(org, repo) doesn't make sense as there is no way different repos share the same CloneURI