### PR TITLE
k8s-infra: remove presets for registry.k8s.io

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -235,7 +235,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-      preset-use-new-registry: "true"
     spec:
       containers:
         - args:
@@ -402,7 +401,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-      preset-use-new-registry: "true"
     spec:
       containers:
         - args:
@@ -460,7 +458,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-use-new-registry: "true"
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
@@ -507,7 +504,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
     preset-dind-enabled: "true"
     preset-pull-kubernetes-e2e: "true"
     preset-pull-kubernetes-e2e-gce: "true"
@@ -554,7 +550,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
   spec:
     containers:
     - args:
@@ -594,7 +589,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
   spec:
     containers:
       - args:
@@ -673,7 +667,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
   spec:
     containers:
     - args:
@@ -799,7 +792,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -19,7 +19,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-ci-gce-device-plugin-gpu: "true"
-    preset-use-new-registry: "true"
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -28,7 +28,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-      preset-use-new-registry: "true"
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -45,7 +45,6 @@ periodics:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-    preset-use-new-registry: "true"
   name: ci-kubernetes-e2e-gce-device-plugin-gpu-1-24
   spec:
     containers:
@@ -745,7 +744,6 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
-      preset-use-new-registry: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -45,7 +45,6 @@ periodics:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-    preset-use-new-registry: "true"
   name: ci-kubernetes-e2e-gce-device-plugin-gpu-1-25
   spec:
     containers:
@@ -728,7 +727,6 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
-      preset-use-new-registry: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd
     spec:
       containers:
@@ -838,7 +836,6 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
-      preset-use-new-registry: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-serial
     optional: true
     spec:


### PR DESCRIPTION
The presets were added to ensure the tests can pull registry.k8s.io. Since https://github.com/kubernetes/kubernetes/pull/109938 is merged, the presets can be removed.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>