### PR TITLE
azure: don’t run extra capz coverage presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -5,13 +5,33 @@ presubmits:
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
     branches:
     - ^main$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221005-c39d34590b-1.24
         command:
-        - "./scripts/ci-test.sh"
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          result=0
+          ./scripts/ci-test-coverage.sh || result=$?
+          cp coverage.* ${ARTIFACTS}
+          cd ../../k8s.io/test-infra/gopherage
+          GO111MODULE=on go build .
+          ./gopherage filter --exclude-path="zz_generated,generated\.go" "${ARTIFACTS}/coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+          ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
+          ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
+          exit $result
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-test-main
@@ -393,38 +413,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main
-  - name: pull-cluster-api-provider-azure-coverage
-    always_run: true
-    optional: true
-    decorate: true
-    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    branches:
-    - ^main$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221005-c39d34590b-1.24
-        command:
-        - runner.sh
-        args:
-        - bash
-        - -c
-        - |
-          result=0
-          ./scripts/ci-test-coverage.sh || result=$?
-          cp coverage.* ${ARTIFACTS}
-          cd ../../k8s.io/test-infra/gopherage
-          GO111MODULE=on go build .
-          ./gopherage filter --exclude-path="zz_generated,generated\.go" "${ARTIFACTS}/coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
-          ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
-          ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
-          exit $result
-        securityContext:
-          privileged: true
   - name: pull-cluster-api-provider-azure-e2e-workload-upgrade
     labels:
       preset-dind-enabled: "true"

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -49,9 +49,6 @@ dashboards:
     - name: capz-periodic-coverage-main
       test_group_name: periodic-cluster-api-provider-azure-coverage
       base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-    - name: capz-pr-coverage-main
-      test_group_name: pull-cluster-api-provider-azure-coverage
-      base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: sig-cluster-lifecycle-cluster-api-provider-digitalocean
 - name: sig-cluster-lifecycle-cluster-api-provider-gcp
 - name: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
@@ -77,9 +74,6 @@ dashboards:
 test_groups:
 - name: periodic-cluster-api-provider-azure-coverage
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-coverage
-  short_text_metric: coverage
-- name: pull-cluster-api-provider-azure-coverage
-  gcs_prefix: kubernetes-jenkins/logs/pull-cluster-api-provider-azure-coverage
   short_text_metric: coverage
 - name: periodic-cluster-api-provider-aws-coverage
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-coverage


### PR DESCRIPTION
This PR retires the presubmit `pull-cluster-api-provider-azure-coverage` job against capz main branch. Instead we can just include UT coverage in the existing `pull-cluster-api-provider-azure-test` CI job by invoking `./scripts/ci-test-coverage.sh` instead of `./scripts/ci-test.sh`