### PR TITLE
ClusterAPI: respect branch protection on merge

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -801,6 +801,9 @@ tide:
         # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
         # to ensure things get merged in.
         - "cla/linuxfoundation"
+        repos:
+          cluster-api:
+            from-branch-protection: true
   batch_size_limit:
     "kubernetes/kubernetes": 15
   priority:


### PR DESCRIPTION
With this setting tide will consider the required contexts configured under branch protection when merging.

Under branch protection we configured the linter:
```
branch-protection:
...
        cluster-api:
          required_status_checks:
            contexts:
            - lint
```