### PR TITLE
Add service account to swap fedora CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -92,6 +92,7 @@ periodics:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
           - --root=/go/src
+          - "--service-account=/etc/service-account/service-account.json"
           - --scenario=kubernetes_e2e
           - --
           - --deployment=node
@@ -101,7 +102,7 @@ periodics:
           - '--node-test-args=--feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
           - --timeout=180m
         env:
           - name: GOPATH
@@ -176,6 +177,7 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
       - --root=/go/src
+      - "--service-account=/etc/service-account/service-account.json"
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node


### PR DESCRIPTION
Testgrids [sig-node-kubelet#kubelet-gce-e2e-swap-fedora](https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora) and [sig-node-kubelet#kubelet-gce-e2e-swap-fedora-serial](https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora-serial) are consistently failing.

I previously fixed the PR jobs in https://github.com/kubernetes/test-infra/pull/26483. The only considerable difference is the missing service account, this PR adds it to the CI jobs.

/sig node
/triage accepted
/priority important-soon
/area test