### PR TITLE
cloud-provider-gcp: periodically publish cloud-controller-manager image

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -101,3 +101,50 @@ periodics:
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
           kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version=v1.25.0 --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-cloud-provider-gcp-publish-cloud-controller-manager
+  decorate: true
+  decoration_config:
+    timeout: 80m
+  annotations:
+    testgrid-tab-name: Publish Cloud Controller Manager - Cloud Provider GCP - master
+    testgrid-dashboards: provider-gcp-periodics
+    description: Build and publish cloud-controller-manager image on cloud-provider-gcp master
+  labels:
+    preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-gcp
+    base_ref: master
+    path_alias: k8s.io/cloud-provider-gcp
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221010-3da4a9c21a-master
+      resources:
+        limits:
+          cpu: 4
+          memory: 14Gi
+        requests:
+          cpu: 4
+          memory: 14Gi
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      command:
+      - runner.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
+        cd;
+        export GO111MODULE=on;
+        export BAZEL_VERSION=5.3.0;
+        /workspace/test-infra/images/kubekins-e2e/install-bazel.sh;
+        bazel run //cmd/cloud-controller-manager:publish


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

Temporarily add a 4h periodic job to publish `cloud-controller-manager` image from `k8s.io/cloud-provider-gcp`. I intend to eventually move this to a postsubmit trigger but using a periodic job for testing purposes now.