### PR TITLE
sig-cluster-lifecycle: move tests to k8s-infra

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-no-addons-latest
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -37,6 +38,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,11 +38,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -77,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -117,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -157,11 +170,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-22
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -197,6 +214,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
@@ -39,8 +39,8 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2000m
           memory: "9000Mi"
+          cpu: 2000m
         requests:
-          cpu: 2000m
           memory: "9000Mi"
+          cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,11 +38,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -77,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -117,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -157,11 +170,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-22
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -197,6 +214,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,11 +38,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -77,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -117,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -157,11 +170,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-22
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -197,6 +214,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,11 +38,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-24-on-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -77,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-24-on-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -117,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-23-on-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -157,11 +170,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-23-on-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -197,11 +214,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-22-on-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -237,11 +258,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-22-on-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -277,6 +302,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-patches-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,6 +38,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
@@ -39,8 +39,8 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2000m
           memory: "9000Mi"
+          cpu: 2000m
         requests:
-          cpu: 2000m
           memory: "9000Mi"
+          cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-25-latest
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,11 +38,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-24-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -77,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-23-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -117,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-22-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -157,6 +170,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -2,6 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-latest-on-1-25
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -37,11 +38,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-25-on-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -77,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-24-on-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -117,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-23-on-1-22
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -157,6 +170,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -39,13 +39,14 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2000m
           memory: "9000Mi"
+          cpu: 2000m
         requests:
-          cpu: 2000m
           memory: "9000Mi"
+          cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-25
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -81,11 +82,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-24
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -121,11 +126,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-23
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -161,11 +170,15 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-22
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -201,6 +214,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
         requests:
           memory: "9000Mi"
           cpu: 2000m


### PR DESCRIPTION
Ensure periodic kubeadm tests are running in the community infrastructure

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>