### PR TITLE
k8s-infra: preset for registry-sandbox.k8s.io

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -9,19 +9,6 @@ presets:
   env:
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
-- labels:
-    preset-use-new-registry: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST
-    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
-  - name: KUBE_DOCKER_REGISTRY
-    value: registry.k8s.io
-  - name: KUBE_ADDON_REGISTRY
-    value: registry.k8s.io
-  - name: TEST_ETCD_DOCKER_REPOSITORY
-    value: registry.k8s.io/etcd
-  - name: CONTAINERD_INFRA_CONTAINER
-    value: registry.k8s.io/pause:3.6
 
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
@@ -1,3 +1,18 @@
+presets:
+- labels:
+    preset-use-sandbox-registry: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST
+    value: https://raw.githubusercontent.com/kubernetes/registry.k8s.io/main/hack/images/default-sandbox.yaml
+  - name: KUBE_DOCKER_REGISTRY
+    value: registry-sandbox.k8s.io
+  - name: KUBE_ADDON_REGISTRY
+    value: registry-sandbox.k8s.io
+  - name: TEST_ETCD_DOCKER_REPOSITORY
+    value: registry-sandbox.k8s.io/etcd
+  - name: CONTAINERD_INFRA_CONTAINER
+    value: registry-sandbox.k8s.io/pause:3.8
+
 periodics:
 - name: e2e-kops-grid-gcr-mirror-canary
   cron: '11 0-23/1 * * *'


### PR DESCRIPTION
Add a preset that can be used by other tests to pull images from registry-sandbox.k8s.io

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>