### PR TITLE
Enable HPA ScaleToZero and HPAContainerMetrics feature gate in HPA E2e Custom Metrics Tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -207,6 +207,10 @@ periodics:
       - --gcp-project=k8s-jkns-gci-autoscaling
       - --gcp-zone=us-west1-b
       - --provider=gce
+      # Enable HPAContainerMetrics. Required for container metrics tests.
+      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
+      # Enable HPAScaleToZero. Required for scale to zero test scenario.
+      - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master
@@ -267,6 +271,10 @@ periodics:
       - --gcp-project=k8s-jkns-gci-autoscaling-migs
       - --gcp-zone=us-west1-b
       - --provider=gce
+      # Enable HPAContainerMetrics. Required for container metrics tests.
+      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
+      # Enable HPAScaleToZero. Required for scale to zero test scenario.
+      - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master


### PR DESCRIPTION
Enable `ScaleToZero` and `HPAConteinerMetrics` in `ci-kubernetes-e2e-gci-gce-autoscaling-hpa-cm` and `ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa` tests.

Required to support tests which were added in https://github.com/kubernetes/kubernetes/pull/112444 - with Custom Metrics we will now also have a test scenario with Scale to Zero as well as Container Resource metrics.