### PR TITLE
prow/bugzilla/client.go: retrieve bug flags

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -232,6 +232,11 @@ func (c *client) GetBug(id int) (*Bug, error) {
 	if err != nil {
 		return nil, err
 	}
+	values := req.URL.Query()
+	values.Add("include_fields", "_default")
+	// redhat bugzilla docs claim that flags are a default field, but they are actually not returned unless added to include_fields
+	values.Add("include_fields", "flags")
+	req.URL.RawQuery = values.Encode()
 	raw, err := c.request(req, logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds `flags` to the `include_fields` for the `GetBug` function. Red Hat Bugzilla documentation claims that these should be included by default, but they are not. By setting `include_fields` to `_default` and `flags`, we make the client act as expected based on documentation.