### PR TITLE
fixed resources block indentation issue in files

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -168,13 +168,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-    resources:
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Migration Kubernetes Master Driver Stable
@@ -205,13 +205,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-    resources:
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Migration Kubernetes Master Driver Latest

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -34,13 +34,13 @@ periodics:
         value: "prepull-head.yaml"
       securityContext:
         privileged: true
-    resources:
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: ci-windows-20h2-provider-gcp-compute-persistent-disk-csi-driver
@@ -80,13 +80,13 @@ periodics:
         value: "prepull-head.yaml"
       securityContext:
         privileged: true
-    resources:
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: ci-windows-2019-provider-gcp-compute-persistent-disk-csi-driver
@@ -124,13 +124,13 @@ presubmits:
           value: "prepull-head.yaml"
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
     annotations:
       testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
       testgrid-tab-name: windows-2019-presubmit-gcp-compute-persistent-disk-csi-driver
@@ -167,13 +167,13 @@ presubmits:
           value: "prepull-head.yaml"
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
     annotations:
       testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
       testgrid-tab-name: windows-20h2-presubmit-gcp-compute-persistent-disk-csi-driver

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -47,13 +47,13 @@ postsubmits:
         - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --confirm
-      resources:
-        requests:
-          cpu: 2
-          memory: "4Gi"
-        limits:
-          cpu: 2
-          memory: "4Gi"
+        resources:
+          requests:
+            cpu: 2
+            memory: "4Gi"
+          limits:
+            cpu: 2
+            memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -216,6 +216,9 @@ postsubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "15"
       tolerations:
       - key: "highcpu"
         operator: "Equal"
@@ -223,9 +226,6 @@ postsubmits:
         effect: "NoSchedule"
       nodeSelector:
         highcpu: "true"
-      resources:
-        requests:
-          cpu: "15"
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: push-prow


### PR DESCRIPTION
### Issues
file: config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
- [error unmarshaling config/jobs/kubernetes/test-infra/test-infra-trusted.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"resources\" #27437](https://github.com/kubernetes/test-infra/issues/27437)

file: config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
- [error unmarshaling config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"resources\" #27431](https://github.com/kubernetes/test-infra/issues/27431)

file: config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
- [error unmarshaling config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"resources\" #27446](https://github.com/kubernetes/test-infra/issues/27446)

file: config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
- [error unmarshaling config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"requests\" #27451](https://github.com/kubernetes/test-infra/issues/27451)



The files were affected by a similar indentation issue for the `resources:` block as discussed in their respective issues above...