### PR TITLE
Remove https:// prefix from org name in artifacts uploading path

### DIFF
--- a/prow/gcsupload/run_test.go
+++ b/prow/gcsupload/run_test.go
@@ -295,6 +295,15 @@ func TestBuilderForStrategy(t *testing.T) {
 				{org: "org2", repo: "repo"}: "org2_repo",
 			},
 		},
+		{
+			name:        "gerrit",
+			strategy:    prowapi.PathStrategyLegacy,
+			defaultOrg:  "org",
+			defaultRepo: "repo",
+			expectedPaths: map[info]string{
+				{org: "https://org", repo: "repo/sub"}: "org_repo_sub",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/prow/pod-utils/gcs/target.go
+++ b/prow/pod-utils/gcs/target.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	gerritsource "k8s.io/test-infra/prow/gerrit/source"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 )
 
@@ -117,6 +118,7 @@ func NewLegacyRepoPathBuilder(defaultOrg, defaultRepo string) RepoPathBuilder {
 			return repo
 		}
 		// handle gerrit repo
+		org = gerritsource.TrimHTTPSPrefix(org)
 		repo = strings.Replace(repo, "/", "_", -1)
 		return fmt.Sprintf("%s_%s", org, repo)
 	}
@@ -130,6 +132,7 @@ func NewSingleDefaultRepoPathBuilder(defaultOrg, defaultRepo string) RepoPathBui
 			return ""
 		}
 		// handle gerrit repo
+		org = gerritsource.TrimHTTPSPrefix(org)
 		repo = strings.Replace(repo, "/", "_", -1)
 		return fmt.Sprintf("%s_%s", org, repo)
 	}
@@ -140,6 +143,7 @@ func NewSingleDefaultRepoPathBuilder(defaultOrg, defaultRepo string) RepoPathBui
 func NewExplicitRepoPathBuilder() RepoPathBuilder {
 	return func(org, repo string) string {
 		// handle gerrit repo
+		org = gerritsource.TrimHTTPSPrefix(org)
 		repo = strings.Replace(repo, "/", "_", -1)
 		return fmt.Sprintf("%s_%s", org, repo)
 	}


### PR DESCRIPTION
This fixes a bug that artifacts for Gerrit jobs were pushed to wrong GCS location