### PR TITLE
Updating timeout for SIG-windows serial slow jobs on master

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -108,7 +108,7 @@ periodics:
   interval: 24h
   decorate: true
   decoration_config:
-    timeout: 4h
+    timeout: 5h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -183,7 +183,7 @@ periodics:
   interval: 24h
   decorate: true
   decoration_config:
-    timeout: 4h
+    timeout: 5h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Recently the `ginkgo.timeout` for these jobs was increased from 3 hours to 4 hours (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2653) to address job timeouts.

This improved the stability of the v1.25 serial slow tests 
![image](https://user-images.githubusercontent.com/18291632/191072948-22bec559-f4f5-4a03-84d6-9e4432a043e4.png)

Unfortunately it looks like there are other issues in the serial slow tests on master that are causing the test job to run for the full 4 hours. Since the PROW job is also configured to only run for 4 hours the resulting test-pass artifacts are getting malformed. 
https://testgrid.k8s.io/sig-windows-master-release#capz-windows-containerd-master-serial-slow

This PR updates the PROW job timeout to assist in debugging the other test issues.