### PR TITLE
CAPZ: add v1.6 release milestone

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -169,7 +169,7 @@ label:
         allowed_teams:
         - enhancements
       # Restrict setting of 'lead-opted-in' label to SIG leads.
-      - label: lead-opted-in  
+      - label: lead-opted-in
         allowed_teams:
         - sig-api-machinery-leads
         - sig-apps-leads
@@ -461,9 +461,9 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.5
+    main: v1.6
+    release-1.5: v1.5
     release-1.4: v1.4
-    release-1.3: v1.3
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0


### PR DESCRIPTION
Adds v1.6 milestone in preparation for the v1.6.0 release.

See #26763 and [CAPZ release docs](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#change-milestone-skip-for-patch-releases) for details.

/assign @bridgetkromhout @jackfrancis @sonasingh46