### PR TITLE
Fix the release-0.3 branch jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
@@ -18,7 +18,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.24
         imagePullPolicy: Always
         resources:
           requests:
@@ -37,7 +37,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.24
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
@@ -57,7 +57,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.24
         imagePullPolicy: Always
         env:
         - name: "IBMCLOUD_API_KEY"
@@ -81,7 +81,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.24
         command:
         - "./scripts/ci-build.sh"
         resources:
@@ -101,10 +101,30 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.23
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.24
           command:
             - "make"
             - "verify"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify-release-0-3
+  - name: pull-cluster-api-provider-ibmcloud-apidiff-release-0-3
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
+    always_run: true
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-0.3
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.24
+          command:
+            - runner.sh
+          args:
+            - ./scripts/ci-apidiff.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-apidiff-release-0-3


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/829


- Update `kubekins-e2e` image to 1.24, any newly created branch's job will be copy from main branch job except the branch restriction
- Add the missing `apidiff` job which got added recently for the main branch.