### PR TITLE
removed always_run from periodics job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -86,7 +86,6 @@ periodics:
   - interval: 24h
     name: periodic-soak-tests-capz-windows-2019
     decorate: true
-    always_run: false
     optional: true
     decoration_config:
       timeout: 8h


### PR DESCRIPTION
### Issue 
[error unmarshaling config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"always_run\" #27455](https://github.com/kubernetes/test-infra/issues/27455)

As discussed in the aforementioned issue... the [solution is already merged and tested for a similar issue...](https://github.com/kubernetes/test-infra/issues/27454)