### PR TITLE
update the github-token secret name

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -22,5 +22,5 @@ periodics:
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
-              name: k8s-triage-robot-github-token
+              name: k8s-release-enhancements-triage-github-token
               key: token


### PR DESCRIPTION
The PR makes the following changes, as a fix for the failing prow job https://testgrid.k8s.io/sig-release-release-team-periodics#periodic-sync-enhancements-github-project-beta-1-26

- update the secret name referenced by the `GITHUB_TOKEN` environment variable in the `periodic-sync-enhancements-github-project-beta-1-26` periodic prow job