### PR TITLE
Update openshift testgrids ownwers file

### DIFF
--- a/config/testgrids/openshift/OWNERS
+++ b/config/testgrids/openshift/OWNERS
@@ -1,15 +1,15 @@
 reviewers:
-- stevekuznetsov
 - droslean
 - hongkailiu
-- petr-muller
+- jmguzik
+- smg247
 - bparees
 - jeremyeder
+
 approvers:
-- stevekuznetsov
 - droslean
 - hongkailiu
-- petr-muller
+- jmguzik
+- smg247
 - bparees
 - jeremyeder
-- alvaroaleman


### PR DESCRIPTION
`testgrids/openshift/OWNERS` file is not up to date anymore.