### PR TITLE
Renaming cloneURIResolverFactory to gerritResolverFactory

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -123,7 +123,11 @@ func defaultClientFactoryOpts(cfo *ClientFactoryOpts) {
 }
 
 // NewClientFactory allows for the creation of repository clients. It uses github.com
-// without authentication by default.
+// without authentication by default, if UseSSH then returns
+// sshRemoteResolverFactory, and if CookieFilePath is provided then returns
+// gerritResolverFactory(Assuming that git http.cookiefile is used only by
+// Gerrit, this function needs to be updated if it turned out that this
+// assumtpion is not correct.)
 func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 	o := ClientFactoryOpts{}
 	defaultClientFactoryOpts(&o)
@@ -148,7 +152,7 @@ func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 			username: o.Username,
 		}
 	} else if o.CookieFilePath != "" {
-		remote = &cloneURIResolverFactory{}
+		remote = &gerritResolverFactory{}
 	} else {
 		remote = &httpResolverFactory{
 			host:     o.Host,

--- a/prow/git/v2/remote.go
+++ b/prow/git/v2/remote.go
@@ -146,23 +146,28 @@ func (f *pathResolverFactory) PublishRemote(org, repo string) RemoteResolver {
 	}
 }
 
-// Publish Remote will not be used by Gerrit, but cloneURIResolverFactory can be used
-// by Gerrit when CentralRemote == PublishRemote == CloneURI so both methods will return CloneURI
-type cloneURIResolverFactory struct{}
+// gerritResolverFactory is meant to be used by Gerrit only. It's so diffrent
+// from GitHub that there is no way any of the remotes logic can be shared
+// between these two providers. The resulting CentralRemote and PublishRemote
+// are both the clone URI.
+type gerritResolverFactory struct{}
 
-func (f *cloneURIResolverFactory) CentralRemote(org, repo string) RemoteResolver {
+func (f *gerritResolverFactory) CentralRemote(org, repo string) RemoteResolver {
 	return func() (string, error) {
-		return cloneURIFromOrgRepo(org, repo), nil
+		return gerritCloneURIFromOrgRepo(org, repo), nil
 	}
 }
 
-func (f *cloneURIResolverFactory) PublishRemote(org, repo string) RemoteResolver {
+func (f *gerritResolverFactory) PublishRemote(org, repo string) RemoteResolver {
 	return func() (string, error) {
-		return cloneURIFromOrgRepo(org, repo), nil
+		return gerritCloneURIFromOrgRepo(org, repo), nil
 	}
 }
 
-func cloneURIFromOrgRepo(org, repo string) string {
+// gerritCloneURIFromOrgRepo returns Gerrit clone URI from org and repo. The org
+// is normalized to enure that it contains `https://` and `http://` prefixes
+// that are required for Gerrit.
+func gerritCloneURIFromOrgRepo(org, repo string) string {
 	scheme := "https"
 	if strings.HasPrefix(org, "http://") {
 		scheme = "http"

--- a/prow/git/v2/remote_test.go
+++ b/prow/git/v2/remote_test.go
@@ -226,7 +226,7 @@ func TestHTTPResolverFactory(t *testing.T) {
 	}
 }
 
-func TestCloneURIFromOrgRepo(t *testing.T) {
+func TestGerritCloneURIFromOrgRepo(t *testing.T) {
 	tests := []struct {
 		name string
 		org  string
@@ -256,7 +256,7 @@ func TestCloneURIFromOrgRepo(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if got, want := cloneURIFromOrgRepo(tc.org, tc.repo), tc.want; got != want {
+			if got, want := gerritCloneURIFromOrgRepo(tc.org, tc.repo), tc.want; got != want {
 				t.Errorf("wrong cloneURI. Want: '%s', got: '%s'", want, got)
 			}
 		})


### PR DESCRIPTION
This resolver factory takes the assumption that central remote and publish remote are both clone URI, which so far should only used by Gerrit repos, renaming it to make it more explicit.

followup of #27597 
/cc @cjwagner @listx 
