### PR TITLE
Remove GCR to AR sync jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
@@ -1,88 +1,31 @@
-periodics:
-  - name: gcr-to-ar-sync-europe
-    interval: 2h
-    cluster: k8s-infra-prow-build-trusted
-    decorate: true
-    max_concurrency: 1
-    annotations:
-      testgrid-dashboards: sig-k8s-infra-k8sio
-      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-    rerun_auth_config:
-      github_team_slugs:
-        - org: kubernetes
-          slug: sig-k8s-infra-leads
-        - org: kubernetes
-          slug: release-managers
-    spec:
-      serviceAccountName: k8s-infra-gcr-promoter
-      containers:
-        - image: golang:1.18
-          imagePullPolicy: Always
-          command:
-            - /bin/bash
-          args:
-            - -c
-            - |
-              export PATH=$PATH:$GOPATH/bin
-              apt update && apt install parallel -qqy
-              go install github.com/google/go-containerregistry/cmd/gcrane@latest
-              parallel "gcrane cp --recursive --allow-nondistributable-artifacts eu.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west4 europe-west8 europe-west9
-  - name: gcr-to-ar-sync-asia
-    interval: 2h
-    cluster: k8s-infra-prow-build-trusted
-    decorate: true
-    max_concurrency: 1
-    annotations:
-      testgrid-dashboards: sig-k8s-infra-k8sio
-      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-    rerun_auth_config:
-      github_team_slugs:
-        - org: kubernetes
-          slug: sig-k8s-infra-leads
-        - org: kubernetes
-          slug: release-managers
-    spec:
-      serviceAccountName: k8s-infra-gcr-promoter
-      containers:
-        - image: golang:1.18
-          imagePullPolicy: Always
-          command:
-            - /bin/bash
-          args:
-            - -c
-            - |
-              export PATH=$PATH:$GOPATH/bin
-              apt update && apt install parallel -qqy
-              go install github.com/google/go-containerregistry/cmd/gcrane@latest
-              parallel "gcrane cp --recursive --allow-nondistributable-artifacts asia.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: asia-east1 asia-south1 asia-northeast1 asia-northeast2 australia-southeast1
-  - name: gcr-to-ar-sync-us
-    interval: 2h
-    cluster: k8s-infra-prow-build-trusted
-    decorate: true
-    max_concurrency: 1
-    annotations:
-      testgrid-dashboards: sig-k8s-infra-k8sio
-      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-    rerun_auth_config:
-      github_team_slugs:
-        - org: kubernetes
-          slug: sig-k8s-infra-leads
-        - org: kubernetes
-          slug: release-managers
-    spec:
-      serviceAccountName: k8s-infra-gcr-promoter
-      containers:
-        - image: golang:1.18
-          imagePullPolicy: Always
-          command:
-            - /bin/bash
-          args:
-            - -c
-            - |
-              export PATH=$PATH:$GOPATH/bin
-              apt update && apt install parallel -qqy
-              go install github.com/google/go-containerregistry/cmd/gcrane@latest
-              parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: southamerica-west1 us-central1 us-east1 us-east4 us-east5 us-south1 us-west1 us-west2
+# If you are adding new AR regions, you need to run this job for a while and then add the manifests in k/k8s.io
+# periodics:
+#   - name: gcr-to-ar-sync-europe
+#     interval: 2h
+#     cluster: k8s-infra-prow-build-trusted
+#     decorate: true
+#     max_concurrency: 1
+#     annotations:
+#       testgrid-dashboards: sig-k8s-infra-k8sio
+#       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+#       testgrid-num-failures-to-alert: '1'
+#     rerun_auth_config:
+#       github_team_slugs:
+#         - org: kubernetes
+#           slug: sig-k8s-infra-leads
+#         - org: kubernetes
+#           slug: release-managers
+#     spec:
+#       serviceAccountName: k8s-infra-gcr-promoter
+#       containers:
+#         - image: golang:1.18
+#           imagePullPolicy: Always
+#           command:
+#             - /bin/bash
+#           args:
+#             - -c
+#             - |
+#               export PATH=$PATH:$GOPATH/bin
+#               apt update && apt install parallel -qqy
+#               go install github.com/google/go-containerregistry/cmd/gcrane@latest
+#               parallel "gcrane cp --recursive --allow-nondistributable-artifacts eu.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west4 europe-west8 europe-west9


### PR DESCRIPTION
These jobs are no longer need as the migration is now complete with the merge of https://github.com/kubernetes/k8s.io/pull/4308

I left one job commented out for when we add new regions in the future. I'll need to write the steps for that somewhere

/cc @ameukam @BenTheElder 