### PR TITLE
feat: updates to CAPA job owners

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
@@ -1,32 +1,20 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chuckha
-- davidewatson
-- detiber
-- d-nishi
-- enxebre
-- ingvagabund
-- kris-nova
-- luxas
-- randomvariable
-- richardcase
-- sedefsavas
-- timothysc
-- vincepri
+- dthorsen
+- pydctw
+- shivi28
+- AverageMarcus
 approvers:
-- chuckha
-- davidewatson
-- detiber
-- d-nishi
-- enxebre
-- ingvagabund
-- kris-nova
-- luxas
-- randomvariable
 - richardcase
 - sedefsavas
-- timothysc
-- vincepri
+- Skarlso
+- Ankitasw
+- dlipovetsky
 emeritus_approvers:
-  - ncdc
+- chuckha
+- detiber
+- ncdc
+- randomvariable
+- rudoi
+- vincepri


### PR DESCRIPTION
Changes to the owners of the CAPA jobs as of 2022-10-19.

Until https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3775 merges:

/hold

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3620

Signed-off-by: Richard Case <richard.case@outlook.com>