### PR TITLE
Gencred generates and rotates build cluster from rules-k8s

### DIFF
--- a/config/prow/gencred-config/gencred-config.yaml
+++ b/config/prow/gencred-config/gencred-config.yaml
@@ -12,3 +12,10 @@ clusters:
   gsm:
     name: gke_k8s-prow_us-central1-f_prow__default__prow-services
     project: k8s-prow
+# Build cluster from rules-k8s
+- gke: projects/rules-k8s/locations/us-central1-f/clusters/testing
+  name: gke_rules-k8s_us-central1-f_testing
+  duration: 48h
+  gsm:
+    name: gke_rules-k8s_us-central1-f_testing__default__build-rules-k8s
+    project: k8s-prow


### PR DESCRIPTION
The root CA of the rules-k8s build cluster was expired, and needs to be rotated

/cc @cjwagner @listx 