### PR TITLE
Fix Feature Gates for E2E HPA tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -207,10 +207,8 @@ periodics:
       - --gcp-project=k8s-jkns-gci-autoscaling
       - --gcp-zone=us-west1-b
       - --provider=gce
-      # Enable HPAContainerMetrics. Required for container metrics tests.
-      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
-      # Enable HPAScaleToZero. Required for scale to zero test scenario.
-      - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
+      # Enable HPAContainerMetrics and HPAScaleToZero. Required for container metrics and scale to zero tests.
+      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true,HPAScaleToZero=true
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master
@@ -271,10 +269,8 @@ periodics:
       - --gcp-project=k8s-jkns-gci-autoscaling-migs
       - --gcp-zone=us-west1-b
       - --provider=gce
-      # Enable HPAContainerMetrics. Required for container metrics tests.
-      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
-      # Enable HPAScaleToZero. Required for scale to zero test scenario.
-      - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
+      # Enable HPAContainerMetrics and HPAScaleToZero. Required for container metrics and scale to zero tests.
+      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true,HPAScaleToZero=true
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220903-da891f21aa-master


### PR DESCRIPTION
Fix Features Gates - they need to be separated by comma instead of passed as separate arguments (otherwise they overwrite each other).