### PR TITLE
removed always_run from periodics job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -86,7 +86,6 @@ periodics:
   - interval: 24h
     name: periodic-soak-tests-capz-windows-2019
     decorate: true
-    always_run: false
     optional: true
     decoration_config:
       timeout: 8h

--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml
@@ -43,7 +43,6 @@ periodics:
     testgrid-alert-email: kubernetes-hnc-dev+alerts@googlegroups.com
     testgrid-num-failures-to-alert: "1"
   interval: 24h
-  always_run: true # Different from the postsubmit; copied from kind periodics
   decorate: true
   decoration_config:
     timeout: 1h


### PR DESCRIPTION
### Issue
[error unmarshaling config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"always_run\" #27456](https://github.com/kubernetes/test-infra/issues/27456)

As discussed in the above issue... the solution is already [merged for another similar issue](https://github.com/kubernetes/test-infra/issues/27454) and tested