### PR TITLE
Gerrit syncs states back to GCS periodically

### DIFF
--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -294,7 +294,7 @@ func (s *fakeSync) Current() client.LastSyncState {
 	return s.val
 }
 
-func (s *fakeSync) Update(t client.LastSyncState) error {
+func (s *fakeSync) Update(t client.LastSyncState, force bool) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.val = t

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -243,7 +243,7 @@ func (c *Client) applyGlobalConfigOnce(orgRepoConfigGetter func() *config.Gerrit
 		logrus.WithError(err).Error("Updating clients.")
 	}
 	if lastSyncTracker != nil {
-		if err := lastSyncTracker.update(orgReposConfig.AllRepos()); err != nil {
+		if err := lastSyncTracker.loadFromConfig(orgReposConfig.AllRepos()); err != nil {
 			logrus.WithError(err).Error("Syncing states.")
 		}
 	}

--- a/prow/gerrit/client/syncer.go
+++ b/prow/gerrit/client/syncer.go
@@ -37,40 +37,48 @@ type opener interface {
 }
 
 type SyncTime struct {
-	val    LastSyncState
-	lock   sync.RWMutex
-	path   string
-	opener opener
-	ctx    context.Context
+	val       LastSyncState
+	lock      sync.RWMutex
+	path      string
+	opener    opener
+	ctx       context.Context
+	stateChan chan struct {
+		lastSyncState LastSyncState
+		forceFlush    bool
+	}
+	waitChan       chan struct{}
+	uploadInterval time.Duration
 }
 
 func NewSyncTime(path string, opener opener, ctx context.Context) *SyncTime {
 	return &SyncTime{
-		path:   path,
-		opener: opener,
-		ctx:    ctx,
+		path:           path,
+		opener:         opener,
+		ctx:            ctx,
+		uploadInterval: time.Minute,
 	}
 }
 
 func (st *SyncTime) Init(hostProjects ProjectsFlag) error {
 	logrus.WithField("projects", hostProjects).Info(st.val)
-	st.lock.RLock()
-	zero := st.val == nil
-	st.lock.RUnlock()
-	if !zero {
-		return nil
-	}
-	return st.update(ProjectsFlagToConfig(hostProjects))
+	return st.loadFromConfig(ProjectsFlagToConfig(hostProjects))
 }
 
-func (st *SyncTime) update(hostProjects map[string]map[string]*config.GerritQueryFilter) error {
+func (st *SyncTime) loadFromConfig(hostProjects map[string]map[string]*config.GerritQueryFilter) error {
 	timeNow := time.Now()
 	st.lock.Lock()
 	defer st.lock.Unlock()
-	state, err := st.currentState()
-	if err != nil {
-		return err
+	var state LastSyncState
+	var err error
+	if st.val == nil {
+		state, err = st.currentState()
+		if err != nil {
+			return err
+		}
+	} else {
+		state = st.val
 	}
+
 	if state != nil {
 		// Initialize new hosts, projects
 		for host, projects := range hostProjects {
@@ -84,7 +92,7 @@ func (st *SyncTime) update(hostProjects map[string]map[string]*config.GerritQuer
 			}
 		}
 		st.val = state
-		logrus.WithField("lastSync", st.val).Infoln("Initialized successfully from lastSyncFallback.")
+		logrus.WithField("lastSync", st.val).Debug("Initialized successfully from lastSyncFallback.")
 	} else {
 		targetState := LastSyncState{}
 		for host, projects := range hostProjects {
@@ -126,10 +134,8 @@ func (st *SyncTime) Current() LastSyncState {
 	return st.val
 }
 
-func (st *SyncTime) Update(newState LastSyncState) error {
+func (st *SyncTime) Update(newState LastSyncState, force bool) error {
 	st.lock.Lock()
-	defer st.lock.Unlock()
-
 	targetState := st.val.DeepCopy()
 
 	var changed bool
@@ -146,25 +152,96 @@ func (st *SyncTime) Update(newState LastSyncState) error {
 		}
 	}
 
-	if !changed {
-		return nil
+	st.val = targetState
+
+	// Pediodically sync time back to storage instead of writing after every
+	// single project is processed, as the I/O would become performance
+	// bottleneck when there are lots of projects.
+	// Use stateChan to ensure that there is only a single goroutine.
+	if st.stateChan == nil {
+		st.stateChan = make(chan struct {
+			lastSyncState LastSyncState
+			forceFlush    bool
+		})
+		st.waitChan = make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(st.uploadInterval)
+			defer ticker.Stop()
+
+			var curState *LastSyncState
+			for {
+				select {
+				case newState := <-st.stateChan:
+					// save the state, if force flush is false then the state
+					// will be flushed at time ticks later.
+					curState = &newState.lastSyncState
+					// Allows caller to force flush instead of waiting for the
+					// ticks. This useful for cases like interruptions, that an
+					// emergency flushing is supposed to happen right away.
+					if !newState.forceFlush {
+						continue
+					}
+					st.uploadOnce(*curState)
+					curState = nil
+					st.waitChan <- struct{}{}
+				case <-ticker.C:
+					// curState is reset after uploads, skip uploading if it's
+					// not updated.
+					if curState == nil {
+						continue
+					}
+					st.uploadOnce(*curState)
+					curState = nil
+				}
+			}
+		}()
 	}
+
+	st.lock.Unlock()
+
+	if changed || force {
+		st.stateChan <- struct {
+			lastSyncState LastSyncState
+			forceFlush    bool
+		}{targetState, force}
+	}
+
+	if force {
+		// waits for completion
+		for range st.waitChan {
+			break
+		}
+	}
+	return nil
+}
+
+func (st *SyncTime) uploadOnce(curState LastSyncState) {
+	log := logrus.WithFields(logrus.Fields{"path": st.path})
+	var stateBytes []byte
+	var err error
+	st.lock.RLock()
+	if curState != nil {
+		stateBytes, err = json.Marshal(curState)
+		if err != nil {
+			log.WithError(err).Warn("Could not marshal curState.")
+			st.lock.RUnlock()
+			return
+		}
+	}
+	st.lock.RUnlock()
 
 	w, err := st.opener.Writer(st.ctx, st.path)
 	if err != nil {
-		return fmt.Errorf("open for write %q: %w", st.path, err)
-	}
-	stateBytes, err := json.Marshal(targetState)
-	if err != nil {
-		return fmt.Errorf("marshall state: %w", err)
+		log.WithError(err).Warn("Could not create writer.")
+		return
 	}
 	if _, err := fmt.Fprint(w, string(stateBytes)); err != nil {
 		io.LogClose(w)
-		return fmt.Errorf("write %q: %w", st.path, err)
+		log.WithError(err).Warn("Write error.")
+		return
 	}
 	if err := w.Close(); err != nil {
-		return fmt.Errorf("close %q: %w", st.path, err)
+		log.WithError(err).Warn("Close error.")
+		return
 	}
-	st.val = targetState
-	return nil
 }


### PR DESCRIPTION
Gerrit currently syncs states back to GCS every time an instance is synced, this is fine for now as there aren't many instances. However batch processing all projects from an instance is not very performant, namely smaller projects suffer from latency introduced from larger projects.

/cc chaodaiG