### PR TITLE
removed optional field from periodics

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -86,7 +86,6 @@ periodics:
   - interval: 24h
     name: periodic-soak-tests-capz-windows-2019
     decorate: true
-    optional: true
     decoration_config:
       timeout: 8h
     path_alias: k8s.io/perf-tests


### PR DESCRIPTION
### Issue
[error unmarshaling config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"always_run\" #27455](https://github.com/kubernetes/test-infra/issues/27455)


as discussed in the aforementioned issue periodics dont have the optional field and never did... the aforementioned issue also had an always run issue that was patched but there was still this optional field here that needs to be removed 