### PR TITLE
greenhouse: stop scraping metrics from k8s-infra

### DIFF
--- a/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -22,7 +22,6 @@ stringData:
       static_configs:
         - targets:
             - "35.225.115.154" # external ip greenhouse-metrics for k8s-prow-builds
-            - "34.72.140.202" # external ip greenhouse-metrics for k8s-infra-prow-build
     - job_name: blackbox
       metrics_path: /probe
       params:


### PR DESCRIPTION
Part of:
  - https://github.com/kubernetes/test-infra/issues/24247

Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/4245

Stop scraping metrics from the greenhouse instance deployed in k8s-infra.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>