### PR TITLE
kubebuilder presubmits use go 1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: golang:1.18
+      - image: golang:1.19
         command:
         - ./test.sh
         resources:


### PR DESCRIPTION
Update kubebuilder presubmits to use go 1.19

cc @camilamacedo86 @sbueringer 

Related pr: https://github.com/kubernetes-sigs/kubebuilder/pull/2911