### PR TITLE
override: fix whitespace handling

### DIFF
--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -41,7 +41,7 @@ import (
 const pluginName = "override"
 
 var (
-	overrideRe = regexp.MustCompile(`(?mi)^/override( (.+))?$`)
+	overrideRe = regexp.MustCompile(`(?mi)^/override( ([^\r\n]+))?[\r\n]?$`)
 )
 
 type Context struct {

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -674,7 +674,7 @@ func TestHandle(t *testing.T) {
 		{
 			name: "override with extra whitespace",
 			// Note two spaces here to start, and trailing whitespace
-			comment: "/override  broken-test \n",
+			comment: "/override  broken-test \r\n", // github ends lines with \r\n
 			contexts: []github.Status{
 				{
 					Context: "broken-test",


### PR DESCRIPTION
Recent refactors to override[1][2] greatly increased it's complexity and difficulty in handling various edge cases.

When pasting a job name from the status bar on GitHub to override, it includes a trailing space.  GitHub also terminates lines in that comment with `\r\n`[3]. Those two factors combined produces an override with a blank name which ends up with an error like this[4]:

```
@stbenjam: /override requires failed status contexts, check run or a prowjob name to operate on.
The following unknown contexts/checkruns were given:

    ``
```

Refactoring the whitespace test case to include the actual github line ending, `\r\n`, reproduces the error.  The adjustments in this PR to the regex prevent it.

[1] https://github.com/kubernetes/test-infra/pull/27491
[2] https://github.com/kubernetes/test-infra/pull/27288
[3] https://api.github.com/repos/openshift/origin/issues/comments/1262152801
[4] https://github.com/openshift/origin/pull/27443#issuecomment-1262153054