### PR TITLE
add kubernetes v1.25 test for secrets-store

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -497,6 +497,46 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-2
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.2"
       testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-0
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: false
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    # e2e-provider is only available in release-1.* branches
+    - ^release-1.*
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.24
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            ./test/scripts/e2e_provider.sh
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBERNETES_VERSION
+          value: "1.25.0"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-25-0
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.25.0"
+      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-akeyless
     decorate: true
     decoration_config:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- PR to support v1.25 has been merged in the driver https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/1040. Adding a prow job to test against v1.25 kind cluster.

/assign @tam7t 
/cc @nilekhc