### PR TITLE
Tide for gerrit pass in prowjob list client

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -201,6 +201,7 @@ func main() {
 		c, err = tide.NewGerritController(
 			mgr,
 			configAgent,
+			gitClient,
 			o.maxRecordsPerPool,
 			opener,
 			o.historyURI,


### PR DESCRIPTION
It's used for listing Prowjobs in the cluster, which is how Gerrit controller figures out whether the prowjobs are against latest base SHA or not

/cc @cjwagner @listx 