### PR TITLE
sig node: set provider in presubmit test for Dynamic Resource Allocation

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1297,7 +1297,7 @@ presubmits:
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
           test/e2e/dra/kind-build-image.sh dra/node:latest &&
           kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest &&
-          KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation
 
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Without it, the default is gce which doesn't work for the kind cluster:
```
 + KUBECONFIG=/root/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=/logs/artifacts hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation Setting up for KUBERNETES_PROVIDER="gce".
Project: k8s-prow-builds
Network Project: k8s-prow-builds
Zone: us-central1-b
Trying to find master named 'e2e-test-root-master' Looking for address 'e2e-test-root-master-ip'
ERROR: (gcloud.compute.addresses.describe) Could not fetch resource:
 - Required 'compute.addresses.get' permission for 'projects/k8s-prow-builds/regions/us-central1/addresses/e2e-test-root-master-ip'
 ```