### PR TITLE
kubekins-e2e use go 1.19.1 for test-infra and experimental variants

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.18.6
+    GO_VERSION: 1.19.1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -15,7 +15,7 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.18.6
+    GO_VERSION: 1.19.1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0


### PR DESCRIPTION
Preparing dependency and go version updates by bumping go version in these variants.