### PR TITLE
update team for permissions to edit tracked labels

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -162,12 +162,15 @@ label:
       - label: tracked/no
         allowed_teams:
         - release-team-enhancements
+        - release-team-leads
       - label: tracked/yes
         allowed_teams:
         - release-team-enhancements
+        - release-team-leads
       - label: tracked/out-of-tree
         allowed_teams:
         - release-team-enhancements
+        - release-team-leads
       # Restrict setting of 'lead-opted-in' label to SIG leads.
       - label: lead-opted-in
         allowed_teams:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -161,16 +161,17 @@ label:
       # Restrict setting of tracked/* labels to the enhancements team.
       - label: tracked/no
         allowed_teams:
-        - enhancements
+        - release-team-enhancements
       - label: tracked/yes
         allowed_teams:
-        - enhancements
+        - release-team-enhancements
       - label: tracked/out-of-tree
         allowed_teams:
-        - enhancements
+        - release-team-enhancements
       # Restrict setting of 'lead-opted-in' label to SIG leads.
-      - label: lead-opted-in  
+      - label: lead-opted-in
         allowed_teams:
+        - release-team-enhancements
         - sig-api-machinery-leads
         - sig-apps-leads
         - sig-architecture-leads


### PR DESCRIPTION
Update the Github team used to give the enhancements team permission to the tracked labels. 

/cc @leonardpahlke @marosset 