### PR TITLE
azure: add capz v1.5 periodic coverage, include v1.4 as well

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1beta1.yaml
@@ -11,7 +11,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.4
+      base_ref: release-1.5
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -44,7 +44,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.4
+      base_ref: release-1.5
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -81,7 +81,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.4
+      base_ref: release-1.5
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -115,7 +115,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.4
+      base_ref: release-1.5
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -135,4 +135,72 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-full-v1beta1
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-minus-1
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.4
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.24
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Cluster API E2E tests"
+        - name: GINKGO_SKIP
+          value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-minus-1
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-e2e-full-v1beta1-minus-1
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.4
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.24
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Workload cluster creation"
+        - name: GINKGO_SKIP
+          value: ""
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-full-v1beta1-minus-1
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
This PR adds default capz v1beta1 coverage against the new 1.5 release. We also retain capi and capz E2E coverage for the 1.4 release branch at a reduced periodicity.