### PR TITLE
requests was incorrectly used in gcp-compute-persistent-disk-csi-driver-postsubmits.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -24,12 +24,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Kubernetes Master Driver Latest Release
@@ -60,12 +61,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Kubernetes Master Driver Latest Release Candidate
@@ -96,12 +98,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Kubernetes Master Driver Latest
@@ -132,12 +135,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Kubernetes Master Driver Latest Canary Sidecars


### PR DESCRIPTION
### Issue
[error unmarshaling config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"requests\" #27451](https://github.com/kubernetes/test-infra/issues/27451)

`requests:` was incorrectly used... as discussed in the aforementioned issue