### PR TITLE
Downgrade golangci-lint to match Go 1.18

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -912,7 +912,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-verify-lint
     spec:
       containers:
-      - image: golangci/golangci-lint:v1.50
+      - image: golangci/golangci-lint:v1.47.3
         command:
         - make
         args:


### PR DESCRIPTION
`golangci-lint` Docker image version specified at https://github.com/kubernetes/test-infra/commit/7363de73fd56f6ff8f9ecbdec0a956bf48a32144 comes with Go 1.19 which has a breaking changes when it comes to formatting comments. This causes the `pull-perf-tests-verify-lint` to fail: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/perf-tests/2156/pull-perf-tests-verify-lint/1580165899304833024

This PR downgrades the Docker image for `golangci-lint` to the latest version that comes with Go 1.18. We should not upgrade until we fix all the comments in `perf-tests` (which may require a lot of work, especially for `clusterloader2`).

I've tested this locally with `docker run` and the `perf-tests` repository. I do not expect any other problem to occur. The `pull-perf-tests-verify-test` presubmit works well: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/perf-tests/2156/pull-perf-tests-verify-test/1580165899254501376

/assign @marseel 