### PR TITLE
test-infra: enable nilness linter and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,9 @@ linters-settings:
     threshold: 100
   gocyclo:
     min-complexity: 50
+  govet:
+    enable:
+      - nilness
 
 linters:
   enable:

--- a/experiment/service-account-creator/main.go
+++ b/experiment/service-account-creator/main.go
@@ -152,7 +152,7 @@ func run(o options) error {
 			logrus.WithField("serviceAccount", user).Warn("Cannot parse prefix and project from service account")
 			return fmt.Errorf("validate account pre-existence: %w", err)
 		}
-		if cerr := create(o.serviceAccountProject, o.serviceAccountPrefix); err != nil {
+		if cerr := create(o.serviceAccountProject, o.serviceAccountPrefix); cerr != nil {
 			return fmt.Errorf("create account: %w", cerr)
 		}
 	}

--- a/kubetest/aks.go
+++ b/kubetest/aks.go
@@ -208,9 +208,6 @@ func (a *aksDeployer) Up() error {
 		return fmt.Errorf("failed to extract resulting managed cluster: %w", err)
 	}
 	masterIP := *managedCluster.ManagedClusterProperties.Fqdn
-	if err != nil {
-		return fmt.Errorf("failed to get masterIP: %w", err)
-	}
 	masterInternalIP := masterIP
 
 	if err := os.Setenv("KUBE_MASTER_IP", strings.TrimSpace(string(masterIP))); err != nil {

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -459,7 +459,7 @@ func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch
 	}
 
 	// Return error if apps restrictions if feature is disabled, but there are apps restrictions in the config
-	if !p.enableAppsRestrictions && bp != nil && bp.Restrictions != nil && bp.Restrictions.Apps != nil {
+	if !p.enableAppsRestrictions && bp.Restrictions != nil && bp.Restrictions.Apps != nil {
 		return fmt.Errorf("'enable-apps-restrictions' command line flag is not true, but Apps Restrictions are maintained for %s/%s=%s", orgName, repo, branchName)
 	}
 

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -884,7 +884,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 				if !tc.err {
 					t.Errorf("unexpected error: %v", err)
 				}
-			case err == nil && tc.err:
+			case tc.err:
 				t.Errorf("failed to receive an error")
 			default:
 				normalize(actual)


### PR DESCRIPTION
This pr enables the govet nilness linter and fixes the findings. It actually found some interesting mistakes in the code which are hard to find without it.

Note to reviewers: when reviewing look at the findings below and the checks that are done before the findings. In most cases there are explicit checks earlier that make the findings understandable.

Linter output:
```
experiment/service-account-creator/main.go:155:75: nilness: tautological condition: non-nil != nil (govet)
                if cerr := create(o.serviceAccountProject, o.serviceAccountPrefix); err != nil {
                                                                                        ^
kubetest/aks.go:211:9: nilness: impossible condition: nil != nil (govet)
        if err != nil {
               ^
prow/cmd/branchprotector/protect.go:462:37: nilness: tautological condition: non-nil != nil (govet)
        if !p.enableAppsRestrictions && bp != nil && bp.Restrictions != nil && bp.Restrictions.Apps != nil {
                                           ^
prow/config/branch_protection_test.go:887:13: nilness: tautological condition: nil == nil (govet)
                        case err == nil && tc.err:
                                 ^
```