### PR TITLE
Deck: Fix colors in job history view

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -916,6 +916,11 @@ func handlePRHistory(o options, cfg config.Getter, opener io.Opener, gitHubClien
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
+		for idx := range tmpl.Jobs {
+			for jdx, build := range tmpl.Jobs[idx].Builds {
+				tmpl.Jobs[idx].Builds[jdx].Result = strings.ToUpper(build.Result)
+			}
+		}
 		handleSimpleTemplate(o, cfg, "pr-history.html", tmpl)(w, r)
 	}
 }

--- a/prow/cmd/deck/template/pr-history.html
+++ b/prow/cmd/deck/template/pr-history.html
@@ -38,7 +38,7 @@
       <tr>
         <td class="mdl-data-table__cell--non-numeric">{{if .Link}}<a href="{{.Link}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</td>
         {{range .Builds}}
-        <td class="mdl-data-table__cell--non-numeric {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else if eq .Result "Pending"}}run-pending{{else if eq .Result "ABORTED"}}run-aborted{{end}}">{{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>{{else}}{{.ID}}{{end}}</td>
+        <td class="mdl-data-table__cell--non-numeric {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else if eq .Result "PENDING"}}run-pending{{else if eq .Result "ABORTED"}}run-aborted{{end}}">{{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>{{else}}{{.ID}}{{end}}</td>
         {{end}}
       </tr>
       {{end}}


### PR DESCRIPTION
When the uploading of finished.json was moved to crier, it also ended up
inserting a lowercased result. This breaks the coloring in the template,
as that expects it to be uppercased.

As there is data following both patterns out there already, fix this in
Deck by uppercasing the result field before passing it onto the
template.

/assign @chaodaiG 