### PR TITLE
Add CAPA release-1.6 tests and remove release-1.5 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.6.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-aws-e2e-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-release-1-6
   decorate: true
   decoration_config:
     timeout: 5h
@@ -13,7 +13,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
-    base_ref: release-1.5
+    base_ref: release-1.6
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
@@ -36,11 +36,11 @@ periodics:
           cpu: 2
           memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-e2e-release-1-5
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-e2e-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-eks-e2e-release-1-5
+- name: periodic-cluster-api-provider-aws-eks-e2e-release-1-6
   decorate: true
   decoration_config:
     timeout: 5h
@@ -54,7 +54,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
-    base_ref: release-1.5
+    base_ref: release-1.6
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
@@ -74,11 +74,11 @@ periodics:
           cpu: 2
           memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-eks-e2e-release-1-5
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-eks-e2e-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-conformance-release-1-6
   decorate: true
   decoration_config:
     timeout: 5h
@@ -92,7 +92,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: release-1.5
+      base_ref: release-1.6
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
@@ -115,11 +115,11 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-conformance-release-1-5
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-conformance-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts-release-1-6
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -134,7 +134,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: release-1.5
+      base_ref: release-1.6
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     - org: kubernetes-sigs
       repo: image-builder
@@ -170,7 +170,7 @@ periodics:
             memory: "9Gi"
             cpu: 2
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-conformance-release-1-5-k8s-main
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-conformance-release-1-6-k8s-main
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.6.yaml
@@ -1,9 +1,9 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-aws:
-  - name: pull-cluster-api-provider-aws-test-release-1-5
+  - name: pull-cluster-api-provider-aws-test-release-1-6
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     always_run: true
     optional: false
     decorate: true
@@ -14,9 +14,9 @@ presubmits:
         command:
         - "./scripts/ci-test.sh"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-test-release-1-5
-  - name: pull-cluster-api-provider-aws-apidiff-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-test-release-1-6
+  - name: pull-cluster-api-provider-aws-apidiff-release-1-6
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-aws
     always_run: true
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     spec:
       containers:
       - command:
@@ -33,15 +33,15 @@ presubmits:
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220928-cd48f52a16-1.24
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-apidiff-release-1-5
-  - name: pull-cluster-api-provider-aws-build-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-apidiff-release-1-6
+  - name: pull-cluster-api-provider-aws-build-release-1-6
     always_run: true
     optional: false
     decorate: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-1.5$
+      - ^release-1.6$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
@@ -49,13 +49,13 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-build-release-1-5
-  - name: pull-cluster-api-provider-aws-verify-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-build-release-1-6
+  - name: pull-cluster-api-provider-aws-verify-release-1-6
     always_run: true
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
@@ -70,15 +70,15 @@ presubmits:
         securityContext:
             privileged: true
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-verify-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-verify-release-1-6
     labels:
       preset-dind-enabled: "true"
   # conformance test
-  - name: pull-cluster-api-provider-aws-e2e-conformance-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-conformance-release-1-6
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -122,14 +122,14 @@ presubmits:
               memory: "9Gi"
               cpu: 2
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-conformance-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-conformance-release-1-6
       testgrid-num-columns-recent: '20'
   # conformance test against kubernetes main branch with `kind` + cluster-api-provider-aws
-  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-1-6
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true
@@ -163,13 +163,13 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-conformance-release-1-5-k8s-main
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-conformance-release-1-6-k8s-main
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-blocking-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-blocking-release-1-6
     branches:
       # The script this job runs is not in all branches.
-      - ^release-1.5$
+      - ^release-1.6$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     #run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     always_run: true
@@ -207,13 +207,13 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-quick-e2e-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-quick-e2e-release-1-6
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-release-1-6
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true
@@ -245,13 +245,13 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-e2e-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-e2e-release-1-6
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-eks-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-eks-release-1-6
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-1.6$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true
@@ -283,6 +283,6 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-e2e-eks-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-e2e-eks-release-1-6
       testgrid-num-columns-recent: '20'

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -11,7 +11,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-1.1
     - sig-cluster-lifecycle-cluster-api-1.2
     - sig-cluster-lifecycle-cluster-api-provider-aws
-    - sig-cluster-lifecycle-cluster-api-provider-aws-1.5
+    - sig-cluster-lifecycle-cluster-api-provider-aws-1.6
     - sig-cluster-lifecycle-cluster-api-provider-azure
     - sig-cluster-lifecycle-cluster-api-provider-digitalocean
     - sig-cluster-lifecycle-cluster-api-provider-vsphere
@@ -38,7 +38,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-1.0
 - name: sig-cluster-lifecycle-cluster-api-1.1
 - name: sig-cluster-lifecycle-cluster-api-1.2
-- name: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
+- name: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
   dashboard_tab:
     - name: periodic-test-coverage-main


### PR DESCRIPTION
This PR adds CAPA v1.6 tests instead of already released 1.5 tests.