### PR TITLE
Crier upload finished.json explicitly sets not to overwrite

### DIFF
--- a/prow/io/fakeopener/fakeopener.go
+++ b/prow/io/fakeopener/fakeopener.go
@@ -65,10 +65,10 @@ func (fo *FakeOpener) Writer(ctx context.Context, path string, opts ...pkgio.Wri
 		fo.Buffer = make(map[string]*bytes.Buffer)
 	}
 
-	var overWrite bool
+	overWrite := true
 	for _, o := range opts {
-		if o.PreconditionDoesNotExist != nil && !*o.PreconditionDoesNotExist {
-			overWrite = true
+		if o.PreconditionDoesNotExist != nil && *o.PreconditionDoesNotExist {
+			overWrite = false
 			break
 		}
 	}


### PR DESCRIPTION
This was a bug introduced in https://github.com/kubernetes/test-infra/pull/27301. The problem is that when PreconditionDoesNotExist is not provided, the default is to overwrite, which is not the desired behavior of crier for finished.json for now.

/cc @cjwagner @listx @alvaroaleman 