### PR TITLE
Crier Gerrit reporter indicates jobs created by Tide

### DIFF
--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -49,7 +49,7 @@ var (
 		kube.GerritPatchset,
 		kube.GerritReportLabel,
 		github.EventGUID,
-		"created-by-tide",
+		kube.CreatedByTideLabel,
 		// Annotations
 		kube.GerritID,
 		kube.GerritInstance,

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -23,6 +23,9 @@ const (
 	// resources
 	// TODO: Namespace this label.
 	CreatedByProw = "created-by-prow"
+	// CreatedByTideLabel is added by tide when it triggered a job.
+	// TODO: Namespace this label.
+	CreatedByTideLabel = "created-by-tide"
 	// ProwJobTypeLabel is added in resources created by prow and
 	// carries the job type (presubmit, postsubmit, periodic, batch)
 	// that the pod is running.


### PR DESCRIPTION
Currently Prow reports to Gerrit as issue comments. When jobs triggered by Tide finished Prow would post a comment on the Gerrit PR, this would be confusing to users without mentioning where this new comment is from

Technically this problem can also be solved by asking Tide to comment on Gerrit, this however is a little more involved and will very likely not applicable once Prow reports to Gerrit Checks instead of comments

/cc @cjwagner @listx 