### PR TITLE
Replacing "latest" KUBERNETES_VERSION with an hard-coded version.

### DIFF
--- a/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
@@ -69,8 +69,7 @@ presubmits:
         - name: USE_TEST_INFRA_LOG_DUMPING
           value: "true"
         - name: KUBERNETES_VERSION
-          value: "latest"
-          #value: "1.25.0"
+          value: "1.25.0"
         - name: TEST
           value: ci/prow/e2e-pre-built-driver-container-no-nfd
         command:


### PR DESCRIPTION
"latest" seems to not be working.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>