### PR TITLE
Flipped checkconfig-beta to required

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -47,34 +47,8 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: gubernator
 
-  # Please keep this in sync with the `ci-test-infra-prow-checkconfig` job
   - name: pull-test-infra-prow-checkconfig
     decorate: true
-    run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
-    spec:
-      containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20220916-c3af09ab20
-        command:
-        - checkconfig
-        args:
-        - --config-path=config/prow/config.yaml
-        - --job-config-path=config/jobs
-        - --plugin-config=config/prow/plugins.yaml
-        - --strict
-        - --warnings=mismatched-tide-lenient
-        - --warnings=tide-strict-branch
-        - --warnings=needs-ok-to-test
-        - --warnings=validate-owners
-        - --warnings=missing-trigger
-        - --warnings=validate-urls
-        - --warnings=unknown-fields
-        - --warnings=duplicate-job-refs
-    annotations:
-      testgrid-dashboards: presubmits-test-infra
-  - name: pull-test-infra-prow-checkconfig-beta
-    decorate: true
-    optional: true
-    always_run: false
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:


### PR DESCRIPTION
Presubmit job `pull-test-infra-prow-checkconfig-beta` flipped to required after it has been green over the weekend 