### PR TITLE
Inrepoconfig cache handler is consumed directly

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -136,7 +136,11 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating opener")
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheGetter(ca, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, &o.config.InRepoConfigCacheDirBase, prowflagutil.GitHubOptions{}, o.cookiefilePath, o.dryRun)
+	gitClient, err := (&prowflagutil.GitHubOptions{}).GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating git client.")
+	}
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, ca, gitClient, o.config.InRepoConfigCacheCopies)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -133,17 +133,21 @@ func main() {
 		}
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheGetter(configAgent, o.config.InRepoConfigCacheSize, o.config.InRepoConfigCacheCopies, &o.config.InRepoConfigCacheDirBase, o.github, o.cookiefilePath, o.dryRun)
+	gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Git client.")
+	}
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}
 
 	s := &subscriber.Subscriber{
-		ConfigAgent:             configAgent,
-		Metrics:                 promMetrics,
-		ProwJobClient:           kubeClient,
-		Reporter:                pubsub.NewReporter(configAgent.Config), // reuse crier reporter
-		InRepoConfigCacheGetter: cacheGetter,
+		ConfigAgent:              configAgent,
+		Metrics:                  promMetrics,
+		ProwJobClient:            kubeClient,
+		Reporter:                 pubsub.NewReporter(configAgent.Config), // reuse crier reporter
+		InRepoConfigCacheHandler: cacheGetter,
 	}
 
 	subMux := http.NewServeMux()

--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -20,14 +20,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os/exec"
-	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/cache"
-	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/git/v2"
 )
 
