### PR TITLE
Add Makefile target dockerfile-lint. Fix error findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ verify:
 .PHONY: verify-eslint
 verify-eslint:
 	hack/make-rules/verify/eslint.sh
+.PHONY: dockerfile-lint
+dockerfile-lint:
+	hack/make-rules/verify/dockerfile-lint.sh
 # go linters
 .PHONY: go-lint
 go-lint:

--- a/hack/make-rules/verify/dockerfile-lint.sh
+++ b/hack/make-rules/verify/dockerfile-lint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+HADOLINT_VER=${1:-v2.10.0}
+HADOLINT_FAILURE_THRESHOLD=${2:-error}
+
+FILES=$(find -- * -name Dockerfile)
+while read -r file; do
+  echo "Linting: ${file}"
+  # Configure the linter to fail for warnings and errors. Can be set to: error | warning | info | style | ignore | none
+  docker run --rm -i ghcr.io/hadolint/hadolint:"${HADOLINT_VER}" hadolint --failure-threshold "${HADOLINT_FAILURE_THRESHOLD}" - < "${file}"
+done <<< "${FILES}"

--- a/images/bigquery/Dockerfile
+++ b/images/bigquery/Dockerfile
@@ -42,5 +42,5 @@ RUN gcloud config set core/disable_usage_reporting true && \
     gcloud --version
 
 WORKDIR /workspace
-ADD runner /
+COPY runner /
 ENTRYPOINT ["/bin/bash", "/runner"]

--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -54,7 +54,7 @@ RUN cp /qemu-bin/qemu-* /usr/bin/ && \
     rm -rf /qemu-bin
 COPY --from=qemu-image /qemu-binfmt-conf.sh /qemu-binfmt-conf.sh
 COPY --from=qemu-image /register /register
-ADD ./buildx-entrypoint.sh /buildx-entrypoint
+COPY ./buildx-entrypoint.sh /buildx-entrypoint
 
 RUN apk add qemu
 

--- a/images/gcloud-in-go/Dockerfile
+++ b/images/gcloud-in-go/Dockerfile
@@ -43,5 +43,5 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
-ADD runner /
+COPY runner /
 ENTRYPOINT ["/bin/bash", "/runner"]

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -123,11 +123,11 @@ ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
 # everything below will be triggered on every new image tag ...
-ADD ["images/kubekins-e2e/kops-e2e-runner.sh", \
-    "images/kubekins-e2e/kubetest", \
-    "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \
-    "logexporter/cluster/log-dump.sh", \
-    "logexporter/cluster/logexporter-daemonset.yaml", \
-    "/workspace/"]
+COPY ["images/kubekins-e2e/kops-e2e-runner.sh", \
+      "images/kubekins-e2e/kubetest", \
+      "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \
+      "logexporter/cluster/log-dump.sh", \
+      "logexporter/cluster/logexporter-daemonset.yaml", \
+      "/workspace/"]
 ENV LOG_DUMP_SCRIPT_PATH "/workspace/log-dump.sh"
 RUN ["chmod", "+x", "/workspace/get-kube.sh", "/workspace/log-dump.sh"]

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -40,7 +40,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     ./google-cloud-sdk/install.sh -q && \
     ln -s /google-cloud-sdk/bin/* /bin/
 
-ADD *.py schema.json runner.sh buckets.yaml /kettle/
+COPY *.py schema.json runner.sh buckets.yaml /kettle/
 
 VOLUME ["/data"]
 

--- a/logexporter/cmd/Dockerfile
+++ b/logexporter/cmd/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && \
     apt-get install -y systemd python3
 
 # Setup gcloud SDK for using gsutil.
-ADD ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
-     "/workspace/"]
+COPY ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
+      "/workspace/"]
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
@@ -35,7 +35,7 @@ RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
     gcloud info | tee /workspace/gcloud-info.txt
 
 # Setup the log exporter script.
-ADD ["logexporter", "/workspace/"]
+COPY ["logexporter", "/workspace/"]
 WORKDIR "/workspace"
 
 ENTRYPOINT ["/workspace/logexporter"]


### PR DESCRIPTION
Adds a Makefile target to lint dockerfiles. Also fixes the findings. 

The script is more or less the same as I added to cluster-api but I changed the default version from latest to v2.10.0 and the failure threshold to error. Hopefully in the near future we can work to lower the threshold to warning.

script output with the fixes in this pr
```shell
make dockerfile-lint
hack/make-rules/verify/dockerfile-lint.sh
Linting: experiment/clusterfuzzlite/Dockerfile
-:18 DL3007 warning: Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
-:19 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:28 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:38 SC1091 info: Not following: File not included in mock.
-:38 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:58 SC2016 info: Expressions don't expand in single quotes, use double quotes for that.
-:58 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:65 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:66 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:68 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
Linting: gencred/Dockerfile
Linting: images/alpine/Dockerfile
-:15 DL3007 warning: Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
-:20 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
Linting: images/bazelbuild/Dockerfile
-:26 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:26 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:52 DL3016 warning: Pin versions in npm. Instead of `npm install <package>` use `npm install <package>@<version>`
Linting: images/gcb-docker-gcloud/Dockerfile
-:32 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
-:36 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
-:37 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
-:59 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
-:59 DL3019 info: Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages
Linting: images/gcloud-terraform/Dockerfile
-:25 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
-:40 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Linting: images/gcloud-in-go/Dockerfile
-:23 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:23 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:36 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Linting: images/bootstrap/Dockerfile
-:30 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:30 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:67 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:86 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:96 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:96 DL4001 warning: Either use Wget or Curl but not both
-:96 SC1091 info: Not following: File not included in mock.
-:118 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:118 SC2016 info: Expressions don't expand in single quotes, use double quotes for that.
Linting: images/pull-test-infra-gubernator/Dockerfile
-:20 DL3027 warning: Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead
-:30 DL3027 warning: Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead
-:30 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:30 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
Linting: images/builder/Dockerfile
Linting: images/bigquery/Dockerfile
-:17 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:17 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:31 SC1083 warning: This } is literal. Check expression (missing ;/\n?) or quote it.
-:36 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
-:37 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
-:37 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
-:38 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
-:39 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Linting: images/bazel/Dockerfile
Linting: images/git/Dockerfile
-:20 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
Linting: images/kubekins-e2e/Dockerfile
-:40 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:40 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:47 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:61 SC2086 info: Double quote to prevent globbing and word splitting.
-:61 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
-:61 DL4001 warning: Either use Wget or Curl but not both
-:69 DL4001 warning: Either use Wget or Curl but not both
-:75 DL4001 warning: Either use Wget or Curl but not both
-:93 SC2015 info: Note that A && B || C is not if-then-else. C may run when A is true.
-:93 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:100 DL4001 warning: Either use Wget or Curl but not both
-:107 DL4001 warning: Either use Wget or Curl but not both
-:117 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Linting: images/krte/Dockerfile
-:52 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:52 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:52 SC1091 info: Not following: File not included in mock.
Linting: kettle/Dockerfile
-:19 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:19 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:33 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:36 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:39 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Linting: logexporter/cmd/Dockerfile
-:21 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:21 DL3009 info: Delete the apt-get lists after installing something
-:21 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:29 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Linting: pkg/benchmarkjunit/Dockerfile
Linting: triage/Dockerfile
-:42 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
```