### PR TITLE
double cip workers

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -51,7 +51,7 @@ postsubmits:
         # https://www.geeksforgeeks.org/golang-goroutine-vs-thread/
         #
         # this should probably be a multiple of cores below
-        - --threads=14
+        - --threads=28
         env:
         - name: GOMAXPROCS
           value: "7"
@@ -159,7 +159,7 @@ periodics:
       # https://www.geeksforgeeks.org/golang-goroutine-vs-thread/
       #
       # this should probably be a multiple of cores below
-      - --threads=14
+      - --threads=28
       env:
       - name: GOMAXPROCS
         value: "7"


### PR DESCRIPTION
see this discussion:
https://kubernetes.slack.com/archives/CJH2GBF7Y/p1665728380786019?thread_ts=1665599508.703749&cid=CJH2GBF7Y

we're not remotely saturating the CPU, let's see performance 2x-ing worker goroutines