### PR TITLE
Stop supporting supplying Gerrit org/repo as commandline args

### DIFF
--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -33,8 +33,6 @@ func TestOptions(t *testing.T) {
 	var defaultGitHubOptions flagutil.GitHubOptions
 	defaultGitHubOptions.AddFlags(flag.NewFlagSet("", flag.ContinueOnError))
 
-	defaultGerritProjects := make(map[string][]string)
-
 	cases := []struct {
 		name     string
 		args     []string
@@ -52,13 +50,10 @@ func TestOptions(t *testing.T) {
 		//Gerrit Reporter
 		{
 			name: "gerrit supports multiple workers",
-			args: []string{"--gerrit-workers=99", "--gerrit-projects=foo=bar", "--cookiefile=foobar", "--config-path=foo"},
+			args: []string{"--gerrit-workers=99", "--cookiefile=foobar", "--config-path=foo"},
 			expected: &options{
 				gerritWorkers:  99,
 				cookiefilePath: "foobar",
-				gerritProjects: map[string][]string{
-					"foo": {"bar"},
-				},
 				config: configflagutil.ConfigOptions{
 					ConfigPathFlagName:                    "config-path",
 					JobConfigPathFlagName:                 "job-config-path",
@@ -74,12 +69,9 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name: "gerrit missing --cookiefile",
-			args: []string{"--gerrit-workers=5", "--gerrit-projects=foo=bar", "--config-path=foo"},
+			args: []string{"--gerrit-workers=5", "--config-path=foo"},
 			expected: &options{
 				gerritWorkers: 5,
-				gerritProjects: map[string][]string{
-					"foo": {"bar"},
-				},
 				config: configflagutil.ConfigOptions{
 					ConfigPathFlagName:                    "config-path",
 					JobConfigPathFlagName:                 "job-config-path",
@@ -108,7 +100,6 @@ func TestOptions(t *testing.T) {
 				},
 				pubsubWorkers:          7,
 				github:                 defaultGitHubOptions,
-				gerritProjects:         defaultGerritProjects,
 				k8sReportFraction:      1.0,
 				instrumentationOptions: prowflagutil.DefaultInstrumentationOptions(),
 			},
@@ -133,7 +124,6 @@ func TestOptions(t *testing.T) {
 					InRepoConfigCacheCopies:               1,
 				},
 				github:                 defaultGitHubOptions,
-				gerritProjects:         defaultGerritProjects,
 				k8sReportFraction:      1.0,
 				instrumentationOptions: prowflagutil.DefaultInstrumentationOptions(),
 			},
@@ -158,7 +148,6 @@ func TestOptions(t *testing.T) {
 				},
 				dryrun:                 true,
 				github:                 defaultGitHubOptions,
-				gerritProjects:         defaultGerritProjects,
 				k8sReportFraction:      1.0,
 				instrumentationOptions: prowflagutil.DefaultInstrumentationOptions(),
 			},
@@ -177,7 +166,6 @@ func TestOptions(t *testing.T) {
 					InRepoConfigCacheCopies:               1,
 				},
 				github:                 defaultGitHubOptions,
-				gerritProjects:         defaultGerritProjects,
 				k8sReportFraction:      1.0,
 				instrumentationOptions: prowflagutil.DefaultInstrumentationOptions(),
 			},
@@ -196,7 +184,6 @@ func TestOptions(t *testing.T) {
 					InRepoConfigCacheCopies:               1,
 				},
 				github:                 defaultGitHubOptions,
-				gerritProjects:         defaultGerritProjects,
 				k8sReportFraction:      0.5,
 				instrumentationOptions: prowflagutil.DefaultInstrumentationOptions(),
 			},

--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -25,7 +25,6 @@ import (
 
 	"k8s.io/test-infra/prow/flagutil"
 	configflagutil "k8s.io/test-infra/prow/flagutil/config"
-	"k8s.io/test-infra/prow/gerrit/client"
 )
 
 func TestFlags(t *testing.T) {
@@ -85,9 +84,7 @@ func TestFlags(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			expected := &options{
-				projects:           client.ProjectsFlag{},
-				projectsOptOutHelp: client.ProjectsFlag{},
-				lastSyncFallback:   "gs://path",
+				lastSyncFallback: "gs://path",
 				config: configflagutil.ConfigOptions{
 					ConfigPathFlagName:                    "config-path",
 					JobConfigPathFlagName:                 "job-config-path",
@@ -100,17 +97,13 @@ func TestFlags(t *testing.T) {
 				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
 				changeWorkerPoolSize:   1,
 			}
-			expected.projects.Set("foo=bar,baz")
-			expected.projectsOptOutHelp.Set("foo=bar")
 			if tc.expected != nil {
 				tc.expected(expected)
 			}
 			argMap := map[string]string{
-				"--gerrit-projects":              "foo=bar,baz",
-				"--gerrit-projects-opt-out-help": "foo=bar",
-				"--last-sync-fallback":           "gs://path",
-				"--config-path":                  "yo",
-				"--dry-run":                      "false",
+				"--last-sync-fallback": "gs://path",
+				"--config-path":        "yo",
+				"--dry-run":            "false",
 			}
 			for k, v := range tc.args {
 				argMap[k] = v

--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -130,8 +130,10 @@ type JobReport struct {
 }
 
 // NewReporter returns a reporter client
-func NewReporter(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, cookiefilePath string, projects map[string][]string, pjclientset ctrlruntimeclient.Client) (*Client, error) {
-	gc, err := client.NewClient(client.ProjectsFlagToConfig(projects))
+func NewReporter(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, cookiefilePath string, pjclientset ctrlruntimeclient.Client) (*Client, error) {
+	// Initialize an empty client, the orgs/repos will be filled in by
+	// ApplyGlobalConfig later.
+	gc, err := client.NewClient(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -75,45 +75,6 @@ func init() {
 	prometheus.MustRegister(clientMetrics.queryResults)
 }
 
-// ProjectsFlag is the flag type for gerrit projects when initializing a gerrit client
-type ProjectsFlag map[string][]string
-
-func (p ProjectsFlag) String() string {
-	var hosts []string
-	for host, repos := range p {
-		hosts = append(hosts, host+"="+strings.Join(repos, ","))
-	}
-	return strings.Join(hosts, " ")
-}
-
-// Set populates ProjectsFlag upon flag.Parse()
-func (p ProjectsFlag) Set(value string) error {
-	parts := strings.SplitN(value, "=", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("%s not in the form of host=repo-a,repo-b,etc", value)
-	}
-	host := parts[0]
-	if _, ok := p[host]; ok {
-		return fmt.Errorf("duplicate host: %s", host)
-	}
-	repos := strings.Split(parts[1], ",")
-	p[host] = repos
-	return nil
-}
-
-// ProjectsFlagToConfig converts Gerrit project configured as command line args
-// to prow config struct for backward compatilibity
-func ProjectsFlagToConfig(hostProjects ProjectsFlag) map[string]map[string]*config.GerritQueryFilter {
-	res := make(map[string]map[string]*config.GerritQueryFilter)
-	for host, projects := range hostProjects {
-		res[host] = make(map[string]*config.GerritQueryFilter)
-		for _, project := range projects {
-			res[host][project] = nil
-		}
-	}
-	return res
-}
-
 type gerritAuthentication interface {
 	SetCookieAuth(name, value string)
 }

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -257,26 +257,26 @@ func newStamp(t time.Time) *gerrit.Timestamp {
 func TestUpdateClients(t *testing.T) {
 	tests := []struct {
 		name              string
-		existingInstances map[string][]string
-		newInstances      map[string][]string
+		existingInstances map[string]map[string]*config.GerritQueryFilter
+		newInstances      map[string]map[string]*config.GerritQueryFilter
 		wantInstances     map[string]map[string]*config.GerritQueryFilter
 	}{
 		{
 			name:              "normal",
-			existingInstances: map[string][]string{"foo1": {"bar1"}},
-			newInstances:      map[string][]string{"foo2": {"bar2"}},
+			existingInstances: map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar1": nil}},
+			newInstances:      map[string]map[string]*config.GerritQueryFilter{"foo2": {"bar2": nil}},
 			wantInstances:     map[string]map[string]*config.GerritQueryFilter{"foo2": {"bar2": nil}},
 		},
 		{
 			name:              "same instance",
-			existingInstances: map[string][]string{"foo1": {"bar1"}},
-			newInstances:      map[string][]string{"foo1": {"bar2"}},
+			existingInstances: map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar1": nil}},
+			newInstances:      map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar2": nil}},
 			wantInstances:     map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar2": nil}},
 		},
 		{
 			name:              "delete",
-			existingInstances: map[string][]string{"foo1": {"bar1"}, "foo2": {"bar2"}},
-			newInstances:      map[string][]string{"foo1": {"bar1"}},
+			existingInstances: map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar1": nil}, "foo2": {"bar2": nil}},
+			newInstances:      map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar1": nil}},
 			wantInstances:     map[string]map[string]*config.GerritQueryFilter{"foo1": {"bar1": nil}},
 		},
 	}
@@ -286,14 +286,14 @@ func TestUpdateClients(t *testing.T) {
 			client := &Client{
 				handlers: make(map[string]*gerritInstanceHandler),
 			}
-			for instance, projects := range ProjectsFlagToConfig(tc.existingInstances) {
+			for instance, projects := range tc.existingInstances {
 				client.handlers[instance] = &gerritInstanceHandler{
 					instance: instance,
 					projects: projects,
 				}
 			}
 
-			if err := client.UpdateClients(ProjectsFlagToConfig(tc.newInstances)); err != nil {
+			if err := client.UpdateClients(tc.newInstances); err != nil {
 				t.Fatal(err)
 			}
 			gotInstances := make(map[string]map[string]*config.GerritQueryFilter)

--- a/prow/gerrit/client/syncer.go
+++ b/prow/gerrit/client/syncer.go
@@ -52,15 +52,14 @@ func NewSyncTime(path string, opener opener, ctx context.Context) *SyncTime {
 	}
 }
 
-func (st *SyncTime) Init(hostProjects ProjectsFlag) error {
-	logrus.WithField("projects", hostProjects).Info(st.val)
+func (st *SyncTime) Init(hostProjects map[string]map[string]*config.GerritQueryFilter) error {
 	st.lock.RLock()
 	zero := st.val == nil
 	st.lock.RUnlock()
 	if !zero {
 		return nil
 	}
-	return st.update(ProjectsFlagToConfig(hostProjects))
+	return st.update(hostProjects)
 }
 
 func (st *SyncTime) update(hostProjects map[string]map[string]*config.GerritQueryFilter) error {

--- a/prow/gerrit/client/syncer_test.go
+++ b/prow/gerrit/client/syncer_test.go
@@ -64,9 +64,13 @@ func TestSyncTime(t *testing.T) {
 		opener: open,
 		ctx:    ctx,
 	}
-	testProjectsFlag := ProjectsFlag{"foo": []string{"bar"}}
+	testProjects := map[string]map[string]*config.GerritQueryFilter{
+		"foo": map[string]*config.GerritQueryFilter{
+			"bar": &config.GerritQueryFilter{},
+		},
+	}
 	now := time.Now()
-	if err := st.Init(testProjectsFlag); err != nil {
+	if err := st.Init(testProjects); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
 	cur := st.Current()["foo"]["bar"]
@@ -97,7 +101,7 @@ func TestSyncTime(t *testing.T) {
 		opener: open,
 		ctx:    ctx,
 	}
-	if err := st.Init(testProjectsFlag); err != nil {
+	if err := st.Init(testProjects); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
 	if actual := st.Current()["foo"]["bar"]; !actual.Equal(expected) {
@@ -121,7 +125,7 @@ func TestSyncTime(t *testing.T) {
 		opener: fakeOpener{}, // return storage.ErrObjectNotExist on open
 		ctx:    ctx,
 	}
-	if err := st.Init(testProjectsFlag); err != nil {
+	if err := st.Init(testProjects); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
 	if actual := st.Current()["foo"]["bar"]; now.After(actual) || actual.After(later) {
@@ -146,11 +150,15 @@ func TestSyncTimeThreadSafe(t *testing.T) {
 		opener: open,
 		ctx:    ctx,
 	}
-	testProjectsFlag := ProjectsFlag{
-		"foo1": []string{"bar1"},
-		"foo2": []string{"bar2"},
+	testProjects := map[string]map[string]*config.GerritQueryFilter{
+		"foo1": map[string]*config.GerritQueryFilter{
+			"bar1": &config.GerritQueryFilter{},
+		},
+		"foo2": map[string]*config.GerritQueryFilter{
+			"bar2": &config.GerritQueryFilter{},
+		},
 	}
-	if err := st.Init(testProjectsFlag); err != nil {
+	if err := st.Init(testProjects); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
 
@@ -217,7 +225,15 @@ func TestNewProjectAddition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create opener: %v", err)
 	}
-	testProjectsFlag := ProjectsFlag{"foo": []string{"bar"}, "qwe": []string{"qux"}}
+
+	testProjects := map[string]map[string]*config.GerritQueryFilter{
+		"foo": map[string]*config.GerritQueryFilter{
+			"bar": &config.GerritQueryFilter{},
+		},
+		"qwe": map[string]*config.GerritQueryFilter{
+			"qux": &config.GerritQueryFilter{},
+		},
+	}
 
 	st := SyncTime{
 		path:   path,
@@ -225,7 +241,7 @@ func TestNewProjectAddition(t *testing.T) {
 		ctx:    ctx,
 	}
 
-	if err := st.Init(testProjectsFlag); err != nil {
+	if err := st.Init(testProjects); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
 	if _, ok := st.val["qwe"]; !ok {


### PR DESCRIPTION
This was long been announced deprecation, remove the support before it's picked up by someone else.

/cc @cjwagner @listx 