### PR TITLE
Move git ClientFactory constructor logic to GitHub options

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -396,11 +396,10 @@ func main() {
 			if err != nil {
 				logrus.WithError(err).Fatal("Error getting GitHub client.")
 			}
-			g, err := o.github.GitClient(o.dryRun)
+			gitClient, err = o.github.GitClientFactory("", &o.config.InRepoConfigCacheDirBase, o.dryRun)
 			if err != nil {
 				logrus.WithError(err).Fatal("Error getting Git client.")
 			}
-			gitClient = git.ClientFactoryFrom(g)
 		} else {
 			if len(cfg().InRepoConfig.Enabled) > 0 {
 				logrus.Info(" --github-token-path not configured. InRepoConfigEnabled, but current configuration won't display full PR history")

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -136,7 +136,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating opener")
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheGetter(ca, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheDirBase, prowflagutil.GitHubOptions{}, o.cookiefilePath, o.dryRun)
+	cacheGetter, err := config.NewInRepoConfigCacheGetter(ca, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, &o.config.InRepoConfigCacheDirBase, prowflagutil.GitHubOptions{}, o.cookiefilePath, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -33,7 +33,6 @@ import (
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	configflagutil "k8s.io/test-infra/prow/flagutil/config"
 	pluginsflagutil "k8s.io/test-infra/prow/flagutil/plugins"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/githubeventserver"
 	"k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/interrupts"
@@ -150,7 +149,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	gitClient, err := o.github.GitClient(o.dryRun)
+	gitClient, err := o.github.GitClientFactory("", &o.config.InRepoConfigCacheDirBase, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
@@ -220,14 +219,14 @@ func main() {
 	resolver := func(org, repo string) ownersconfig.Filenames {
 		return pluginAgent.Config().OwnersFilenames(org, repo)
 	}
-	ownersClient := repoowners.NewClient(git.ClientFactoryFrom(gitClient), githubClient, mdYAMLEnabled, skipCollaborators, ownersDirDenylist, resolver)
+	ownersClient := repoowners.NewClient(gitClient, githubClient, mdYAMLEnabled, skipCollaborators, ownersDirDenylist, resolver)
 
 	clientAgent := &plugins.ClientAgent{
 		GitHubClient:              githubClient,
 		ProwJobClient:             prowJobClient,
 		KubernetesClient:          infrastructureClient,
 		BuildClusterCoreV1Clients: buildClusterCoreV1Clients,
-		GitClient:                 git.ClientFactoryFrom(gitClient),
+		GitClient:                 gitClient,
 		SlackClient:               slackClient,
 		OwnersClient:              ownersClient,
 		BugzillaClient:            bugzillaClient,

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -133,7 +133,7 @@ func main() {
 		}
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheGetter(configAgent, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheDirBase, o.github, o.cookiefilePath, o.dryRun)
+	cacheGetter, err := config.NewInRepoConfigCacheGetter(configAgent, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, &o.config.InRepoConfigCacheDirBase, o.github, o.cookiefilePath, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config/secret"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
@@ -103,7 +102,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	gitClient, err := o.github.GitClient(o.dryRun)
+	gitClient, err := o.github.GitClientFactory("", nil, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
@@ -132,7 +131,7 @@ func main() {
 		botUser:        botUser,
 		email:          email,
 
-		gc:  git.ClientFactoryFrom(gitClient),
+		gc:  gitClient,
 		ghc: githubClient,
 		log: log,
 

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -1365,7 +1365,7 @@ func TestProcessChange(t *testing.T) {
 
 			var gc fgc
 			gc.instanceMap = tc.instancesMap
-			inRepoConfigCacheGetter, err := config.NewInRepoConfigCacheGetter(nil, 1, 1, "", flagutil.GitHubOptions{}, "", false)
+			inRepoConfigCacheGetter, err := config.NewInRepoConfigCacheGetter(nil, 1, 1, nil, flagutil.GitHubOptions{}, "", false)
 			if err != nil {
 				t.Fatalf("Failed creating cache getter: %v", err)
 			}

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -90,7 +90,7 @@ func NewGerritController(
 		newPoolPending:   make(chan bool),
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheGetter(cfgAgent, configOptions.InRepoConfigCacheSize, configOptions.InRepoConfigCacheCopies, configOptions.InRepoConfigCacheDirBase, flagutil.GitHubOptions{}, cookieFilePath, false)
+	cacheGetter, err := config.NewInRepoConfigCacheGetter(cfgAgent, configOptions.InRepoConfigCacheSize, configOptions.InRepoConfigCacheCopies, &configOptions.InRepoConfigCacheDirBase, flagutil.GitHubOptions{}, cookieFilePath, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating inrepoconfig cache getter: %v", err)
 	}


### PR DESCRIPTION
This is part one of migrating git client from GitHub to native git v2 instead of wrapping around v1. The second part of this migration would be much more risky and I'd prefer to do it in a separate PR.

One other thing worth mentioning is that this will also unblock me from consolidating inrepoconfig logic to all using the same cache client that was proven to work well with Gerrit.