### PR TITLE
enhancements sync job - inject secret as env var rather than volume mount

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -19,10 +19,8 @@ periodics:
       env:
         - name: GITHUB_PROJECT_BETA_NUMBER
           value: "98"
-      volumeMounts:
-      - name: token
-        mountPath: /etc/github-token
-    volumes:
-    - name: token
-      secret:
-        secretName: k8s-triage-robot-github-token
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: k8s-triage-robot-github-token
+              key: token


### PR DESCRIPTION
This should resolve [an error](https://prow.k8s.io/log?job=periodic-sync-enhancements-github-project-beta-1-26&id=1569795313504358400) with exposing the github token for consumption by the enhancements sync script.  

```
Startig sync...
[INFO] Fetching the list of open KEP issues from k/enhancements with the label, "lead-opted-in"
gh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.
{"component":"entrypoint","error":"wrapped process failed: exit status 4","file":"k8s.io/test-infra/prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2022-09-13T21:09:08Z"}
```

This change makes the token available as an env var `GITHUB_TOKEN` so the Github cli tool can reference it - https://cli.github.com/manual/gh_help_environment.

/cc @Priyankasaggu11929 @marosset @reylejano @leonardpahlke 
