### PR TITLE
add lead-opted-in label and updated tracked/* label docs

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -50,7 +50,7 @@ sync github labels across repos in the [kubernetes github org](https://github.co
 
 The rule of thumb is that labels are here because they are intended to be produced or consumed by
 our automation (primarily prow) across all repos. There are some labels that can only be manually
-applied/removed, and where possible we would rather remove them or add automation to allow a 
+applied/removed, and where possible we would rather remove them or add automation to allow a
 larger set of contributors to apply/remove them.
 
 ### How do I add a new label?
@@ -346,12 +346,13 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="lead-opted-in" href="#lead-opted-in">`lead-opted-in`</a> | Denotes that an issue has been opted in to a release| SIG leads ONLY | |
 | <a id="stage/alpha" href="#stage/alpha">`stage/alpha`</a> | Denotes an issue tracking an enhancement targeted for Alpha status| anyone |  [stage](https://git.k8s.io/test-infra/prow/plugins/stage) |
 | <a id="stage/beta" href="#stage/beta">`stage/beta`</a> | Denotes an issue tracking an enhancement targeted for Beta status| anyone |  [stage](https://git.k8s.io/test-infra/prow/plugins/stage) |
 | <a id="stage/stable" href="#stage/stable">`stage/stable`</a> | Denotes an issue tracking an enhancement targeted for Stable/GA status| anyone |  [stage](https://git.k8s.io/test-infra/prow/plugins/stage) |
-| <a id="tracked/no" href="#tracked/no">`tracked/no`</a> | Denotes an enhancement issue is NOT actively being tracked by the Release Team| humans | |
-| <a id="tracked/out-of-tree" href="#tracked/out-of-tree">`tracked/out-of-tree`</a> | Denotes an out-of-tree enhancement issue, which does not need to be tracked by the Release Team| humans | |
-| <a id="tracked/yes" href="#tracked/yes">`tracked/yes`</a> | Denotes an enhancement issue is actively being tracked by the Release Team| humans | |
+| <a id="tracked/no" href="#tracked/no">`tracked/no`</a> | Denotes an enhancement issue is NOT actively being tracked by the Release Team| Release enhancements team ONLY | |
+| <a id="tracked/out-of-tree" href="#tracked/out-of-tree">`tracked/out-of-tree`</a> | Denotes an out-of-tree enhancement issue, which does not need to be tracked by the Release Team| Release enhancements team ONLY | |
+| <a id="tracked/yes" href="#tracked/yes">`tracked/yes`</a> | Denotes an enhancement issue is actively being tracked by the Release Team| Release enhancements team ONLY | |
 
 ## Labels that apply to kubernetes/k8s.io, for both issues and PRs
 
@@ -560,5 +561,3 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="refactor" href="#refactor">`refactor`</a> | Indicates a PR with large refactoring changes e.g. removes files or moves content| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-
-

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -50,7 +50,7 @@ sync github labels across repos in the [kubernetes github org](https://github.co
 
 The rule of thumb is that labels are here because they are intended to be produced or consumed by
 our automation (primarily prow) across all repos. There are some labels that can only be manually
-applied/removed, and where possible we would rather remove them or add automation to allow a
+applied/removed, and where possible we would rather remove them or add automation to allow a 
 larger set of contributors to apply/remove them.
 
 ### How do I add a new label?
@@ -346,13 +346,13 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="lead-opted-in" href="#lead-opted-in">`lead-opted-in`</a> | Denotes that an issue has been opted in to a release| SIG leads ONLY | |
+| <a id="lead-opted-in" href="#lead-opted-in">`lead-opted-in`</a> | Denotes that an issue has been opted in to a release| SIG leads ONLY |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="stage/alpha" href="#stage/alpha">`stage/alpha`</a> | Denotes an issue tracking an enhancement targeted for Alpha status| anyone |  [stage](https://git.k8s.io/test-infra/prow/plugins/stage) |
 | <a id="stage/beta" href="#stage/beta">`stage/beta`</a> | Denotes an issue tracking an enhancement targeted for Beta status| anyone |  [stage](https://git.k8s.io/test-infra/prow/plugins/stage) |
 | <a id="stage/stable" href="#stage/stable">`stage/stable`</a> | Denotes an issue tracking an enhancement targeted for Stable/GA status| anyone |  [stage](https://git.k8s.io/test-infra/prow/plugins/stage) |
-| <a id="tracked/no" href="#tracked/no">`tracked/no`</a> | Denotes an enhancement issue is NOT actively being tracked by the Release Team| Release enhancements team ONLY | |
-| <a id="tracked/out-of-tree" href="#tracked/out-of-tree">`tracked/out-of-tree`</a> | Denotes an out-of-tree enhancement issue, which does not need to be tracked by the Release Team| Release enhancements team ONLY | |
-| <a id="tracked/yes" href="#tracked/yes">`tracked/yes`</a> | Denotes an enhancement issue is actively being tracked by the Release Team| Release enhancements team ONLY | |
+| <a id="tracked/no" href="#tracked/no">`tracked/no`</a> | Denotes an enhancement issue is NOT actively being tracked by the Release Team| Release enhancements team ONLY |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="tracked/out-of-tree" href="#tracked/out-of-tree">`tracked/out-of-tree`</a> | Denotes an out-of-tree enhancement issue, which does not need to be tracked by the Release Team| Release enhancements team ONLY |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="tracked/yes" href="#tracked/yes">`tracked/yes`</a> | Denotes an enhancement issue is actively being tracked by the Release Team| Release enhancements team ONLY |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes/k8s.io, for both issues and PRs
 
@@ -561,3 +561,5 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="refactor" href="#refactor">`refactor`</a> | Indicates a PR with large refactoring changes e.g. removes files or moves content| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+
+

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -850,6 +850,12 @@ repos:
         prowPlugin: label
         addedBy: anyone
       - color: d93f0b
+        description: Denotes that an issue has been opted in to a release
+        name: lead-opted-in
+        target: issues
+        prowPlugin: label
+        addedBy: SIG leads ONLY
+      - color: d93f0b
         description: Denotes an issue tracking an enhancement targeted for Alpha status
         name: stage/alpha
         target: issues
@@ -871,17 +877,20 @@ repos:
         description: Denotes an out-of-tree enhancement issue, which does not need to be tracked by the Release Team
         name: tracked/out-of-tree
         target: issues
-        addedBy: humans
+        prowPlugin: label
+        addedBy: Release enhancements team ONLY
       - color: e04338
         description: Denotes an enhancement issue is NOT actively being tracked by the Release Team
         name: tracked/no
         target: issues
-        addedBy: humans
+        prowPlugin: label
+        addedBy: Release enhancements team ONLY
       - color: 108737
         description: Denotes an enhancement issue is actively being tracked by the Release Team
         name: tracked/yes
         target: issues
-        addedBy: humans
+        prowPlugin: label
+        addedBy: Release enhancements team ONLY
   kubernetes/k8s.io:
     labels:
       - color: 0052cc
@@ -2055,4 +2064,3 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
-


### PR DESCRIPTION
- Update docs for tracked/* labels to indicate the label is restricted to just the enhancements team
- Add the new `lead-opted-in` label

/cc @gracenng @leonardpahlke @marosset @reylejano

Part of https://github.com/kubernetes/sig-release/issues/2009