### PR TITLE
triage: upgrade to python3

### DIFF
--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -35,12 +35,12 @@ RUN env GOOS=linux \
 
 
 # Stage 2
-FROM alpine:3.12.0
+FROM alpine:3.15.6
 
-# Google Cloud SDK requires python 2.7.9+ (https://cloud.google.com/python/setup#installing_the_cloud_sdk).
+# Google Cloud SDK requires python 3.9+ (https://cloud.google.com/python/setup#installing_the_cloud_sdk).
 # update_summaries.sh requires bash.
 RUN apk add --no-cache \
-    python2 \
+    python3 \
     bash
 
 # Copy the Google Cloud SDK and link the binaries


### PR DESCRIPTION
ci-test-infra-triage job is failing with:

```bash
 ImportError: No module named enum
```

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-test-infra-triage/1573399794209001472/build-log.txt

Bumping python to v3 expecting we can get the missing python package.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>