### PR TITLE
go-deps.sh: fix error message

### DIFF
--- a/hack/make-rules/verify/go-deps.sh
+++ b/hack/make-rules/verify/go-deps.sh
@@ -75,7 +75,7 @@ main() {
           -x "bazel-testlogs" \
          "${REPO_ROOT}" "${TMP_REPO}" 2>/dev/null || true)
   if [[ -n "${diff}" ]]; then
-    echo "unexpectedly dirty working directory after hack/update/deps.sh" >&2
+    echo "unexpectedly dirty working directory after ${0}" >&2
     echo "" >&2
     echo "${diff}" >&2
     echo "" >&2


### PR DESCRIPTION
When investigating a failed build I noticed the error output referenced a file that didn't exist. 

This change outputs the name of the script:
`unexpectedly dirty working directory after ./hack/make-rules/verify/go-deps.sh` 