### PR TITLE
Disable automatic self-approvals for aws-ebs-csi-driver

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -62,6 +62,7 @@ approve:
   - kubernetes/cloud-provider-aws
   - kubernetes/kops
   - kubernetes/website
+  - kubernetes-sigs/aws-ebs-csi-driver
   require_self_approval: true
   lgtm_acts_as_approve: false
 - repos:


### PR DESCRIPTION
We over at the [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/) want to opt-out of automatic self-approvals of PRs.

Signed-off-by: Connor Catlett <conncatl@amazon.com>