### PR TITLE
test-images: Adds user-with-predefined-group postsubmit job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -47,6 +47,7 @@ readonly IMAGES=(
     resource-consumer
     sample-apiserver
     sample-device-plugin
+    user-with-predefined-group
     volume/iscsi
     volume/rbd
     volume/nfs

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -1262,6 +1262,48 @@ postsubmits:
               # We override that with the sample-device-plugin image.
               - name: WHAT
                 value: "sample-device-plugin"
+    - name: post-kubernetes-push-e2e-user-with-predefined-group-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
+          - mkumatag
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/user-with-predefined-group\/'
+      branches:
+        # TODO(releng): Remove once repo default branch has been renamed
+        - ^master$
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20221010-3da4a9c21a
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+              # By default, the E2E test image's WHAT is all-conformance.
+              # We override that with the user-with-predefined-group image.
+              - name: WHAT
+                value: "user-with-predefined-group"
     - name: post-kubernetes-push-e2e-volume-iscsi-test-images
       rerun_auth_config:
         github_team_slugs:


### PR DESCRIPTION
This PR adds `user-with-predefined-group` postsubmit job
The image is defined in https://github.com/kubernetes/kubernetes/pull/113168