### PR TITLE
Remove deprecated infra-commit column header from defaults.

### DIFF
--- a/config/testgrids/default.yaml
+++ b/config/testgrids/default.yaml
@@ -9,7 +9,6 @@ default_test_group:
   ignore_skip: true # Don't show skipped tests by default.
   column_header:
     - configuration_value: Commit # Shows the commit number on column header
-    - configuration_value: infra-commit
   num_columns_recent: 10
   use_kubernetes_client: true # These two fields are deprecated and should always be true
   is_external: true

--- a/testgrid/config.md
+++ b/testgrid/config.md
@@ -275,10 +275,8 @@ test_groups:
   gcs_prefix:
   kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default
   column_header:
-  - configuration_value: node_os_image
-  - configuration_value: master_os_image
   - configuration_value: Commit
-  - configuration_value: infra-commit
+  - configuration_value: my_custom_key
 ```
 
 ### Email alerts


### PR DESCRIPTION
infra-commit is published by bootstrap.py, which is deprecated and not in wide use. Remove it as a default column header for TestGrid config. (This can still be specified in individual configs if it's still needed).