### PR TITLE
Adds test jobs for CAPV release-1.3 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.3.yaml
@@ -1,0 +1,76 @@
+periodics:
+  - name: periodic-cluster-api-provider-vsphere-e2e-release-1-3
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    interval: 12h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-vsphere
+        base_ref: release-1.3
+        path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.23
+          command:
+            - runner.sh
+          args:
+            - ./hack/e2e.sh
+          env:
+            - name: GINKGO_SKIP
+              value: "\\[Conformance\\] \\[clusterctl-Upgrade\\] \\[specialized-infra\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: periodic-e2e-release-1-3
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs all the e2e tests
+
+  - name: periodic-cluster-api-provider-vsphere-conformance-release-1-3
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    interval: 24h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-vsphere
+        base_ref: release-1.3
+        path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.23
+          command:
+            - runner.sh
+          args:
+            - ./hack/e2e.sh
+          env:
+            - name: GINKGO_FOCUS
+              value: "\\[Conformance\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: periodic-conformance-release-1-3
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs conformance tests for CAPV

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.3.yaml
@@ -1,0 +1,117 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-vsphere:
+  - name: pull-cluster-api-provider-vsphere-verify-lint-release-1-3
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.3$
+    always_run: false
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.23
+        command:
+        - hack/check-lint.sh
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-lint-release-1-3
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies the Golang sources are linted
+
+  - name: pull-cluster-api-provider-vsphere-test-release-1-3
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.3$
+    always_run: false
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile|go\.mod|go\.sum)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.23
+        resources:
+          requests:
+            cpu: "500m"
+        command:
+        - runner.sh
+        args:
+        - make
+        - test
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-test-release-1-3
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs unit tests
+
+  - name: pull-cluster-api-provider-vsphere-integration-test-release-1-3
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile|go\.mod|go\.sum)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.3$
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.23
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-integration
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-test-integration-release-1-3
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs integration tests
+
+  - name: pull-cluster-api-provider-vsphere-e2e-release-1-3
+    branches:
+      - ^release-1.3$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    run_if_changed: '^((api|cmd|config|contrib|controllers|packaging|pkg|test)/|Dockerfile|Makefile|hack/e2e\.sh|go\.mod|go\.sum)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-1.23
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[PR-Blocking\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-release-1-3
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs e2e tests

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -101,6 +101,9 @@ presubmits:
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-lint
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
     always_run: false
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh)'
     decorate: true
@@ -172,6 +175,9 @@ presubmits:
       description: Verifies the CRDs have been updated
 
   - name: pull-cluster-api-provider-vsphere-test
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
     always_run: false
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile|go\.mod|go\.sum)'
     decorate: true
@@ -229,7 +235,6 @@ presubmits:
   - name: pull-cluster-api-provider-vsphere-e2e
     branches:
       - ^main$
-      - ^release-1.*
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"


### PR DESCRIPTION
This is the last branch which has support for CAPI 1.1.x release line. We will be back porting fixes to this branch for some time, hence creating jobs specific to this release line.