### PR TITLE
upgrade cypress/base to enable child process management

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: cypress/base:14.17.6
+      - image: cypress/base:18.6.0
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Changes done via https://github.com/kubernetes/test-infra/pull/27567 were not enough to handle the child process management of the cypress runtime for `e2e` tests. 


xref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_release-notes/316/pull-release-notes-e2e/1571903632096366592

```bash
[?25hevents.js:377
      throw er; // Unhandled 'error' event
      ^
Error: spawn ps ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:269:19)
    at onErrorNT (internal/child_process.js:467:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
    at onErrorNT (internal/child_process.js:467:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn ps',
  path: 'ps',
  spawnargs: [ '-A', '-o', 'ppid,pid,stat,comm' ]
}
```
Seems like this is due to the missing `ps` capability in the version used. Up ticking to the latest one solved the issue.

```bash
❯ npm run e2e-cy-ci-docker

> relnotes@1.0.0 e2e-cy-ci-docker
> docker build . -f Dockerfile-dev -t relenotes:dev-build --build-arg BASE=cypress/base:16.17.0 && docker run relenotes:dev-build npm run e2e-cy-ci

[+] Building 318.6s (11/11) FINISHED
 => [internal] load build definition from Dockerfile-dev                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 815B                                                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                          0.0s
 => => transferring context: 111B                                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/cypress/base:16.17.0                                                                                                                                                                                                            4.9s
 => [1/6] FROM docker.io/cypress/base:16.17.0@sha256:158c406df6d039d27d407a00c0caa05db6224e01d335911c3f5a3003b35fcc09                                                                                                                                                     57.4s
 => => resolve docker.io/cypress/base:16.17.0@sha256:158c406df6d039d27d407a00c0caa05db6224e01d335911c3f5a3003b35fcc09                                                                                                                                                      0.0s
 => => sha256:158c406df6d039d27d407a00c0caa05db6224e01d335911c3f5a3003b35fcc09 743B / 743B                                                                                                                                                                                 0.0s
 => => sha256:065fda631bffac8aa07440d44064117eee8bbfb50d65e04dbd5b29021c0140bf 4.18kB / 4.18kB                                                                                                                                                                             0.8s
 => => sha256:8870f8b81b668639dc33301e8197b549f9d7a8fb85598376cc3cccdc8e0282ec 35.35MB / 35.35MB                                                                                                                                                                          21.0s
 => => sha256:7220c1c470ce4cb258947a4f4e983915a5ef5cfe8a4060e6fe2f31c05e8645a9 1.79kB / 1.79kB                                                                                                                                                                             0.0s
 => => sha256:8526dd794363acbc4bc08274832e098dac1c626d4ff18b7fbb2e6f82a989d11f 8.21kB / 8.21kB                                                                                                                                                                             0.0s
 => => sha256:ec1aeb08c8d655334863d3f8cbada8f83783bcbf4daa4c04868a404169c9e97a 2.77MB / 2.77MB                                                                                                                                                                             0.8s
 => => extracting sha256:065fda631bffac8aa07440d44064117eee8bbfb50d65e04dbd5b29021c0140bf                                                                                                                                                                                  0.5s
 => => sha256:966b53e24fb119c330b50554b3fb4ee6405799a4389684d4edbf8b0350a60ed8 206.40MB / 206.40MB                                                                                                                                                                        47.3s
 => => sha256:f41346f34487d2de1801efdbb3cc550aa6ba3ac1b5778c7fdb8ed411b7ac1db5 451B / 451B                                                                                                                                                                                 1.3s
 => => sha256:966ce9fb4d3c94daf6253b3e2dc89e8706533bd3612241e248fa967b8488cb51 3.74MB / 3.74MB                                                                                                                                                                             4.0s
 => => extracting sha256:8870f8b81b668639dc33301e8197b549f9d7a8fb85598376cc3cccdc8e0282ec                                                                                                                                                                                  1.6s
 => => extracting sha256:ec1aeb08c8d655334863d3f8cbada8f83783bcbf4daa4c04868a404169c9e97a                                                                                                                                                                                  0.2s
 => => extracting sha256:f41346f34487d2de1801efdbb3cc550aa6ba3ac1b5778c7fdb8ed411b7ac1db5                                                                                                                                                                                  0.0s
 => => extracting sha256:966b53e24fb119c330b50554b3fb4ee6405799a4389684d4edbf8b0350a60ed8                                                                                                                                                                                  9.7s
 => => extracting sha256:966ce9fb4d3c94daf6253b3e2dc89e8706533bd3612241e248fa967b8488cb51                                                                                                                                                                                  0.1s
 => [internal] load build context                                                                                                                                                                                                                                         10.9s
 => => transferring context: 546.52MB                                                                                                                                                                                                                                     10.9s
 => [2/6] COPY package-lock.json ./                                                                                                                                                                                                                                        0.5s
 => [3/6] COPY package.json ./                                                                                                                                                                                                                                             0.0s
 => [4/6] RUN npm ci && mkdir /ng-app && mv ./node_modules ./ng-app                                                                                                                                                                                                      203.8s
 => [5/6] WORKDIR /ng-app                                                                                                                                                                                                                                                  0.0s
 => [6/6] COPY . .                                                                                                                                                                                                                                                         7.2s
 => exporting to image                                                                                                                                                                                                                                                    44.4s
 => => exporting layers                                                                                                                                                                                                                                                   44.4s
 => => writing image sha256:123b4422d24c693f5a4e1aaffa8cab6dac30a42c038d1cb9258cd6d9f191884a                                                                                                                                                                               0.0s
 => => naming to docker.io/library/relenotes:dev-build                                                                                                                                                                                                                     0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

> relnotes@1.0.0 e2e-cy-ci
> start-server-and-test start:test http-get://localhost:4200 e2e-cy

1: starting server using command "npm run start:test"
and when url "[ 'http-get://localhost:4200' ]" is responding with HTTP status code 200
running tests using command "npm run e2e-cy"


> relnotes@1.0.0 start:test
> ng serve --configuration=test

- Generating browser application bundles (phase: setup)...
✔ Browser application bundle generation complete.

Initial Chunk Files   | Names         |  Raw Size
vendor.js             | vendor        |   4.40 MB |
polyfills.js          | polyfills     |   1.15 MB |
styles.css, styles.js | styles        | 388.95 kB |
scripts.js            | scripts       | 170.13 kB |
main.js               | main          | 108.26 kB |
runtime.js            | runtime       |   6.51 kB |

| Initial Total |   6.21 MB

Build at: 2022-09-19T17:22:27.980Z - Hash: b05f4c01ff7752f9 - Time: 26510ms

./node_modules/bootstrap/dist/css/bootstrap.css.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[5].rules[0].oneOf[0].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[5].rules[0].oneOf[0].use[2]!./node_modules/bootstrap/dist/css/bootstrap.css - Warning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
Warning

(3769:3) autoprefixer: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.



** Angular Live Development Server is listening on localhost:4200, open your browser on http://localhost:4200/ **


✔ Compiled successfully.

> relnotes@1.0.0 e2e-cy
> cypress run

[17:22:29]  Verifying Cypress can run /root/.cache/Cypress/4.12.1/Cypress [started]
✔ Browser application bundle generation complete.

Initial Chunk Files | Names   | Raw Size
runtime.js          | runtime |  6.51 kB |

5 unchanged chunks

Build at: 2022-09-19T17:22:29.199Z - Hash: 6a8b6144a4495525 - Time: 722ms

✔ Compiled successfully.
[17:22:32]  Verified Cypress!       /root/.cache/Cypress/4.12.1/Cypress [title changed]
[17:22:32]  Verified Cypress!       /root/.cache/Cypress/4.12.1/Cypress [completed]

================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:    4.12.1                                                                             │
  │ Browser:    Electron 80 (headless)                                                             │
  │ Specs:      1 found (app.spec.ts)                                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────

  Running:  app.spec.ts                                                                     (1 of 1)


  Release Notes App
    ✓ should have the correct title (1755ms)
    ✓ should have everything visible (1020ms)
    ✓ should show only entries for version '1.14.0' if selected (1152ms)
    ✓ should show only entries for version '1.15.0' if selected (1064ms)
    ✓ should show only 'kubelet' entries if selected (627ms)
    ✓ should be possible to filter two options together (715ms)
    ✓ should be possible to search entries (678ms)
    ✓ should be possible to open the 'About' page (807ms)
    ✓ should be open the 'Additional Documentation' tooltip on hover (636ms)
    ✓ should be possible to open the 'Additional Documentation' (804ms)
    ✓ should be possible to filter 'KEP' doc types (641ms)
    ✓ should be possible to filter 'external' doc types (663ms)
    ✓ should show double filtered documentation entries only once (797ms)
    ✓ should be possible to access the page with pre defined filter (1294ms)
    ✓ should be possible to enable showing pre-releases (973ms)
    ✓ should be possible to filter via the labels ('bug') (626ms)
    ✓ should be possible to filter via the labels ('testing') (655ms)


  17 passing (15s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        17                                                                               │
  │ Passing:      17                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     15 seconds                                                                       │
  │ Spec Ran:     app.spec.ts                                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  app.spec.ts                              00:15       17       17        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:15       17       17        -        -        -
``` 
