### PR TITLE
kubekins-e2e use go 1.18.6 for test-infra variant

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -15,7 +15,7 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.15.8
+    GO_VERSION: 1.18.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0


### PR DESCRIPTION
While working on #27533 in order to use go1.18 I noticed the kubekins-e2e container uses an old go version.