### PR TITLE
bump to node container to node 18

### DIFF
--- a/hack/run-in-node-container.sh
+++ b/hack/run-in-node-container.sh
@@ -22,7 +22,7 @@ set -o pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${REPO_ROOT}"
 
-NODE_IMAGE='node:14-bullseye-slim'
+NODE_IMAGE='node:18-bullseye-slim'
 
 DOCKER=(docker)
 


### PR DESCRIPTION
Bump the node lint container from node 14 to 18

Signed-off-by: jbpratt <jbpratt78@gmail.com>

closes https://github.com/kubernetes/test-infra/issues/25811

Seems to have worked for linting, the same amount of eslint warnings are spit out and the gopherage rollup stuff is not failing ( :smile_cat: )

before:
```
✖ 381 problems (0 errors, 381 warnings)
```
after:
```
✖ 381 problems (0 errors, 381 warnings)
```