### PR TITLE
Pause enhancements sync job for v1.26 enhancements freeze

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -12,6 +12,7 @@ periodics:
     repo: sig-release
     base_ref: master
   spec:
+    suspend: true
     containers:
     - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
       command:


### PR DESCRIPTION
This isn't completely necessary since the job is already partially broken, but for most future releases we will want to pause this sync job to ensure that new enhancements are not added after freeze even if the `lead-opted-in` label is added.

It may actually be counterproductive to pause it right now this cycle, since having it running will likely be useful for @Priyankasaggu11929 and @ameukam to debug the job.  Let me know your thoughts.

/hold 

/cc @Priyankasaggu11929 @leonardpahlke 

