### PR TITLE
Allow release-team-leads to set the lead-opted-in label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -176,6 +176,7 @@ label:
       - label: lead-opted-in
         allowed_teams:
         - release-team-enhancements
+        - release-team-leads
         - sig-api-machinery-leads
         - sig-apps-leads
         - sig-architecture-leads


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

This PR adds @kubernetes/release-team-leads to the list of authorized groups to set the `lead-opted-in` label 

ref: https://github.com/kubernetes/enhancements/issues/281#issuecomment-1273837636 
 
cc @rhockenbury @marosset 