### PR TITLE
Use Local (GCS) copy of cni-plugins artifact to prevent http error 502

### DIFF
--- a/jobs/e2e_node/containerd/init.yaml
+++ b/jobs/e2e_node/containerd/init.yaml
@@ -14,7 +14,7 @@ runcmd:
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
 
   - echo "Download and install CNI to /home/containerd"
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
 
   - echo "Set containerd configuration"


### PR DESCRIPTION
Seeing errors like these in the logs of some CI jobs:
```
[   24.234006] cloud-init[1219]: Download and install CNI configuration to /home/containerd
[   24.268352] cloud-init[1219]: Download and install CNI to /home/containerd
[   25.382948] cloud-init[1219]: curl: (22) The requested URL returned error: 502
[   28.415400] cloud-init[1219]: curl: (22) The requested URL returned error: 502
[   31.452287] cloud-init[1219]: curl: (22) The requested URL returned error: 502
[   34.484638] cloud-init[1219]: curl: (22) The requested URL returned error: 502
[   37.519683] cloud-init[1219]: curl: (22) The requested URL returned error: 502
[   40.553977] cloud-init[1219]: curl: (22) The requested URL returned error: 502
```

Example snippet from:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/google_cadvisor/3168/pull-cadvisor-e2e/1570161838149079040/artifacts/tmp-node-e2e-b0b43dfc-ubuntu-gke-2204-1-24-v20220908/serial-1.log

So let's please use the copy of the CNI tar/gz from GCS.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>