### PR TITLE
Changing the 'git' image for KMM's check-commit-count job.

### DIFF
--- a/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
       description: "make sure each PR to kernel-module-management has a single commit."
     spec:
       containers:
-      - image: gcr.io/k8s-prow/git:latest
+      - image: docker.io/bitnami/git
         command:
         - ci/prow/check-commits-count
   - name: pull-kernel-module-management-lint


### PR DESCRIPTION
Unlike the `bitnami` image, the `k8s-prow` image doesn't have the `bash` binary in it. Instead it is using `busybox`.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>