### PR TITLE
NFD: Restructure jobs based on the branch version

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -1,24 +1,6 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
-  - name: pull-node-feature-discovery-verify
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    skip_branches:
-    - gh-pages
-    - ^release-0.6
-    - ^release-0.7
-    - ^release-0.8
-    - ^release-0.9
-    decorate: true
-    annotations:
-      testgrid-dashboards: sig-node-node-feature-discovery
-      testgrid-tab-name: verify
-      description: "Verify source code of node-feature-discovery: check formatting, lint etc."
-    spec:
-      containers:
-      - image: golang:1.19
-        command:
-        - scripts/test-infra/verify.sh
-  - name: pull-node-feature-discovery-verify-0-9
+  - name: pull-node-feature-discovery-verify-release-06-09
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.6
@@ -35,35 +17,7 @@ presubmits:
       - image: golang:1.16
         command:
         - scripts/test-infra/verify.sh
-  - name: pull-node-feature-discovery-verify-docs
-    run_if_changed: "^docs/"
-    skip_branches:
-    - gh-pages
-    decorate: true
-    annotations:
-      testgrid-dashboards: sig-node-node-feature-discovery
-      testgrid-tab-name: verify-docs
-      description: "Verify documentation sources"
-    spec:
-      containers:
-      - image: ruby:slim
-        command:
-        - scripts/test-infra/mdlint.sh
-  - name: pull-node-feature-discovery-build
-    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    skip_branches:
-    - gh-pages
-    decorate: true
-    annotations:
-      testgrid-dashboards: sig-node-node-feature-discovery
-      testgrid-tab-name: build
-      description: "Build node-feature-discovery binaries"
-    spec:
-      containers:
-      - image: golang:1.19
-        command:
-        - scripts/test-infra/build.sh
-  - name: pull-node-feature-discovery-build-image
+  - name: pull-node-feature-discovery-build-image-generic
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -83,7 +37,7 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-image.sh
-  - name: pull-node-feature-discovery-build-image-cross
+  - name: pull-node-feature-discovery-build-image-cross-generic
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -107,7 +61,7 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-image-cross.sh
-  - name: pull-node-feature-discovery-build-gh-pages
+  - name: pull-node-feature-discovery-build-gh-pages-generic
     run_if_changed: "^docs/"
     skip_branches:
     - gh-pages

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -1,0 +1,44 @@
+presubmits:
+  kubernetes-sigs/node-feature-discovery:
+  - name: pull-node-feature-discovery-verify-master
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^master
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-master
+      description: "Verify source code of node-feature-discovery: check formatting, lint etc."
+    spec:
+      containers:
+      - image: golang:1.19
+        command:
+        - scripts/test-infra/verify.sh
+  - name: pull-node-feature-discovery-verify-docs-master
+    run_if_changed: "^docs/"
+    branches:
+    - ^master
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-docs-master
+      description: "Verify documentation sources"
+    spec:
+      containers:
+      - image: ruby:slim
+        command:
+        - scripts/test-infra/mdlint.sh
+  - name: pull-node-feature-discovery-build-master
+    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^master
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: build-master
+      description: "Build node-feature-discovery binaries"
+    spec:
+      containers:
+      - image: golang:1.19
+        command:
+        - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-10.yaml
@@ -1,0 +1,44 @@
+presubmits:
+  kubernetes-sigs/node-feature-discovery:
+  - name: pull-node-feature-discovery-verify-release-0-10
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^release-0.10
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-release-0.10
+      description: "Verify source code of node-feature-discovery: check formatting, lint etc."
+    spec:
+      containers:
+      - image: golang:1.17
+        command:
+        - scripts/test-infra/verify.sh
+  - name: pull-node-feature-discovery-verify-docs-release-0-10
+    run_if_changed: "^docs/"
+    branches:
+    - ^release-0.10
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-docs-release-0.10
+      description: "Verify documentation sources"
+    spec:
+      containers:
+      - image: ruby:2.7
+        command:
+        - scripts/test-infra/mdlint.sh
+  - name: pull-node-feature-discovery-build-release-0-10
+    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^release-0.10
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: build-release-0.10
+      description: "Build node-feature-discovery binaries"
+    spec:
+      containers:
+      - image: golang:1.17
+        command:
+        - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-11.yaml
@@ -1,0 +1,44 @@
+presubmits:
+  kubernetes-sigs/node-feature-discovery:
+  - name: pull-node-feature-discovery-verify-release-0-11
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^release-0.11
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-release-0.11
+      description: "Verify source code of node-feature-discovery: check formatting, lint etc."
+    spec:
+      containers:
+      - image: golang:1.17
+        command:
+        - scripts/test-infra/verify.sh
+  - name: pull-node-feature-discovery-verify-docs-release-0-11
+    run_if_changed: "^docs/"
+    branches:
+    - ^release-0.11
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-docs-release-0.11
+      description: "Verify documentation sources"
+    spec:
+      containers:
+      - image: ruby:2.7
+        command:
+        - scripts/test-infra/mdlint.sh
+  - name: pull-node-feature-discovery-build-release-0-11
+    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^release-0.11
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: build-release-0.11
+      description: "Build node-feature-discovery binaries"
+    spec:
+      containers:
+      - image: golang:1.17
+        command:
+        - scripts/test-infra/build.sh


### PR DESCRIPTION
This patch restructures jobs per branch so that we can control parameters
differently depending on the branch name. Starting from release-0.10 we
will have a separate file (branch name as prefix) to keep branch specific
parameters. For those jobs that are common between multiple branches,
a generic file is created.