### PR TITLE
Update go version to v1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -12,7 +12,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.19
         command:
         - /bin/bash
         - -c

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -12,7 +12,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.19
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Tests failed due to Go version.
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kube-scheduler-simulator/228/pull-kube-scheduler-simulator-backend-unit-test/1571294742459715584