### PR TITLE
Upload the .git directory to GCB for KMM builds

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kmm.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kmm.yaml
@@ -17,4 +17,5 @@ postsubmits:
               - --project=k8s-staging-kmm
               - --scratch-bucket=gs://k8s-staging-kmm-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .


### PR DESCRIPTION
The KMM build process requires `.git` to be present as it leverages a [Go compiler feature](https://tip.golang.org/doc/go1.18#debug/buildinfo) to include VCS information in the controller binary.

Some context on Slack: https://kubernetes.slack.com/archives/C09QZ4DQB/p1664444873044709?thread_ts=1664375168.747399&cid=C09QZ4DQB