### PR TITLE
Correctly matching repo name for Gerrit repos

### DIFF
--- a/prow/cmd/deck/static/tide-history/tide-history.ts
+++ b/prow/cmd/deck/static/tide-history/tide-history.ts
@@ -44,7 +44,7 @@ function optionsForRepoBranch(repo: string, branch: string): Options {
     if (!match) {
       continue;
     }
-    const recRepo = match[3];
+    const recRepo = match[1];
     const recBranch = match[4];
 
     opts.repos[recRepo] = true;


### PR DESCRIPTION
In previous PR the regex matching group was the wrong index, fix it here. The matching is confirmed by https://regex101.com/r/7U9Zii/1