### PR TITLE
upgrade cypress/base for node 14.x

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: cypress/base:14.1.0
+      - image: cypress/base:14.17.6
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Required to run e2e tests for the changes under https://github.com/kubernetes-sigs/release-notes/pull/316


```bash
❯ docker run cypress/base:14.17.6 node --version
Unable to find image 'cypress/base:14.17.6' locally
14.17.6: Pulling from cypress/base
07aded7c29c6: Pull complete
92706508d124: Pull complete
55e8d26a9ca5: Pull complete
1d542bcc5a62: Pull complete
3864fb8d130a: Pull complete
f63d2f7e1363: Pull complete
e82a15f40576: Pull complete
Digest: sha256:64fe1c4800e1a7487f870897cf2334f737d6c8d3eeddbf525ff560f7ea0da3ec
Status: Downloaded newer image for cypress/base:14.17.6
v14.17.6
```