### PR TITLE
Remove aws-ebs-csi-driver migration test; Add self to OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/OWNERS
@@ -1,14 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- leakingtapan
-- gyuho
 - bertinatto
+- ConnorJC3
+- gyuho
+- leakingtapan
 - torredil
 - wongma7
 approvers:
-- leakingtapan
-- gyuho
 - bertinatto
+- ConnorJC3
+- gyuho
+- leakingtapan
 - torredil
 - wongma7

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -1,32 +1,4 @@
 periodics:
-- name: ci-aws-ebs-csi-driver-migration-test
-  decorate: true
-  decoration_config:
-    timeout: 1h20m
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-aws-credential-aws-oss-testing: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: aws-ebs-csi-driver
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230120-fd0935fac9-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - test-e2e-migration
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: provider-aws-ebs-csi-driver
-    testgrid-tab-name: ci-migration-test
-    description: aws ebs csi driver migration test, continuous
-    testgrid-num-columns-recent: '30'
 - name: ci-aws-ebs-csi-driver-unit-test
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -112,30 +112,6 @@ presubmits:
       testgrid-tab-name: pull-e2e-test-multi-az
       description: aws ebs csi driver e2e test on mutiple AZs on pull request
       testgrid-num-columns-recent: '30'
-  - name: pull-aws-ebs-csi-driver-migration-test
-    always_run: true
-    decorate: true
-    skip_branches:
-    - gh-pages
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-aws-credential-aws-oss-testing: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230120-fd0935fac9-master
-          command:
-            - runner.sh
-          args:
-            - make
-            - test-e2e-migration
-          securityContext:
-            privileged: true
-    annotations:
-      testgrid-dashboards: provider-aws-ebs-csi-driver
-      testgrid-tab-name: pull-migration-test
-      description: aws ebs csi driver migration test on pull request
-      testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test
     always_run: true
     decorate: true


### PR DESCRIPTION
- Adds myself to the OWNERS file
- Resorts OWNERS to be in alphabetical order
- Removes test that is no longer needed upstream

cc @wongma7 