### PR TITLE
Delete unused jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -465,33 +465,6 @@ periodics:
     testgrid-tab-name: e2e-cos-device-plugin-gpu
     testgrid-num-failures-to-alert: '8'
     testgrid-alert-stale-results-hours: '24'
-- interval: 1h
-  name: ci-cri-containerd-e2e-cos-gce
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221207-9bb38b7b14-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos
 - interval: 2h
   name: ci-cri-containerd-e2e-cos-gce-alpha-features
   labels:


### PR DESCRIPTION
## What does this PR do?
Delete job `ci-cri-containerd-e2e-cos-gce` (listed in https://github.com/kubernetes/kubernetes/issues/111876). This job is constantly failing, confirmed that not COS nor containerd monitor this Testgrid so we can delete them. Also, we have a similar job (`ci-containerd-e2e-ubuntu-gce`) running.