### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/config/tests/mergelists/mergelist_test.go
+++ b/config/tests/mergelists/mergelist_test.go
@@ -18,7 +18,7 @@ package mergelist_test
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -32,7 +32,7 @@ func TestMergelist(t *testing.T) {
 
 	for _, filename := range files {
 		t.Run(filename, func(t *testing.T) {
-			file, err := ioutil.ReadFile(filename)
+			file, err := os.ReadFile(filename)
 			if err != nil {
 				t.Errorf("Can't read file: %v", err)
 			}

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/mail"
 	"os"
 	"path"
@@ -102,7 +101,7 @@ func TestMain(m *testing.M) {
 			inputs = defaultInputs
 		}
 		// Generate proto from testgrid config
-		tmpDir, err := ioutil.TempDir("", "testgrid-config-test")
+		tmpDir, err := os.MkdirTemp("", "testgrid-config-test")
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/def/configmap/main.go
+++ b/def/configmap/main.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -91,7 +90,7 @@ func buildConfigMap(name, namespace string, labels map[string]string, data map[s
 	if len(data) > 0 {
 		cm.Data = map[string]string{}
 		for key, value := range data {
-			buf, err := ioutil.ReadFile(value)
+			buf, err := os.ReadFile(value)
 			if err != nil {
 				wd, _ := os.Getwd()
 				return nil, fmt.Errorf("could not read %s/%s: %w", wd, value, err)
@@ -119,7 +118,7 @@ func main() {
 		fmt.Print(string(buf))
 		return
 	}
-	err = ioutil.WriteFile(opt.output, buf, 0644)
+	err = os.WriteFile(opt.output, buf, 0644)
 	if err != nil {
 		log.Fatalf("Failed to write %s: %v", opt.output, err)
 	}

--- a/experiment/bumpmonitoring/main.go
+++ b/experiment/bumpmonitoring/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,7 +64,7 @@ func parseOptions() (*options, error) {
 	flag.Parse()
 
 	var o options
-	data, err := ioutil.ReadFile(config)
+	data, err := os.ReadFile(config)
 	if err != nil {
 		return nil, fmt.Errorf("read %q: %w", config, err)
 	}
@@ -167,11 +166,11 @@ func (c *client) copyFiles() error {
 	for _, subPath := range c.paths {
 		SrcPath := path.Join(c.srcPath, subPath)
 		DstPath := path.Join(c.dstPath, subPath)
-		content, err := ioutil.ReadFile(SrcPath)
+		content, err := os.ReadFile(SrcPath)
 		if err != nil {
 			return fmt.Errorf("failed reading file %q: %w", SrcPath, err)
 		}
-		if err := ioutil.WriteFile(DstPath, content, 0755); err != nil {
+		if err := os.WriteFile(DstPath, content, 0755); err != nil {
 			return fmt.Errorf("failed writing file %q: %w", DstPath, err)
 		}
 	}

--- a/experiment/bumpmonitoring/main_test.go
+++ b/experiment/bumpmonitoring/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -87,7 +86,7 @@ func TestFindConfigToUpdate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", tc.name)
+			tmpDir, err := os.MkdirTemp("", tc.name)
 			if err != nil {
 				t.Fatalf("Failed creating temp dir: %v", err)
 			}
@@ -161,7 +160,7 @@ func TestCopyFiles(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", tc.name)
+			tmpDir, err := os.MkdirTemp("", tc.name)
 			if err != nil {
 				t.Fatalf("Failed creating temp dir: %v", err)
 			}
@@ -207,7 +206,7 @@ func pathToNode(t *testing.T, root, p string) node {
 	if info.IsDir() {
 		n.IsDir = true
 	} else {
-		bs, err := ioutil.ReadFile(p)
+		bs, err := os.ReadFile(p)
 		if err != nil {
 			t.Fatalf("Failed to read %q: %v", p, err)
 		}
@@ -233,7 +232,7 @@ func seedTempDir(t *testing.T, root string, srcNodes, dstNodes []node) (string, 
 				if err := os.MkdirAll(dir, 0755); err != nil {
 					t.Fatalf("Failed creating dir %q: %v", dir, err)
 				}
-				if err := ioutil.WriteFile(p, []byte(n.Content), 0777); err != nil {
+				if err := os.WriteFile(p, []byte(n.Content), 0777); err != nil {
 					t.Fatalf("Failed creating file %q: %v", p, err)
 				}
 			}

--- a/experiment/coverage/apicoverage.go
+++ b/experiment/coverage/apicoverage.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -93,7 +92,7 @@ func getOpenAPISpec(url string) apiArray {
 	if err != nil {
 		log.Fatal(err)
 	}
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/experiment/gerrit-onboarder/onboarder.go
+++ b/experiment/gerrit-onboarder/onboarder.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -164,7 +163,7 @@ func ensureUUID(groupsFile, uuid, group string) (string, error) {
 }
 
 func updateGroups(workDir, uuid, group string) error {
-	data, err := ioutil.ReadFile(path.Join(workDir, groupsFile))
+	data, err := os.ReadFile(path.Join(workDir, groupsFile))
 	if err != nil {
 		return fmt.Errorf("failed to read groups file: %w", err)
 	}
@@ -174,7 +173,7 @@ func updateGroups(workDir, uuid, group string) error {
 		return fmt.Errorf("failed to ensure group exists: %w", err)
 	}
 
-	err = ioutil.WriteFile(path.Join(workDir, groupsFile), []byte(newData), 0755)
+	err = os.WriteFile(path.Join(workDir, groupsFile), []byte(newData), 0755)
 	if err != nil {
 		return fmt.Errorf("failed to write groups file: %w", err)
 	}
@@ -297,7 +296,7 @@ func verifyInTree(workDir, host, cur_branch string, configMap map[string][]strin
 			// If it failed to fetch refs/meta/config for parent, or checkout the FETCH_HEAD, just catch the error and return False
 			return false, nil
 		}
-		data, err := ioutil.ReadFile(path.Join(workDir, projectConfigFile))
+		data, err := os.ReadFile(path.Join(workDir, projectConfigFile))
 		if err != nil {
 			return false, fmt.Errorf("failed to read project.config file: %w", err)
 		}
@@ -355,7 +354,7 @@ func ensureProjectConfig(workDir, config, host, cur_branch, groupName string) (s
 }
 
 func updatePojectConfig(workDir, host, cur_branch, groupName string) error {
-	data, err := ioutil.ReadFile(path.Join(workDir, projectConfigFile))
+	data, err := os.ReadFile(path.Join(workDir, projectConfigFile))
 	if err != nil {
 		return fmt.Errorf("failed to read project.config file: %w", err)
 	}
@@ -364,7 +363,7 @@ func updatePojectConfig(workDir, host, cur_branch, groupName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to ensure updated project config: %w", err)
 	}
-	err = ioutil.WriteFile(path.Join(workDir, projectConfigFile), []byte(newData), 0755)
+	err = os.WriteFile(path.Join(workDir, projectConfigFile), []byte(newData), 0755)
 	if err != nil {
 		return fmt.Errorf("failed to write groups file: %w", err)
 	}
@@ -453,7 +452,7 @@ func main() {
 			logrus.Fatal(err)
 		}
 	} else {
-		workDir, err = ioutil.TempDir("", "gerrit_onboarding")
+		workDir, err = os.MkdirTemp("", "gerrit_onboarding")
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/experiment/image-bumper/bumper/bumper.go
+++ b/experiment/image-bumper/bumper/bumper.go
@@ -19,9 +19,9 @@ package bumper
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -262,14 +262,14 @@ func updateAllTags(tagPicker func(host, image, tag string) (string, error), cont
 // UpdateFile updates a file in place.
 func (cli *Client) UpdateFile(tagPicker func(imageHost, imageName, currentTag string) (string, error),
 	path string, imageFilter *regexp.Regexp) error {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
 	newContent := updateAllTags(tagPicker, content, imageFilter)
 
-	if err := ioutil.WriteFile(path, newContent, 0644); err != nil {
+	if err := os.WriteFile(path, newContent, 0644); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 	return nil

--- a/experiment/ml/analyze/http.go
+++ b/experiment/ml/analyze/http.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -71,7 +71,7 @@ func processRequest(ctx context.Context, storageClient *storage.Client, predicto
 	if r.ContentLength > maxRequestLen {
 		return http.StatusBadRequest, "Request too long", fmt.Errorf("%d byte request", r.ContentLength)
 	}
-	bytes, err := ioutil.ReadAll(r.Body)
+	bytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return http.StatusBadRequest, "Could not read request", fmt.Errorf("read request: %w", err)
 	}

--- a/experiment/ml/prowlog/csv/generate-dataset.go
+++ b/experiment/ml/prowlog/csv/generate-dataset.go
@@ -42,7 +42,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -103,7 +102,7 @@ func main() {
 			continue
 		}
 		defer zf.Close()
-		b, err := ioutil.ReadAll(zf)
+		b, err := io.ReadAll(zf)
 		if err != nil {
 			log.Println("Failed to read eample", f.Name, err)
 			continue

--- a/experiment/ml/prowlog/generate-dataset.go
+++ b/experiment/ml/prowlog/generate-dataset.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -753,11 +752,11 @@ func (bc *buildCache) open(ctx context.Context, client gcs.ConditionalClient, pa
 		if bc.archivePath == "" {
 			return r, nil, nil
 		}
-		buf, err := ioutil.ReadAll(r)
+		buf, err := io.ReadAll(r)
 		if err != nil {
 			return nil, nil, fmt.Errorf("read: %v", err)
 		}
-		f = ioutil.NopCloser(bytes.NewBuffer(buf))
+		f = io.NopCloser(bytes.NewBuffer(buf))
 		when = &attrs.LastModified
 		if err := bc.initAdditional(); err != nil {
 			return nil, nil, fmt.Errorf("init additional: %v", err)

--- a/experiment/slack-oncall-updater/main.go
+++ b/experiment/slack-oncall-updater/main.go
@@ -20,9 +20,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -104,7 +104,7 @@ func updateGroupMembership(token, groupID, userID string) error {
 }
 
 func getTokenFromPath(path string) (string, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("couldn't open file: %w", err)
 	}

--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -152,7 +151,7 @@ func getStorageClient(o options) (*storage.Client, error) {
 	}
 
 	if o.oauthTokenFile != "" {
-		b, err := ioutil.ReadFile(o.oauthTokenFile)
+		b, err := os.ReadFile(o.oauthTokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("error reading oauth token file %s: %w", o.oauthTokenFile, err)
 		}

--- a/gencred/cmd/gencred/main.go
+++ b/gencred/cmd/gencred/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -143,7 +142,7 @@ func (o *options) defaultAndValidateFlags() (*config, error) {
 	var c config
 	if len(o.config) > 0 {
 		// Load from config yaml file
-		body, err := ioutil.ReadFile(o.config)
+		body, err := os.ReadFile(o.config)
 		if err != nil {
 			util.PrintErrAndExit(err)
 		}
@@ -194,13 +193,13 @@ func (o *options) defaultAndValidateFlags() (*config, error) {
 
 // mergeConfigs merges an existing kubeconfig file with a new entry with precedence given to the existing config.
 func mergeConfigs(c clusterConfig, kubeconfig []byte) ([]byte, error) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, &util.ExitError{Message: err.Error(), Code: 1}
 	}
 	defer os.Remove(tmpFile.Name())
 
-	err = ioutil.WriteFile(tmpFile.Name(), kubeconfig, 0644)
+	err = os.WriteFile(tmpFile.Name(), kubeconfig, 0644)
 	if err != nil {
 		return nil, &util.ExitError{Message: err.Error(), Code: 1}
 	}
@@ -257,7 +256,7 @@ func writeConfig(c clusterConfig, clientset kubernetes.Interface) error {
 			}
 		}
 
-		if err = ioutil.WriteFile(*c.Output, kubeconfig, 0644); err != nil {
+		if err = os.WriteFile(*c.Output, kubeconfig, 0644); err != nil {
 			return &util.ExitError{Message: fmt.Sprintf("unable to write to file %v: %v.", file, err), Code: 1}
 		}
 	}

--- a/gencred/cmd/gencred/main_test.go
+++ b/gencred/cmd/gencred/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gencred
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -114,7 +113,7 @@ func TestValidateFlags(t *testing.T) {
 			if len(test.config) > 0 {
 				tmpDir := t.TempDir()
 				tmpFile := path.Join(tmpDir, test.name+".yaml")
-				if err := ioutil.WriteFile(tmpFile, []byte(test.config), 0644); err != nil {
+				if err := os.WriteFile(tmpFile, []byte(test.config), 0644); err != nil {
 					t.Fatalf("Failed writing tmp file: %v", err)
 				}
 				os.Args = append(os.Args, "--config="+tmpFile)

--- a/ghproxy/apptokenequalizer/app_token_equalizer_test.go
+++ b/ghproxy/apptokenequalizer/app_token_equalizer_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -107,11 +106,11 @@ func TestRoundTrip(t *testing.T) {
 				t.Errorf("actual status code differs from expected: %s", diff)
 			}
 
-			actualBody, err := ioutil.ReadAll(response.Body)
+			actualBody, err := io.ReadAll(response.Body)
 			if err != nil {
 				t.Fatalf("failed to read actual response body: %v", err)
 			}
-			expectedBody, err := ioutil.ReadAll(tc.expectedResponse.Body)
+			expectedBody, err := io.ReadAll(tc.expectedResponse.Body)
 			if err != nil {
 				t.Fatalf("failed to read expected response body: %v", err)
 			}
@@ -127,7 +126,7 @@ func serializeOrDie(in interface{}) io.ReadCloser {
 	if err != nil {
 		panic(fmt.Sprintf("Serialization failed: %v", err))
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(rawData))
+	return io.NopCloser(bytes.NewBuffer(rawData))
 }
 
 type fakeRoundTripper struct {

--- a/ghproxy/ghcache/coalesce_test.go
+++ b/ghproxy/ghcache/coalesce_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -61,7 +61,7 @@ func (fre *fakeRequestExecutor) RoundTrip(req *http.Request) (*http.Response, er
 		header = http.Header{}
 	}
 	return &http.Response{
-			Body:   ioutil.NopCloser(bytes.NewBufferString("Response")),
+			Body:   io.NopCloser(bytes.NewBufferString("Response")),
 			Header: header,
 		},
 		nil
@@ -240,7 +240,7 @@ func runRequest(rt http.RoundTripper, uri string, immediate bool) (*http.Respons
 		defer close(waitChan)
 		resp, err = rt.RoundTrip(req)
 		if err == nil {
-			if b, readErr := ioutil.ReadAll(resp.Body); readErr != nil {
+			if b, readErr := io.ReadAll(resp.Body); readErr != nil {
 				err = readErr
 			} else if string(b) != "Response" {
 				err = errors.New("unexpected response value")

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -29,7 +29,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -441,7 +440,7 @@ func Prune(baseDir string, now func() time.Time) {
 			metadataPath := path.Join(base, cachePartitionCandidate.Name(), cachePartitionMetadataFileName)
 
 			// Read optimistically and just ignore errors
-			raw, err := ioutil.ReadFile(metadataPath)
+			raw, err := os.ReadFile(metadataPath)
 			if err != nil {
 				continue
 			}
@@ -479,7 +478,7 @@ func writecachePartitionMetadata(basePath, tempDir string, expiresAt *time.Time)
 			errs = append(errs, fmt.Errorf("failed to create dir %s: %w", destBase, err))
 		}
 		dest := path.Join(destBase, cachePartitionMetadataFileName)
-		if err := ioutil.WriteFile(dest, serialized, 0644); err != nil {
+		if err := os.WriteFile(dest, serialized, 0644); err != nil {
 			errs = append(errs, fmt.Errorf("failed to write %s: %w", dest, err))
 		}
 	}

--- a/gopherage/cmd/html/html.go
+++ b/gopherage/cmd/html/html.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -83,7 +82,7 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Couldn't read the HTML template: %v.", err)
 		os.Exit(1)
 	}
-	script, err := ioutil.ReadFile(filepath.Join(resourceDir, "browser_bundle.es2015.js"))
+	script, err := os.ReadFile(filepath.Join(resourceDir, "browser_bundle.es2015.js"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't read JavaScript: %v.", err)
 		os.Exit(1)
@@ -103,9 +102,9 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		var content []byte
 		var err error
 		if arg == "-" {
-			content, err = ioutil.ReadAll(os.Stdin)
+			content, err = io.ReadAll(os.Stdin)
 		} else {
-			content, err = ioutil.ReadFile(arg)
+			content, err = os.ReadFile(arg)
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't read coverage file: %v.", err)

--- a/gopherage/pkg/util/util.go
+++ b/gopherage/pkg/util/util.go
@@ -18,11 +18,11 @@ package util
 
 import (
 	"fmt"
-	"golang.org/x/tools/cover"
 	"io"
-	"io/ioutil"
-	"k8s.io/test-infra/gopherage/pkg/cov"
 	"os"
+
+	"golang.org/x/tools/cover"
+	"k8s.io/test-infra/gopherage/pkg/cov"
 )
 
 // DumpProfile dumps the profile to the given file destination.
@@ -54,7 +54,7 @@ func LoadProfile(origin string) ([]*cover.Profile, error) {
 		// Annoyingly, ParseProfiles only accepts a filename, so we have to write the bytes to disk
 		// so it can read them back.
 		// We could probably also just give it /dev/stdin, but that'll break on Windows.
-		tf, err := ioutil.TempFile("", "")
+		tf, err := os.CreateTemp("", "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp file: %w", err)
 		}

--- a/greenhouse/diskcache/cache.go
+++ b/greenhouse/diskcache/cache.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +99,7 @@ func (c *Cache) Put(key string, content io.Reader, contentSHA256 string) error {
 	}
 
 	// create a temp file to get the content on disk
-	temp, err := ioutil.TempFile(dir, "temp-put")
+	temp, err := os.CreateTemp(dir, "temp-put")
 	if err != nil {
 		return fmt.Errorf("failed to create cache entry: %w", err)
 	}

--- a/greenhouse/diskcache/cache_test.go
+++ b/greenhouse/diskcache/cache_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -88,7 +87,7 @@ func TestPathToKeyKeyToPath(t *testing.T) {
 // test stateful cache methods
 func TestCacheStorage(t *testing.T) {
 	// create a cache in a tempdir
-	dir, err := ioutil.TempDir("", "cache-tests")
+	dir, err := os.MkdirTemp("", "cache-tests")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir for tests! %v", err)
 	}
@@ -170,7 +169,7 @@ func TestCacheStorage(t *testing.T) {
 				t.Fatalf("Got key does not exist for test case '%s' which should.", tc.Name)
 			}
 			if exists {
-				read, err2 := ioutil.ReadAll(contents)
+				read, err2 := io.ReadAll(contents)
 				if err2 != nil {
 					t.Fatalf("Failed to read contents for test case '%s", tc.Name)
 				}

--- a/hack/gen-prow-documented/main.go
+++ b/hack/gen-prow-documented/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -77,7 +76,7 @@ func (g *genConfig) gen(rootDir string) error {
 	if err != nil {
 		return fmt.Errorf("genyaml errored: %w", err)
 	}
-	if err := ioutil.WriteFile(path.Join(rootDir, g.out), []byte(actualYaml), 0644); err != nil {
+	if err := os.WriteFile(path.Join(rootDir, g.out), []byte(actualYaml), 0644); err != nil {
 		return fmt.Errorf("failed to write fixture: %w", err)
 	}
 	return nil

--- a/hack/gen-prow-documented/main_test.go
+++ b/hack/gen-prow-documented/main_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -64,7 +64,7 @@ skip_report: true
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			in, out := tc.name+".in", tc.name+".out"
-			if err := ioutil.WriteFile(path.Join(tmpDir, in), tc.rawContents, 0644); err != nil {
+			if err := os.WriteFile(path.Join(tmpDir, in), tc.rawContents, 0644); err != nil {
 				t.Fatalf("Failed creating input: %v", err)
 			}
 			g := genConfig{
@@ -79,7 +79,7 @@ skip_report: true
 				t.Fatalf("Got unexpected error: %v", err)
 			}
 
-			got, err := ioutil.ReadFile(path.Join(tmpDir, out))
+			got, err := os.ReadFile(path.Join(tmpDir, out))
 			if err != nil {
 				t.Fatalf("Failed reading out: %v", err)
 			}

--- a/hack/prowimagebuilder/main.go
+++ b/hack/prowimagebuilder/main.go
@@ -18,10 +18,10 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -29,8 +29,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"context"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/flagutil"
@@ -144,7 +142,7 @@ type imageDefs struct {
 }
 
 func loadImageDefs(p string) ([]imageDef, error) {
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/prowimagebuilder/main_test.go
+++ b/hack/prowimagebuilder/main_test.go
@@ -19,7 +19,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -149,7 +149,7 @@ func TestLoadImageDefs(t *testing.T) {
 		{Dir: "prow/cmd/clonerefs", Arch: "all"},
 	}
 
-	if err := ioutil.WriteFile(file, []byte(body), 0644); err != nil {
+	if err := os.WriteFile(file, []byte(body), 0644); err != nil {
 		t.Fatalf("Failed write file: %v", err)
 	}
 	defs, err := loadImageDefs(file)

--- a/hack/ts-rollup/main.go
+++ b/hack/ts-rollup/main.go
@@ -18,17 +18,15 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
 	"sync"
-
-	"context"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -78,7 +76,7 @@ type packageInfo struct {
 }
 
 func loadPackagesInfo(f string) (*packagesInfo, error) {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("reading file %q: %w", f, err)
 	}

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -63,7 +62,7 @@ func getProjectID() (string, error) {
 
 func getImageName(o options, tag string, config string) (string, error) {
 	var cloudbuildyamlFile CloudBuildYAMLFile
-	buf, _ := ioutil.ReadFile(o.cloudbuildFile)
+	buf, _ := os.ReadFile(o.cloudbuildFile)
 	if err := yaml.Unmarshal(buf, &cloudbuildyamlFile); err != nil {
 		return "", fmt.Errorf("failed to get image name: %w", err)
 	}
@@ -127,7 +126,7 @@ func (o *options) validateConfigDir() error {
 }
 
 func (o *options) uploadBuildDir(targetBucket string) (string, error) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
@@ -223,7 +222,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 
 	if err := cmd.Run(); err != nil {
 		if o.logDir != "" {
-			buildLog, _ := ioutil.ReadFile(logFilePath)
+			buildLog, _ := os.ReadFile(logFilePath)
 			fmt.Println(string(buildLog))
 		}
 		return fmt.Errorf("error running %s: %w", cmd.Args, err)
@@ -235,7 +234,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 type variants map[string]map[string]string
 
 func getVariants(o options) (variants, error) {
-	content, err := ioutil.ReadFile(path.Join(o.configDir, "variants.yaml"))
+	content, err := os.ReadFile(path.Join(o.configDir, "variants.yaml"))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to load variants.yaml: %w", err)

--- a/kubetest/aks.go
+++ b/kubetest/aks.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	mathrand "math/rand"
 	"os"
@@ -93,7 +92,7 @@ func newAksDeployer() (*aksDeployer, error) {
 		return nil, fmt.Errorf("error trying to get Azure Client: %w", err)
 	}
 
-	outputDir, err := ioutil.TempDir(os.Getenv("HOME"), "aks")
+	outputDir, err := os.MkdirTemp(os.Getenv("HOME"), "aks")
 	if err != nil {
 		return nil, fmt.Errorf("error creating tempdir: %w", err)
 	}
@@ -142,7 +141,7 @@ func (a *aksDeployer) Up() error {
 		return fmt.Errorf("error downloading AKS cluster template: %v with error %w", a.templateURL, err)
 	}
 
-	template, err := ioutil.ReadFile(templateFile)
+	template, err := os.ReadFile(templateFile)
 	if err != nil {
 		return fmt.Errorf("failed to read downloaded cluster template file: %w", err)
 	}
@@ -199,7 +198,7 @@ func (a *aksDeployer) Up() error {
 	}
 
 	kubeconfigPath := path.Join(a.outputDir, "kubeconfig")
-	if err := ioutil.WriteFile(kubeconfigPath, *(*credentialList.Kubeconfigs)[0].Value, 0644); err != nil {
+	if err := os.WriteFile(kubeconfigPath, *(*credentialList.Kubeconfigs)[0].Value, 0644); err != nil {
 		return fmt.Errorf("failed to write kubeconfig out")
 	}
 
@@ -352,7 +351,7 @@ func (a *aksDeployer) dockerLogin() error {
 		log.Println("Attempting Docker login with docker cred.")
 		username = os.Getenv("DOCKER_USERNAME")
 		passwordFile := os.Getenv("DOCKER_PASSWORD_FILE")
-		password, err := ioutil.ReadFile(passwordFile)
+		password, err := os.ReadFile(passwordFile)
 		if err != nil {
 			return fmt.Errorf("error reading docker password file %v: %w", passwordFile, err)
 		}

--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -366,7 +365,7 @@ func getOAuthConfig(env azure.Environment, subscriptionID, tenantID string) (*ad
 }
 
 func getAzCredentials() (*Creds, error) {
-	content, err := ioutil.ReadFile(*aksCredentialsFile)
+	content, err := os.ReadFile(*aksCredentialsFile)
 	log.Printf("Reading credentials file %v", *aksCredentialsFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading credentials file %v %w", *aksCredentialsFile, err)
@@ -462,7 +461,7 @@ func populateAzureCloudConfig(isVMSS bool, credentials Creds, azureEnvironment, 
 	}
 
 	cloudConfigPath := path.Join(outputDir, "azure.json")
-	if err := ioutil.WriteFile(cloudConfigPath, cloudConfig, 0644); err != nil {
+	if err := os.WriteFile(cloudConfigPath, cloudConfig, 0644); err != nil {
 		return fmt.Errorf("cannot write Azure cloud config to file: %w", err)
 	}
 	if err := os.Setenv("CLOUD_CONFIG", cloudConfigPath); err != nil {

--- a/kubetest/aksengine_test.go
+++ b/kubetest/aksengine_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 )
@@ -189,12 +189,12 @@ func TestStrictJSON(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "")
+			tempDir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatalf("failed to create a temporary directory: %v", err)
 			}
 			// Write tc.apiModel to a file so aksEngineDeployer can read it
-			if err := ioutil.WriteFile(path.Join(tempDir, "kubernetes.json"), []byte(tc.apiModel), 0644); err != nil {
+			if err := os.WriteFile(path.Join(tempDir, "kubernetes.json"), []byte(tc.apiModel), 0644); err != nil {
 				t.Fatalf("failed to write kubernetes.json: %v", err)
 			}
 			c := getMockAKSEngineDeployer(tempDir)

--- a/kubetest/boskos/client/client.go
+++ b/kubetest/boskos/client/client.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -407,7 +406,7 @@ func (c *Client) acquire(rtype, state, dest, requestID string) (*common.Resource
 
 		switch resp.StatusCode {
 		case http.StatusOK:
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return false, err
 			}
@@ -560,7 +559,7 @@ func (c *Client) reset(rtype, state string, expire time.Duration, dest string) (
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusOK {
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return false, err
 			}
@@ -594,7 +593,7 @@ func (c *Client) metric(rtype string) (common.Metric, error) {
 			return false, nil
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, err
 		}

--- a/kubetest/boskos/common/config.go
+++ b/kubetest/boskos/common/config.go
@@ -19,7 +19,7 @@ package common
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -105,7 +105,7 @@ func ValidateConfig(config *BoskosConfig) error {
 // ParseConfig reads in configPath and returns a list of resource objects
 // on success.
 func ParseConfig(configPath string) (*BoskosConfig, error) {
-	file, err := ioutil.ReadFile(configPath)
+	file, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -161,7 +160,7 @@ func Test_logDumperNode_shellToFile(t *testing.T) {
 			stderr:  []byte(g.stderr),
 		})
 
-		tmpfile, err := ioutil.TempFile("", "")
+		tmpfile, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Errorf("error creating temp file: %v", err)
 			continue
@@ -184,7 +183,7 @@ func Test_logDumperNode_shellToFile(t *testing.T) {
 			continue
 		}
 
-		actual, err := ioutil.ReadFile(tmpfile.Name())
+		actual, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
 			t.Errorf("unexpected error reading file: %v", err)
 			continue
@@ -198,7 +197,7 @@ func Test_logDumperNode_shellToFile(t *testing.T) {
 }
 
 func Test_logDumperNode_dump(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("error creating temp dir: %v", err)
 		return

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -305,7 +304,7 @@ func run(deploy deployer, o options) error {
 	if len(errs) == 0 && o.publish != "" {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "Publish version", func() error {
 			// Use plaintext version file packaged with kubernetes.tar.gz
-			v, err := ioutil.ReadFile("version")
+			v, err := os.ReadFile("version")
 			if err != nil {
 				return err
 			}
@@ -390,7 +389,7 @@ func listNodes(dp deployer, dump string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(dump, "nodes.yaml"), b, 0644)
+	return os.WriteFile(filepath.Join(dump, "nodes.yaml"), b, 0644)
 }
 
 func listKubemarkNodes(dp deployer, dump string) error {
@@ -406,13 +405,13 @@ func listKubemarkNodes(dp deployer, dump string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(dump, "kubemark_nodes.yaml"), b, 0644)
+	return os.WriteFile(filepath.Join(dump, "kubemark_nodes.yaml"), b, 0644)
 }
 
 func diffResources(before, clusterUp, clusterDown, after []byte, location string) error {
 	if location == "" {
 		var err error
-		location, err = ioutil.TempDir("", "e2e-check-resources")
+		location, err = os.MkdirTemp("", "e2e-check-resources")
 		if err != nil {
 			return fmt.Errorf("Could not create e2e-check-resources temp dir: %s", err)
 		}
@@ -425,21 +424,21 @@ func diffResources(before, clusterUp, clusterDown, after []byte, location string
 	ap := filepath.Join(location, "gcp-resources-after.txt")
 	dp := filepath.Join(location, "gcp-resources-diff.txt")
 
-	if err := ioutil.WriteFile(bp, before, mode); err != nil {
+	if err := os.WriteFile(bp, before, mode); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(up, clusterUp, mode); err != nil {
+	if err := os.WriteFile(up, clusterUp, mode); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(cdp, clusterDown, mode); err != nil {
+	if err := os.WriteFile(cdp, clusterDown, mode); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(ap, after, mode); err != nil {
+	if err := os.WriteFile(ap, after, mode); err != nil {
 		return err
 	}
 
 	stdout, cerr := control.Output(exec.Command("diff", "-sw", "-U0", "-F^\\[.*\\]$", bp, ap))
-	if err := ioutil.WriteFile(dp, stdout, mode); err != nil {
+	if err := os.WriteFile(dp, stdout, mode); err != nil {
 		return err
 	}
 	if cerr == nil { // No diffs

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -137,7 +137,7 @@ func (e extractStrategy) name() string {
 
 func (l extractStrategies) Extract(project, zone, region, ciBucket, releaseBucket string, extractSrc bool) error {
 	// rm -rf kubernetes*
-	files, err := ioutil.ReadDir(".")
+	files, err := os.ReadDir(".")
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func ensureKube() (string, error) {
 	}
 
 	// Download it to a temp file
-	f, err := ioutil.TempFile("", "get-kube")
+	f, err := os.CreateTemp("", "get-kube")
 	if err != nil {
 		return "", err
 	}
@@ -339,7 +339,7 @@ var httpCat = func(url string) ([]byte, error) {
 		return nil, fmt.Errorf("Unexpected HTTP status code: %d", resp.StatusCode)
 	}
 
-	release, err := ioutil.ReadAll(resp.Body)
+	release, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (e extractStrategy) Extract(project, zone, region, ciBucket, releaseBucket 
 	switch e.mode {
 	case localBazel:
 		vFile := util.K8s("kubernetes", "bazel-bin", "version")
-		vByte, err := ioutil.ReadFile(vFile)
+		vByte, err := os.ReadFile(vFile)
 		if err != nil {
 			return err
 		}
@@ -451,7 +451,7 @@ func (e extractStrategy) Extract(project, zone, region, ciBucket, releaseBucket 
 		return getKube(fmt.Sprintf("file://%s", root), version, extractSrc)
 	case local:
 		url := util.K8s("kubernetes", "_output", "gcs-stage")
-		files, err := ioutil.ReadDir(url)
+		files, err := os.ReadDir(url)
 		if err != nil {
 			return err
 		}

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -117,7 +116,7 @@ func TestGetKube(t *testing.T) {
 	} else {
 		defer os.Chdir(o)
 	}
-	if d, err := ioutil.TempDir("", "extract"); err != nil {
+	if d, err := os.MkdirTemp("", "extract"); err != nil {
 		t.Fatal(err)
 	} else if err := os.Chdir(d); err != nil {
 		t.Fatal(err)
@@ -125,7 +124,7 @@ func TestGetKube(t *testing.T) {
 
 	for _, tc := range cases {
 		bytes := []byte(fmt.Sprintf("#!/bin/bash\necho hello\n%s\nmkdir -p ./kubernetes/cluster && touch ./kubernetes/cluster/get-kube-binaries.sh", tc.script))
-		if err := ioutil.WriteFile("./get-kube.sh", bytes, 0700); err != nil {
+		if err := os.WriteFile("./get-kube.sh", bytes, 0700); err != nil {
 			t.Fatal(err)
 		}
 		err := getKube("url", "version", false)
@@ -267,7 +266,7 @@ func TestExtractStrategies(t *testing.T) {
 	releaseBucket := "k8s-release"
 
 	for _, tc := range cases {
-		if d, err := ioutil.TempDir("", "extract"); err != nil {
+		if d, err := os.MkdirTemp("", "extract"); err != nil {
 			t.Fatal(err)
 		} else if err := os.Chdir(d); err != nil {
 			t.Fatal(err)
@@ -363,7 +362,7 @@ func TestGciExtractStrategy(t *testing.T) {
 	releaseBucket := "k8s-release"
 
 	for _, tc := range cases {
-		if d, err := ioutil.TempDir("", "extract"); err != nil {
+		if d, err := os.MkdirTemp("", "extract"); err != nil {
 			t.Fatal(err)
 		} else if err := os.Chdir(d); err != nil {
 			t.Fatal(err)

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -242,7 +241,7 @@ func newGKE(provider, project, zone, region, network, image, imageFamily, imageP
 	}
 
 	// Override kubecfg to a temporary file rather than trashing the user's.
-	f, err := ioutil.TempFile("", "gke-kubecfg")
+	f, err := os.CreateTemp("", "gke-kubecfg")
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +559,7 @@ export KUBE_NODE_OS_DISTRIBUTION='%[3]s'
 		return wrapErrors("DumpClusterLogs", errs...)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(localPath, "gke-configmap.json"), jsonDump, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(localPath, "gke-configmap.json"), jsonDump, 0644); err != nil {
 		errs = append(errs, err)
 		return wrapErrors("DumpClusterLogs", errs...)
 	}

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -191,7 +190,7 @@ func migrateKopsEnv() error {
 }
 
 func newKops(provider, gcpProject, cluster string) (*kops, error) {
-	tmpdir, err := ioutil.TempDir("", "kops")
+	tmpdir, err := os.MkdirTemp("", "kops")
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +546,7 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 	if strings.HasPrefix(privateKeyPath, "~/") {
 		privateKeyPath = filepath.Join(os.Getenv("HOME"), privateKeyPath[2:])
 	}
-	key, err := ioutil.ReadFile(privateKeyPath)
+	key, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		return fmt.Errorf("error reading private key %q: %w", k.sshPrivateKey, err)
 	}

--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -41,7 +40,7 @@ type localCluster struct {
 var _ deployer = localCluster{}
 
 func newLocalCluster() *localCluster {
-	tempDir, err := ioutil.TempDir("", "kubetest-local")
+	tempDir, err := os.MkdirTemp("", "kubetest-local")
 	if err != nil {
 		log.Fatal("unable to create temp directory")
 	}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -491,7 +490,7 @@ func acquireKubernetes(o *options, d deployer) error {
 func findVersion() string {
 	// The version may be in a version file
 	if _, err := os.Stat("version"); err == nil {
-		b, err := ioutil.ReadFile("version")
+		b, err := os.ReadFile("version")
 		if err == nil {
 			return strings.TrimSpace(string(b))
 		}
@@ -514,7 +513,7 @@ func findVersion() string {
 
 // maybeMergeMetadata will add new keyvals into the map; quietly eats errors.
 func maybeMergeJSON(meta map[string]string, path string) {
-	if data, err := ioutil.ReadFile(path); err == nil {
+	if data, err := os.ReadFile(path); err == nil {
 		json.Unmarshal(data, &meta)
 	}
 }
@@ -810,7 +809,7 @@ func prepareGcp(o *options) error {
 	log.Printf("Checking presence of public key in %s", o.gcpProject)
 	if out, err := control.Output(exec.Command("gcloud", "compute", "--project="+o.gcpProject, "project-info", "describe")); err != nil {
 		return err
-	} else if b, err := ioutil.ReadFile(pk); err != nil {
+	} else if b, err := os.ReadFile(pk); err != nil {
 		return err
 	} else if !strings.Contains(string(out), string(b)) {
 		log.Print("Uploading public ssh key to project metadata...")
@@ -1014,7 +1013,7 @@ func prepareGinkgoParallel(v *ginkgoParallelValue) error {
 }
 
 func publish(pub string) error {
-	v, err := ioutil.ReadFile("version")
+	v, err := os.ReadFile("version")
 	if err != nil {
 		return err
 	}

--- a/kubetest/main_test.go
+++ b/kubetest/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -63,13 +62,13 @@ func TestWriteMetadata(t *testing.T) {
 
 	writeTmpMetadataSource := func(filePath string, md mdata) {
 		outputBytes, _ := json.MarshalIndent(md, "", "  ")
-		if err := ioutil.WriteFile(filePath, outputBytes, 0644); err != nil {
+		if err := os.WriteFile(filePath, outputBytes, 0644); err != nil {
 			t.Fatalf("write to %q: %v", filePath, err)
 		}
 	}
 
 	for _, tc := range cases {
-		topDir, err := ioutil.TempDir("", "TestWriteMetadata")
+		topDir, err := os.MkdirTemp("", "TestWriteMetadata")
 
 		if err != nil {
 			t.Fatal(err)
@@ -82,7 +81,7 @@ func TestWriteMetadata(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(topDir, "version"), []byte(tc.version+"\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(topDir, "version"), []byte(tc.version+"\n"), 0644); err != nil {
 			t.Fatalf("write %q/version: %v", topDir, err)
 		}
 		sourceNames := []string{}

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -305,7 +304,7 @@ func getChannelGKEVersion(project, zone, region, gkeChannel, extractionMethod st
 // gcsWrite uploads contents to the dest location in GCS.
 // It currently shells out to gsutil, but this could change in future.
 func gcsWrite(dest string, contents []byte) error {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return fmt.Errorf("error creating temp file: %w", err)
 	}

--- a/kubetest/util_test.go
+++ b/kubetest/util_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -27,7 +26,7 @@ import (
 
 func TestHttpFileScheme(t *testing.T) {
 	expected := "some testdata"
-	tmpfile, err := ioutil.TempFile("", "test_http_file_scheme")
+	tmpfile, err := os.CreateTemp("", "test_http_file_scheme")
 	if err != nil {
 		t.Errorf("Error creating temporary file: %v", err)
 	}

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -353,7 +352,7 @@ func LoadConfig(path string, orgs string) (*Configuration, error) {
 		return nil, errors.New("empty path")
 	}
 	var c Configuration
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/linkcheck/links.go
+++ b/linkcheck/links.go
@@ -23,7 +23,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -84,7 +83,7 @@ func newWalkFunc(invalidLink *bool, client *http.Client) filepath.WalkFunc {
 			return nil
 		}
 
-		fileBytes, err := ioutil.ReadFile(filePath)
+		fileBytes, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}

--- a/logexporter/cmd/main.go
+++ b/logexporter/cmd/main.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -108,7 +107,7 @@ func createSystemdLogfile(service string, outputMode string, outputDir string) e
 		return fmt.Errorf("Journalctl command for '%v' service failed: %w", service, err)
 	}
 	logfile := filepath.Join(outputDir, service+".log")
-	if err := ioutil.WriteFile(logfile, output, 0444); err != nil {
+	if err := os.WriteFile(logfile, output, 0444); err != nil {
 		return fmt.Errorf("Writing to file of journalctl logs for '%v' service failed: %w", service, err)
 	}
 	return nil
@@ -123,7 +122,7 @@ func createFullSystemdLogfile(outputDir string) error {
 		return fmt.Errorf("Journalctl command failed: %w", err)
 	}
 	logfile := filepath.Join(outputDir, "systemd.log")
-	if err := ioutil.WriteFile(logfile, output, 0444); err != nil {
+	if err := os.WriteFile(logfile, output, 0444); err != nil {
 		return fmt.Errorf("Writing full journalctl logs to file failed: %w", err)
 	}
 	return nil
@@ -247,7 +246,7 @@ func runCommand(name string, arg ...string) error {
 
 func dumpNetworkDebugInfo() {
 	klog.Info("Dumping network connectivity debug info")
-	resolv, err := ioutil.ReadFile("/etc/resolv.conf")
+	resolv, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {
 		klog.Errorf("Failed to read /etc/resolv.conf: %v", err)
 	}
@@ -278,7 +277,7 @@ func main() {
 		klog.Fatalf("Bad config provided: %v", err)
 	}
 
-	localTmpLogPath, err := ioutil.TempDir("/tmp", "k8s-systemd-logs")
+	localTmpLogPath, err := os.MkdirTemp("/tmp", "k8s-systemd-logs")
 	if err != nil {
 		klog.Fatalf("Could not create temporary dir locally for copying logs: %v", err)
 	}

--- a/pkg/benchmarkjunit/integration_test.go
+++ b/pkg/benchmarkjunit/integration_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 )
 
 func createTempFile() (string, error) {
-	outFile, err := ioutil.TempFile("", "dummybenchmarks")
+	outFile, err := os.CreateTemp("", "dummybenchmarks")
 	if err != nil {
 		return "", fmt.Errorf("create error: %w", err)
 	}
@@ -84,14 +83,14 @@ func TestDummybenchmarksIntegration(t *testing.T) {
 	t.Log("Finished running benchmarkjunit. Validating JUnit XML...")
 
 	// Print log file contents.
-	rawLog, err := ioutil.ReadFile(opts.logFile)
+	rawLog, err := os.ReadFile(opts.logFile)
 	if err != nil {
 		t.Fatalf("Error reading log file: %v.", err)
 	}
 	t.Logf("Log file output:\n%s\n\n", string(rawLog))
 
 	// Read and parse JUnit output.
-	raw, err := ioutil.ReadFile(opts.outputFile)
+	raw, err := os.ReadFile(opts.outputFile)
 	if err != nil {
 		t.Fatalf("Error reading output file: %v.", err)
 	}

--- a/pkg/benchmarkjunit/main.go
+++ b/pkg/benchmarkjunit/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -86,7 +85,7 @@ func run(opts *options, args []string) {
 		logrus.WithError(testErr).Error("Error(s) executing benchmarks.")
 	}
 	if len(opts.logFile) > 0 && opts.logFile != "-" {
-		if err := ioutil.WriteFile(opts.logFile, testOutput, 0666); err != nil {
+		if err := os.WriteFile(opts.logFile, testOutput, 0666); err != nil {
 			logrus.WithError(err).Fatalf("Failed to write to log file %q.", opts.logFile)
 		}
 	}
@@ -107,7 +106,7 @@ func run(opts *options, args []string) {
 	if opts.outputFile == "-" {
 		fmt.Println(string(junitBytes))
 	} else {
-		if err := ioutil.WriteFile(opts.outputFile, junitBytes, 0666); err != nil {
+		if err := os.WriteFile(opts.outputFile, junitBytes, 0666); err != nil {
 			logrus.WithError(err).Fatalf("Failed to write JUnit to output file %q.", opts.outputFile)
 		}
 	}

--- a/pkg/genyaml/genyaml_test.go
+++ b/pkg/genyaml/genyaml_test.go
@@ -19,7 +19,7 @@ package genyaml
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,7 +56,7 @@ func fileName(t *testing.T, extension string) string {
 }
 
 func readFile(t *testing.T, extension string) []byte {
-	data, err := ioutil.ReadFile(fileName(t, extension))
+	data, err := os.ReadFile(fileName(t, extension))
 	if err != nil {
 		t.Errorf("Failed reading .%s file: %v.", extension, err)
 	}

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -747,7 +747,7 @@ func (c *client) request(req *http.Request, logger *logrus.Entry) ([]byte, error
 			logger.WithError(err).Warn("could not close response body")
 		}
 	}()
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not read response body: %w", err)
 	}

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -156,7 +156,7 @@ func TestCreateBug(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("failed to read request body: %v", err)
 			http.Error(w, "500 Server Error", http.StatusInternalServerError)
@@ -342,7 +342,7 @@ func TestCreateComment(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("failed to read request body: %v", err)
 			http.Error(w, "500 Server Error", http.StatusInternalServerError)
@@ -520,7 +520,7 @@ func TestUpdateBug(t *testing.T) {
 			return
 		} else {
 			if id == 1705243 {
-				raw, err := ioutil.ReadAll(r.Body)
+				raw, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Errorf("failed to read update body: %v", err)
 				}
@@ -659,7 +659,7 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 			Parameters []AddExternalBugParameters `json:"params"`
 			ID         string                     `json:"id"`
 		}
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("failed to read request body: %v", err)
 			http.Error(w, "500 Server Error", http.StatusInternalServerError)
@@ -790,7 +790,7 @@ func TestRemovePullRequestAsExternalBug(t *testing.T) {
 			Parameters []RemoveExternalBugParameters `json:"params"`
 			ID         string                        `json:"id"`
 		}
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("failed to read request body: %v", err)
 			http.Error(w, "500 Server Error", http.StatusInternalServerError)

--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -106,7 +105,7 @@ func (o *Options) createRecords() []clone.Record {
 	// Print md5 sum of cookiefile for debugging purpose
 	if len(o.CookiePath) > 0 {
 		l := logrus.WithField("http-cookiefile", o.CookiePath)
-		f, err := ioutil.ReadFile(o.CookiePath)
+		f, err := os.ReadFile(o.CookiePath)
 		if err != nil {
 			l.WithError(err).Warn("Cannot read http cookiefile")
 		} else {
@@ -167,7 +166,7 @@ func (o Options) Run() error {
 		return fmt.Errorf("marshal clone records: %w", err)
 	}
 
-	if err := ioutil.WriteFile(o.Log, logData, 0755); err != nil {
+	if err := os.WriteFile(o.Log, logData, 0755); err != nil {
 		return fmt.Errorf("write clone records: %w", err)
 	}
 

--- a/prow/clonerefs/run_test.go
+++ b/prow/clonerefs/run_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -41,13 +40,13 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	srcRoot, err := ioutil.TempDir("", "clonerefs_unittest")
+	srcRoot, err := os.MkdirTemp("", "clonerefs_unittest")
 	if err != nil {
 		t.Fatalf("Error while creating temp dir: %v.", err)
 	}
 	defer os.RemoveAll(srcRoot)
 
-	oauthTokenDir, err := ioutil.TempDir("", "oauth")
+	oauthTokenDir, err := os.MkdirTemp("", "oauth")
 	if err != nil {
 		t.Fatalf("Error while creating oauth token dir: %v.", err)
 	}
@@ -55,11 +54,11 @@ func TestRun(t *testing.T) {
 
 	oauthTokenFilePath := filepath.Join(oauthTokenDir, "oauth-token")
 	oauthTokenValue := []byte("12345678")
-	if err := ioutil.WriteFile(oauthTokenFilePath, oauthTokenValue, 0644); err != nil {
+	if err := os.WriteFile(oauthTokenFilePath, oauthTokenValue, 0644); err != nil {
 		t.Fatalf("Error while create oauth token file: %v", err)
 	}
 
-	githubAppDir, err := ioutil.TempDir("", "github-app")
+	githubAppDir, err := os.MkdirTemp("", "github-app")
 	if err != nil {
 		t.Fatalf("Error while creating github app dir: %v.", err)
 	}
@@ -73,7 +72,7 @@ func TestRun(t *testing.T) {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
 	})
-	if err := ioutil.WriteFile(githubAppPrivateKeyFilePath, githubAppPrivateKeyValue, 0644); err != nil {
+	if err := os.WriteFile(githubAppPrivateKeyFilePath, githubAppPrivateKeyValue, 0644); err != nil {
 		t.Fatalf("Error while create github app private key file: %v", err)
 	}
 

--- a/prow/cmd/admission/admission.go
+++ b/prow/cmd/admission/admission.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -65,7 +64,7 @@ func readRequest(r io.Reader, contentType string) (*admissionapi.AdmissionReques
 	if r == nil {
 		return nil, fmt.Errorf("no body")
 	}
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("read body: %w", err)
 	}

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	stdio "io"
 	"io/fs"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -376,7 +376,7 @@ func validate(o options) error {
 			errs = append(errs, err)
 		}
 	} else if unknownEnabled {
-		cfgBytes, err := ioutil.ReadFile(o.config.ConfigPath)
+		cfgBytes, err := os.ReadFile(o.config.ConfigPath)
 		if err != nil {
 			return fmt.Errorf("error reading Prow config for validation: %w", err)
 		}
@@ -385,7 +385,7 @@ func validate(o options) error {
 		}
 	}
 	if pcfg != nil && (unknownEnabled || unknownAllEnabled) {
-		pcfgBytes, err := ioutil.ReadFile(o.pluginsConfig.PluginConfigPath)
+		pcfgBytes, err := os.ReadFile(o.pluginsConfig.PluginConfigPath)
 		if err != nil {
 			return fmt.Errorf("error reading Prow plugin config for validation: %w", err)
 		}
@@ -1225,7 +1225,7 @@ func validateCluster(cfg *config.Config, opener io.Opener) error {
 			logrus.Warnf("Build cluster status file location was specified, but could not be found: %v. This is expected when the location is first configured, before plank creates the file.", err)
 		} else {
 			defer reader.Close()
-			b, err := ioutil.ReadAll(reader)
+			b, err := stdio.ReadAll(reader)
 			if err != nil {
 				return fmt.Errorf("error reading build cluster status file: %w", err)
 			}

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -689,14 +689,14 @@ presubmits:
 		tc := testcases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			// Set up config files
-			root, err := ioutil.TempDir("", fmt.Sprintf("TestValidateUnknownFieldsAll-%s_*", tc.name))
+			root, err := os.MkdirTemp("", fmt.Sprintf("TestValidateUnknownFieldsAll-%s_*", tc.name))
 			if err != nil {
 				t.Fatalf("Error creating temp dir: %v.", err)
 			}
 			defer os.RemoveAll(root) // clean up
 
 			prowConfigFile := filepath.Join(root, "config.yaml")
-			if err := ioutil.WriteFile(prowConfigFile, []byte(tc.configContent), 0666); err != nil {
+			if err := os.WriteFile(prowConfigFile, []byte(tc.configContent), 0666); err != nil {
 				t.Fatalf("Error writing config.yaml file: %v.", err)
 			}
 			var jobConfigDir string
@@ -707,7 +707,7 @@ presubmits:
 				}
 				for file, content := range tc.jobConfigContent {
 					file = filepath.Join(jobConfigDir, file)
-					if err := ioutil.WriteFile(file, []byte(content), 0666); err != nil {
+					if err := os.WriteFile(file, []byte(content), 0666); err != nil {
 						t.Fatalf("Error writing %q file: %v.", file, err)
 					}
 				}
@@ -718,7 +718,7 @@ presubmits:
 				if tc.expectedErr {
 					t.Error("Expected an error, but did not receive one.")
 				} else {
-					content, _ := ioutil.ReadFile(prowConfigFile)
+					content, _ := os.ReadFile(prowConfigFile)
 					t.Log(string(content))
 					t.Errorf("Unexpected error: %v.", err)
 				}
@@ -1597,7 +1597,7 @@ func TestValidateInRepoConfig(t *testing.T) {
 
 		if tc.prowYAMLData != nil {
 			fileName := filepath.Join(t.TempDir(), ".prow.yaml")
-			if err := ioutil.WriteFile(fileName, tc.prowYAMLData, 0666); err != nil {
+			if err := os.WriteFile(fileName, tc.prowYAMLData, 0666); err != nil {
 				t.Fatalf("failed to write to tempfile: %v", err)
 			}
 
@@ -1605,7 +1605,7 @@ func TestValidateInRepoConfig(t *testing.T) {
 		}
 
 		// Need an empty file to load the config from so we go through its defaulting
-		tempConfig, err := ioutil.TempFile("", "prow-test")
+		tempConfig, err := os.CreateTemp("", "prow-test")
 		if err != nil {
 			t.Fatalf("failed to get tempfile: %v", err)
 		}
@@ -1748,7 +1748,7 @@ func (fo *fakeOpener) Reader(ctx context.Context, path string) (io.ReadCloser, e
 	if fo.readError != nil {
 		return nil, fo.readError
 	}
-	return ioutil.NopCloser(strings.NewReader(fo.content)), nil
+	return stdio.NopCloser(strings.NewReader(fo.content)), nil
 }
 
 func (fo *fakeOpener) Close() error {

--- a/prow/cmd/cm2kc/main.go
+++ b/prow/cmd/cm2kc/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -135,7 +134,7 @@ func main() {
 
 	o.parseFlags()
 
-	in, err := ioutil.ReadFile(o.input)
+	in, err := os.ReadFile(o.input)
 	if err != nil {
 		printErrAndExit(err, 1)
 	}
@@ -155,7 +154,7 @@ func main() {
 		printErrAndExit(err, 1)
 	}
 
-	if err = ioutil.WriteFile(o.output, kc, 0644); err != nil {
+	if err = os.WriteFile(o.output, kc, 0644); err != nil {
 		printErrAndExit(err, 1)
 	}
 }

--- a/prow/cmd/cm2kc/main_test.go
+++ b/prow/cmd/cm2kc/main_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,12 +59,12 @@ func TestGenjobs(t *testing.T) {
 			in := resolvePath(t, "_in.yaml")
 			outE := resolvePath(t, "_out.yaml")
 
-			expected, err := ioutil.ReadFile(outE)
+			expected, err := os.ReadFile(outE)
 			if err != nil {
 				t.Errorf("Failed reading expected output file %v: %v", outE, err)
 			}
 
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Errorf("Failed creating temp file: %v", err)
 			}
@@ -79,7 +78,7 @@ func TestGenjobs(t *testing.T) {
 			os.Args = append(os.Args, "--input="+in, "--output="+outA)
 			main()
 
-			actual, err := ioutil.ReadFile(outA)
+			actual, err := os.ReadFile(outA)
 			if err != nil {
 				t.Errorf("Failed reading actual output file %v: %v", outA, err)
 			}
@@ -88,7 +87,7 @@ func TestGenjobs(t *testing.T) {
 			t.Logf("actual (%v):\n%v\n", test.name, string(actual))
 
 			if os.Getenv("REFRESH_GOLDEN") == "true" {
-				if err = ioutil.WriteFile(outE, actual, 0644); err != nil {
+				if err = os.WriteFile(outE, actual, 0644); err != nil {
 					t.Errorf("Failed writing expected output file %v: %v", outE, err)
 				}
 				expected = actual

--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"errors"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -94,7 +93,7 @@ func (g *osFileGetter) GetFile(filename string) ([]byte, error) {
 		candidatePath := filepath.Join(root, filename)
 		if _, err := os.Stat(candidatePath); err == nil {
 			// we found the file under this root
-			return ioutil.ReadFile(candidatePath)
+			return os.ReadFile(candidatePath)
 		} else if !os.IsNotExist(err) {
 			// record this for later in case we can't find the file
 			loadErr = err
@@ -114,7 +113,7 @@ func run(sourcePaths []string, defaultNamespace string, configUpdater plugins.Co
 
 		versionFilePath := filepath.Join(sourcePath, config.ConfigVersionFileName)
 		if _, errAccess := os.Stat(versionFilePath); errAccess == nil {
-			content, err := ioutil.ReadFile(versionFilePath)
+			content, err := os.ReadFile(versionFilePath)
 			if err != nil {
 				logrus.WithError(err).Warn("failed to read versionfile")
 			} else if version == "" {

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"path"
 	"regexp"
@@ -116,7 +115,7 @@ func (bucket blobStorageBucket) readObject(ctx context.Context, key string) ([]b
 		return nil, fmt.Errorf("creating reader for object %s: %w", key, err)
 	}
 	defer rc.Close()
-	return ioutil.ReadAll(rc)
+	return io.ReadAll(rc)
 }
 
 func (bucket blobStorageBucket) getName() string {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -26,6 +26,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	stdio "io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -522,7 +523,7 @@ func (c *podLogClient) GetLogs(name, container string) ([]byte, error) {
 		return nil, err
 	}
 	defer reader.Close()
-	return io.ReadAll(reader)
+	return stdio.ReadAll(reader)
 }
 
 type pjListingClientWrapper struct {
@@ -1253,7 +1254,7 @@ func handleRemoteLens(lens config.LensFileConfig, w http.ResponseWriter, r *http
 
 	var data string
 	if requestType != spyglassapi.RequestActionInitial {
-		dataBytes, err := io.ReadAll(r.Body)
+		dataBytes, err := stdio.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to read body: %v", err), http.StatusInternalServerError)
 			return
@@ -1280,7 +1281,7 @@ func handleRemoteLens(lens config.LensFileConfig, w http.ResponseWriter, r *http
 		Director: func(r *http.Request) {
 			r.URL = lens.RemoteConfig.ParsedEndpoint
 			r.ContentLength = int64(len(serializedRequest))
-			r.Body = io.NopCloser(bytes.NewBuffer(serializedRequest))
+			r.Body = stdio.NopCloser(bytes.NewBuffer(serializedRequest))
 		},
 	}).ServeHTTP(w, r)
 }

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -26,7 +26,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -336,7 +335,7 @@ func main() {
 		var fjc fakePjListingClientWrapper
 		var pjs prowapi.ProwJobList
 		staticPjsPath := path.Join(o.pregeneratedData, "prowjobs.json")
-		content, err := ioutil.ReadFile(staticPjsPath)
+		content, err := os.ReadFile(staticPjsPath)
 		if err != nil {
 			logrus.WithError(err).Fatal("Failed to read jobs from prowjobs.json.")
 		}
@@ -523,7 +522,7 @@ func (c *podLogClient) GetLogs(name, container string) ([]byte, error) {
 		return nil, err
 	}
 	defer reader.Close()
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 type pjListingClientWrapper struct {
@@ -727,7 +726,7 @@ func initLocalLensHandler(cfg config.Getter, o options, sg *spyglass.Spyglass) e
 }
 
 func loadToken(file string) ([]byte, error) {
-	raw, err := ioutil.ReadFile(file)
+	raw, err := os.ReadFile(file)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -1254,7 +1253,7 @@ func handleRemoteLens(lens config.LensFileConfig, w http.ResponseWriter, r *http
 
 	var data string
 	if requestType != spyglassapi.RequestActionInitial {
-		dataBytes, err := ioutil.ReadAll(r.Body)
+		dataBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to read body: %v", err), http.StatusInternalServerError)
 			return
@@ -1281,7 +1280,7 @@ func handleRemoteLens(lens config.LensFileConfig, w http.ResponseWriter, r *http
 		Director: func(r *http.Request) {
 			r.URL = lens.RemoteConfig.ParsedEndpoint
 			r.ContentLength = int64(len(serializedRequest))
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(serializedRequest))
+			r.Body = io.NopCloser(bytes.NewBuffer(serializedRequest))
 		},
 	}).ServeHTTP(w, r)
 }

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -25,7 +25,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -249,7 +248,7 @@ func TestHandleLog(t *testing.T) {
 			} else {
 				resp := rr.Result()
 				defer resp.Body.Close()
-				if body, err := ioutil.ReadAll(resp.Body); err != nil {
+				if body, err := io.ReadAll(resp.Body); err != nil {
 					t.Errorf("Error reading response body: %v", err)
 				} else if string(body) != "hello" {
 					t.Errorf("Unexpected body: got %s.", string(body))
@@ -321,7 +320,7 @@ func TestHandleProwJobs(t *testing.T) {
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %v", err)
 	}
@@ -390,7 +389,7 @@ func TestProwJob(t *testing.T) {
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %v", err)
 	}
@@ -468,7 +467,7 @@ func TestTide(t *testing.T) {
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %v", err)
 	}
@@ -531,7 +530,7 @@ func TestTideHistory(t *testing.T) {
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %v", err)
 	}
@@ -577,7 +576,7 @@ func TestHelp(t *testing.T) {
 		}
 		resp := rr.Result()
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("Error reading response body: %v", err)
 		}
@@ -786,7 +785,7 @@ func TestHandleConfig(t *testing.T) {
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %v", err)
 	}
@@ -828,7 +827,7 @@ func TestHandlePluginConfig(t *testing.T) {
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %v", err)
 	}

--- a/prow/cmd/deck/rerun_test.go
+++ b/prow/cmd/deck/rerun_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -271,7 +271,7 @@ func TestRerun(t *testing.T) {
 			} else if !tc.rerunCreatesJob && tc.httpCode == http.StatusOK {
 				resp := rr.Result()
 				defer resp.Body.Close()
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatalf("Error reading response body: %v", err)
 				}
@@ -582,7 +582,7 @@ func TestLatestRerun(t *testing.T) {
 
 				resp := rr.Result()
 				defer resp.Body.Close()
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatalf("Error reading response body: %v", err)
 				}

--- a/prow/cmd/entrypoint/main.go
+++ b/prow/cmd/entrypoint/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -40,7 +39,7 @@ func copy(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("read info '%s': %w", src, err)
 	}
-	body, err := ioutil.ReadFile(src)
+	body, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("read file '%s': %w", src, err)
 	}
@@ -49,7 +48,7 @@ func copy(src, dst string) error {
 	if err := os.MkdirAll(dstDir, 0755); err != nil {
 		return fmt.Errorf("create dir '%s': %w", dstDir, err)
 	}
-	if err := ioutil.WriteFile(dst, body, info.Mode()); err != nil {
+	if err := os.WriteFile(dst, body, info.Mode()); err != nil {
 		return fmt.Errorf("write file '%s': %w", dst, err)
 	}
 	return nil

--- a/prow/cmd/entrypoint/main_test.go
+++ b/prow/cmd/entrypoint/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -43,7 +42,7 @@ func TestCopy(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			src := path.Join(srcDir, tc.name)
-			ioutil.WriteFile(src, []byte(tc.name+"\nsome\nother\ncontent"), tc.fileMode)
+			os.WriteFile(src, []byte(tc.name+"\nsome\nother\ncontent"), tc.fileMode)
 
 			// One level down, for exercising dir creation logic
 			dst := path.Join(srcDir, "dst", tc.name)
@@ -59,7 +58,7 @@ func TestCopy(t *testing.T) {
 				t.Errorf("File mode mismatch. Want: %s, got: %s", want, got)
 			}
 
-			gotContent, err := ioutil.ReadFile(dst)
+			gotContent, err := os.ReadFile(dst)
 			if err != nil {
 				t.Fatalf("Failed read %q: %v", dst, err)
 			}

--- a/prow/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package bumper
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -167,13 +166,13 @@ func (w *fakeWriter) Write(content []byte) (n int, err error) {
 }
 
 func writeToFile(t *testing.T, path, content string) {
-	if err := ioutil.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Errorf("write file %s dir with error '%v'", path, err)
 	}
 }
 
 func TestCallWithWriter(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestCallWithWriter")
+	dir, err := os.MkdirTemp("", "TestCallWithWriter")
 	if err != nil {
 		t.Errorf("failed to create temp dir '%s': '%v'", dir, err)
 	}

--- a/prow/cmd/generic-autobumper/main.go
+++ b/prow/cmd/generic-autobumper/main.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -172,7 +172,7 @@ func parseOptions() (*options, *bumper.Options, error) {
 	flag.Parse()
 
 	var pro bumper.Options
-	data, err := ioutil.ReadFile(config)
+	data, err := os.ReadFile(config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read %q: %w", config, err)
 	}
@@ -443,7 +443,7 @@ func parseUpstreamImageVersion(upstreamAddress, prefix string) (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("HTTP error %d (%q) fetching upstream config file", resp.StatusCode, resp.Status)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading the response body: %w", err)
 	}

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -242,7 +241,7 @@ func loadCerts(certFile, keyFile, caCertFile string) (*tls.Config, error) {
 	}
 
 	if caCertFile != "" {
-		caCert, err := ioutil.ReadFile(caCertFile)
+		caCert, err := os.ReadFile(caCertFile)
 		if err != nil {
 			return nil, err
 		}

--- a/prow/cmd/mkpod/main.go
+++ b/prow/cmd/mkpod/main.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -73,13 +73,13 @@ func main() {
 
 	var rawJob []byte
 	if o.prowJobPath == "-" {
-		raw, err := ioutil.ReadAll(os.Stdin)
+		raw, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			logrus.WithError(err).Fatal("Could not read ProwJob YAML from stdin.")
 		}
 		rawJob = raw
 	} else {
-		raw, err := ioutil.ReadFile(o.prowJobPath)
+		raw, err := os.ReadFile(o.prowJobPath)
 		if err != nil {
 			logrus.WithError(err).Fatal("Could not open ProwJob YAML.")
 		}
@@ -112,7 +112,7 @@ func main() {
 		if outDir == "" {
 			prefix := strings.Join([]string{"prowjob-out", job.Spec.Job, o.buildID}, "-")
 			logrus.Infof("Creating temp directory for job output in %q with prefix %q.", os.TempDir(), prefix)
-			outDir, err = ioutil.TempDir("", prefix)
+			outDir, err = os.MkdirTemp("", prefix)
 			if err != nil {
 				logrus.WithError(err).Fatal("Could not create temp directory for job output.")
 			}

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -178,7 +177,7 @@ func main() {
 		return
 	}
 
-	raw, err := ioutil.ReadFile(o.config)
+	raw, err := os.ReadFile(o.config)
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not read --config-path file")
 	}

--- a/prow/cmd/phaino/local_test.go
+++ b/prow/cmd/phaino/local_test.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"context"
-	"github.com/sirupsen/logrus"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,6 +27,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
 	coreapi "k8s.io/api/core/v1"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -88,7 +87,7 @@ func TestPathAlias(t *testing.T) {
 }
 
 func TestReadRepo(t *testing.T) {
-	dir, err := ioutil.TempDir("", "read-repo")
+	dir, err := os.MkdirTemp("", "read-repo")
 	if err != nil {
 		t.Fatalf("Cannot create temp dir: %v", err)
 	}
@@ -243,7 +242,7 @@ func TestFindRepoFromLocal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "find-repo-"+tc.name)
+			dir, err := os.MkdirTemp("", "find-repo-"+tc.name)
 			if err != nil {
 				t.Fatalf("Cannot create temp dir: %v", err)
 			}

--- a/prow/cmd/phaino/main.go
+++ b/prow/cmd/phaino/main.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -114,7 +113,7 @@ func validate(pj prowapi.ProwJob) error {
 
 func readPJ(reader io.ReadCloser) (*prowapi.ProwJob, error) {
 	var pj prowapi.ProwJob
-	buf, err := ioutil.ReadAll(reader)
+	buf, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}

--- a/prow/cmd/phony/main.go
+++ b/prow/cmd/phony/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/sirupsen/logrus"
 
@@ -39,7 +39,7 @@ func main() {
 	if *payload == "" {
 		body = []byte("{}")
 	} else {
-		d, err := ioutil.ReadFile(*payload)
+		d, err := os.ReadFile(*payload)
 		if err != nil {
 			logrus.WithError(err).Fatal("Could not read payload file.")
 		}

--- a/prow/cmd/tot/fallbackcheck/main.go
+++ b/prow/cmd/tot/fallbackcheck/main.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -78,7 +78,7 @@ func main() {
 		logrus.Fatalf("status code not 2XX: %v", resp.Status)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logrus.Fatalf("cannot read request body: %v", err)
 	}

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -98,7 +98,7 @@ func newStore(storagePath string) (*store, error) {
 		Number:      make(map[string]int),
 		storagePath: storagePath,
 	}
-	buf, err := ioutil.ReadFile(storagePath)
+	buf, err := os.ReadFile(storagePath)
 	if err == nil {
 		err = json.Unmarshal(buf, s)
 		if err != nil {
@@ -115,7 +115,7 @@ func (s *store) save() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(s.storagePath+".tmp", buf, 0644)
+	err = os.WriteFile(s.storagePath+".tmp", buf, 0644)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func (s *store) handle(w http.ResponseWriter, r *http.Request) {
 		logrus.Infof("Peeking %s number %d to %s.", jobName, n, r.RemoteAddr)
 		fmt.Fprintf(w, "%d", n)
 	case "POST":
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			logrus.WithError(err).Error("Unable to read body.")
 			return
@@ -205,7 +205,7 @@ func (f fallbackHandler) get(jobName string) int {
 		if err == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				body, err = ioutil.ReadAll(resp.Body)
+				body, err = io.ReadAll(resp.Body)
 				if err == nil {
 					break
 				} else {

--- a/prow/cmd/tot/main_test.go
+++ b/prow/cmd/tot/main_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,7 +37,7 @@ func expectEqual(t *testing.T, msg string, have interface{}, want interface{}) {
 }
 
 func makeStore(t *testing.T) *store {
-	tmp, err := ioutil.TempFile("", "tot_test_")
+	tmp, err := os.CreateTemp("", "tot_test_")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +176,7 @@ postsubmits:
 	}
 	tmpDir := t.TempDir()
 	for fp, content := range configs {
-		if err := ioutil.WriteFile(path.Join(tmpDir, fp), []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path.Join(tmpDir, fp), []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/prow/cmd/webhook-server/clients.go
+++ b/prow/cmd/webhook-server/clients.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,13 +117,13 @@ func (l *localFSClient) AddSecretVersion(ctx context.Context, secretName string,
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(certFile, []byte(serverCertPerm), 0666); err != nil {
+	if err := os.WriteFile(certFile, []byte(serverCertPerm), 0666); err != nil {
 		return fmt.Errorf("could not write contents of cert file")
 	}
-	if err := ioutil.WriteFile(privKeyFile, []byte(serverPrivKey), 0666); err != nil {
+	if err := os.WriteFile(privKeyFile, []byte(serverPrivKey), 0666); err != nil {
 		return fmt.Errorf("could not write contents of privkey file")
 	}
-	if err := ioutil.WriteFile(caBundleFile, []byte(caPem), 0666); err != nil {
+	if err := os.WriteFile(caBundleFile, []byte(caPem), 0666); err != nil {
 		return fmt.Errorf("could not write contents of caBundle file")
 	}
 	return nil
@@ -138,12 +137,12 @@ func (l *localFSClient) GetSecretValue(ctx context.Context, secretName string, v
 		return nil, false, err
 	}
 	secretsMap := make(map[string]string)
-	files, err := ioutil.ReadDir(l.path)
+	files, err := os.ReadDir(l.path)
 	if err != nil {
 		return nil, false, fmt.Errorf("could not read file path")
 	}
 	for _, f := range files {
-		content, err := ioutil.ReadFile(filepath.Join(l.path, f.Name()))
+		content, err := os.ReadFile(filepath.Join(l.path, f.Name()))
 		if err != nil {
 			return nil, false, fmt.Errorf("error reading file %v", err)
 		}
@@ -171,7 +170,7 @@ func (l *localFSClient) checkSecret(ctx context.Context, secretName string) erro
 		return err
 	}
 
-	files, err := ioutil.ReadDir(l.path)
+	files, err := os.ReadDir(l.path)
 	if err != nil {
 		return err
 	}
@@ -179,7 +178,7 @@ func (l *localFSClient) checkSecret(ctx context.Context, secretName string) erro
 		return nil
 	}
 	for _, f := range files {
-		_, err := ioutil.ReadFile(filepath.Join(l.path, f.Name()))
+		_, err := os.ReadFile(filepath.Join(l.path, f.Name()))
 		if err != nil {
 			return fmt.Errorf("error reading file %v", err)
 		}

--- a/prow/cmd/webhook-server/helpers.go
+++ b/prow/cmd/webhook-server/helpers.go
@@ -23,13 +23,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"io/ioutil"
-
 	"encoding/json"
 	"encoding/pem"
-
 	"fmt"
-
+	stdio "io"
 	"math/big"
 	"strings"
 	"time"
@@ -459,7 +456,7 @@ func (wa *webhookAgent) fetchClusters(d time.Duration, ctx context.Context, stat
 					logrus.Warnf("Build cluster status file location was specified, but could not be found: %v. This is expected when the location is first configured, before plank creates the file.", err)
 				} else {
 					defer reader.Close()
-					b, err := ioutil.ReadAll(reader)
+					b, err := stdio.ReadAll(reader)
 					if err != nil {
 						return fmt.Errorf("error reading build cluster status file: %w", err)
 					}

--- a/prow/cmd/webhook-server/main.go
+++ b/prow/cmd/webhook-server/main.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -235,16 +234,16 @@ func handleSecrets(client ClientInterface, ctx context.Context, clientoptions cl
 	if err = reconcileWebhooks(ctx, caPem, cl); err != nil {
 		return "", "", err
 	}
-	tempDir, err := ioutil.TempDir("", "cert")
+	tempDir, err := os.MkdirTemp("", "cert")
 	if err != nil {
 		return "", "", fmt.Errorf("unable to create temp directory %v", err)
 	}
 	certFile := filepath.Join(tempDir, certFile)
-	if err := ioutil.WriteFile(certFile, []byte(cert), 0666); err != nil {
+	if err := os.WriteFile(certFile, []byte(cert), 0666); err != nil {
 		return "", "", fmt.Errorf("could not write contents of cert file %v", err)
 	}
 	privKeyFile := filepath.Join(tempDir, privKeyFile)
-	if err := ioutil.WriteFile(privKeyFile, []byte(privKey), 0666); err != nil {
+	if err := os.WriteFile(privKeyFile, []byte(privKey), 0666); err != nil {
 		return "", "", fmt.Errorf("could not write contents of privKey file %v", err)
 	}
 	return certFile, privKeyFile, nil

--- a/prow/cmd/webhook-server/mutation.go
+++ b/prow/cmd/webhook-server/mutation.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -32,7 +32,7 @@ import (
 )
 
 func (wa *webhookAgent) serveMutate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Info("unable to read request")
 		http.Error(w, fmt.Sprintf("bad request %v", err), http.StatusBadRequest)

--- a/prow/cmd/webhook-server/validation.go
+++ b/prow/cmd/webhook-server/validation.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -41,7 +41,7 @@ const (
 )
 
 func (wa *webhookAgent) serveValidate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Info("unable to read request")
 		http.Error(w, fmt.Sprintf("bad request %v", err), http.StatusBadRequest)

--- a/prow/config/agent.go
+++ b/prow/config/agent.go
@@ -19,7 +19,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -49,7 +48,7 @@ type Agent struct {
 
 // IsConfigMapMount determines whether the provided directory is a configmap mounted directory
 func IsConfigMapMount(path string) (bool, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return false, fmt.Errorf("Could not read provided directory %s: %w", path, err)
 	}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -1730,7 +1730,7 @@ func loadConfig(prowConfig, jobConfig string, additionalProwConfigDirs []string,
 
 	versionFilePath := filepath.Join(path.Dir(prowConfig), ConfigVersionFileName)
 	if _, errAccess := os.Stat(versionFilePath); errAccess == nil {
-		content, err := ioutil.ReadFile(versionFilePath)
+		content, err := os.ReadFile(versionFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read versionfile %s: %w", versionFilePath, err)
 		}
@@ -1846,10 +1846,10 @@ func yamlToConfig(path string, nc interface{}, opts ...yaml.JSONOpt) error {
 	return nil
 }
 
-// ReadFileMaybeGZIP wraps ioutil.ReadFile, returning the decompressed contents
+// ReadFileMaybeGZIP wraps os.ReadFile, returning the decompressed contents
 // if the file is gzipped, or otherwise the raw contents.
 func ReadFileMaybeGZIP(path string) ([]byte, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -1863,7 +1863,7 @@ func ReadFileMaybeGZIP(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(gzipReader)
+	return io.ReadAll(gzipReader)
 }
 
 func (c *Config) mergeJobConfig(jc JobConfig) error {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -291,14 +290,14 @@ deck:
 	}
 	for _, tc := range testCases {
 		// save the config
-		spyglassConfigDir, err := ioutil.TempDir("", "spyglassConfig")
+		spyglassConfigDir, err := os.MkdirTemp("", "spyglassConfig")
 		if err != nil {
 			t.Fatalf("fail to make tempdir: %v", err)
 		}
 		defer os.RemoveAll(spyglassConfigDir)
 
 		spyglassConfig := filepath.Join(spyglassConfigDir, "config.yaml")
-		if err := ioutil.WriteFile(spyglassConfig, []byte(tc.spyglassConfig), 0666); err != nil {
+		if err := os.WriteFile(spyglassConfig, []byte(tc.spyglassConfig), 0666); err != nil {
 			t.Fatalf("fail to write spyglass config: %v", err)
 		}
 
@@ -1007,7 +1006,7 @@ periodics:
 			prowConfigDir := t.TempDir()
 
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-			if err := ioutil.WriteFile(prowConfig, []byte(tc.rawConfig), 0666); err != nil {
+			if err := os.WriteFile(prowConfig, []byte(tc.rawConfig), 0666); err != nil {
 				t.Fatalf("fail to write prow config: %v", err)
 			}
 
@@ -1130,7 +1129,7 @@ gerrit:
 			prowConfigDir := t.TempDir()
 
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-			if err := ioutil.WriteFile(prowConfig, []byte(tc.rawConfig), 0666); err != nil {
+			if err := os.WriteFile(prowConfig, []byte(tc.rawConfig), 0666); err != nil {
 				t.Fatalf("fail to write prow config: %v", err)
 			}
 
@@ -3261,27 +3260,27 @@ postsubmits:
 		t.Run(tc.name, func(t *testing.T) {
 
 			// save the config
-			prowConfigDir, err := ioutil.TempDir("", "prowConfig")
+			prowConfigDir, err := os.MkdirTemp("", "prowConfig")
 			if err != nil {
 				t.Fatalf("fail to make tempdir: %v", err)
 			}
 			defer os.RemoveAll(prowConfigDir)
 
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-			if err := ioutil.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
+			if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
 				t.Fatalf("fail to write prow config: %v", err)
 			}
 
 			if tc.versionFileContent != "" {
 				versionFile := filepath.Join(prowConfigDir, "VERSION")
-				if err := ioutil.WriteFile(versionFile, []byte(tc.versionFileContent), 0600); err != nil {
+				if err := os.WriteFile(versionFile, []byte(tc.versionFileContent), 0600); err != nil {
 					t.Fatalf("failed to write prow version file: %v", err)
 				}
 			}
 
 			jobConfig := ""
 			if len(tc.jobConfigs) > 0 {
-				jobConfigDir, err := ioutil.TempDir("", "jobConfig")
+				jobConfigDir, err := os.MkdirTemp("", "jobConfig")
 				if err != nil {
 					t.Fatalf("fail to make tempdir: %v", err)
 				}
@@ -3291,7 +3290,7 @@ postsubmits:
 				if len(tc.jobConfigs) == 1 {
 					// a single file
 					jobConfig = filepath.Join(jobConfigDir, "config.yaml")
-					if err := ioutil.WriteFile(jobConfig, []byte(tc.jobConfigs[0]), 0666); err != nil {
+					if err := os.WriteFile(jobConfig, []byte(tc.jobConfigs[0]), 0666); err != nil {
 						t.Fatalf("fail to write job config: %v", err)
 					}
 				} else {
@@ -3299,7 +3298,7 @@ postsubmits:
 					jobConfig = jobConfigDir
 					for idx, config := range tc.jobConfigs {
 						subConfig := filepath.Join(jobConfigDir, fmt.Sprintf("config_%d.yaml", idx))
-						if err := ioutil.WriteFile(subConfig, []byte(config), 0666); err != nil {
+						if err := os.WriteFile(subConfig, []byte(config), 0666); err != nil {
 							t.Fatalf("fail to write job config: %v", err)
 						}
 					}
@@ -3467,7 +3466,7 @@ bar_jobs.yaml`,
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			jobConfigDir, err := ioutil.TempDir("", "jobConfig")
+			jobConfigDir, err := os.MkdirTemp("", "jobConfig")
 			if err != nil {
 				t.Fatalf("fail to make tempdir: %v", err)
 			}
@@ -3480,7 +3479,7 @@ bar_jobs.yaml`,
 			for _, fileMap := range []map[string]string{commonFiles, tc.files} {
 				for name, content := range fileMap {
 					fullName := filepath.Join(jobConfigDir, name)
-					if err := ioutil.WriteFile(fullName, []byte(content), 0666); err != nil {
+					if err := os.WriteFile(fullName, []byte(content), 0666); err != nil {
 						t.Fatalf("fail to write file %s: %v", fullName, err)
 					}
 				}
@@ -3626,7 +3625,7 @@ func TestSecretAgentLoading(t *testing.T) {
 	changedTokenValue := "121f3cb3e7f70feeb35f9204f5a988d7292c7ba0"
 
 	// Creating a temporary directory.
-	secretDir, err := ioutil.TempDir("", "secretDir")
+	secretDir, err := os.MkdirTemp("", "secretDir")
 	if err != nil {
 		t.Fatalf("fail to create a temporary directory: %v", err)
 	}
@@ -3634,13 +3633,13 @@ func TestSecretAgentLoading(t *testing.T) {
 
 	// Create the first temporary secret.
 	firstTempSecret := filepath.Join(secretDir, "firstTempSecret")
-	if err := ioutil.WriteFile(firstTempSecret, []byte(tempTokenValue), 0666); err != nil {
+	if err := os.WriteFile(firstTempSecret, []byte(tempTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
 
 	// Create the second temporary secret.
 	secondTempSecret := filepath.Join(secretDir, "secondTempSecret")
-	if err := ioutil.WriteFile(secondTempSecret, []byte(tempTokenValue), 0666); err != nil {
+	if err := os.WriteFile(secondTempSecret, []byte(tempTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
 
@@ -3660,10 +3659,10 @@ func TestSecretAgentLoading(t *testing.T) {
 	}
 
 	// Change the values of the files.
-	if err := ioutil.WriteFile(firstTempSecret, []byte(changedTokenValue), 0666); err != nil {
+	if err := os.WriteFile(firstTempSecret, []byte(changedTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
-	if err := ioutil.WriteFile(secondTempSecret, []byte(changedTokenValue), 0666); err != nil {
+	if err := os.WriteFile(secondTempSecret, []byte(changedTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
 
@@ -3733,14 +3732,14 @@ github_reporter:
 
 	for _, tc := range testCases {
 		// save the config
-		prowConfigDir, err := ioutil.TempDir("", "prowConfig")
+		prowConfigDir, err := os.MkdirTemp("", "prowConfig")
 		if err != nil {
 			t.Fatalf("fail to make tempdir: %v", err)
 		}
 		defer os.RemoveAll(prowConfigDir)
 
 		prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-		if err := ioutil.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
+		if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
 			t.Fatalf("fail to write prow config: %v", err)
 		}
 
@@ -4273,14 +4272,14 @@ tide:
 
 	for _, tc := range testCases {
 		// save the config
-		prowConfigDir, err := ioutil.TempDir("", "prowConfig")
+		prowConfigDir, err := os.MkdirTemp("", "prowConfig")
 		if err != nil {
 			t.Fatalf("fail to make tempdir: %v", err)
 		}
 		defer os.RemoveAll(prowConfigDir)
 
 		prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-		if err := ioutil.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
+		if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
 			t.Fatalf("fail to write prow config: %v", err)
 		}
 
@@ -8092,7 +8091,7 @@ func loadConfigYaml(prowConfigYaml string, t *testing.T, supplementalProwConfigs
 	prowConfigDir := t.TempDir()
 
 	prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-	if err := ioutil.WriteFile(prowConfig, []byte(prowConfigYaml), 0666); err != nil {
+	if err := os.WriteFile(prowConfig, []byte(prowConfigYaml), 0666); err != nil {
 		t.Fatalf("fail to write prow config: %v", err)
 	}
 
@@ -8106,7 +8105,7 @@ func loadConfigYaml(prowConfigYaml string, t *testing.T, supplementalProwConfigs
 
 		// use a random prefix for the file to make sure that the loading correctly loads all supplemental configs with the
 		// right suffix.
-		if err := ioutil.WriteFile(filepath.Join(dir, strconv.Itoa(time.Now().Nanosecond())+"_prowconfig.yaml"), []byte(cfg), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, strconv.Itoa(time.Now().Nanosecond())+"_prowconfig.yaml"), []byte(cfg), 0644); err != nil {
 			t.Fatalf("failed to write supplemental prow config: %v", err)
 		}
 	}

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -175,7 +174,7 @@ func ReadProwYAML(log *logrus.Entry, dir string, strict bool) (*ProwYAML, error)
 					return nil
 				}
 				log.Debugf("Reading YAML file %q", p)
-				bytes, err := ioutil.ReadFile(p)
+				bytes, err := os.ReadFile(p)
 				if err != nil {
 					return err
 				}
@@ -197,7 +196,7 @@ func ReadProwYAML(log *logrus.Entry, dir string, strict bool) (*ProwYAML, error)
 		log.WithField("file", inRepoConfigFileName).Debug("Attempting to get inreconfigfile")
 		prowYAMLFilePath := path.Join(dir, inRepoConfigFileName)
 		if _, err := os.Stat(prowYAMLFilePath); err == nil {
-			bytes, err := ioutil.ReadFile(prowYAMLFilePath)
+			bytes, err := os.ReadFile(prowYAMLFilePath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read %q: %w", prowYAMLDirPath, err)
 			}

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -804,7 +803,7 @@ func TestInRepoConfigClean(t *testing.T) {
 	clonedRepo := casted.cache["org/repo"]
 	dir := clonedRepo.RepoClient.Directory()
 	f := path.Join(dir, "new-file")
-	if err := ioutil.WriteFile(f, []byte("something"), 0644); err != nil {
+	if err := os.WriteFile(f, []byte("something"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/prow/config/secret/agent_test.go
+++ b/prow/config/secret/agent_test.go
@@ -19,7 +19,6 @@ package secret
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -33,7 +32,7 @@ import (
 
 func TestCensoringFormatter(t *testing.T) {
 	var err error
-	secret1, err := ioutil.TempFile("", "")
+	secret1, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to set up a temporary file: %v", err)
 	}
@@ -42,7 +41,7 @@ func TestCensoringFormatter(t *testing.T) {
 	}
 	defer secret1.Close()
 	defer os.Remove(secret1.Name())
-	secret2, err := ioutil.TempFile("", "")
+	secret2, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to set up a temporary file: %v", err)
 	}
@@ -119,7 +118,7 @@ func testAddWithParser(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	secretPath := filepath.Join(tmpDir, "secret")
-	if err := ioutil.WriteFile(secretPath, []byte("1"), 0644); err != nil {
+	if err := os.WriteFile(secretPath, []byte("1"), 0644); err != nil {
 		t.Fatalf("failed to write initial content of secret: %v", err)
 	}
 
@@ -163,13 +162,13 @@ func testAddWithParser(t *testing.T) {
 	}
 	checkValueAndErr(1, nil)
 
-	if err := ioutil.WriteFile(secretPath, []byte("2"), 0644); err != nil {
+	if err := os.WriteFile(secretPath, []byte("2"), 0644); err != nil {
 		t.Fatalf("failed to update secret on disk: %v", err)
 	}
 	// expect secret to get updated
 	checkValueAndErr(2, nil)
 
-	if err := ioutil.WriteFile(secretPath, []byte("not-a-number"), 0644); err != nil {
+	if err := os.WriteFile(secretPath, []byte("not-a-number"), 0644); err != nil {
 		t.Fatalf("failed to update secret on disk: %v", err)
 	}
 	// expect secret to remain unchanged and an error in the parsing func

--- a/prow/config/secret/secret.go
+++ b/prow/config/secret/secret.go
@@ -19,12 +19,12 @@ package secret
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // loadSingleSecret reads and returns the value of a single file.
 func loadSingleSecret(path string) ([]byte, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}

--- a/prow/crier/reporters/gcs/reporter_test.go
+++ b/prow/crier/reporters/gcs/reporter_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"path"
 	"strings"
 	"testing"
@@ -136,7 +136,7 @@ func TestReportJobFinished(t *testing.T) {
 			var content []byte
 			for path, buf := range fakeOpener.Buffer {
 				if strings.HasSuffix(path, prowv1.FinishedStatusFile) {
-					content, err = ioutil.ReadAll(buf)
+					content, err = stdio.ReadAll(buf)
 					if err != nil {
 						t.Fatalf("Failed reading content: %v", err)
 					}
@@ -484,7 +484,7 @@ func TestReportProwJob(t *testing.T) {
 	var err error
 	for p, b := range fakeOpener.Buffer {
 		if strings.HasSuffix(p, prowv1.ProwJobFile) {
-			content, err = ioutil.ReadAll(b)
+			content, err = stdio.ReadAll(b)
 			if err != nil {
 				t.Fatalf("Failed reading content: %v", err)
 			}

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"sort"
 	"sync"
@@ -265,7 +265,7 @@ func (ja *JobAgent) GetJobLog(job, id string, container string) ([]byte, error) 
 			return nil, err
 		}
 		defer resp.Body.Close()
-		return ioutil.ReadAll(resp.Body)
+		return stdio.ReadAll(resp.Body)
 
 	}
 	return nil, fmt.Errorf("cannot get logs for prowjob %q with agent %q: the agent is missing from the prow config file", j.ObjectMeta.Name, j.Spec.Agent)

--- a/prow/entrypoint/run.go
+++ b/prow/entrypoint/run.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -202,11 +201,11 @@ func (o *Options) Mark(exitCode int) error {
 
 	// create temp file in the same directory as the desired marker file
 	dir := filepath.Dir(o.MarkerFile)
-	tmpDir, err := ioutil.TempDir(dir, o.ContainerName)
+	tmpDir, err := os.MkdirTemp(dir, o.ContainerName)
 	if err != nil {
 		return fmt.Errorf("%s: error creating temp dir: %w", o.ContainerName, err)
 	}
-	tempFile, err := ioutil.TempFile(tmpDir, "temp-marker")
+	tempFile, err := os.CreateTemp(tmpDir, "temp-marker")
 	if err != nil {
 		return fmt.Errorf("could not create temp marker file in %s: %w", tmpDir, err)
 	}

--- a/prow/entrypoint/run_test.go
+++ b/prow/entrypoint/run_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package entrypoint
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -150,7 +149,7 @@ func TestOptions_Run(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", testCase.name)
+			tmpDir, err := os.MkdirTemp("", testCase.name)
 			if err != nil {
 				t.Errorf("%s: error creating temp dir: %v", testCase.name, err)
 			}
@@ -174,7 +173,7 @@ func TestOptions_Run(t *testing.T) {
 			if testCase.previousMarker != "" {
 				p := path.Join(tmpDir, "previous-marker.txt")
 				options.PreviousMarker = p
-				if err := ioutil.WriteFile(p, []byte(testCase.previousMarker), 0600); err != nil {
+				if err := os.WriteFile(p, []byte(testCase.previousMarker), 0600); err != nil {
 					t.Fatalf("could not create previous marker: %v", err)
 				}
 			}
@@ -196,7 +195,7 @@ func TestOptions_Run(t *testing.T) {
 }
 
 func compareFileContents(name, file, expected string, t *testing.T) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("%s: could not read file: %v", name, err)
 	}

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"text/template"
@@ -128,7 +128,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		return fmt.Errorf("status code not 2XX: %v", resp.Status)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/prow/flagutil/kubernetes_cluster_clients_test.go
+++ b/prow/flagutil/kubernetes_cluster_clients_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package flagutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 func TestExperimentalKubernetesOptions_Validate(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "some-file")
-	if err := ioutil.WriteFile(configFile, []byte("a"), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte("a"), 0644); err != nil {
 		t.Fatalf("failed to write kubeconfig file %q: %v", configFile, err)
 	}
 	configDir := filepath.Join(dir, "some-dir")
@@ -138,7 +137,7 @@ users:
     token: cde
 `
 
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to get tempfile: %v", err)
 	}

--- a/prow/gcsupload/run_test.go
+++ b/prow/gcsupload/run_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gcsupload
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -204,7 +203,7 @@ func TestOptions_AssembleTargets(t *testing.T) {
 				BuildID: "build",
 			}
 
-			tmpDir, err := ioutil.TempDir("", testCase.name)
+			tmpDir, err := os.MkdirTemp("", testCase.name)
 			if err != nil {
 				t.Errorf("%s: error creating temp dir: %v", testCase.name, err)
 			}

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -22,8 +22,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -261,7 +262,7 @@ func (c *Client) Authenticate(cookiefilePath, tokenPath string) {
 		}
 		auth = func() (string, error) {
 			// TODO(fejta): listen for changes
-			raw, err := ioutil.ReadFile(cookiefilePath)
+			raw, err := os.ReadFile(cookiefilePath)
 			if err != nil {
 				return "", fmt.Errorf("read cookie: %w", err)
 			}
@@ -271,7 +272,7 @@ func (c *Client) Authenticate(cookiefilePath, tokenPath string) {
 		}
 	case tokenPath != "":
 		auth = func() (string, error) {
-			raw, err := ioutil.ReadFile(tokenPath)
+			raw, err := os.ReadFile(tokenPath)
 			if err != nil {
 				return "", fmt.Errorf("read token: %w", err)
 			}
@@ -448,7 +449,7 @@ func responseBodyError(err error, resp *gerrit.Response) error {
 		return err
 	}
 	defer resp.Body.Close()
-	b, _ := ioutil.ReadAll(resp.Body) // Ignore the error since this is best effort.
+	b, _ := io.ReadAll(resp.Body) // Ignore the error since this is best effort.
 	return fmt.Errorf("%w, response body: %q", err, string(b))
 }
 

--- a/prow/gerrit/client/syncer.go
+++ b/prow/gerrit/client/syncer.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"sync"
 	"time"
 
@@ -106,7 +106,7 @@ func (st *SyncTime) currentState() (LastSyncState, error) {
 		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer io.LogClose(r)
-	buf, err := ioutil.ReadAll(r)
+	buf, err := stdio.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}

--- a/prow/gerrit/client/syncer_test.go
+++ b/prow/gerrit/client/syncer_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -46,7 +45,7 @@ func (o fakeOpener) Writer(ctx context.Context, path string, _ ...io.WriterOptio
 
 func TestSyncTime(t *testing.T) {
 
-	dir, err := ioutil.TempDir("", "fake-gerrit-value")
+	dir, err := os.MkdirTemp("", "fake-gerrit-value")
 	if err != nil {
 		t.Fatalf("Could not create temp file: %v", err)
 	}
@@ -207,7 +206,7 @@ func TestSyncTimeThreadSafe(t *testing.T) {
 }
 
 func TestNewProjectAddition(t *testing.T) {
-	dir, err := ioutil.TempDir("", "fake-gerrit-value")
+	dir, err := os.MkdirTemp("", "fake-gerrit-value")
 	if err != nil {
 		t.Fatalf("Could not create temp file: %v", err)
 	}
@@ -217,7 +216,7 @@ func TestNewProjectAddition(t *testing.T) {
 	testTime := time.Now().Add(-time.Minute)
 	testStVal := LastSyncState{"foo": {"bar": testTime}}
 	testStValBytes, _ := json.Marshal(testStVal)
-	_ = ioutil.WriteFile(path, testStValBytes, os.ModePerm)
+	_ = os.WriteFile(path, testStValBytes, os.ModePerm)
 
 	var noCreds string
 	ctx := context.Background()

--- a/prow/ghhook/ghhook.go
+++ b/prow/ghhook/ghhook.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -93,7 +93,7 @@ func GetOptions(fs *flag.FlagSet, args []string) (*Options, error) {
 }
 
 func (o *Options) hmacValueFromFile() (string, error) {
-	b, err := ioutil.ReadFile(o.HMACPath)
+	b, err := os.ReadFile(o.HMACPath)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", o.HMACPath, err)
 	}

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,7 +86,7 @@ func NewClientWithHost(host string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	t, err := ioutil.TempDir("", "git")
+	t, err := os.MkdirTemp("", "git")
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +190,7 @@ func (c *Client) Clone(organization, repository string) (*Repo, error) {
 			return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
 		}
 	}
-	t, err := ioutil.TempDir("", "git")
+	t, err := os.MkdirTemp("", "git")
 	if err != nil {
 		return nil, err
 	}

--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -20,7 +20,6 @@ package localgit
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func New() (*LocalGit, v2.ClientFactory, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	t, err := ioutil.TempDir("", "localgit")
+	t, err := os.MkdirTemp("", "localgit")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,7 +143,7 @@ func (lg *LocalGit) AddCommit(org, repo string, files map[string][]byte) error {
 		if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(path, b, os.ModePerm); err != nil {
+		if err := os.WriteFile(path, b, os.ModePerm); err != nil {
 			return err
 		}
 		if err := runCmd(lg.Git, rdir, "add", f); err != nil {
@@ -201,7 +200,7 @@ func NewV2() (*LocalGit, v2.ClientFactory, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	t, err := ioutil.TempDir("", "localgit")
+	t, err := os.MkdirTemp("", "localgit")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -18,7 +18,6 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -141,7 +140,7 @@ func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 		}
 	}
 
-	cacheDir, err := ioutil.TempDir(*o.CacheDirBase, "gitcache")
+	cacheDir, err := os.MkdirTemp(*o.CacheDirBase, "gitcache")
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +175,7 @@ func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 // NewLocalClientFactory allows for the creation of repository clients
 // based on a local filepath remote for testing
 func NewLocalClientFactory(baseDir string, gitUser GitUserGetter, censor Censor) (ClientFactory, error) {
-	cacheDir, err := ioutil.TempDir("", "gitcache")
+	cacheDir, err := os.MkdirTemp("", "gitcache")
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +267,7 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 		return nil, err
 	}
 
-	repoDir, err := ioutil.TempDir(c.cacheDirBase, "gitrepo")
+	repoDir, err := os.MkdirTemp(c.cacheDirBase, "gitrepo")
 	if err != nil {
 		return nil, err
 	}

--- a/prow/github/app_auth_roundtripper_integration_test.go
+++ b/prow/github/app_auth_roundtripper_integration_test.go
@@ -18,7 +18,6 @@ package github
 
 import (
 	"crypto/rsa"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -34,7 +33,7 @@ func TestGetOrg(t *testing.T) {
 	if appID == "" || privateKeyPath == "" || org == "" {
 		t.SkipNow()
 	}
-	keyData, err := ioutil.ReadFile(privateKeyPath)
+	keyData, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		t.Fatalf("Failed to read private key: %v", err)
 	}

--- a/prow/github/app_auth_roundtripper_test.go
+++ b/prow/github/app_auth_roundtripper_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -105,7 +104,7 @@ func TestAppsAuth(t *testing.T) {
 			},
 			responses: map[string]*http.Response{"/app": {
 				StatusCode: 401,
-				Body:       ioutil.NopCloser(&bytes.Buffer{}),
+				Body:       io.NopCloser(&bytes.Buffer{}),
 			}},
 			verifyRequests: func(r []*http.Request) error {
 				if n := len(r); n != 1 {
@@ -521,5 +520,5 @@ func serializeOrDie(in interface{}) io.ReadCloser {
 	if err != nil {
 		panic(fmt.Sprintf("Serialization failed: %v", err))
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(rawData))
+	return io.NopCloser(bytes.NewBuffer(rawData))
 }

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -1021,7 +1020,7 @@ func (c *client) requestRawWithContext(ctx context.Context, r *request) (int, []
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -1132,7 +1131,7 @@ func (c *client) requestRetryWithContext(ctx context.Context, method, path, acce
 					if acceptedScopes != "" && !want.HasAny(got...) {
 						err = fmt.Errorf("the account is using %s oauth scopes, please make sure you are using at least one of the following oauth scopes: %s", authorizedScopes, acceptedScopes)
 					} else {
-						body, _ := ioutil.ReadAll(resp.Body)
+						body, _ := io.ReadAll(resp.Body)
 						err = fmt.Errorf("the GitHub API request returns a 403 error: %s", string(body))
 					}
 					resp.Body.Close()
@@ -2004,7 +2003,7 @@ func (c *client) readPaginatedResultsWithValuesWithContext(ctx context.Context, 
 			return fmt.Errorf("return code not 2XX: %s", resp.Status)
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -267,7 +267,7 @@ func TestCreateComment(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5/comments" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -294,7 +294,7 @@ func TestCreateCommentCensored(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5/comments" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -758,7 +758,7 @@ func TestCreateStatus(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/statuses/abcdef" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -859,7 +859,7 @@ func addLabelHTTPServer(t *testing.T, org, repo string, number int, labels ...st
 		if r.URL.Path != fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, number) {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1073,7 +1073,7 @@ func TestAssignIssue(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5/assignees" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1123,7 +1123,7 @@ func TestUnassignIssue(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5/assignees" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1380,7 +1380,7 @@ func TestRequestReview(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/pulls/5/requested_reviewers" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1442,7 +1442,7 @@ func TestUnrequestReview(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/pulls/5/requested_reviewers" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1490,7 +1490,7 @@ func TestCloseIssue(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1520,7 +1520,7 @@ func TestCloseIssueAsNotPlanned(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1550,7 +1550,7 @@ func TestReopenIssue(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1578,7 +1578,7 @@ func TestClosePR(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/pulls/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1606,7 +1606,7 @@ func TestReopenPR(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/pulls/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1919,7 +1919,7 @@ func TestCreateTeam(t *testing.T) {
 		if r.URL.Path != "/orgs/foo/teams" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -1967,7 +1967,7 @@ func TestEditTeam(t *testing.T) {
 		if r.URL.Path != "/orgs/someOrg/teams/some-team" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -2500,7 +2500,7 @@ func TestUpdateBranchProtection(t *testing.T) {
 			if r.URL.Path != "/repos/org/repo/branches/master/protection" {
 				t.Errorf("Bad request path: %s", r.URL.Path)
 			}
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("Could not read request body: %v", err)
 			}
@@ -2573,7 +2573,7 @@ func TestClearMilestone(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -2600,7 +2600,7 @@ func TestSetMilestone(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/issues/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -2699,7 +2699,7 @@ func TestUpdatePullRequestBranch(t *testing.T) {
 				t.Errorf("Bad request path: %s", r.URL.Path)
 			}
 
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("Could not read request body: %v", err)
 			}
@@ -2848,7 +2848,7 @@ func TestCreateRepo(t *testing.T) {
 				} else if !tc.isUser && r.URL.Path != "/orgs/org/repos" {
 					t.Errorf("Bad request path to create org-owned repo: %s", r.URL.Path)
 				}
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Fatalf("Could not read request body: %v", err)
 				}
@@ -2932,7 +2932,7 @@ func TestUpdateRepo(t *testing.T) {
 				if r.URL.Path != expectedPath {
 					t.Errorf("Bad request path to create user-owned repo: %s (expected %s)", r.URL.Path, expectedPath)
 				}
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Fatalf("Could not read request body: %v", err)
 				}
@@ -3215,7 +3215,7 @@ func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
 						t.Errorf("Request didn't have %s header set to 'org'", githubOrgHeaderKey)
 					}
 				}
-				return &http.Response{Body: ioutil.NopCloser(&bytes.Buffer{})}, nil
+				return &http.Response{Body: io.NopCloser(&bytes.Buffer{})}, nil
 			}}
 			ghClient.(*client).client.(*http.Client).Transport = checkingRoundTripper
 			ghClient.(*client).gqlc.(*graphQLGitHubAppsAuthClientWrapper).Client = githubv4.NewClient(&http.Client{Transport: checkingRoundTripper})
@@ -3354,7 +3354,7 @@ func TestV4ClientSetsUserAgent(t *testing.T) {
 		if got := r.Header.Get("User-Agent"); got != expectedUserAgent {
 			return nil, fmt.Errorf("expected User-Agent %q, got %q", expectedUserAgent, got)
 		}
-		return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBufferString("{}"))}, nil
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBufferString("{}"))}, nil
 	}}
 
 	_, _, client, err := NewClientFromOptions(
@@ -3517,7 +3517,7 @@ func TestCreatePullRequestReviewComment(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/pulls/5/comments" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
@@ -3589,7 +3589,7 @@ func TestCreateCheckRun(t *testing.T) {
 		if r.URL.Path != "/repos/k8s/kuber/check-runs" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}

--- a/prow/github/webhooks.go
+++ b/prow/github/webhooks.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -56,7 +56,7 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func
 		responseHTTPError(w, http.StatusBadRequest, "400 Bad Request: Hook only accepts content-type: application/json - please reconfigure this hook on GitHub")
 		return "", "", nil, false, http.StatusBadRequest
 	}
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		responseHTTPError(w, http.StatusInternalServerError, "500 Internal Server Error: Failed to read request body")
 		return "", "", nil, false, http.StatusInternalServerError

--- a/prow/githubeventserver/githubeventserver.go
+++ b/prow/githubeventserver/githubeventserver.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -475,7 +475,7 @@ func (s *serveMuxHandler) dispatch(endpoint string, payload []byte, h http.Heade
 		return err
 	}
 	defer resp.Body.Close()
-	rb, err := ioutil.ReadAll(resp.Body)
+	rb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -250,7 +250,7 @@ func (s *Server) dispatch(endpoint string, payload []byte, h http.Header) error 
 		return err
 	}
 	defer resp.Body.Close()
-	rb, err := ioutil.ReadAll(resp.Body)
+	rb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -18,7 +18,7 @@ package hook
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -547,7 +547,7 @@ foo/bar:
 				m.Unlock()
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+					Body:       io.NopCloser(bytes.NewBufferString(`OK`)),
 					Header:     make(http.Header),
 				}
 			})

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
@@ -77,7 +77,7 @@ func (o Options) Run() error {
 //          error - when unexpected file operation happens
 func processCloneLog(logfile string, uploadTargets map[string]gcs.UploadFunc) (bool, []clone.Record, error) {
 	var cloneRecords []clone.Record
-	data, err := ioutil.ReadFile(logfile)
+	data, err := os.ReadFile(logfile)
 	if err != nil {
 		return true, cloneRecords, fmt.Errorf("could not read clone log: %w", err)
 	}

--- a/prow/interrupts/interrupts_test.go
+++ b/prow/interrupts/interrupts_test.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -258,7 +257,7 @@ func generateCerts(url string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to create certificate: %s", err)
 	}
 
-	certOut, err := ioutil.TempFile("", "cert.pem")
+	certOut, err := os.CreateTemp("", "cert.pem")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to open cert.pem for writing: %s", err)
 	}
@@ -269,7 +268,7 @@ func generateCerts(url string) (string, string, error) {
 		return "", "", fmt.Errorf("error closing cert.pem: %s", err)
 	}
 
-	keyOut, err := ioutil.TempFile("", "key.pem")
+	keyOut, err := os.CreateTemp("", "key.pem")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to open key.pem for writing: %w", err)
 	}

--- a/prow/io/opener.go
+++ b/prow/io/opener.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -105,7 +104,7 @@ func NewOpener(ctx context.Context, gcsCredentialsFile, s3CredentialsFile string
 	}
 	var s3Credentials []byte
 	if s3CredentialsFile != "" {
-		s3Credentials, err = ioutil.ReadFile(s3CredentialsFile)
+		s3Credentials, err = os.ReadFile(s3CredentialsFile)
 		if err != nil {
 			return nil, err
 		}
@@ -493,7 +492,7 @@ func ReadContent(ctx context.Context, logger *logrus.Entry, opener Opener, path 
 		return nil, err
 	}
 	defer r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func WriteContent(ctx context.Context, logger *logrus.Entry, opener Opener, path string, content []byte, opts ...WriterOptions) error {

--- a/prow/io/opener_test.go
+++ b/prow/io/opener_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -120,7 +119,7 @@ RU5EIFBSSVZBVEUgS0VZLS0tLS1cbgo=`)
 		t.Run(tt.name, func(t *testing.T) {
 			var gcsCredentialsFile string
 			if tt.fakeCreds != "" {
-				fp, err := ioutil.TempFile("", "fake-creds")
+				fp, err := os.CreateTemp("", "fake-creds")
 				if err != nil {
 					t.Fatalf("Failed to create fake creds: %v", err)
 				}

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -354,7 +354,7 @@ func readResp(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("response not 2XX: %s", resp.Status)
 	}
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := stdio.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -707,7 +707,7 @@ func JiraErrorBody(err error) string {
 func HandleJiraError(response *jira.Response, err error) error {
 	if err != nil && strings.Contains(err.Error(), "Please analyze the request body for more details.") {
 		if response != nil && response.Response != nil {
-			body, readError := ioutil.ReadAll(response.Body)
+			body, readError := stdio.ReadAll(response.Body)
 			if readError != nil && readError.Error() != "http: read on closed response body" {
 				logrus.WithError(readError).Warn("Failed to read Jira response body.")
 			}

--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -19,7 +19,7 @@ package kube
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -92,7 +92,7 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 		candidates = append(candidates, opts.file)
 	}
 	if opts.dir != "" {
-		files, err := ioutil.ReadDir(opts.dir)
+		files, err := os.ReadDir(opts.dir)
 		if err != nil {
 			return nil, fmt.Errorf("kubecfg dir: %w", err)
 		}

--- a/prow/metrics/push.go
+++ b/prow/metrics/push.go
@@ -21,7 +21,7 @@ package metrics
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -93,7 +93,7 @@ func push(job string, grouping map[string]string, pushURL string, g prometheus.G
 	}
 	defer resp.Body.Close()
 	if !(resp.StatusCode == 200 || resp.StatusCode == 202) {
-		body, _ := ioutil.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
+		body, _ := io.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
 		return fmt.Errorf("unexpected status code %d while pushing to %s: %s", resp.StatusCode, pushURL, body)
 	}
 	return nil

--- a/prow/phony/phony.go
+++ b/prow/phony/phony.go
@@ -19,7 +19,7 @@ package phony
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"k8s.io/test-infra/prow/github"
@@ -42,7 +42,7 @@ func SendHook(address, eventType string, payload, hmac []byte) error {
 		return err
 	}
 	defer resp.Body.Close()
-	rb, err := ioutil.ReadAll(resp.Body)
+	rb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/prow/pjutil/pprof/pprof.go
+++ b/prow/pjutil/pprof/pprof.go
@@ -18,9 +18,9 @@ limitations under the License.
 package pprof
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"runtime"
 	runtimepprof "runtime/pprof"
 	"strconv"
@@ -61,13 +61,13 @@ func Serve(port int) {
 // pre-determined interval for future parsing and analysis.
 func WriteMemoryProfiles(interval time.Duration) {
 	logrus.Info("Writing memory profiles.")
-	profileDir, err := ioutil.TempDir("", "heap-profiles-")
+	profileDir, err := os.MkdirTemp("", "heap-profiles-")
 	if err != nil {
 		logrus.WithError(err).Warn("Could not create a directory to store memory profiles.")
 		return
 	}
 	interrupts.TickLiteral(func() {
-		profile, err := ioutil.TempFile(profileDir, "heap-profile-")
+		profile, err := os.CreateTemp(profileDir, "heap-profile-")
 		if err != nil {
 			logrus.WithError(err).Warn("Could not create a file to store a memory profile.")
 			return

--- a/prow/pjutil/tot.go
+++ b/prow/pjutil/tot.go
@@ -18,7 +18,7 @@ package pjutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -104,7 +104,7 @@ func GetBuildID(name, totURL string) (string, error) {
 			continue
 		}
 		var buf []byte
-		buf, err = ioutil.ReadAll(resp.Body)
+		buf, err = io.ReadAll(resp.Body)
 		if err == nil {
 			return string(buf), nil
 		}

--- a/prow/pluginhelp/externalplugins/externalplugins.go
+++ b/prow/pluginhelp/externalplugins/externalplugins.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -55,7 +55,7 @@ func ServeExternalPluginHelp(mux *http.ServeMux, log *logrus.Entry, provider Ext
 				http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)
 				return
 			}
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				serverError("reading request body", err)
 				return

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -18,8 +18,8 @@ package approve
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -50,7 +50,7 @@ const prNumber = 1
 func TestPluginConfig(t *testing.T) {
 	pa := &plugins.ConfigAgent{}
 
-	b, err := ioutil.ReadFile("../../../config/prow/plugins.yaml")
+	b, err := os.ReadFile("../../../config/prow/plugins.yaml")
 	if err != nil {
 		t.Fatalf("Failed to read plugin config: %v.", err)
 	}
@@ -159,7 +159,7 @@ func (fr fakeRepo) ParseSimpleConfig(path string) (repoowners.SimpleConfig, erro
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.SimpleConfig{}, err
 	}
@@ -176,7 +176,7 @@ func (fr fakeRepo) ParseFullConfig(path string) (repoowners.FullConfig, error) {
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.FullConfig{}, err
 	}

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -19,7 +19,7 @@ package blunderbuss
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -171,7 +171,7 @@ func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleCo
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.SimpleConfig{}, err
 	}
@@ -188,7 +188,7 @@ func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.FullConfig{}, err
 	}

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -21,7 +21,7 @@ package buildifier
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -113,7 +113,7 @@ func modifiedBazelFiles(ghc githubClient, org, repo string, number int, sha stri
 func problemsInFiles(r git.RepoClient, files map[string]string) (map[string]bool, error) {
 	problems := map[string]bool{}
 	for f := range files {
-		src, err := ioutil.ReadFile(filepath.Join(r.Directory(), f))
+		src, err := os.ReadFile(filepath.Join(r.Directory(), f))
 		if err != nil {
 			return nil, err
 		}

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -108,7 +108,7 @@ func (c *realClowder) setKey(keyPath string, log *logrus.Entry) {
 		c.key = ""
 		return
 	}
-	b, err := ioutil.ReadFile(keyPath)
+	b, err := os.ReadFile(keyPath)
 	if err == nil {
 		c.key = strings.TrimSpace(string(b))
 		return

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -18,7 +18,7 @@ package golint
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -158,7 +158,7 @@ func problemsInFiles(r git.RepoClient, files map[string]string) (map[string]map[
 	l := new(lint.Linter)
 	for f, patch := range files {
 		problems[f] = make(map[int]lint.Problem)
-		src, err := ioutil.ReadFile(filepath.Join(r.Directory(), f))
+		src, err := os.ReadFile(filepath.Join(r.Directory(), f))
 		if err != nil {
 			lintErrorComments = append(lintErrorComments, github.DraftReviewComment{
 				Path: f,

--- a/prow/plugins/goose/goose.go
+++ b/prow/plugins/goose/goose.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -105,7 +105,7 @@ func (g *realGaggle) setKey(keyPath string, log *logrus.Entry) {
 		g.key = ""
 		return
 	}
-	b, err := ioutil.ReadFile(keyPath)
+	b, err := os.ReadFile(keyPath)
 	if err == nil {
 		g.key = strings.TrimSpace(string(b))
 		return

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -18,7 +18,7 @@ package lgtm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -120,7 +120,7 @@ func (f *fakeRepoOwners) ParseSimpleConfig(path string) (repoowners.SimpleConfig
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.SimpleConfig{}, err
 	}
@@ -137,7 +137,7 @@ func (f *fakeRepoOwners) ParseFullConfig(path string) (repoowners.FullConfig, er
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.FullConfig{}, err
 	}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -283,7 +283,7 @@ func NewFakeConfigAgent() ConfigAgent {
 // loading fail.
 // If skipResolveConfigUpdater is true, the ConfigUpdater of the config will not be resolved.
 func (pa *ConfigAgent) Load(path string, supplementalPluginConfigDirs []string, supplementalPluginConfigFileSuffix string, checkUnknownPlugins, skipResolveConfigUpdater bool) error {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func (pa *ConfigAgent) Load(path string, supplementalPluginConfigDirs []string, 
 				return nil
 			}
 
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to read %s: %w", path, err))
 				return nil

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package plugins
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -323,11 +323,11 @@ plugins:
 			t.Parallel()
 
 			tempDir := t.TempDir()
-			if err := ioutil.WriteFile(filepath.Join(tempDir, "_plugins.yaml"), []byte(tc.config), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tempDir, "_plugins.yaml"), []byte(tc.config), 0644); err != nil {
 				t.Fatalf("failed to write config: %v", err)
 			}
 			for supplementalConfigName, supplementalConfig := range tc.supplementalConfigs {
-				if err := ioutil.WriteFile(filepath.Join(tempDir, supplementalConfigName), []byte(supplementalConfig), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(tempDir, supplementalConfigName), []byte(supplementalConfig), 0644); err != nil {
 					t.Fatalf("failed to write supplemental config %s: %v", supplementalConfigName, err)
 				}
 			}
@@ -417,7 +417,7 @@ func TestLoadConfigUpdater(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			if err := ioutil.WriteFile(filepath.Join(tempDir, "_plugins.yaml"), []byte(tc.config), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(tempDir, "_plugins.yaml"), []byte(tc.config), 0644); err != nil {
 				t.Fatalf("failed to write config: %v", err)
 			}
 			agent := &ConfigAgent{}

--- a/prow/plugins/transfer-issue/transfer-issue_test.go
+++ b/prow/plugins/transfer-issue/transfer-issue_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -225,7 +225,7 @@ func (t *testClient) MutateWithGitHubAppsSupport(ctx context.Context, m interfac
 	gqlc := githubv4.NewClient(&http.Client{
 		Transport: testRoundTripper{rt: func(r *http.Request) (*http.Response, error) {
 			defer r.Body.Close()
-			body, err := ioutil.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				return nil, err
 			}
@@ -233,7 +233,7 @@ func (t *testClient) MutateWithGitHubAppsSupport(ctx context.Context, m interfac
 			if !(strings.Contains(s, "fakeRepoNodeID") && strings.Contains(s, "fakeIssueNodeID")) {
 				return nil, fmt.Errorf("unexpected request body: %s", s)
 			}
-			return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(bytes.NewBufferString(mr))}, nil
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(mr))}, nil
 		}},
 	})
 

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -21,7 +21,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -93,7 +93,7 @@ type OSFileGetter struct {
 }
 
 func (g *OSFileGetter) GetFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filepath.Join(g.Root, filename))
+	return os.ReadFile(filepath.Join(g.Root, filename))
 }
 
 // Update updates the configmap with the data from the identified files.

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -18,7 +18,6 @@ package verifyowners
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -462,7 +461,7 @@ func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, trigger
 	// If OWNERS_ALIASES exists, get all aliases.
 	path := filepath.Join(dir, filenames.OwnersAliases)
 	if _, err := os.Stat(path); err == nil {
-		b, err := ioutil.ReadFile(path)
+		b, err := os.ReadFile(path)
 		if err != nil {
 			return nonTrustedUsers, trustedUsers, repoAliases, fmt.Errorf("Failed to read %s: %w", path, err)
 		}

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -19,7 +19,7 @@ package verifyowners
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -274,7 +274,7 @@ func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleCo
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.SimpleConfig{}, err
 	}
@@ -291,7 +291,7 @@ func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return repoowners.FullConfig{}, err
 	}

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -19,7 +19,7 @@ package welcome
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -452,7 +452,7 @@ func TestWelcomeConfig(t *testing.T) {
 func TestPluginConfig(t *testing.T) {
 	pa := &plugins.ConfigAgent{}
 
-	b, err := ioutil.ReadFile("../../../config/prow/plugins.yaml")
+	b, err := os.ReadFile("../../../config/prow/plugins.yaml")
 	if err != nil {
 		t.Fatalf("Failed to read plugin config: %v.", err)
 	}

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -18,7 +18,6 @@ package clone
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -796,7 +795,7 @@ func TestGitHeadTimestamp(t *testing.T) {
 
 // makeFakeGitRepo creates a fake git repo with a constant digest and timestamp.
 func makeFakeGitRepo(fakeTimestamp int) (string, error) {
-	fakeGitDir, err := ioutil.TempDir("", "fakegit")
+	fakeGitDir, err := os.MkdirTemp("", "fakegit")
 	if err != nil {
 		return "", err
 	}

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -18,7 +18,6 @@ package decorate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1116,11 +1115,11 @@ func TestProwJobToPod(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to marhsal pod: %v", err)
 				}
-				if err := ioutil.WriteFile(fixtureName, marshalled, 0644); err != nil {
+				if err := os.WriteFile(fixtureName, marshalled, 0644); err != nil {
 					t.Errorf("failed to update fixture: %v", err)
 				}
 			}
-			expectedRaw, err := ioutil.ReadFile(fixtureName)
+			expectedRaw, err := os.ReadFile(fixtureName)
 			if err != nil {
 				t.Fatalf("failed to read fixture: %v", err)
 			}

--- a/prow/pod-utils/gcs/upload_test.go
+++ b/prow/pod-utils/gcs/upload_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"sync"
 	"testing"
 
@@ -225,7 +225,7 @@ func Test_openerObjectWriter_Write(t *testing.T) {
 				t.Errorf("Got unexpected error reading object %s: %v", tt.ObjectDest, err)
 			}
 
-			gotObjectContent, err := ioutil.ReadAll(reader)
+			gotObjectContent, err := stdio.ReadAll(reader)
 			if err != nil {
 				t.Errorf("Got unexpected error reading object %s: %v", tt.ObjectDest, err)
 			}

--- a/prow/pod-utils/wrapper/options.go
+++ b/prow/pod-utils/wrapper/options.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -159,7 +158,7 @@ func populateMapWithError(markerMap map[string]MarkerResult, err error, paths ..
 }
 
 func readMarkerFile(path string) MarkerResult {
-	returnCodeData, err := ioutil.ReadFile(path)
+	returnCodeData, err := os.ReadFile(path)
 	if err != nil {
 		return MarkerResult{-1, fmt.Errorf("bad read: %w", err)}
 	}

--- a/prow/prstatus/prstatus_test.go
+++ b/prow/prstatus/prstatus_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -128,7 +128,7 @@ func TestHandlePrStatusWithoutLogin(t *testing.T) {
 	}
 	response := rr.Result()
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatalf("Error with reading response body: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestHandlePrStatusWithInvalidToken(t *testing.T) {
 	response := rr.Result()
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatalf("Error with reading response body: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestHandlePrStatusWithLogin(t *testing.T) {
 			}
 			response := rr.Result()
 			defer response.Body.Close()
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			if err != nil {
 				t.Fatalf("Error with reading response body: %v", err)
 			}

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -18,7 +18,6 @@ package repoowners
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -462,7 +461,7 @@ func (a RepoAliases) ExpandAllAliases() sets.String {
 
 func loadAliasesFrom(baseDir, filename string, log *logrus.Entry) RepoAliases {
 	path := filepath.Join(baseDir, filename)
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		log.WithError(err).Infof("No alias file exists at %q. Using empty alias map.", path)
 		return nil
@@ -598,7 +597,7 @@ func (o *RepoOwners) ParseFullConfig(path string) (FullConfig, error) {
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return FullConfig{}, err
 	}
@@ -617,7 +616,7 @@ func (o *RepoOwners) ParseSimpleConfig(path string) (SimpleConfig, error) {
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return SimpleConfig{}, err
 	}
@@ -637,7 +636,7 @@ func SaveSimpleConfig(simple SimpleConfig, path string) error {
 	if err != nil {
 		return nil
 	}
-	return ioutil.WriteFile(path, b, 0644)
+	return os.WriteFile(path, b, 0644)
 }
 
 // LoadFullConfig loads FullConfig from bytes `b`
@@ -653,7 +652,7 @@ func SaveFullConfig(full FullConfig, path string) error {
 	if err != nil {
 		return nil
 	}
-	return ioutil.WriteFile(path, b, 0644)
+	return os.WriteFile(path, b, 0644)
 }
 
 // ParseAliasesConfig will unmarshal an OWNERS_ALIASES file's content into RepoAliases.
@@ -680,7 +679,7 @@ var mdStructuredHeaderRegex = regexp.MustCompile("^---\n(.|\n)*\n---")
 // If no yaml header is found, do nothing
 // Returns an error if the file cannot be read or the yaml header is found but cannot be unmarshalled.
 func decodeOwnersMdConfig(path string, config *SimpleConfig) error {
-	fileBytes, err := ioutil.ReadFile(path)
+	fileBytes, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -18,7 +18,6 @@ package repoowners
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1188,7 +1187,7 @@ func TestExpandAliases(t *testing.T) {
 }
 
 func TestSaveSimpleConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "simpleConfig")
+	dir, err := os.MkdirTemp("", "simpleConfig")
 	if err != nil {
 		t.Errorf("unexpected error when creating temp dir")
 	}
@@ -1225,7 +1224,7 @@ reviewers:
 		if err != nil {
 			t.Errorf("unexpected error when writing simple config")
 		}
-		b, err := ioutil.ReadFile(file)
+		b, err := os.ReadFile(file)
 		if err != nil {
 			t.Errorf("unexpected error when reading file: %s", file)
 		}
@@ -1244,7 +1243,7 @@ reviewers:
 }
 
 func TestSaveFullConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "fullConfig")
+	dir, err := os.MkdirTemp("", "fullConfig")
 	if err != nil {
 		t.Errorf("unexpected error when creating temp dir")
 	}
@@ -1287,7 +1286,7 @@ options: {}
 		if err != nil {
 			t.Errorf("unexpected error when writing full config")
 		}
-		b, err := ioutil.ReadFile(file)
+		b, err := os.ReadFile(file)
 		if err != nil {
 			t.Errorf("unexpected error when reading file: %s", file)
 		}

--- a/prow/sidecar/censor.go
+++ b/prow/sidecar/censor.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -216,7 +215,7 @@ func determineContentType(path string) (string, error) {
 // handleArchive unravels the archive in order to censor data in the files that were added to it.
 // This is mostly stolen from build/internal/untar/untar.go
 func handleArchive(archivePath string, censor func(wg *sync.WaitGroup, file string)) error {
-	outputDir, err := ioutil.TempDir("", "tmp-unpack")
+	outputDir, err := os.MkdirTemp("", "tmp-unpack")
 	if err != nil {
 		return fmt.Errorf("could not create temporary dir for unpacking: %w", err)
 	}
@@ -320,7 +319,7 @@ func validRelPath(p string) bool {
 func archive(srcDir, destArchive string) error {
 	// we want the temporary file we use for output to be in the same directory as the real destination, so
 	// we can be certain that our final os.Rename() call will not have to operate across a device boundary
-	output, err := ioutil.TempFile(filepath.Dir(destArchive), "tmp-archive")
+	output, err := os.CreateTemp(filepath.Dir(destArchive), "tmp-archive")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file for archive: %w", err)
 	}
@@ -412,7 +411,7 @@ func handleFile(path string, censorer secretutil.Censorer, bufferSize int) error
 
 	// we want the temporary file we use for output to be in the same directory as the real destination, so
 	// we can be certain that our final os.Rename() call will not have to operate across a device boundary
-	output, err := ioutil.TempFile(filepath.Dir(path), "tmp-censor")
+	output, err := os.CreateTemp(filepath.Dir(path), "tmp-censor")
 	if err != nil {
 		return fmt.Errorf("could not create temporary file for censoring: %w", err)
 	}
@@ -497,7 +496,7 @@ func loadSecrets(paths, iniFilenames []string) ([][]byte, error) {
 			if info.IsDir() {
 				return nil
 			}
-			raw, err := ioutil.ReadFile(path)
+			raw, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/prow/sidecar/censor_test.go
+++ b/prow/sidecar/censor_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,7 +64,7 @@ func TestCensor(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			censorer := secretutil.NewCensorer()
 			censorer.Refresh(testCase.secrets...)
-			input := ioutil.NopCloser(bytes.NewBufferString(testCase.input))
+			input := io.NopCloser(bytes.NewBufferString(testCase.input))
 			outputSink := &bytes.Buffer{}
 			output := nopWriteCloser(outputSink)
 			if err := censor(input, output, censorer, testCase.bufferSize); err != nil {
@@ -110,7 +109,7 @@ func copyTestData(t *testing.T) string {
 			return os.Symlink(link, dest)
 		}
 		if info.Name() == "link" {
-			link, err := ioutil.ReadFile(path)
+			link, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("failed to read input link: %v", err)
 			}
@@ -187,7 +186,7 @@ func TestCensorRobustnessForCorruptArchive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open archived input: %v", err)
 	}
-	raw, err := ioutil.ReadAll(file)
+	raw, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatalf("failed to read archived input: %v", err)
 	}

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -50,7 +49,7 @@ const LogFileName = "sidecar-logs.json"
 func LogSetup() (*os.File, error) {
 	logrusutil.ComponentInit()
 	logrus.SetLevel(logrus.DebugLevel)
-	logFile, err := ioutil.TempFile("", "sidecar-logs*.txt")
+	logFile, err := os.CreateTemp("", "sidecar-logs*.txt")
 	if err == nil {
 		logrus.SetOutput(io.MultiWriter(os.Stderr, logFile))
 	}
@@ -188,7 +187,7 @@ func combineMetadata(entries []wrapper.Options) map[string]interface{} {
 			}
 			continue
 		}
-		metadataRaw, err := ioutil.ReadFile(metadataFile)
+		metadataRaw, err := os.ReadFile(metadataFile)
 		if err != nil {
 			logrus.WithError(err).Errorf("cannot read %s", metadataFile)
 			errors[ent] = err

--- a/prow/sidecar/run_test.go
+++ b/prow/sidecar/run_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -114,7 +114,7 @@ func TestWait(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", tc.name)
+			tmpDir, err := os.MkdirTemp("", tc.name)
 			if err != nil {
 				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
 			}
@@ -130,7 +130,7 @@ func TestWait(t *testing.T) {
 				p := path.Join(tmpDir, fmt.Sprintf("marker-%d.txt", i))
 				var opt wrapper.Options
 				opt.MarkerFile = p
-				if err := ioutil.WriteFile(p, []byte(m), 0600); err != nil {
+				if err := os.WriteFile(p, []byte(m), 0600); err != nil {
 					t.Fatalf("could not create marker %d: %v", i, err)
 				}
 				entries = append(entries, opt)
@@ -222,7 +222,7 @@ func TestWaitParallelContainers(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", tc.name)
+			tmpDir, err := os.MkdirTemp("", tc.name)
 			if err != nil {
 				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
 			}
@@ -361,7 +361,7 @@ func TestCombineMetadata(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", tc.name)
+			tmpDir, err := os.MkdirTemp("", tc.name)
 			if err != nil {
 				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
 			}
@@ -386,7 +386,7 @@ func TestCombineMetadata(t *testing.T) {
 					continue
 				}
 				// not-json is invalid json
-				if err := ioutil.WriteFile(p, []byte(m), 0600); err != nil {
+				if err := os.WriteFile(p, []byte(m), 0600); err != nil {
 					t.Fatalf("could not create metadata %d: %v", i, err)
 				}
 			}
@@ -479,7 +479,7 @@ func TestLogReaders(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", tc.name)
+			tmpDir, err := os.MkdirTemp("", tc.name)
 			if err != nil {
 				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
 			}
@@ -494,7 +494,7 @@ func TestLogReaders(t *testing.T) {
 				if log == "missing" {
 					continue
 				}
-				if err := ioutil.WriteFile(p, []byte(log), 0600); err != nil {
+				if err := os.WriteFile(p, []byte(log), 0600); err != nil {
 					t.Fatalf("could not create log %s: %v", name, err)
 				}
 			}
@@ -517,7 +517,7 @@ func TestLogReaders(t *testing.T) {
 			const repl = "$1 <SNIP>"
 			actual := make(map[string]string)
 			for name, reader := range readers {
-				buf, err := ioutil.ReadAll(reader)
+				buf, err := io.ReadAll(reader)
 				if err != nil {
 					t.Fatalf("failed to read all: %v", err)
 				}
@@ -546,7 +546,7 @@ func TestSideCarLogsUpload(t *testing.T) {
 	logrus.Info(testString)
 	var once sync.Once
 
-	localOutputDir, err := ioutil.TempDir("", "testdir")
+	localOutputDir, err := os.MkdirTemp("", "testdir")
 	if err != nil {
 		t.Errorf("Unable to create temp dir: %v", err)
 	}
@@ -585,7 +585,7 @@ func TestSideCarLogsUpload(t *testing.T) {
 
 	options.doUpload(context.Background(), spec, true, false, metadata, buildLogs, logFile, &once)
 
-	files, err := ioutil.ReadDir(localOutputDir)
+	files, err := os.ReadDir(localOutputDir)
 	if err != nil {
 		t.Errorf("Unable to access files in directory: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestSideCarLogsUpload(t *testing.T) {
 	}
 
 	var s []byte
-	s, err = ioutil.ReadFile(filepath.Join(localOutputDir, LogFileName))
+	s, err = os.ReadFile(filepath.Join(localOutputDir, LogFileName))
 	if err != nil {
 		t.Fatalf("Unable to read log file: %v", err)
 	}

--- a/prow/slack/client.go
+++ b/prow/slack/client.go
@@ -19,7 +19,7 @@ package slack
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -118,7 +118,7 @@ func (sl *Client) postMessage(url string, uv *url.Values) error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	apiResponse := struct {
 		Ok    bool   `json:"ok"`
 		Error string `json:"error"`

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -19,7 +19,7 @@ package buildlog
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1108,7 +1108,7 @@ func TestAnalyzeArtifact(t *testing.T) {
 func testHighlighter(t *testing.T, wantReq highlightRequest, code int, response string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
-		buf, err := ioutil.ReadAll(r.Body)
+		buf, err := stdio.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Failed to read body: %v", err)
 		}

--- a/prow/spyglass/lenses/common/bindata.go
+++ b/prow/spyglass/lenses/common/bindata.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -203,7 +202,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/prow/spyglass/lenses/common/common.go
+++ b/prow/spyglass/lenses/common/common.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -97,7 +97,7 @@ type lensHandlerOpts struct {
 
 func newLensHandler(lens api.Lens, opts lensHandlerOpts) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			writeHTTPError(w, fmt.Errorf("failed to read request body: %w", err), http.StatusInternalServerError)
 			return

--- a/prow/spyglass/lenses/fake/fake.go
+++ b/prow/spyglass/lenses/fake/fake.go
@@ -19,7 +19,7 @@ package fake
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 )
 
 type Artifact struct {
@@ -62,7 +62,7 @@ func (fa *Artifact) ReadAt(b []byte, off int64) (int, error) {
 
 func (fa *Artifact) ReadAll() ([]byte, error) {
 	r := bytes.NewReader(fa.Content)
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (fa *Artifact) ReadTail(n int64) ([]byte, error) {

--- a/prow/spyglass/lenses/html/html_test.go
+++ b/prow/spyglass/lenses/html/html_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,11 +125,11 @@ func TestRenderBody(t *testing.T) {
 			body := (Lens{}).Body([]api.Artifact{&tc.artifact}, ".", "", nil, config.Spyglass{})
 			fixtureName := filepath.Join("testdata", fmt.Sprintf("%s.yaml", strings.ReplaceAll(t.Name(), "/", "_")))
 			if os.Getenv("UPDATE") != "" {
-				if err := ioutil.WriteFile(fixtureName, []byte(body), 0644); err != nil {
+				if err := os.WriteFile(fixtureName, []byte(body), 0644); err != nil {
 					t.Errorf("failed to update fixture: %v", err)
 				}
 			}
-			expectedRaw, err := ioutil.ReadFile(fixtureName)
+			expectedRaw, err := os.ReadFile(fixtureName)
 			if err != nil {
 				t.Fatalf("failed to read fixture: %v", err)
 			}

--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"context"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -81,7 +81,7 @@ func (fa *FakeArtifact) ReadAll() ([]byte, error) {
 		return nil, lenses.ErrFileTooLarge
 	}
 	r := bytes.NewReader(fa.content)
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (fa *FakeArtifact) ReadTail(n int64) ([]byte, error) {

--- a/prow/spyglass/lenses/podinfo/podinfo_test.go
+++ b/prow/spyglass/lenses/podinfo/podinfo_test.go
@@ -18,7 +18,7 @@ package podinfo
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -119,7 +119,7 @@ func TestBody(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logHook.Reset()
 			wantFile := path.Join("testdata", "test_"+tc.name+".html")
-			wantBytes, err := ioutil.ReadFile(wantFile)
+			wantBytes, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatalf("Failed reading output file %s: %v", wantFile, err)
 			}

--- a/prow/spyglass/storageartifact.go
+++ b/prow/spyglass/storageartifact.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 
 	pkgio "k8s.io/test-infra/prow/io"
@@ -197,7 +196,7 @@ func (a *StorageArtifact) ReadAtMost(n int64) ([]byte, error) {
 			return nil, fmt.Errorf("error getting artifact reader: %w", err)
 		}
 		defer reader.Close()
-		p, err = ioutil.ReadAll(reader) // Must readall for gzipped files
+		p, err = io.ReadAll(reader) // Must readall for gzipped files
 		if err != nil {
 			return nil, fmt.Errorf("error reading all from artifact: %w", err)
 		}
@@ -225,7 +224,7 @@ func (a *StorageArtifact) ReadAtMost(n int64) ([]byte, error) {
 		return nil, fmt.Errorf("error getting artifact reader: %w", err)
 	}
 	defer reader.Close()
-	p, err = ioutil.ReadAll(reader)
+	p, err = io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading all from artifact: %w", err)
 	}
@@ -249,7 +248,7 @@ func (a *StorageArtifact) ReadAll() ([]byte, error) {
 		return nil, fmt.Errorf("error getting artifact reader: %w", err)
 	}
 	defer reader.Close()
-	p, err := ioutil.ReadAll(reader)
+	p, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading all from artifact: %w", err)
 	}
@@ -283,7 +282,7 @@ func (a *StorageArtifact) ReadTail(n int64) ([]byte, error) {
 		return nil, fmt.Errorf("error getting artifact reader: %w", err)
 	}
 	defer reader.Close()
-	read, err := ioutil.ReadAll(reader)
+	read, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading all from artiact: %w", err)
 	}

--- a/prow/spyglass/storageartifact_fetcher_test.go
+++ b/prow/spyglass/storageartifact_fetcher_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -409,7 +408,7 @@ RU5EIFBSSVZBVEUgS0VZLS0tLS1cbgo=`)
 		t.Run(tc.name, func(t *testing.T) {
 			var path string
 			if tc.fakeCreds != "" {
-				fp, err := ioutil.TempFile("", "fake-creds")
+				fp, err := os.CreateTemp("", "fake-creds")
 				if err != nil {
 					t.Fatalf("Failed to create fake creds: %v", err)
 				}

--- a/prow/statusreconciler/status.go
+++ b/prow/statusreconciler/status.go
@@ -18,7 +18,7 @@ package statusreconciler
 
 import (
 	"context"
-	"io/ioutil"
+	stdio "io"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -116,7 +116,7 @@ func (s *statusController) loadState() (storedState, error) {
 	}
 	defer io.LogClose(reader)
 
-	buf, err := ioutil.ReadAll(reader)
+	buf, err := stdio.ReadAll(reader)
 	if err != nil {
 		entry.WithError(err).Warn("Cannot read stored state")
 		return state, err

--- a/prow/statusreconciler/status_test.go
+++ b/prow/statusreconciler/status_test.go
@@ -18,7 +18,6 @@ package statusreconciler
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -217,7 +216,7 @@ func TestSave(t *testing.T) {
 			}
 
 			if statusURI != "" {
-				buf, err := ioutil.ReadFile(statusURI)
+				buf, err := os.ReadFile(statusURI)
 				if err != nil {
 					t.Fatalf("%s: unexpected error reading status file: %v", tc.name, err)
 				}
@@ -233,7 +232,7 @@ func TestSave(t *testing.T) {
 }
 
 func getConfigFile(t *testing.T, config config.Config) (string, func()) {
-	tempFile, err := ioutil.TempFile("/tmp", "prow-test")
+	tempFile, err := os.CreateTemp("/tmp", "prow-test")
 	if err != nil {
 		t.Fatalf("failed to get tempfile: %v", err)
 	}

--- a/prow/test/integration/internal/fakegitserver/fakegitserver.go
+++ b/prow/test/integration/internal/fakegitserver/fakegitserver.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cgi"
 	"os"
@@ -125,7 +125,7 @@ func GitCGIHandler(gitBinary, gitReposParentDir string) http.Handler {
 // repo.
 func SetupRepoHandler(gitReposParentDir string, mux *sync.Mutex) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		buf, err := ioutil.ReadAll(req.Body)
+		buf, err := io.ReadAll(req.Body)
 		defer req.Body.Close()
 		if err != nil {
 			logrus.Errorf("failed to read request body: %v", err)
@@ -250,7 +250,7 @@ func convertToBareRepo(repo *git.Repository, repoPath string) error {
 	config.Core.IsBare = true
 	repo.SetConfig(config)
 
-	tempDir, err := ioutil.TempDir("", "fgs")
+	tempDir, err := os.MkdirTemp("", "fgs")
 	if err != nil {
 		return err
 	}

--- a/prow/test/integration/test/deck_test.go
+++ b/prow/test/integration/test/deck_test.go
@@ -19,7 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -234,7 +234,7 @@ func TestDeck(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Expected response status code %d, got %d, ", http.StatusOK, resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Failed getting deck body response content %v", err)
 	}
@@ -300,7 +300,7 @@ func TestDeckTenantIDs(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				t.Fatalf("Expected response status code %d, got %d, ", http.StatusOK, resp.StatusCode)
 			}
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("Failed getting deck body response content %v", err)
 			}
@@ -435,7 +435,7 @@ func TestRerun(t *testing.T) {
 				time.Sleep(waitDur)
 				continue
 			}
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				lastErr = fmt.Errorf("could not read body response %v", err)
 				res.Body.Close()

--- a/prow/test/integration/test/hook_test.go
+++ b/prow/test/integration/test/hook_test.go
@@ -18,7 +18,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -65,7 +65,7 @@ func TestHook(t *testing.T) {
 		t.Fatalf("Failed add label: %v", err)
 	}
 
-	d, err := ioutil.ReadFile(commentFile)
+	d, err := os.ReadFile(commentFile)
 	if err != nil {
 		t.Fatalf("Could not read payload file: %v", err)
 	}

--- a/prow/test/integration/test/webhook_server_test.go
+++ b/prow/test/integration/test/webhook_server_test.go
@@ -18,11 +18,9 @@ package integration
 
 import (
 	"context"
-
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
-
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -109,7 +107,7 @@ func TestWebhookServerMutateProwjob(t *testing.T) {
 		t.Fatalf("could not get prowjob: %v", err)
 	}
 
-	originalProwJobYAML, err := ioutil.ReadFile(absValidBareProwJobPath)
+	originalProwJobYAML, err := os.ReadFile(absValidBareProwJobPath)
 	if err != nil {
 		t.Fatalf("unable to read yaml file %v", err)
 	}

--- a/prow/testutil/fixtures.go
+++ b/prow/testutil/fixtures.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,7 +50,7 @@ func CompareWithFixtureDir(t *testing.T, golden, output string) {
 // CompareWithFixture will compare output files with a test fixture and allows to automatically update them
 // by setting the UPDATE env var. The output and golden paths are relative to the test's directory.
 func CompareWithFixture(t *testing.T, golden, output string) {
-	actual, err := ioutil.ReadFile(output)
+	actual, err := os.ReadFile(output)
 	if err != nil {
 		t.Fatalf("failed to read testdata file: %v", err)
 	}
@@ -59,11 +58,11 @@ func CompareWithFixture(t *testing.T, golden, output string) {
 		if err := os.MkdirAll(filepath.Dir(golden), 0755); err != nil {
 			t.Fatalf("failed to create fixture directory: %v", err)
 		}
-		if err := ioutil.WriteFile(golden, actual, 0644); err != nil {
+		if err := os.WriteFile(golden, actual, 0644); err != nil {
 			t.Fatalf("failed to write updated fixture: %v", err)
 		}
 	}
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	if err != nil {
 		t.Fatalf("failed to read testdata file: %v", err)
 	}
@@ -92,7 +91,7 @@ func sanitizeFilename(s string) string {
 // serialized version of the data.
 func CompareWithSerializedFixture(t *testing.T, data interface{}) {
 	t.Helper()
-	tempFile, err := ioutil.TempFile("", "tmp-serialized")
+	tempFile, err := os.CreateTemp("", "tmp-serialized")
 	if err != nil {
 		t.Fatalf("could not create temporary file to hold serialized data: %v", err)
 	}

--- a/prow/tide/history/history.go
+++ b/prow/tide/history/history.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"sort"
 	"sync"
@@ -64,7 +64,7 @@ func readHistory(maxRecordsPerKey int, opener opener, path string) (map[string]*
 		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer io.LogClose(reader)
-	raw, err := ioutil.ReadAll(reader)
+	raw, err := stdio.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/url"
 	"sort"
 	"strconv"
@@ -504,7 +504,7 @@ func (sc *statusController) load() {
 	}
 	defer io.LogClose(reader)
 
-	buf, err := ioutil.ReadAll(reader)
+	buf, err := stdio.ReadAll(reader)
 	if err != nil {
 		entry.WithError(err).Warn("Cannot read stored state")
 		return

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 	"text/template"
@@ -436,7 +436,7 @@ func main() {
 	}
 
 	if o.outputPath != "" {
-		if err := ioutil.WriteFile(o.outputPath, output, 0666); err != nil {
+		if err := os.WriteFile(o.outputPath, output, 0666); err != nil {
 			log.Fatalf("Failed to write new presubmits: %v.\n", err)
 		}
 	} else {

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -148,7 +147,7 @@ func main() {
 		log.Fatalf("Failed to marshal new presubmits: %v\n", err)
 	}
 
-	if err := ioutil.WriteFile(o.configFile, output, 0666); err != nil {
+	if err := os.WriteFile(o.configFile, output, 0666); err != nil {
 		log.Fatalf("Failed to write new presubmits: %v.\n", err)
 	}
 }

--- a/robots/coverage/downloader/downloader.go
+++ b/robots/coverage/downloader/downloader.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"sort"
 	"strconv"
@@ -68,7 +68,7 @@ func readGcsObject(ctx context.Context, client *storage.Client, bucket, object s
 	if err != nil {
 		return nil, fmt.Errorf("cannot read object '%s': %w", object, err)
 	}
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 // FindBaseProfile finds the coverage profile file from the latest healthy build

--- a/robots/issue-creator/creator/creator.go
+++ b/robots/issue-creator/creator/creator.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -157,7 +157,7 @@ func (c *IssueCreator) initialize() error {
 	if c.tokenFile == "" {
 		return errors.New("'--token-file' is a required flag")
 	}
-	b, err := ioutil.ReadFile(c.tokenFile)
+	b, err := os.ReadFile(c.tokenFile)
 	if err != nil {
 		return fmt.Errorf("failed to read token file '%s': %w", c.tokenFile, err)
 	}

--- a/robots/issue-creator/sources/flakyjob-reporter.go
+++ b/robots/issue-creator/sources/flakyjob-reporter.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"time"
@@ -272,7 +272,7 @@ func ReadHTTP(url string) ([]byte, error) {
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			continue
 		}

--- a/robots/issue-creator/testowner/owner_test.go
+++ b/robots/issue-creator/testowner/owner_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -133,7 +132,7 @@ func TestReloadingOwnerList(t *testing.T) {
 			err:    true,
 		},
 	}
-	tempfile, err := ioutil.TempFile(os.TempDir(), "ownertest")
+	tempfile, err := os.CreateTemp(os.TempDir(), "ownertest")
 	if err != nil {
 		t.Error(err)
 	}

--- a/testgrid/cmd/transfigure/cmd/transfigure.go
+++ b/testgrid/cmd/transfigure/cmd/transfigure.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -163,7 +163,7 @@ func init() {
 }
 
 func createTempWorkingDir() error {
-	tempDir, err := ioutil.TempDir(".", "transfigure_")
+	tempDir, err := os.MkdirTemp(".", "transfigure_")
 	if err != nil {
 		return fmt.Errorf("%v (Caused by: %v)", "Error creating temp directory", err)
 	}
@@ -294,7 +294,7 @@ func populateGitUserAndEmail() error {
 		return fmt.Errorf("%v (Caused by: %v)", "Error sending request", err)
 	}
 	// Read in the desired fields from the response body.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%v (Caused by: %v)", "Error reading from response", err)
 	}
@@ -322,7 +322,7 @@ func populateGitUserAndEmail() error {
 }
 
 func readGitHubToken() error {
-	token, err := ioutil.ReadFile(o.githubToken)
+	token, err := os.ReadFile(o.githubToken)
 	o.tokenContents = strings.TrimSpace(string(token))
 	return wrapErrorOrNil("Error reading github token "+o.githubToken, err)
 }

--- a/testgrid/pkg/configurator/configurator/client.go
+++ b/testgrid/pkg/configurator/configurator/client.go
@@ -19,7 +19,6 @@ package configurator
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -116,7 +115,7 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 		return fmt.Errorf("invalid url %s: %w", path, err)
 	}
 	if u.Scheme != "gs" {
-		return ioutil.WriteFile(path, bytes, 0644)
+		return os.WriteFile(path, bytes, 0644)
 	}
 	var p gcs.Path
 	if err = p.SetURL(u); err != nil {
@@ -143,7 +142,7 @@ func doOneshot(ctx context.Context, opt *options.Options, prowConfigAgent *prowC
 	// Remains nil if no default YAML
 	var d *yamlcfg.DefaultConfiguration
 	if opt.DefaultYAML != "" {
-		b, err := ioutil.ReadFile(opt.DefaultYAML)
+		b, err := os.ReadFile(opt.DefaultYAML)
 		if err != nil {
 			return err
 		}

--- a/testgrid/pkg/configurator/configurator/client_test.go
+++ b/testgrid/pkg/configurator/configurator/client_test.go
@@ -18,7 +18,6 @@ package configurator
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -47,13 +46,13 @@ func Test_announceChanges(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			directory, err := ioutil.TempDir("", "")
+			directory, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatalf("Error in creating temporary dir: %v", err)
 			}
 			defer os.RemoveAll(directory)
 
-			file, err := ioutil.TempFile(directory, "1*.yaml")
+			file, err := os.CreateTemp(directory, "1*.yaml")
 			if err != nil {
 				t.Fatalf("Error in creating temporary file: %v", err)
 			}
@@ -77,7 +76,7 @@ func Test_announceChanges(t *testing.T) {
 					t.Fatalf("OS error with deleting file")
 				}
 			case test.addFile:
-				if _, err := ioutil.TempFile(directory, "2*.yaml"); err != nil {
+				if _, err := os.CreateTemp(directory, "2*.yaml"); err != nil {
 					t.Fatalf("OS error with adding new file")
 				}
 			}

--- a/triage/summarize/files.go
+++ b/triage/summarize/files.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -379,7 +378,7 @@ func loadTests(testsFilepaths []string, memoize bool) (map[string][]failure, err
 // into v. Internally, it calls encoding/json's Unmarshal using v as the second argument. Therefore,
 // v mut be a non-nil pointer.
 func getJSON(filepath string, v interface{}) error {
-	contents, err := ioutil.ReadFile(filepath)
+	contents, err := os.ReadFile(filepath)
 	if err != nil {
 		return fmt.Errorf("Could not open file '%s': %s", filepath, err)
 	}
@@ -400,7 +399,7 @@ func writeJSON(filepath string, v interface{}) error {
 		return fmt.Errorf("Could not encode JSON: %s\nTried to encode the following: %#v", err, v)
 	}
 
-	err = ioutil.WriteFile(filepath, output, 0644)
+	err = os.WriteFile(filepath, output, 0644)
 	if err != nil {
 		return fmt.Errorf("Could not write JSON to file: %s", err)
 	}

--- a/triage/summarize/summarize_test.go
+++ b/triage/summarize/summarize_test.go
@@ -19,7 +19,6 @@ package summarize
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -138,7 +137,7 @@ func failOnMismatchedTestSlices(t *testing.T, want []test, got []test) {
 
 func TestSummarize(t *testing.T) {
 	// Setup
-	tmpdir, err := ioutil.TempDir("", "summarize_test_*")
+	tmpdir, err := os.MkdirTemp("", "summarize_test_*")
 	if err != nil {
 		t.Errorf("Could not create temporary directory: %s", err)
 		return
@@ -207,7 +206,7 @@ func TestSummarize(t *testing.T) {
 		tests = append(tests, result...)
 		tests = append(tests, []byte("\n")...)
 	}
-	err = ioutil.WriteFile(testsPath, tests, 0644)
+	err = os.WriteFile(testsPath, tests, 0644)
 	if err != nil {
 		t.Errorf("Could not write JSON to file: %s", err)
 		return


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir