### PR TITLE
Added a presubmit job to check for all unknown fields

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -71,6 +71,32 @@ presubmits:
         - --warnings=duplicate-job-refs
     annotations:
       testgrid-dashboards: presubmits-test-infra
+  - name: pull-test-infra-prow-checkconfig-beta
+    decorate: true
+    optional: true
+    always_run: false
+    run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/checkconfig:v20220905-8bcebc6376
+        command:
+        - checkconfig
+        args:
+        - --config-path=config/prow/config.yaml
+        - --job-config-path=config/jobs
+        - --plugin-config=config/prow/plugins.yaml
+        - --strict
+        - --warnings=mismatched-tide-lenient
+        - --warnings=tide-strict-branch
+        - --warnings=needs-ok-to-test
+        - --warnings=validate-owners
+        - --warnings=missing-trigger
+        - --warnings=validate-urls
+        - --warnings=unknown-fields
+        - --warnings=duplicate-job-refs
+        - --warnings=unknown-fields-all
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration
     branches:
     - master

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -95,8 +95,6 @@ presubmits:
         - --warnings=unknown-fields
         - --warnings=duplicate-job-refs
         - --warnings=unknown-fields-all
-    annotations:
-      testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration
     branches:
     - master

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -95,6 +95,8 @@ presubmits:
         - --warnings=unknown-fields
         - --warnings=duplicate-job-refs
         - --warnings=unknown-fields-all
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration
     branches:
     - master


### PR DESCRIPTION
## Issue
Unknown field checks are not enabled for ProwJob configuration. https://github.com/kubernetes/test-infra/issues/26368

## Description
Prow's [checkconfig](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/checkconfig) tool is responsible for presubmit validation of ProwJob configuration. It has an optional check for unknown fields in ProwJob config that can be enabled with --warnings=unknown-fields-all. We [currently do not have this check enabled](https://github.com/kubernetes/test-infra/blob/c930a1d5f949bb9212078a05442cd39ccaae8cf3/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml#L64-L71).
As a result it is possible to add configuration that is not recognized by Prow, causing it to be silently ignored. Common examples of this are typos in a field name and incorrect indentation.

## What was done
- Added a presubmit job to check for all unknown fields in this PR... 

All errors in the configs were fixed (of which there were alot) in the [PR #27386](https://github.com/kubernetes/test-infra/pull/27386)....