### PR TITLE
Readd gsutil to gcb-docker-gcloud image

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -38,7 +38,7 @@ RUN rm google-cloud-sdk.tar.gz
 RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \
-    gcloud components install alpha beta gke-gcloud-auth-plugin && \
+    gcloud components install alpha beta gke-gcloud-auth-plugin gsutil && \
     gcloud --version && \
     gcloud info > /workspace/gcloud-info.txt
 


### PR DESCRIPTION
This commit would readd `gsutil` to the `gcb-docker-gcloud` image.

It got removed in #26616 by removing the call to `/google-cloud-sdk/install.sh` (cc @upodroid maybe you could help to get context if it was on purpose to remove).

Cluster API's Job `cluster-api-push-images-nightly` makes use of `gsutil` via this image.

Open question for me is: was it removed on purpose so readding it would not be an option?

xref CAPI issue:

- https://github.com/kubernetes-sigs/cluster-api/issues/7165