@@ -72,87 +69,6 @@ type InrepoconfigPostsubmitRequest struct {
 	HeadSHAGetters []RefGetter
 	resChan        chan []Postsubmit
 	errChan        chan error
-}
-
-type InRepoConfigCacheGetter struct {
-	CacheSize      int
-	CacheCopies    int
-	CacheDir       string
-	Agent          *Agent
-	mu             sync.Mutex
-	GitHubOptions  flagutil.GitHubOptions
-	CookieFilePath string
-	DryRun         bool
-
-	Cache *InRepoConfigCacheHandler
-}
-
-// NewInRepoConfigCacheGetter initialize InRepoConfigCacheGetter.
-func NewInRepoConfigCacheGetter(
-	configAgent *Agent,
-	inRepoConfigCacheSize int,
-	inRepoConfigCacheCopies int,
-	inRepoConfigCacheDirBase *string,
-	gitHubOptions flagutil.GitHubOptions,
-	cookieFilePath string,
-	dryRun bool,
-) (*InRepoConfigCacheGetter, error) {
-
-	// If we are provided credentials for Git hosts, use them. These credentials
-	// hold per-host information in them so it's safe to set them globally.
-	if cookieFilePath != "" {
-		cmd := exec.Command("git", "config", "--global", "http.cookiefile", cookieFilePath)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return nil, fmt.Errorf("unable to set cookiefile. Error: %v\nOutput: %s", err, string(out))
-		}
-	}
-
-	c := &InRepoConfigCacheGetter{
-		CacheSize:      inRepoConfigCacheSize,
-		CacheCopies:    inRepoConfigCacheCopies,
-		Agent:          configAgent,
-		mu:             sync.Mutex{},
-		GitHubOptions:  gitHubOptions,
-		CookieFilePath: cookieFilePath,
-		DryRun:         dryRun,
-	}
-	if inRepoConfigCacheDirBase != nil && *inRepoConfigCacheDirBase != "" {
-		c.CacheDir = *inRepoConfigCacheDirBase
-	}
-	return c, nil
-}
-
-// GetCache returns InRepoConfigCacheHandler based on authentication methods. If
-// GitHub bot token or GitHub app private key is provided then returns handler
-// that works best with GitHub, if http.cookiefile is provided then returns
-// handler that authenticate with cookiefile.
-func (irc *InRepoConfigCacheGetter) GetCache() (*InRepoConfigCacheHandler, error) {
-	// No repo is cloned in getCache, Since this function should happen fast it is safe to lock the whole function.
-	irc.mu.Lock()
-	defer irc.mu.Unlock()
-	if irc.Cache != nil {
-		return irc.Cache, nil
-	}
-
-	gitClientFactory, err := irc.GitHubOptions.GitClientFactory(irc.CookieFilePath, &irc.CacheDir, irc.DryRun)
-	if err != nil {
-		return nil, fmt.Errorf("failed creating git client: %v", err)
-	}
-
-	// Initialize cache for fetching Presubmit and Postsubmit information. If
-	// the cache cannot be initialized, exit with an error.
-	cache, err := NewInRepoConfigCacheHandler(
-		irc.CacheSize,
-		irc.Agent,
-		NewInRepoConfigGitCache(gitClientFactory),
-		irc.CacheCopies)
-	// If we cannot initialize the cache, exit with an error.
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize in-repo-config-cache with size %d: %v", irc.CacheSize, err)
-	}
-
-	irc.Cache = cache
-	return cache, nil
 }
 
 type InRepoConfigCacheHandler struct {

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -105,11 +105,11 @@ type ProwJobClient interface {
 // validates them using Prow Configuration and
 // use a ProwJobClient to create Prow Jobs.
 type Subscriber struct {
-	ConfigAgent             *config.Agent
-	Metrics                 *Metrics
-	ProwJobClient           ProwJobClient
-	Reporter                reportClient
-	InRepoConfigCacheGetter *config.InRepoConfigCacheGetter
+	ConfigAgent              *config.Agent
+	Metrics                  *Metrics
+	ProwJobClient            ProwJobClient
+	Reporter                 reportClient
+	InRepoConfigCacheHandler *config.InRepoConfigCacheHandler
 }
 
 type messageInterface interface {
@@ -456,16 +456,7 @@ func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageIn
 	// Normalize job name
 	pe.Name = strings.TrimSpace(pe.Name)
 
-	var cache *config.InRepoConfigCacheHandler
-	var err error
-	if eType != PeriodicProwJobEvent {
-		cache, err = s.InRepoConfigCacheGetter.GetCache()
-		if err != nil {
-			return err
-		}
-	}
-
-	prowJobSpec, labels, err := jh.getProwJobSpec(s.ConfigAgent.Config(), cache, pe)
+	prowJobSpec, labels, err := jh.getProwJobSpec(s.ConfigAgent.Config(), s.InRepoConfigCacheHandler, pe)
 	if err != nil {
 		// These are user errors, i.e. missing fields, requested prowjob doesn't exist etc.
 		// These errors are already surfaced to user via pubsub two lines below.

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -301,19 +301,14 @@ func TestHandleMessage(t *testing.T) {
 			tc.config.ProwJobNamespace = "prowjobs"
 			ca.Set(tc.config)
 			fr := fakeReporter{}
+			gitClient, _ := (&flagutil.GitHubOptions{}).GitClientFactory("abc", nil, true)
+			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1)
 			s := Subscriber{
-				Metrics:       NewMetrics(),
-				ProwJobClient: fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),
-				ConfigAgent:   ca,
-				Reporter:      &fr,
-				InRepoConfigCacheGetter: &config.InRepoConfigCacheGetter{
-					CacheSize:      100,
-					CacheCopies:    1,
-					Agent:          ca,
-					GitHubOptions:  flagutil.GitHubOptions{},
-					CookieFilePath: "abc",
-					DryRun:         true,
-				},
+				Metrics:                  NewMetrics(),
+				ProwJobClient:            fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),
+				ConfigAgent:              ca,
+				Reporter:                 &fr,
+				InRepoConfigCacheHandler: cacheHandler,
 			}
 			if tc.pe != nil {
 				m, err := tc.pe.ToMessageOfType(tc.eventType)


### PR DESCRIPTION
Current logic is `cacheGetter := NewInRepoConfigCacheGetter(); cacheHandler := cacheGetter.GetCache()`, no need to keep the outer layer since it's 1:1 mapped

/cc @cjwagner @listx 