### PR TITLE
Inrepoconfig all uses cache

### DIFF
--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -87,7 +87,7 @@ func NewInRepoConfigCacheHandler(size int,
 	}
 
 	for i := 0; i < count; i++ {
-		cacheClient, err := NewInRepoConfigCache(size, configAgent, gitClientFactory)
+		cacheClient, err := NewInRepoConfigCache(size, configAgent, NewInRepoConfigGitCache(gitClientFactory))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This was missed from https://github.com/kubernetes/test-infra/commit/59af59f8696747d84641dc3373044152c0c37e07#diff-af03b39f6742c2b4686729a0fba1160903f588138a7f5cc3beb8412e961b7bf0L147

/cc @cjwagner @listx @chases2 