### PR TITLE
Clean up K8s 1.16 dashboards for Gardener

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -121,21 +121,6 @@ dashboards:
     - name: Gardener, v1.17 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.17
-    - name: Gardener, v1.16 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.16
-    - name: Gardener, v1.16 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.16
-    - name: Gardener, v1.16 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.16
-    - name: Gardener, v1.16 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.16
-    - name: Gardener, v1.16 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.16
 
 - name: conformance-apisnoop
 - name: conformance-gce
@@ -362,31 +347,6 @@ dashboards:
     - name: Gardener, v1.17 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.17
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.16 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.16
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.16 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.16
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.16 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.16
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.16 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.16
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.16 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.16
       alert_options:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
@@ -654,31 +614,6 @@ test_groups:
   disable_prowjob_analysis: true
 - name: ci-gardener-e2e-conformance-alicloud-v1.17
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.17
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-aws-v1.16
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.16
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-gce-v1.16
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.16
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-openstack-v1.16
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.16
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-azure-v1.16
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.16
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-alicloud-v1.16
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.16
   alert_stale_results_hours: 168
   num_failures_to_alert: 1
   disable_prowjob_analysis: true


### PR DESCRIPTION
/kind cleanup

Gardener no longer supports Kubernetes 1.16. This PR cleans up Gardener related dashboards for Kubernetes 1.16.