### PR TITLE
Revert - securityContext moved to container template in sig-testing/make-test.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/mtb-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/mtb-presubmit.yaml
@@ -16,5 +16,5 @@ presubmits:
           command:
             - wrapper.sh
             - ./benchmarks/kubectl-mtb/hack/ci-test.sh
-          securityContext:
-            privileged: true
+        securityContext:
+           privileged: true

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -14,6 +14,10 @@ presubmits:
     always_run: true
     path_alias: k8s.io/kubernetes
     spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-master
           command:
@@ -27,10 +31,6 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
-            allowPrivilegeEscalation: false
   - name: pull-kubernetes-unit-experimental
     # try clonerefs with preclone
     decoration_config:
@@ -87,6 +87,10 @@ presubmits:
     skip_report: false
     path_alias: k8s.io/kubernetes
     spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-go-canary
           command:
@@ -100,10 +104,6 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
-            allowPrivilegeEscalation: false
 periodics:
   - interval: 1h
     name: ci-kubernetes-unit
@@ -123,6 +123,10 @@ periodics:
         base_ref: master
         path_alias: k8s.io/kubernetes
     spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-master
           command:
@@ -136,10 +140,6 @@ periodics:
             requests:
               cpu: 4
               memory: "36Gi"
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
-            allowPrivilegeEscalation: false
   - interval: 6h
     name: ci-kubernetes-generate-make-test-count10
     annotations:
@@ -153,6 +153,10 @@ periodics:
     labels:
       preset-service-account: "true"
     spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-master
           command:
@@ -161,7 +165,3 @@ periodics:
             - -c
           args:
             - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10'
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
-            allowPrivilegeEscalation: false

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -14,10 +14,6 @@ presubmits:
     always_run: true
     path_alias: k8s.io/kubernetes
     spec:
-      # unit tests have no business requiring root or doing privileged operations
-      securityContext:
-        runAsUser: 2000
-        allowPrivilegeEscalation: false
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-master
           command:


### PR DESCRIPTION
Revert for https://github.com/kubernetes/test-infra/pull/27515 since it breaks some CI jobs

Plus, one extra commit to drop allowPrivilegeEscalation as it does not exist at the pod spec level