### PR TITLE
presubmit jobs for the capi-ibmcloud release-0.3 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
@@ -1,0 +1,110 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-ibmcloud:
+  - name: pull-cluster-api-provider-ibmcloud-make-release-0-3
+    always_run: true
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-0.3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - "runner.sh"
+        - "./scripts/ci-make.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-make-release-0-3
+  - name: pull-cluster-api-provider-ibmcloud-test-release-0-3
+    always_run: true
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-0.3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+        imagePullPolicy: Always
+        command:
+        - "./scripts/ci-test.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-test-release-0-3
+  - name: pull-cluster-api-provider-ibmcloud-smoke-test-release-0-3
+    always_run: true
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-0.3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+        imagePullPolicy: Always
+        env:
+        - name: "IBMCLOUD_API_KEY"
+          value: "dummyApiKey"
+        command:
+        - "runner.sh"
+        - "./scripts/ci-smoke-test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-smoke-test-release-0-3
+  - name: pull-cluster-api-provider-ibmcloud-build-release-0-3
+    always_run: true
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-0.3
+    optional: false
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+        command:
+        - "./scripts/ci-build.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-build-release-0-3
+  - name: pull-cluster-api-provider-ibmcloud-verify-release-0-3
+    always_run: true
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-0.3
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+          command:
+            - "make"
+            - "verify"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-verify-release-0-3


### PR DESCRIPTION
This change is to add presubmit jobs for `kubernetes-sigs/cluster-api-provider-ibmcloud`  the release-0.3 branch.

I have verified one of them https://prow.ppc64le-cloud.org/view/s3/ppc64le-prow-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-ibmcloud/832/pull-cluster-api-provider-ibmcloud-make-release-0-3/1567423632932605952