### PR TITLE
Tide: remove empty commits check

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -834,9 +834,6 @@ func pickHighestPriorityPR(log *logrus.Entry, prs []CodeReviewCommon, cc map[int
 			if smallestNumber != -1 && pr.Number >= smallestNumber {
 				continue
 			}
-			if commits := pr.GitHubCommits(); commits == nil || len(commits.Nodes) < 1 {
-				continue
-			}
 			if !isPassingTestsFunc(log, &pr, cc[pr.Number]) {
 				continue
 			}


### PR DESCRIPTION
This check is not documented, nor has unit test coverage. Not seeing this being possible for GitHub that a PR doesn't have any commits https://docs.github.com/en/graphql/reference/objects#pullrequestcommit, it's not easily generalized for Gerrit as well. Removing this check makes more sense

/cc @cjwagner @alvaroaleman 
/hold