### PR TITLE
Partial roll forward of https://github.com/kubernetes/test-infra/pull/27290

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -107,6 +107,8 @@ presets:
     value: true
   - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
     value: pd.csi.storage.gke.io
+  - name: CL2_WAIT_FOR_CONTROLLED_PODS_USE_EXACT_OPERATION_TIMEOUT
+    value: true
 
 ### kubemark-gce-scale
 - labels:
@@ -255,6 +257,8 @@ presets:
     value: pd.csi.storage.gke.io
   - name: KUBE_APISERVER_GODEBUG
     value: gctrace=1
+  - name: CL2_WAIT_FOR_CONTROLLED_PODS_USE_EXACT_OPERATION_TIMEOUT
+    value: true
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -272,6 +272,7 @@ presubmits:
         - --metadata-sources=cl2-metadata.json
         - --env=CL2_LOAD_TEST_THROUGHPUT=50
         - --env=CL2_DELETE_TEST_THROUGHPUT=50
+        - --env=CL2_RATE_LIMIT_POD_CREATION=false
         # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
         - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
         # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.
@@ -723,6 +724,7 @@ presubmits:
         - --metadata-sources=cl2-metadata.json
         - --env=CL2_LOAD_TEST_THROUGHPUT=50
         - --env=CL2_DELETE_TEST_THROUGHPUT=50
+        - --env=CL2_RATE_LIMIT_POD_CREATION=false
         # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
         - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
         # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -106,6 +106,7 @@ periodics:
       - --metadata-sources=cl2-metadata.json
       - --env=CL2_LOAD_TEST_THROUGHPUT=50
       - --env=CL2_DELETE_TEST_THROUGHPUT=50
+      - --env=CL2_RATE_LIMIT_POD_CREATION=false
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
       - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
       # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.


### PR DESCRIPTION
This is a partial roll forward of https://github.com/kubernetes/test-infra/pull/27290.

It consists of two parts:
* enabling CL2_WAIT_FOR_CONTROLLED_PODS_USE_EXACT_OPERATION_TIMEOUT everywhere (it proved to be ok with initial submission https://github.com/kubernetes/test-infra/pull/27290 on master and is no-op for older than master branches)
* enabling CL2_RATE_LIMIT_POD_CREATION=false, where this worked OK. In 100 node tests the increased master pressure causes flakiness so we temporarily skip enabling it there. Ultimately we should be able to enabled it there as well (e.g. if we decrease kube-api-qps there to standard levels).

/assign @tosi3k 