### PR TITLE
Add a new flag: --kubeconfig-suffix

### DIFF
--- a/prow/flagutil/kubernetes_cluster_clients_test.go
+++ b/prow/flagutil/kubernetes_cluster_clients_test.go
@@ -78,6 +78,20 @@ func TestExperimentalKubernetesOptions_Validate(t *testing.T) {
 				kubeconfigDir: configDir,
 			},
 		},
+		{
+			name: "kubeconfigSuffix can be set",
+			kubernetes: &KubernetesOptions{
+				kubeconfigDir:    configDir,
+				kubeconfigSuffix: "suffix",
+			},
+		},
+		{
+			name: "kubeconfigSuffix must be used with kubeconfigDir",
+			kubernetes: &KubernetesOptions{
+				kubeconfigSuffix: "suffix",
+			},
+			expectedErr: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -106,6 +106,10 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 				logrus.WithField("filename", filename).Info("Ignored file starting with double dots")
 				continue
 			}
+			if !strings.HasSuffix(filename, opts.suffix) {
+				logrus.WithField("filename", filename).WithField("suffix", opts.suffix).Info("Ignored file without suffix")
+				continue
+			}
 			candidates = append(candidates, filepath.Join(opts.dir, filename))
 		}
 	}
@@ -144,6 +148,7 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 type Options struct {
 	file               string
 	dir                string
+	suffix             string
 	projectedTokenFile string
 	noInClusterConfig  bool
 }
@@ -154,6 +159,13 @@ type ConfigOptions func(*Options)
 func ConfigDir(dir string) ConfigOptions {
 	return func(kc *Options) {
 		kc.dir = dir
+	}
+}
+
+// ConfigSuffix configures the suffix of the file in directory containing kubeconfig files
+func ConfigSuffix(suffix string) ConfigOptions {
+	return func(kc *Options) {
+		kc.suffix = suffix
 	}
 }
 

--- a/prow/kube/config_test.go
+++ b/prow/kube/config_test.go
@@ -119,6 +119,7 @@ func TestLoadClusterConfigs(t *testing.T) {
 		name               string
 		kubeconfig         string
 		kubeconfigDir      string
+		suffix             string
 		projectedTokenFile string
 		noInClusterConfig  bool
 		expected           map[string]rest.Config
@@ -157,6 +158,7 @@ func TestLoadClusterConfigs(t *testing.T) {
 		{
 			name:          "load from kubeconfigDir",
 			kubeconfigDir: filepath.Join("testdata", "load_from_kubeconfigDir"),
+			suffix:        "yaml",
 			expected: map[string]rest.Config{
 				"": {
 					Host:        "https://api.build02.gcp.ci.openshift.org:6443",
@@ -250,7 +252,7 @@ func TestLoadClusterConfigs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, actualErr := LoadClusterConfigs(NewConfig(ConfigFile(tc.kubeconfig),
 				ConfigDir(tc.kubeconfigDir), ConfigProjectedTokenFile(tc.projectedTokenFile),
-				NoInClusterConfig(tc.noInClusterConfig)))
+				NoInClusterConfig(tc.noInClusterConfig), ConfigSuffix(tc.suffix)))
 			if tc.expectedErr != (actualErr != nil) {
 				t.Errorf("%s: actualErr %v does not match expectedErr %v", tc.name, actualErr, tc.expectedErr)
 				return

--- a/prow/kube/testdata/load_from_kubeconfigDir/3.token.txt
+++ b/prow/kube/testdata/load_from_kubeconfigDir/3.token.txt
@@ -1,0 +1,2 @@
+not a valid kubeconfig
+it would cause errors without being ignored


### PR DESCRIPTION
The use case is 
- `kubectl create token` requests a token for a service account, e.g., `deck` and 
-  the token is stored in a file, such as `deck.token.txt`. 
- In the deployment of `deck`, the file comes from a secret and stays as the same folder as the kubeconfig file, such as


```yaml
apiVersion: v1
clusters:
- cluster:
    server: https://api.ci.l2s4.p1.openshiftapps.com:6443
  name: app.ci
contexts:
- context:
    cluster: app.ci
    namespace: ci
    user: deck
  name: deck
current-context: deck
kind: Config
preferences: {}
users:
- name: deck
  user:
    tokenFile: deck.token.txt
```

When we refresh the token (because SA's token expires), we can refresh only `deck.token.txt` and keep kubeconfig intact.

 