### PR TITLE
test-infra: update jobs image tag v20220915-f0ff885869-test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -11,7 +11,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -10,7 +10,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -108,7 +108,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
         command:
         - runner.sh
         args:
@@ -164,7 +164,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
         command:
         - runner.sh
         args:
@@ -200,7 +200,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -201,7 +201,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220915-f0ff885869-test-infra
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Updates the test-infra jobs image to use an image which contain `go1.18.6` instead of `go1.15.8`.

Reference #27537