### PR TITLE
Allow Checkruns with spaces to be overriden

### DIFF
--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -313,14 +313,9 @@ func parseOverrideInput(in string) []string {
 		}
 		return !quoted && r == ' '
 	})
-	retval := []string{}
+	var retval []string
 	for _, val := range f {
-		if val[0:1] == `"` {
-			retval = append(retval, val[1:len(val)-1])
-			fmt.Println(val[1 : len(val)-1])
-		} else {
-			retval = append(retval, strings.TrimRight(val, "\r"))
-		}
+		retval = append(retval, strings.Trim(strings.TrimSpace(val), `"`))
 	}
 
 	return retval

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -350,10 +350,7 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 			return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 		}
 		overrides.Insert(parseOverrideInput(m[2])...)
-		log.Infof("PARSING: %v", parseOverrideInput(m[2]))
 	}
-
-	log.Info(overrides)
 
 	authorized := authorizedUser(oc, log, org, repo, user)
 	if !authorized && len(options.AllowedGitHubTeams) > 0 {

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -411,6 +411,28 @@ func TestHandle(t *testing.T) {
 			usesAppsAuth: true,
 		},
 		{
+			name:    "successfully override unknown context with special characters derived from checkruns",
+			comment: `/override "test / Unit Tests"`,
+			checkruns: &github.CheckRunList{
+				CheckRuns: []github.CheckRun{
+					{Name: "incomplete-checkrun"},
+					{Name: "test / Unit Tests", CompletedAt: "1800 BC", Conclusion: "failure"},
+				},
+			},
+			expected: []github.Status{},
+			expectedCheckRuns: &github.CheckRunList{
+				CheckRuns: []github.CheckRun{
+					{Name: "incomplete-checkrun"},
+					{Name: "test / Unit Tests", CompletedAt: "1800 BC", Conclusion: "failure"},
+					{Name: "test / Unit Tests", CompletedAt: "1800 BC", Status: "completed", Conclusion: "success", Output: github.CheckRunOutput{
+						Title:   fmt.Sprintf("Prow override - %s", "test / Unit Tests"),
+						Summary: fmt.Sprintf("Prow has received override command for the %s checkrun.", "test / Unit Tests"),
+					}},
+				},
+			},
+			usesAppsAuth: true,
+		},
+		{
 			name:    "override a successful unknown context derived from checkruns",
 			comment: "/override success-checkrun",
 			checkruns: &github.CheckRunList{

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -412,7 +412,7 @@ func TestHandle(t *testing.T) {
 		},
 		{
 			name:    "successfully override unknown context with special characters derived from checkruns",
-			comment: `/override "test / Unit Tests"`,
+			comment: `/override potato "test / Unit Tests"`,
 			checkruns: &github.CheckRunList{
 				CheckRuns: []github.CheckRun{
 					{Name: "incomplete-checkrun"},
@@ -1138,6 +1138,7 @@ func TestHandle(t *testing.T) {
 	}
 
 	log := logrus.WithField("plugin", pluginName)
+	log.Logger.SetLevel(logrus.DebugLevel)
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.number == 0 {
@@ -1328,6 +1329,7 @@ func TestAuthorizedGitHubTeamMember(t *testing.T) {
 		},
 	}
 	log := logrus.WithField("plugin", pluginName)
+	log.Logger.SetLevel(logrus.DebugLevel)
 	for _, tc := range cases {
 		authorized := authorizedGitHubTeamMember(&fakeClient{}, log, tc.slugs, fakeOrg, fakeRepo, tc.user)
 		if authorized != tc.expected {


### PR DESCRIPTION
The change in #27288 broke overriding GitHub Actions checkruns as they have spaces and / symbol. This change allows them to be overriden by quoting them.

/cc @chaodaiG 