### PR TITLE
Deck: Fix colors in job history view

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -898,6 +898,10 @@ func handleJobHistory(o options, cfg config.Getter, opener io.Opener, log *logru
 			http.Error(w, msg, httpStatusForError(err))
 			return
 		}
+		for idx, build := range tmpl.Builds {
+			tmpl.Builds[idx].Result = strings.ToUpper(build.Result)
+
+		}
 		handleSimpleTemplate(o, cfg, "job-history.html", tmpl)(w, r)
 	}
 }

--- a/prow/cmd/deck/static/job-history/job-history.ts
+++ b/prow/cmd/deck/static/job-history/job-history.ts
@@ -17,7 +17,7 @@ window.onload = (): void => {
       case "FAILURE":
         className = "run-failure";
         break;
-      case "error":
+      case "ERROR":
         className = "run-error";
         break;
       case "ABORTED":


### PR DESCRIPTION
When the uploading of finished.json was moved to crier, it also ended up
inserting a lowercased result. This breaks the coloring in the template,
as that expects it to be uppercased.

As there is data following both patterns out there already, fix this in
Deck by uppercasing the result field before passing it onto the
template.

This one actually fixes the job history, contrary to https://github.com/kubernetes/test-infra/pull/27381 which claimed to do that but fixes the PR history view instead.

/assign @chaodaiG 