### PR TITLE
Allow setting default memory request on prowjobs

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -143,6 +143,17 @@ spec:
                       that contains a git http.cookiefile, which should be used during
                       the cloning process.
                     type: string
+                  default_memory_request:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: DefaultMemoryRequest is the default requested memory
+                      on a test container. If SetLimitEqualsMemoryRequest is also
+                      true then the Limit will also be set the same as this request.
+                      Could be overridden by memory request defined explicitly on
+                      prowjob.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   default_service_account_name:
                     description: DefaultServiceAccountName is the name of the Kubernetes
                       service account that should be used by the pod if one is not

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -27,6 +27,7 @@ import (
 
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prowgithub "k8s.io/test-infra/prow/github"
@@ -481,6 +482,11 @@ type DecorationConfig struct {
 
 	// SetLimitEqualsMemoryRequest sets memory limit equal to request.
 	SetLimitEqualsMemoryRequest *bool `json:"set_limit_equals_memory_request,omitempty"`
+	// DefaultMemoryRequest is the default requested memory on a test container.
+	// If SetLimitEqualsMemoryRequest is also true then the Limit will also be
+	// set the same as this request. Could be overridden by memory request
+	// defined explicitly on prowjob.
+	DefaultMemoryRequest *resource.Quantity `json:"default_memory_request,omitempty"`
 }
 
 type CensoringOptions struct {
@@ -685,6 +691,10 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 
 	if merged.SetLimitEqualsMemoryRequest == nil {
 		merged.SetLimitEqualsMemoryRequest = def.SetLimitEqualsMemoryRequest
+	}
+
+	if merged.DefaultMemoryRequest == nil {
+		merged.DefaultMemoryRequest = def.DefaultMemoryRequest
 	}
 
 	return &merged

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -163,6 +163,11 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DefaultMemoryRequest != nil {
+		in, out := &in.DefaultMemoryRequest, &out.DefaultMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -672,6 +672,12 @@ plank:
             # a git http.cookiefile, which should be used during the cloning process.
             cookiefile_secret: ""
 
+            # DefaultMemoryRequest is the default requested memory on a test container.
+            # If SetLimitEqualsMemoryRequest is also true then the Limit will also be
+            # set the same as this request. Could be overridden by memory request
+            # defined explicitly on prowjob.
+            default_memory_request: "0"
+
             # DefaultServiceAccountName is the name of the Kubernetes service account
             # that should be used by the pod if one is not specified in the podspec.
             default_service_account_name: ""
@@ -871,6 +877,12 @@ plank:
             # CookieFileSecret is the name of a kubernetes secret that contains
             # a git http.cookiefile, which should be used during the cloning process.
             cookiefile_secret: ""
+
+            # DefaultMemoryRequest is the default requested memory on a test container.
+            # If SetLimitEqualsMemoryRequest is also true then the Limit will also be
+            # set the same as this request. Could be overridden by memory request
+            # defined explicitly on prowjob.
+            default_memory_request: "0"
 
             # DefaultServiceAccountName is the name of the Kubernetes service account
             # that should be used by the pod if one is not specified in the podspec.

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_default_memory_request.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_default_memory_request.yaml
@@ -1,0 +1,128 @@
+containers:
+- command:
+  - /tools/entrypoint
+  env:
+  - name: ARTIFACTS
+    value: /logs/artifacts
+  - name: GOPATH
+    value: /home/prow/go
+  - name: custom
+    value: env
+  - name: ENTRYPOINT_OPTIONS
+    value: '{"timeout":60000000000,"grace_period":3600000000000,"artifact_dir":"/logs/artifacts","args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/test-log.txt","marker_file":"/logs/test-marker.txt","metadata_file":"/logs/artifacts/test-metadata.json"}'
+  name: test
+  resources:
+    limits:
+      memory: 8Gi
+    requests:
+      memory: 8Gi
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /tools
+    name: tools
+  - mountPath: /home/prow/go
+    name: code
+  workingDir: /home/prow/go/src/github.com/org/repo
+- command:
+  - /tools/entrypoint
+  env:
+  - name: ARTIFACTS
+    value: /logs/artifacts
+  - name: GOPATH
+    value: /home/prow/go
+  - name: custom
+    value: env
+  - name: ENTRYPOINT_OPTIONS
+    value: '{"timeout":60000000000,"grace_period":3600000000000,"artifact_dir":"/logs/artifacts","args":["/bin/ls","-l","-a"],"container_name":"test2","process_log":"/logs/test2-log.txt","marker_file":"/logs/test2-marker.txt","metadata_file":"/logs/artifacts/test2-metadata.json"}'
+  name: test2
+  resources:
+    limits:
+      memory: 4Gi
+    requests:
+      memory: 4Gi
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /tools
+    name: tools
+  - mountPath: /home/prow/go
+    name: code
+  workingDir: /home/prow/go/src/github.com/org/repo
+- env:
+  - name: JOB_SPEC
+  - name: SIDECAR_OPTIONS
+    value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/test-log.txt","marker_file":"/logs/test-marker.txt","metadata_file":"/logs/artifacts/test-metadata.json"},{"args":["/bin/ls","-l","-a"],"container_name":"test2","process_log":"/logs/test2-log.txt","marker_file":"/logs/test2-marker.txt","metadata_file":"/logs/artifacts/test2-metadata.json"}],"censoring_options":{}}'
+  image: sidecarimage
+  name: sidecar
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  terminationMessagePolicy: FallbackToLogsOnError
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+initContainers:
+- env:
+  - name: CLONEREFS_OPTIONS
+    value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org","repo":"repo","base_ref":"main","base_sha":"abcd1234","pulls":[{"number":1,"author":"","sha":"aksdjhfkds"}]},{"org":"other","repo":"something","base_ref":"release","base_sha":"sldijfsd"}],"github_api_endpoints":["https://api.github.com"]}'
+  image: cloneimage
+  name: clonerefs
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /home/prow/go
+    name: code
+  - mountPath: /tmp
+    name: clonerefs-tmp
+- env:
+  - name: INITUPLOAD_OPTIONS
+    value: '{"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
+  - name: JOB_SPEC
+  image: initimage
+  name: initupload
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  volumeMounts:
+  - mountPath: /logs
+    name: logs
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+- args:
+  - --copy-mode-only
+  image: entrypointimage
+  name: place-entrypoint
+  resources:
+    limits:
+      cpu: "0"
+    requests:
+      memory: "0"
+  volumeMounts:
+  - mountPath: /tools
+    name: tools
+serviceAccountName: tester
+terminationGracePeriodSeconds: 4500
+volumes:
+- emptyDir: {}
+  name: logs
+- emptyDir: {}
+  name: tools
+- name: gcs-credentials
+  secret:
+    secretName: gcs-secret
+- emptyDir: {}
+  name: clonerefs-tmp
+- emptyDir: {}
+  name: code


### PR DESCRIPTION
This is part of the effort of reducing noisy neighbor problem. Initially default memory request was expected to be set as LimitRanger on each build cluster, which however would not work, as setting this on each container means that pod utils containers will also get this default. Allowing set on Prow job level would solve this problem

/cc @cjwagner @listx @alvaroaleman 