### PR TITLE
azure: add file triggers for capz apiversion-upgrade presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -462,6 +462,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
     decorate: true
+    run_if_changed: '^test\/e2e\/(config\/azure-dev\.yaml)|(data\/shared\/v1beta1_provider\/metadata\.yaml)$'
     optional: true
     always_run: false
     branches:


### PR DESCRIPTION
This change adds some file trigger configuration for the capz apiversion-upgrade presubmit job based on an observed regression from changes in two files:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2497/files