### PR TITLE
update golangci-lint to v1.49.0 for vsphere-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -45,7 +45,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.44.2
+        - image: golangci/golangci-lint:v1.49.0
           command:
             - make
           args:


### PR DESCRIPTION
Update golangci-lint for vsphere-csi-driver to 1.49.0