### PR TITLE
Presubmit job for building the ccm image

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
@@ -1,0 +1,34 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-ibmcloud:
+  - name: pull-cluster-api-provider-ccm-image
+    run_if_changed: '^hack/ccm/'
+    branches:
+      - ^main$
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - "runner.sh"
+        args:
+        - bash
+        - -c
+        - |
+          pushd hack/ccm
+          make build-image-linux-amd64
+          make build-image-linux-ppc64le
+          popd
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220928-cd48f52a16-1.24
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      testgrid-tab-name: pr-ccm


### PR DESCRIPTION
This change is to have a presubmit prow job of image building, for any changes to ` kubernetes-sigs/cluster-api-provider-ibmcloud/hack/ccm`