### PR TITLE
plugins/bugzilla: add EnableBackporting branch option

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -544,18 +544,20 @@ type querySearch struct {
 	Edges []queryEdge
 }
 
-/* emailToLoginQuery is a graphql query struct that should result in this graphql query:
-   {
-     search(type: USER, query: "email", first: 5) {
-       edges {
-         node {
-           ... on User {
-             login
-           }
-         }
-       }
-     }
-   }
+/*
+emailToLoginQuery is a graphql query struct that should result in this graphql query:
+
+	{
+	  search(type: USER, query: "email", first: 5) {
+	    edges {
+	      node {
+	        ... on User {
+	          login
+	        }
+	      }
+	    }
+	  }
+	}
 */
 type emailToLoginQuery struct {
 	Search querySearch `graphql:"search(type:USER query:$email first:5)"`
@@ -612,7 +614,11 @@ func handle(e event, gc githubClient, bc bugzilla.Client, options plugins.Bugzil
 	}
 	// cherrypicks follow a different pattern than normal validation
 	if e.cherrypick {
-		return handleCherrypick(e, gc, bc, options, log)
+		if *options.EnableBackporting {
+			return handleCherrypick(e, gc, bc, options, log)
+		} else {
+			return nil
+		}
 	}
 
 	var needsValidLabel, needsInvalidLabel bool

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1433,7 +1433,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) has been cloned as [Bugzilla bug 124](www.bugzilla/show_bug.cgi?id=124). Retitling PR to link against new bug.
 /retitle [v1] Bug 124: fixed it!
 
@@ -1457,7 +1457,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: Error creating a cherry-pick bug in Bugzilla: failed to check the state of cherrypicked pull request at https://github.com/org/repo/pull/1: pull request number 1 does not exist.
 Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.
 
@@ -1481,7 +1481,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: An error was encountered searching for bug 123 on the Bugzilla server at www.bugzilla. No known errors were detected, please see the full error message for details.
 
 <details><summary>Full error message.</summary>
@@ -1513,7 +1513,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: An error was encountered cloning bug for cherrypick for bug 123 on the Bugzilla server at www.bugzilla. No known errors were detected, please see the full error message for details.
 
 <details><summary>Full error message.</summary>
@@ -1547,7 +1547,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: An error was encountered cloning bug for cherrypick for bug 123 on the Bugzilla server at www.bugzilla. No known errors were detected, please see the full error message for details.
 
 <details><summary>Full error message.</summary>
@@ -1581,7 +1581,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: Detected clone of [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) with correct target release. Retitling PR to link to clone:
 /retitle [v1] Bug 124: fixed it!
 
@@ -1606,7 +1606,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedComment: `org/repo#1:@user: [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) has been cloned as [Bugzilla bug 125](www.bugzilla/show_bug.cgi?id=125). Retitling PR to link against new bug.
 /retitle [v1] Bug 125: fixed it!
 
@@ -1635,7 +1635,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			cherryPick:          true,
 			cherryPickFromPRNum: 1,
 			cherryPickTo:        "v1",
-			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1, EnableBackporting: &yes},
 			expectedSubComponents: map[int]map[string][]string{
 				123: {
 					"TestComponent": {

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1478,6 +1478,10 @@ type BugzillaBranchOptions struct {
 	// ExcludeDefaults excludes defaults from more generic Bugzilla configurations.
 	ExcludeDefaults *bool `json:"exclude_defaults,omitempty"`
 
+	// EnableBackporting enables functionality to create new backport bugs for
+	// cherrypick PRs created by the cherrypick plugin that reference bugzilla bugs.
+	EnableBackporting *bool
+
 	// ValidateByDefault determines whether a validation check is run for all pull
 	// requests by default
 	ValidateByDefault *bool `json:"validate_by_default,omitempty"`

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -93,6 +93,10 @@ bugzilla:
     # The `*` wildcard will apply to all branches.
     default:
         "":
+            # EnableBackporting enables functionality to create new backport bugs for
+            # cherrypick PRs created by the cherrypick plugin that reference bugzilla bugs.
+            EnableBackporting: false
+
             # AddExternalLink determines whether the pull request will be added to the Bugzilla
             # bug using the ExternalBug tracker API after being validated
             add_external_link: false
@@ -180,6 +184,10 @@ bugzilla:
             # The `*` wildcard will apply to all branches.
             default:
                 "":
+                    # EnableBackporting enables functionality to create new backport bugs for
+                    # cherrypick PRs created by the cherrypick plugin that reference bugzilla bugs.
+                    EnableBackporting: false
+
                     # AddExternalLink determines whether the pull request will be added to the Bugzilla
                     # bug using the ExternalBug tracker API after being validated
                     add_external_link: false
@@ -267,6 +275,10 @@ bugzilla:
                     # The `*` wildcard will apply to all branches.
                     branches:
                         "":
+                            # EnableBackporting enables functionality to create new backport bugs for
+                            # cherrypick PRs created by the cherrypick plugin that reference bugzilla bugs.
+                            EnableBackporting: false
+
                             # AddExternalLink determines whether the pull request will be added to the Bugzilla
                             # bug using the ExternalBug tracker API after being validated
                             add_external_link: false


### PR DESCRIPTION
This PR makes the backporting functionality of the bugzilla plugin optional and not enabled by default.

/cc @stevekuznetsov 