### PR TITLE
Remove unused label - area/dependency

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -405,7 +405,6 @@ larger set of contributors to apply/remove them.
 | <a id="area/network-policy" href="#area/network-policy">`area/network-policy`</a> | Issues or PRs related to Network Policy subproject| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="area/stable-metrics" href="#area/stable-metrics">`area/stable-metrics`</a> | Issues or PRs involving stable metrics| label | |
-| <a id="deprecated/hyperkube" href="#deprecated/hyperkube">`deprecated/hyperkube`</a> | Issues or PRs related to the hyperkube subproject <br><br> This was previously `area/hyperkube`, | label | |
 | <a id="official-cve-feed" href="#official-cve-feed">`official-cve-feed`</a> | Issues or PRs related to CVEs officially announced by Security Response Committee (SRC)| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes/kubernetes, only for issues

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1114,13 +1114,6 @@ repos:
         name: area/e2e-test-framework
         target: both
         addedBy: label
-      - color: e11d21
-        description: Issues or PRs related to the hyperkube subproject
-        name: deprecated/hyperkube
-        target: both
-        addedBy: label
-        previously:
-          - name: area/hyperkube
       - color: 0052cc
         description: Issues or PRs related to Network Policy subproject
         name: area/network-policy


### PR DESCRIPTION
We no longer have hyperkube :)

verified usage with:
https://cs.k8s.io/?q=area%2Fhyperkube&i=nope&files=&excludeFiles=&repos=

Signed-off-by: Davanum Srinivas <davanum@gmail.com>