### PR TITLE
Missed setting the stage gcs directory for the pull-e2e-gce-cloud-provider-disabled job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -485,6 +485,7 @@ presubmits:
             - --gcp-zone=us-west1-b
             - --ginkgo-parallel=30
             - --provider=gce
+            - --stage=gs://kubernetes-release-pull/ci/pull-e2e-gce-cloud-provider-disabled
             - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220908-70b61d242b-master


### PR DESCRIPTION
Made a mistake in the previous PR:
https://github.com/kubernetes/test-infra/pull/27667

We need to set the gcs directory for storing the build artifacts

Found this in the log:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/112818/pull-e2e-gce-cloud-provider-disabled/1576306747251888128/build-log.txt

Signed-off-by: Davanum Srinivas <davanum@gmail.com>