### PR TITLE
Enable the use of triage labels other than triage/accepted

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -130,6 +130,131 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
+- name: ci-k8s-triage-robot-merged-pr
+  interval: 10m
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: A job to remove needs-triage from closed issues/PRs that are marked as requiring triage.
+    testgrid-tab-name: triage-merged-pr
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20220907-aef2c49444
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        is:pr
+        is:closed
+        is:merged
+        label:needs-triage
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=This PR was merged without triage. Marking triage as accepted.
+
+        Send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
+
+        /triage accepted
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-closed-pr
+  interval: 10m
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: A job to remove needs-triage from closed issues/PRs that are marked as requiring triage.
+    testgrid-tab-name: triage-closed-pr
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20220907-aef2c49444
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        is:pr
+        is:closed
+        is:unmerged
+        label:needs-triage
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=This PR was closed without triage. Marking triage as unresolved.
+
+        Send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
+
+        /triage unresolved
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-closed-issue
+  interval: 10m
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: A job to remove needs-triage from closed issues/PRs that are marked as requiring triage.
+    testgrid-tab-name: triage-closed-issue
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20220907-aef2c49444
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        is:issue
+        is:closed
+        label:needs-triage
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=This issue was closed without triage. Marking triage as unresolved.
+
+        Send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
+
+        /triage unresolved
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
 - name: ci-k8s-triage-robot-close
   interval: 1h
   cluster: k8s-infra-prow-build-trusted

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -169,7 +169,7 @@ label:
         allowed_teams:
         - enhancements
       # Restrict setting of 'lead-opted-in' label to SIG leads.
-      - label: lead-opted-in  
+      - label: lead-opted-in
         allowed_teams:
         - sig-api-machinery-leads
         - sig-apps-leads
@@ -641,7 +641,7 @@ require_matching_label:
   repo: kubernetes
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -652,7 +652,7 @@ require_matching_label:
   org: kubernetes
   repo: website
   issues: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -663,7 +663,7 @@ require_matching_label:
   org: kubernetes
   repo: kubectl
   issues: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -755,7 +755,7 @@ require_matching_label:
   repo: ingress-nginx
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -785,7 +785,7 @@ require_matching_label:
   repo: kustomize
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -803,7 +803,7 @@ require_matching_label:
   repo: cluster-api
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -815,7 +815,7 @@ require_matching_label:
   repo: cluster-api-provider-aws
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -844,7 +844,7 @@ require_matching_label:
   repo: cloud-provider-aws
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 


### PR DESCRIPTION
We have other triage labels, but we can't use them right now effectively as the only thing that removes "needs-triage" is the "triage/accepted" label.

This fixes that, as well as adds a commenter job that if a PR/issue is closed while "needs-triage", it will get "triage/unresolved" so that it cancels out "needs-triage".