### PR TITLE
Bump master k8s version to v1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.6
+      - image: golang:1.19.0
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.6
+      - image: golang:1.19.0
         command:
         - make
         args:
@@ -38,11 +38,42 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.6
+      - image: golang:1.19.0
         command:
         - make
         args:
         - test-unit
+  - name: pull-cluster-capacity-test-e2e-k8s-master-1-25
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.25
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220928-cd48f52a16-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.25.2"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
   - name: pull-cluster-capacity-test-e2e-k8s-master-1-24
     annotations:
       testgrid-dashboards: sig-scheduling
@@ -97,37 +128,6 @@ presubmits:
         env:
         - name: KUBERNETES_VERSION
           value: "v1.23.3"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-22
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.22
-    decorate: true
-    decoration_config:
-      timeout: 20m
-    path_alias: sigs.k8s.io/cluster-capacity
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220928-cd48f52a16-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.22.5"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
https://hub.docker.com/layers/kindest/node/v1.25.2/images/sha256-6e0f9005eba4010e364aa1bb25c8d7c64f050f744258eb68c4eb40c284c3c0dd?context=explore

Blocks https://github.com/kubernetes-sigs/cluster-capacity/pull/161