### PR TITLE
revert portions of cleanup done to make config-check happy

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -27,9 +27,9 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
+          # FIXME(dims): unit tests have no business requiring root or doing privileged operations
+          #securityContext:
+          #  runAsUser: 2000
   - name: pull-kubernetes-unit-experimental
     # try clonerefs with preclone
     decoration_config:
@@ -94,9 +94,9 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
+          # FIXME(dims): unit tests have no business requiring root or doing privileged operations
+          #securityContext:
+          #  runAsUser: 2000
 periodics:
   - interval: 1h
     name: ci-kubernetes-unit
@@ -129,9 +129,9 @@ periodics:
             requests:
               cpu: 4
               memory: "36Gi"
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
+          # FIXME(dims): unit tests have no business requiring root or doing privileged operations
+          # securityContext:
+          #  runAsUser: 2000
   - interval: 6h
     name: ci-kubernetes-generate-make-test-count10
     annotations:
@@ -153,6 +153,6 @@ periodics:
             - -c
           args:
             - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10'
-          # unit tests have no business requiring root or doing privileged operations
-          securityContext:
-            runAsUser: 2000
+          # FIXME(dims): unit tests have no business requiring root or doing privileged operations
+          # securityContext:
+          #  runAsUser: 2000


### PR DESCRIPTION
Looks like d596bdcf88c12bc7ed2a5fdb4b3abb303895ef62 is breaking up the pull-kubernetes-unit and related CI jobs. So let's comment out the runAsUser change

example log:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/112485/pull-kubernetes-unit/1570497352878264320/build-log.txt

Signed-off-by: Davanum Srinivas <davanum@gmail.com>