### PR TITLE
removed skip_branches from periodics job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -144,8 +144,6 @@ periodics:
   cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
-  skip_branches:
-  - release-\d+\.\d+ # per-release settings
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
### Issue
[error unmarshaling config/jobs/kubernetes/sig-testing/conformance-e2e.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"skip_branches\" #27434](https://github.com/kubernetes/test-infra/issues/27434)

as discussed in the aforementioned issue