### PR TITLE
Make the gerrit adapter's inrepo config cache share cache entries for changes that don't touch inrepoconfig.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -398,7 +398,9 @@ func GetAndCheckRefs(
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to get headRef: %v", err)
 		}
-		headSHAs = append(headSHAs, headSHA)
+		if headSHA != "" {
+			headSHAs = append(headSHAs, headSHA)
+		}
 	}
 
 	return baseSHA, headSHAs, nil

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	gitignore "github.com/denormal/go-gitignore"
@@ -365,4 +366,22 @@ func (rc *skipCleanRepoClient) Clean() error {
 	// Skip cleaning and unlock to allow reuse as a cached entry.
 	rc.Mutex.Unlock()
 	return nil
+}
+
+// ContainsInRepoConfigPath indicates whether the specified list of changed
+// files (repo relative paths) includes a file that might be an inrepo config file.
+//
+// This function could report a false positive as it doesn't consider .prowignore files.
+// It is designed to be used to help short circuit when we know a change doesn't touch
+// the inrepo config.
+func ContainsInRepoConfigPath(files []string) bool {
+	for _, file := range files {
+		if file == inRepoConfigFileName {
+			return true
+		}
+		if strings.HasPrefix(file, inRepoConfigDirName+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -72,6 +72,10 @@ type fgc struct {
 	instanceMap map[string]*gerrit.AccountInfo
 }
 
+func (f *fgc) HasRelatedChanges(instance, id, revision string) (bool, error) {
+	return false, nil
+}
+
 func (f *fgc) ApplyGlobalConfig(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, lastSyncTracker *client.SyncTime, cookiefilePath, tokenPathOverride string, additionalFunc func()) {
 
 }

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -39,6 +39,10 @@ type fgc struct {
 	comments map[string]map[string][]gerrit.CommentInfo
 }
 
+func (f *fgc) GetRelatedChanges(changeID string, revisionID string) (*gerrit.RelatedChangesInfo, *gerrit.Response, error) {
+	return &gerrit.RelatedChangesInfo{}, nil, nil
+}
+
 func (f *fgc) ListChangeComments(id string) (*map[string][]gerrit.CommentInfo, *gerrit.Response, error) {
 	comments := map[string][]gerrit.CommentInfo{}
 

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3575,9 +3575,11 @@ func TestPresubmitsForBatch(t *testing.T) {
 		{
 			name: "Inrepoconfig jobs get included if headref matches",
 			prs: []CodeReviewCommon{
-				*CodeReviewCommonFromPullRequest(getPR("org", "repo", 2)),
+				*CodeReviewCommonFromPullRequest(getPR("org", "repo", 2, func(pr *PullRequest) {
+					pr.HeadRefOID = githubql.String("sha2")
+				})),
 				*CodeReviewCommonFromPullRequest(getPR("org", "repo", 1, func(pr *PullRequest) {
-					pr.HeadRefOID = githubql.String("sha")
+					pr.HeadRefOID = githubql.String("sha1")
 				})),
 			},
 			jobs: []config.Presubmit{
@@ -3586,7 +3588,7 @@ func TestPresubmitsForBatch(t *testing.T) {
 					Reporter:  config.Reporter{Context: "foo"},
 				},
 			},
-			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"sha", ""}, []config.Presubmit{{
+			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"sha1", "sha2"}, []config.Presubmit{{
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "bar"},
 			}}),
@@ -3604,9 +3606,11 @@ func TestPresubmitsForBatch(t *testing.T) {
 		{
 			name: "Inrepoconfig jobs do not get included if headref doesnt match",
 			prs: []CodeReviewCommon{
-				*CodeReviewCommonFromPullRequest(getPR("org", "repo", 2)),
+				*CodeReviewCommonFromPullRequest(getPR("org", "repo", 2, func(pr *PullRequest) {
+					pr.HeadRefOID = githubql.String("sha2")
+				})),
 				*CodeReviewCommonFromPullRequest(getPR("org", "repo", 1, func(pr *PullRequest) {
-					pr.HeadRefOID = githubql.String("sha")
+					pr.HeadRefOID = githubql.String("sha1")
 				})),
 			},
 			jobs: []config.Presubmit{
@@ -3615,7 +3619,7 @@ func TestPresubmitsForBatch(t *testing.T) {
 					Reporter:  config.Reporter{Context: "foo"},
 				},
 			},
-			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"other-sha", ""}, []config.Presubmit{{
+			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"other-sha", "sha2"}, []config.Presubmit{{
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "bar"},
 			}}),


### PR DESCRIPTION
This should reduce latency due to cloning and fetching at the cost of increased API usage. I discussed with Chao and this makes sense for the gerrit adapter at least, less sure about tide or pubsub so we'll hold off on making similar changes there for now.
/assign @chaodaiG 
Also fixes https://github.com/kubernetes/test-infra/pull/27657#discussion_r984063895