### PR TITLE
Fix phaino's setupKubeconfig

### DIFF
--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -385,7 +385,7 @@ func setupKubeconfig(volumeMounts, envs map[string]string) {
 		envs[kubeconfigEnvKey] = kubeconfigEnvVarVal
 		var inexistentKubeconfigFiles []string
 		for _, f := range strings.Split(kubeconfigEnvVarVal, string(os.PathListSeparator)) {
-			if _, err := os.Stat(f); !os.IsNotExist(err) {
+			if _, err := os.Stat(f); os.IsNotExist(err) {
 				inexistentKubeconfigFiles = append(inexistentKubeconfigFiles, f)
 			}
 		}


### PR DESCRIPTION
Phaino treats existing `$KUBECONFIG` file as not existing. This PR contains a one-character fix for that.