### PR TITLE
Prowjob can be required by tide only

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -171,6 +171,12 @@ type Presubmit struct {
 	// (Default: `/test <job name>`)
 	RerunCommand string `json:"rerun_command,omitempty"`
 
+	// RunBeforeMerge indicates that a job should always run by Tide as long as
+	// Brancher matches.
+	// This is used when a prowjob is so expensive that it's not ideal to run on
+	// every single push from all PRs.
+	RunBeforeMerge bool `json:"run_before_merge"`
+
 	Brancher
 
 	RegexpChangeMatcher

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1531,7 +1531,12 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 				continue
 			}
 
-			shouldRun, err := ps.ShouldRun(sp.branch, c.changedFiles.prChanges(&pr), false, false)
+			// Only keep the jobs that are required for this PR. Order of
+			// filters:
+			// - Brancher
+			// - RunBeforeMerge
+			// - Files changed
+			shouldRun, err := ps.ShouldRun(sp.branch, c.changedFiles.prChanges(&pr), ps.RunBeforeMerge, false)
 			if err != nil {
 				return nil, err
 			}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -2983,6 +2983,63 @@ func TestPresubmitsByPull(t *testing.T) {
 			}}},
 		},
 		{
+			name: "no-always-run-no-trigger",
+			presubmits: []config.Presubmit{
+				{
+					Reporter:  config.Reporter{Context: "presubmit"},
+					AlwaysRun: false,
+					Brancher: config.Brancher{
+						Branches: []string{defaultBranch, "dev"},
+					},
+				},
+				{
+					Reporter: config.Reporter{Context: "never"},
+				},
+			},
+			expectedPresubmits: map[int][]config.Presubmit{},
+		},
+		{
+			name: "no-always-run-no-trigger-tide-wants-it",
+			presubmits: []config.Presubmit{
+				{
+					Reporter:  config.Reporter{Context: "presubmit"},
+					AlwaysRun: false,
+					Brancher: config.Brancher{
+						Branches: []string{defaultBranch, "dev"},
+					},
+					RunBeforeMerge: true,
+				},
+				{
+					Reporter: config.Reporter{Context: "never"},
+				},
+			},
+			expectedPresubmits: map[int][]config.Presubmit{100: {{
+				Reporter:       config.Reporter{Context: "presubmit"},
+				AlwaysRun:      false,
+				RunBeforeMerge: true,
+				Brancher: config.Brancher{
+					Branches: []string{defaultBranch, "dev"},
+				},
+			}}},
+		},
+		{
+			name: "brancher-not-match-when-tide-wants-it",
+			presubmits: []config.Presubmit{
+				{
+					Reporter:  config.Reporter{Context: "presubmit"},
+					AlwaysRun: false,
+					Brancher: config.Brancher{
+						Branches: []string{"release", "dev"},
+					},
+					RunBeforeMerge: true,
+				},
+				{
+					Reporter: config.Reporter{Context: "never"},
+				},
+			},
+			expectedPresubmits: map[int][]config.Presubmit{},
+		},
+		{
 			name: "run_if_changed (uncached)",
 			presubmits: []config.Presubmit{
 				{


### PR DESCRIPTION
This is used when a prowjob is so expensive that it's not ideal to run on every single push from all PRs. These jobs can be set to not automatically triggered when a PR is up, and Tide will test them when all other tests passed.

(Note that this is from a feature request from one of our internal users, internal tracking number is 253059454)

/cc @cjwagner @listx @alvaroaleman 

