### PR TITLE
Mounting GITHUB_TOKEN to check-commits-count in KMM.

### DIFF
--- a/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
@@ -10,9 +10,22 @@ presubmits:
       description: "make sure each PR to kernel-module-management has a single commit."
     spec:
       containers:
-      - image: bitnami/git:latest
+      - image: ghcr.io/supportpal/github-gh-cli
         command:
         - ci/prow/check-commits-count
+      env:
+      - name: GH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cluster-lifecycle-github-token
+            key: cluster-lifecycle-github-token
+    volumes:
+    - name: cluster-lifecycle-github-token
+      secret:
+        secretName: cluster-lifecycle-github-token
+        items:
+        - key: cluster-lifecycle-github-token
+          path: cluster-lifecycle-github-token
   - name: pull-kernel-module-management-lint
     always_run: true
     decorate: true


### PR DESCRIPTION
This token is required in order to authenticate to the Github API
server.

Authenticated users are allowed to generate 5000 req/h while
non-authenticated users can only generate 60 req/h.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>