### PR TITLE
Do GMSA provisioning for capz serial-slow tests run with run-capz-e2e.sh

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -68,6 +68,11 @@ presets:
       value: "true"
     - name: WORKER_MACHINE_COUNT
       value: 0 # Don't create linux worker nodes
+- labels:
+    preset-capz-gmsa-setup: "true"
+  env:
+    - name: GMSA
+      value: "true"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-containerd-windows
   interval: 3h
@@ -192,6 +197,7 @@ periodics:
     preset-capz-windows-common-main: "true"
     preset-capz-containerd-latest: "true"
     preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

https://github.com/kubernetes-sigs/windows-testing/pull/328 added support for configuring clusters to perform setup needed to run the GMSA full tests if `GMSA=true` is set. 
This PR sets that for some test passes

/sig windows
/assign @jsturtevant 