### PR TITLE
Decoration config supports setting memory limit equal to request

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -360,6 +360,10 @@ spec:
                     description: S3CredentialsSecret is the name of the Kubernetes
                       secret that holds blob storage push credentials.
                     type: string
+                  set_limit_equals_memory_request:
+                    description: SetLimitEqualsMemoryRequest sets memory limit equal
+                      to request.
+                    type: boolean
                   skip_cloning:
                     description: SkipCloning determines if we should clone source
                       code in the initcontainers for jobs that specify refs

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -478,6 +478,9 @@ type DecorationConfig struct {
 	// UploadIgnoresInterrupts causes sidecar to ignore interrupts for the upload process in
 	// hope that the test process exits cleanly before starting an upload.
 	UploadIgnoresInterrupts *bool `json:"upload_ignores_interrupts,omitempty"`
+
+	// SetLimitEqualsMemoryRequest sets memory limit equal to request.
+	SetLimitEqualsMemoryRequest *bool `json:"set_limit_equals_memory_request,omitempty"`
 }
 
 type CensoringOptions struct {
@@ -678,6 +681,10 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 
 	if merged.UploadIgnoresInterrupts == nil {
 		merged.UploadIgnoresInterrupts = def.UploadIgnoresInterrupts
+	}
+
+	if merged.SetLimitEqualsMemoryRequest == nil {
+		merged.SetLimitEqualsMemoryRequest = def.SetLimitEqualsMemoryRequest
 	}
 
 	return &merged

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -158,6 +158,11 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SetLimitEqualsMemoryRequest != nil {
+		in, out := &in.SetLimitEqualsMemoryRequest, &out.SetLimitEqualsMemoryRequest
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -780,6 +780,9 @@ plank:
             # that holds blob storage push credentials.
             s3_credentials_secret: ""
 
+            # SetLimitEqualsMemoryRequest sets memory limit equal to request.
+            set_limit_equals_memory_request: false
+
             # SkipCloning determines if we should clone source code in the
             # initcontainers for jobs that specify refs
             skip_cloning: false
@@ -976,6 +979,9 @@ plank:
             # S3CredentialsSecret is the name of the Kubernetes secret
             # that holds blob storage push credentials.
             s3_credentials_secret: ""
+
+            # SetLimitEqualsMemoryRequest sets memory limit equal to request.
+            set_limit_equals_memory_request: false
 
             # SkipCloning determines if we should clone source code in the
             # initcontainers for jobs that specify refs

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_enforcing_memory_limit.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_enforcing_memory_limit.yaml
@@ -1,0 +1,103 @@
+containers:
+- command:
+  - /tools/entrypoint
+  env:
+  - name: ARTIFACTS
+    value: /logs/artifacts
+  - name: GOPATH
+    value: /home/prow/go
+  - name: custom
+    value: env
+  - name: ENTRYPOINT_OPTIONS
+    value: '{"timeout":60000000000,"grace_period":3600000000000,"artifact_dir":"/logs/artifacts","args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+  name: test
+  resources:
+    limits:
+      memory: 8Gi
+    requests:
+      memory: 8Gi
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /tools
+    name: tools
+  - mountPath: /home/prow/go
+    name: code
+  workingDir: /home/prow/go/src/github.com/org/repo
+- env:
+  - name: JOB_SPEC
+  - name: SIDECAR_OPTIONS
+    value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"censoring_options":{}}'
+  image: sidecarimage
+  name: sidecar
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  terminationMessagePolicy: FallbackToLogsOnError
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+initContainers:
+- env:
+  - name: CLONEREFS_OPTIONS
+    value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org","repo":"repo","base_ref":"main","base_sha":"abcd1234","pulls":[{"number":1,"author":"","sha":"aksdjhfkds"}]},{"org":"other","repo":"something","base_ref":"release","base_sha":"sldijfsd"}],"github_api_endpoints":["https://api.github.com"]}'
+  image: cloneimage
+  name: clonerefs
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /home/prow/go
+    name: code
+  - mountPath: /tmp
+    name: clonerefs-tmp
+- env:
+  - name: INITUPLOAD_OPTIONS
+    value: '{"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
+  - name: JOB_SPEC
+  image: initimage
+  name: initupload
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+- args:
+  - --copy-mode-only
+  image: entrypointimage
+  name: place-entrypoint
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  volumeMounts:
+  - mountPath: /tools
+    name: tools
+serviceAccountName: tester
+terminationGracePeriodSeconds: 4500
+volumes:
+- emptyDir: {}
+  name: logs
+- emptyDir: {}
+  name: tools
+- name: gcs-credentials
+  secret:
+    secretName: gcs-secret
+- emptyDir: {}
+  name: clonerefs-tmp
+- emptyDir: {}
+  name: code


### PR DESCRIPTION
This will help solving noisy neighbor problem by enforcing pod resource limit equal to request, this can be set per org/repo/cluster. The build cluster itself could choose to set limit-range to cover cases where request is not set on a job

/cc @cjwagner @alvaroaleman 