### PR TITLE
error unmarshaling config/jobs/kubernetes-sigs/cluster-api/cluster-ap…

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -72,19 +72,21 @@ periodics:
       - "runner.sh"
       - "make"
       - "verify-book-links"
+      volumeMounts:
+      - name: cluster-lifecycle-github-token
       env:
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
             name: cluster-lifecycle-github-token
             key: cluster-lifecycle-github-token
-  volumes:
-  - name: cluster-lifecycle-github-token
-    secret:
-      secretName: cluster-lifecycle-github-token
-      items:
-      - key: cluster-lifecycle-github-token
-        path: cluster-lifecycle-github-token
+    volumes:
+    - name: cluster-lifecycle-github-token
+      secret:
+        secretName: cluster-lifecycle-github-token
+        items:
+        - key: cluster-lifecycle-github-token
+          path: cluster-lifecycle-github-token
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-verify-book-links-release-0-3

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
@@ -121,19 +121,21 @@ periodics:
       - "runner.sh"
       - "make"
       - "verify-book-links"
+      volumeMounts:
+      - name: cluster-lifecycle-github-token
       env:
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
             name: cluster-lifecycle-github-token
             key: cluster-lifecycle-github-token
-  volumes:
-  - name: cluster-lifecycle-github-token
-    secret:
-      secretName: cluster-lifecycle-github-token
-      items:
-      - key: cluster-lifecycle-github-token
-        path: cluster-lifecycle-github-token
+    volumes:
+    - name: cluster-lifecycle-github-token
+      secret:
+        secretName: cluster-lifecycle-github-token
+        items:
+        - key: cluster-lifecycle-github-token
+          path: cluster-lifecycle-github-token
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-verify-book-links-release-0-4

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
@@ -12,7 +12,7 @@ periodics:
   spec:
     serviceAccountName: prowjob-default-sa
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.22
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -43,7 +43,7 @@ periodics:
   spec:
     serviceAccountName: prowjob-default-sa
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.22
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.22
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -88,7 +88,7 @@ periodics:
   spec:
     serviceAccountName: prowjob-default-sa
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.22
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.22
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -126,7 +126,7 @@ periodics:
   spec:
     serviceAccountName: prowjob-default-sa
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.22
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -161,24 +161,26 @@ periodics:
   spec:
     serviceAccountName: prowjob-default-sa
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-1.22
       command:
       - "runner.sh"
       - "make"
       - "verify-book-links"
+      volumeMounts:
+      - name: cluster-lifecycle-github-token
       env:
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
             name: cluster-lifecycle-github-token
             key: cluster-lifecycle-github-token
-  volumes:
-  - name: cluster-lifecycle-github-token
-    secret:
-      secretName: cluster-lifecycle-github-token
-      items:
-      - key: cluster-lifecycle-github-token
-        path: cluster-lifecycle-github-token
+    volumes:
+    - name: cluster-lifecycle-github-token
+      secret:
+        secretName: cluster-lifecycle-github-token
+        items:
+        - key: cluster-lifecycle-github-token
+          path: cluster-lifecycle-github-token
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-verify-book-links-release-1-0


### PR DESCRIPTION
### Issue:
[error unmarshaling config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-*.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"volumes\" #27448](https://github.com/kubernetes/test-infra/issues/27448)

As described in the issue above the:
Prow's [checkconfig](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/checkconfig) tool is responsible for presubmit validation of ProwJob configuration. It has an optional check for unknown fields in ProwJob config that can be enabled with --warnings=unknown-fields-all.

As a result it is possible to add configuration that is not recognized by Prow, causing it to be silently ignored. Common examples of this are typos in a field name and incorrect indentation.

It would be great to enable this check across the repo, but before we can we must address all existing unknown fields. This is part of that cleanup...



