### PR TITLE
WIP adds IsGitHubAction to ClientOptions

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -397,11 +397,10 @@ const (
 	// Fake User/Login names this client uses with the ephemeral token assigned
 	// during a GitHub Action run. Only used when this client is instantiated
 	// from a GitHub Action by setting IsGitHubAction to true in ClientOptions
-	GitHubActionEphemeralUser  = "ProwAssignedGithubActionEphemeralUser"
-	GitHubActionEphemeralLogin = "ProwAssignedGithubActionEphemeralLogin"
+	GitHubActionEphemeralUser  = "ProwAssignedGitHubActionEphemeralUser"
+	GitHubActionEphemeralLogin = "ProwAssignedGitHubActionEphemeralLogin"
 )
 
-// Force the compiler to check if the TokenSource is implementing correctly.
 // Tokensource is needed to dynamically update the token in the GraphQL client.
 var _ oauth2.TokenSource = &reloadingTokenSource{}
 


### PR DESCRIPTION
  When instantiated with `IsGitHubAction` set to true in `ClientOptions`
  the client uses that knowledge to avoid making calls to the `/user`
  endpoint on the GitHub API.

  The ephemeral token assigned to GitHub Actions when run is *not*
  granted the permissions to read `/user `on the Github API.

  Not being able to make this call does not seem to adversely affect
  prow plugins launched by pga, though fake User and Login are assigned to make the
  the client behave similarly to the OAuth mechanism as the client
  makes use of these in the `UserGenerator`.

 Implements #27684 