### PR TITLE
Static Prowjobs getter considers org w/o https:// prefix

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -446,7 +446,7 @@ func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch
 	if branch.Unmanaged != nil && *branch.Unmanaged {
 		return nil
 	}
-	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic[orgName+"/"+repo], &protected)
+	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.GetPresubmitsStatic(orgName+"/"+repo), &protected)
 	if err != nil {
 		return fmt.Errorf("get policy: %w", err)
 	}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -470,7 +470,17 @@ func (c *Config) GetPresubmits(gc git.ClientFactory, identifier string, baseSHAG
 
 // GetPresubmitsStatic will return presubmits for the given identifier that are versioned inside the tested repo.
 func (c *Config) GetPresubmitsStatic(identifier string) []Presubmit {
-	return c.PresubmitsStatic[identifier]
+	keys := []string{identifier}
+	if gerritsource.IsGerritOrg(identifier) {
+		// For Gerrit, allow users to define jobs without https:// prefix, which
+		// is what's supported right now.
+		keys = append(keys, gerritsource.TrimHTTPSPrefix(identifier))
+	}
+	var res []Presubmit
+	for _, key := range keys {
+		res = append(res, c.PresubmitsStatic[key]...)
+	}
+	return res
 }
 
 // GetPostsubmits will return all postsubmits for the given identifier. This includes
@@ -485,12 +495,22 @@ func (c *Config) GetPostsubmits(gc git.ClientFactory, identifier string, baseSHA
 		return nil, err
 	}
 
-	return append(c.PostsubmitsStatic[identifier], prowYAML.Postsubmits...), nil
+	return append(c.GetPostsubmitsStatic(identifier), prowYAML.Postsubmits...), nil
 }
 
 // GetPostsubmitsStatic will return postsubmits for the given identifier that are versioned inside the tested repo.
 func (c *Config) GetPostsubmitsStatic(identifier string) []Postsubmit {
-	return c.PostsubmitsStatic[identifier]
+	keys := []string{identifier}
+	if gerritsource.IsGerritOrg(identifier) {
+		// For Gerrit, allow users to define jobs without https:// prefix, which
+		// is what's supported right now.
+		keys = append(keys, gerritsource.TrimHTTPSPrefix(identifier))
+	}
+	var res []Postsubmit
+	for _, key := range keys {
+		res = append(res, c.PostsubmitsStatic[key]...)
+	}
+	return res
 }
 
 // OwnersDirDenylist is used to configure regular expressions matching directories

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -241,10 +241,10 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 	if err := defaultPostsubmits(p.Postsubmits, p.Presets, c, identifier); err != nil {
 		return err
 	}
-	if err := c.validatePresubmits(append(p.Presubmits, c.PresubmitsStatic[identifier]...)); err != nil {
+	if err := c.validatePresubmits(append(p.Presubmits, c.GetPresubmitsStatic(identifier)...)); err != nil {
 		return err
 	}
-	if err := c.validatePostsubmits(append(p.Postsubmits, c.PostsubmitsStatic[identifier]...)); err != nil {
+	if err := c.validatePostsubmits(append(p.Postsubmits, c.GetPostsubmitsStatic(identifier)...)); err != nil {
 		return err
 	}
 

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -466,7 +466,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 			// Static postsubmit jobs are included as part of output from
 			// inRepoConfigCacheHandler.GetPostsubmits, fallback to static only
 			// when inrepoconfig failed.
-			postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI]...)
+			postsubmits = append(postsubmits, c.config().GetPostsubmitsStatic(cloneURI)...)
 		}
 
 		for _, postsubmit := range postsubmits {

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -334,7 +334,7 @@ func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, 
 		// Fall back to static presubmits to avoid deadlocking when a presubmit is used to verify
 		// inrepoconfig. Tide will still respect errors here and not merge.
 		log.WithError(err).Debug("Failed to get presubmits")
-		presubmits = cfg.PresubmitsStatic[orgRepo]
+		presubmits = cfg.GetPresubmitsStatic(orgRepo)
 	}
 	return presubmits
 }
@@ -344,7 +344,7 @@ func getPostsubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config,
 	if err != nil {
 		// Fall back to static postsubmits, loading inrepoconfig returned an error.
 		log.WithError(err).Error("Failed to get postsubmits")
-		postsubmits = cfg.PostsubmitsStatic[orgRepo]
+		postsubmits = cfg.GetPostsubmitsStatic(orgRepo)
 	}
 	return postsubmits
 }


### PR DESCRIPTION
It's already supported and there are already users specifying Gerrit orgs without https:// prefix, this change is for avoiding breaking backward compatibility

/cc @cjwagner @listx 