### PR TITLE
NFD: use ruby:slim instead of ruby:2.7 for docs related prowjobs

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       description: "Verify documentation sources of the operator project"
     spec:
       containers:
-      - image: ruby:2.7
+      - image: ruby:slim
         command:
         - scripts/test-infra/mdlint.sh
   - name: pull-node-feature-discovery-operator-build-image

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits.yaml
@@ -46,7 +46,7 @@ presubmits:
       description: "Verify documentation sources"
     spec:
       containers:
-      - image: ruby:2.7
+      - image: ruby:slim
         command:
         - scripts/test-infra/mdlint.sh
   - name: pull-node-feature-discovery-build


### PR DESCRIPTION
The size of [ruby:2.7](https://hub.docker.com/layers/library/ruby/2.7/images/sha256-5a32f6abc3c485231580c241047954c9d857e208a65392a8bca7fbb1888d2ed6?context=explore) is 321.36 MB while [ruby:slim](https://hub.docker.com/layers/library/ruby/slim/images/sha256-2e3b4a4628fead83109e77fa6732e430cf9881e2d8cb3fa6148935e87ea4ea70?context=explore) is 70.39 MB. ~5 times smaller. This should decrease the prowjob execution time a bit when triggered on PRs.