### PR TITLE
Disable stalebot in ingress-nginx

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -150,6 +150,7 @@ periodics:
         org:kubernetes-client
         org:kubernetes-csi
         -repo:kubernetes-sigs/kind
+        -repo:kubernetes/ingress-nginx
         -label:lifecycle/frozen
         label:lifecycle/rotten
       - --updated=720h
@@ -204,6 +205,7 @@ periodics:
         org:kubernetes-client
         org:kubernetes-csi
         -repo:kubernetes-sigs/kind
+        -repo:kubernetes/ingress-nginx
         -label:lifecycle/frozen
         label:lifecycle/rotten
         label:kind/bug
@@ -321,6 +323,7 @@ periodics:
         org:kubernetes-client
         org:kubernetes-csi
         -repo:kubernetes-sigs/kind
+        -repo:kubernetes/ingress-nginx
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
@@ -376,6 +379,7 @@ periodics:
         org:kubernetes-client
         org:kubernetes-csi
         -repo:kubernetes-sigs/kind
+        -repo:kubernetes/ingress-nginx
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten


### PR DESCRIPTION
We are under a lot of heavy work. This doesn't mean we don't care for issues and PRs, but more that we couldn't check all the reports yet.

We need to do a better job, I know :) we all are contributors and do this for free. This doesn't mean we need to close issues and PRs because we couldn't even triage those.

So based on my experience as a contributor and how upset I get when I  have to keep doing `lifecycle active` commands, I'm proposing that we remove the stale bot (as KinD and @BenTheElder did) so we don't simply close issues and PRs. 

Based on this, and if accepted by other contributors, we have an agreement we need to start taking better care on PRs and issues, even at least saying to the user "ack, we are under heavy work but we understand that this is important to you and wont be automatically closed".

/cc @strongjz @tao12345666333 @ElvinEfendi 