### PR TITLE
Add a dashboard for SIG Node image pushes

### DIFF
--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -14,6 +14,7 @@ dashboard_groups:
     - sig-node-kernel-module-management
     - sig-node-node-problem-detector
     - sig-node-security-profiles-operator
+    - sig-node-image-pushes
 
 dashboards:
 - name: sig-node-release-blocking # Tabs included in this group are defined in the jobs that are included.
@@ -78,3 +79,4 @@ dashboards:
 
 - name: sig-node-cos
 - name: sig-node-presubmits
+- name: sig-node-image-pushes


### PR DESCRIPTION
Adding a postsubmit job to KMM for image pushes requires creating a dashboard for SIG Node image pushes.

Postsubmit PR: https://github.com/kubernetes/test-infra/pull/27461
Kubernetes docs: https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md?plain=1#L134