### PR TITLE
Replace deprecated `deadcode` with `unused` lint check from `golangci-lint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters-settings:
 linters:
   enable:
   - govet
-  - deadcode
+  - unused
   - misspell
   - ineffassign
   - staticcheck

--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -519,7 +519,6 @@ type Record struct {
 	Name  string
 	MTime time.Time
 	Size  int64
-	isDir bool
 }
 
 // Render writes HTML representing this Record to the provided output.

--- a/greenhouse/diskcache/cache.go
+++ b/greenhouse/diskcache/cache.go
@@ -38,7 +38,6 @@ type ReadHandler func(exists bool, contents io.ReadSeeker) error
 // Cache implements disk backed cache storage
 type Cache struct {
 	diskRoot string
-	logger   *logrus.Entry
 }
 
 // NewCache returns a new Cache given the root directory that should be used

--- a/kubetest/conformance/conformance.go
+++ b/kubetest/conformance/conformance.go
@@ -25,23 +25,12 @@ import (
 	"os/exec"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/test-infra/kubetest/e2e"
-	"k8s.io/test-infra/kubetest/process"
 )
-
-// Tester runs conformance tests against a given cluster.
-type Tester struct {
-	kubecfg   string
-	ginkgo    string
-	e2etest   string
-	reportdir string
-	testArgs  *string
-	control   *process.Control
-}
 
 // BuildTester returns an object that knows how to test the cluster it deployed.
 func (d *Deployer) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -131,10 +131,6 @@ func (l *extractStrategies) Enabled() bool {
 	return len(*l) > 0
 }
 
-func (e extractStrategy) name() string {
-	return filepath.Base(e.option)
-}
-
 func (l extractStrategies) Extract(project, zone, region, ciBucket, releaseBucket string, extractSrc bool) error {
 	// rm -rf kubernetes*
 	files, err := os.ReadDir(".")

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -159,9 +159,6 @@ type kops struct {
 
 	// featureFlags is a list of feature flags to enable, comma delimited
 	featureFlags string
-
-	// multipleZones denotes using more than one zone
-	multipleZones bool
 }
 
 var _ deployer = kops{}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -104,7 +104,6 @@ type options struct {
 	nodeArgs                string
 	nodeTestArgs            string
 	nodeTests               bool
-	outputDir               string
 	preTestCmd              string
 	postTestCmd             string
 	provider                string
@@ -115,7 +114,6 @@ type options struct {
 	skipRegex               string
 	soak                    bool
 	soakDuration            time.Duration
-	sshUser                 string
 	stage                   stageStrategy
 	storageTestDriverPath   string
 	test                    bool

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -56,7 +56,6 @@ type options struct {
 	pubsubWorkers         int
 	githubWorkers         int
 	slackWorkers          int
-	k8sGCSWorkers         int
 	blobStorageWorkers    int
 	k8sBlobStorageWorkers int
 

--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -43,27 +43,6 @@ const (
 	gitCmd = "git"
 )
 
-type fileArrayFlag []string
-
-func (af *fileArrayFlag) String() string {
-	return fmt.Sprint(*af)
-}
-
-func (af *fileArrayFlag) Set(value string) error {
-	for _, e := range strings.Split(value, ",") {
-		fn := strings.TrimSpace(e)
-		info, err := os.Stat(fn)
-		if err != nil {
-			return fmt.Errorf("getting file info for %q", fn)
-		}
-		if info.IsDir() && !strings.HasSuffix(fn, string(os.PathSeparator)) {
-			fn = fn + string(os.PathSeparator)
-		}
-		*af = append(*af, fn)
-	}
-	return nil
-}
-
 // Options is the options for autobumper operations.
 type Options struct {
 	// The target GitHub org name where the autobump PR will be created. Only required when SkipPullRequest is false.

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -38,7 +38,6 @@ type options struct {
 	config      configflagutil.ConfigOptions
 	triggerJob  bool
 	failWithJob bool
-	outputPath  string
 	kubeOptions prowflagutil.KubernetesOptions
 	baseRef     string
 	baseSha     string

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -45,7 +45,6 @@ import (
 
 type options struct {
 	allContexts            bool
-	buildCluster           string
 	config                 configflagutil.ConfigOptions
 	kubeconfig             string
 	totURL                 string

--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -51,11 +51,9 @@ var allControllers = sets.NewString(plank.ControllerName)
 type options struct {
 	totURL string
 
-	config                  configflagutil.ConfigOptions
-	buildCluster            string
-	selector                string
-	leaderElectionNamespace string
-	enabledControllers      prowflagutil.Strings
+	config             configflagutil.ConfigOptions
+	selector           string
+	enabledControllers prowflagutil.Strings
 
 	dryRun                 bool
 	kubernetes             prowflagutil.KubernetesOptions

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -182,7 +182,6 @@ func main() {
 
 type controller struct {
 	ctx           context.Context
-	cancel        context.CancelFunc
 	logger        *logrus.Entry
 	prowJobClient ctrlruntimeclient.Client
 	podClients    map[string]ctrlruntimeclient.Client

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -43,7 +43,6 @@ type fghc struct {
 	prs        []github.PullRequest
 	prComments []github.IssueComment
 	prLabels   []github.Label
-	labels     []github.Label
 	orgMembers []github.TeamMember
 	issues     []github.Issue
 }

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -112,7 +112,6 @@ type Controller struct {
 	inRepoConfigCacheHandler *config.InRepoConfigCacheHandler
 	inRepoConfigFailures     map[string]bool
 	instancesWithWorker      map[string]bool
-	repoCacheMapMux          sync.Mutex
 	latestMux                sync.Mutex
 	workerPoolSize           int
 }

--- a/prow/gerrit/client/syncer_test.go
+++ b/prow/gerrit/client/syncer_test.go
@@ -64,8 +64,8 @@ func TestSyncTime(t *testing.T) {
 		ctx:    ctx,
 	}
 	testProjects := map[string]map[string]*config.GerritQueryFilter{
-		"foo": map[string]*config.GerritQueryFilter{
-			"bar": &config.GerritQueryFilter{},
+		"foo": {
+			"bar": {},
 		},
 	}
 	now := time.Now()
@@ -150,11 +150,11 @@ func TestSyncTimeThreadSafe(t *testing.T) {
 		ctx:    ctx,
 	}
 	testProjects := map[string]map[string]*config.GerritQueryFilter{
-		"foo1": map[string]*config.GerritQueryFilter{
-			"bar1": &config.GerritQueryFilter{},
+		"foo1": {
+			"bar1": {},
 		},
-		"foo2": map[string]*config.GerritQueryFilter{
-			"bar2": &config.GerritQueryFilter{},
+		"foo2": {
+			"bar2": {},
 		},
 	}
 	if err := st.Init(testProjects); err != nil {
@@ -226,11 +226,11 @@ func TestNewProjectAddition(t *testing.T) {
 	}
 
 	testProjects := map[string]map[string]*config.GerritQueryFilter{
-		"foo": map[string]*config.GerritQueryFilter{
-			"bar": &config.GerritQueryFilter{},
+		"foo": {
+			"bar": {},
 		},
-		"qwe": map[string]*config.GerritQueryFilter{
-			"qux": &config.GerritQueryFilter{},
+		"qwe": {
+			"qux": {},
 		},
 	}
 

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3626,8 +3626,8 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 	path := fmt.Sprintf("/orgs/%s/teams", org)
 	var retTeam Team
 	_, err := c.request(&request{
-		method: http.MethodPost,
-		path:   path,
+		method:      http.MethodPost,
+		path:        path,
 		accept:      "application/vnd.github+json",
 		org:         org,
 		requestBody: &team,
@@ -3662,8 +3662,8 @@ func (c *client) EditTeam(org string, t Team) (*Team, error) {
 	var retTeam Team
 	path := fmt.Sprintf("/orgs/%s/teams/%s", org, t.Slug)
 	_, err := c.request(&request{
-		method: http.MethodPatch,
-		path:   path,
+		method:      http.MethodPatch,
+		path:        path,
 		accept:      "application/vnd.github+json",
 		org:         org,
 		requestBody: &team,
@@ -4313,7 +4313,7 @@ func (c *client) IsCollaborator(org, repo, user string) (bool, error) {
 		return true, nil
 	}
 	code, err := c.request(&request{
-		method: http.MethodGet,
+		method:    http.MethodGet,
 		accept:    "application/vnd.github+json",
 		path:      fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, user),
 		org:       org,

--- a/prow/jenkins/jenkins_test.go
+++ b/prow/jenkins/jenkins_test.go
@@ -124,11 +124,6 @@ func intP(i int) *int {
 }
 
 func TestListBuilds(t *testing.T) {
-	type Task struct {
-		// Used for tracking unscheduled builds for jobs.
-		Name string `json:"name"`
-	}
-
 	tests := []struct {
 		name string
 
@@ -166,7 +161,9 @@ func TestListBuilds(t *testing.T) {
 				"first-int":  {Number: 1, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "first-int"}, {Name: prowJobID, Value: "first-int"}}}}},
 				"second-int": {Number: 2, Result: strP(success), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "second-int"}, {Name: prowJobID, Value: "second-int"}}}}},
 				// queued_pj_id is returned from the testWrapper
-				"queued_pj_id": {Number: 0, Result: nil, Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "queued-int"}, {Name: prowJobID, Value: "queued_pj_id"}}}}, enqueued: true, Task: Task{Name: "PR-763"}},
+				"queued_pj_id": {Number: 0, Result: nil, Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "queued-int"}, {Name: prowJobID, Value: "queued_pj_id"}}}}, enqueued: true, Task: struct {
+					Name string `json:"name"`
+				}{Name: "PR-763"}},
 			},
 		},
 		{

--- a/prow/kube/ratelimiter.go
+++ b/prow/kube/ratelimiter.go
@@ -31,30 +31,3 @@ func RateLimiter(controllerName string) workqueue.RateLimitingInterface {
 	)
 	return workqueue.NewNamedRateLimitingQueue(rl, controllerName)
 }
-
-// for testing
-
-type fakeLimiter struct {
-	added string
-}
-
-func (fl *fakeLimiter) ShutDown() {}
-func (fl *fakeLimiter) Get() (interface{}, bool) {
-	return "not implemented", true
-}
-func (fl *fakeLimiter) Done(interface{})   {}
-func (fl *fakeLimiter) Forget(interface{}) {}
-func (fl *fakeLimiter) AddRateLimited(a interface{}) {
-	fl.added = a.(string)
-}
-func (fl *fakeLimiter) Add(a interface{}) {
-	fl.added = a.(string)
-}
-func (fl *fakeLimiter) AddAfter(a interface{}, d time.Duration) {
-	fl.added = a.(string)
-}
-func (fl *fakeLimiter) Len() {
-}
-func (fl *fakeLimiter) NumRequeues(item interface{}) int {
-	return 0
-}

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -90,11 +90,10 @@ type clowder interface {
 }
 
 type realClowder struct {
-	url     string
-	lock    sync.RWMutex
-	update  time.Time
-	key     string
-	keyPath string
+	url    string
+	lock   sync.RWMutex
+	update time.Time
+	key    string
 }
 
 func (c *realClowder) setKey(keyPath string, log *logrus.Entry) {

--- a/prow/plugins/goose/goose.go
+++ b/prow/plugins/goose/goose.go
@@ -87,11 +87,10 @@ type gaggle interface {
 }
 
 type realGaggle struct {
-	url     string
-	lock    sync.RWMutex
-	update  time.Time
-	key     string
-	keyPath string
+	url    string
+	lock   sync.RWMutex
+	update time.Time
+	key    string
 }
 
 func (g *realGaggle) setKey(keyPath string, log *logrus.Entry) {

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -18,7 +18,6 @@ package jira
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -104,26 +103,6 @@ func TestRegex(t *testing.T) {
 			}
 		})
 	}
-}
-
-type fakeGitHubClient struct {
-	editedComments map[string]string
-}
-
-func (f *fakeGitHubClient) EditComment(org, repo string, id int, body string) error {
-	if f.editedComments == nil {
-		f.editedComments = map[string]string{}
-	}
-	f.editedComments[fmt.Sprintf("%s/%s:%d", org, repo, id)] = body
-	return nil
-}
-
-func (f *fakeGitHubClient) GetIssue(org, repo string, number int) (*github.Issue, error) {
-	return &github.Issue{}, nil
-}
-
-func (f *fakeGitHubClient) EditIssue(org, repo string, number int, issue *github.Issue) (*github.Issue, error) {
-	return issue, nil
 }
 
 func TestHandle(t *testing.T) {

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -230,7 +230,6 @@ func TestComment(t *testing.T) {
 		body             string
 		expectedMessages map[string][]string
 		issueLabels      []string
-		repoLabels       []string
 		commenter        string
 	}
 	testcases := []testCase{

--- a/prow/spyglass/lenses/html/html_test.go
+++ b/prow/spyglass/lenses/html/html_test.go
@@ -32,9 +32,8 @@ import (
 )
 
 type FakeArtifact struct {
-	path      string
-	content   []byte
-	sizeLimit int64
+	path    string
+	content []byte
 }
 
 func (fa *FakeArtifact) JobPath() string {

--- a/prow/spyglass/storageartifact_fetcher.go
+++ b/prow/spyglass/storageartifact_fetcher.go
@@ -221,11 +221,6 @@ func extractBucketPrefixPair(storagePath string) (string, string) {
 	return split[0], split[1]
 }
 
-// CanonicalLink gets a link to the location of job-specific artifacts in GCS
-func (src *storageJobSource) canonicalLink() string {
-	return path.Join(src.linkPrefix, src.bucket, src.jobPrefix)
-}
-
 // JobPath gets the prefix to all artifacts in GCS in the job
 func (src *storageJobSource) jobPath() string {
 	return fmt.Sprintf("%s/%s", src.bucket, src.jobPrefix)

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -40,7 +40,6 @@ import (
 var _ gerritClient = (*fakeGerritClient)(nil)
 
 type fakeGerritClient struct {
-	reviews int
 	// map{org: map{project: []changes}}
 	changes map[string]map[string][]gerrit.ChangeInfo
 }

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -86,7 +86,6 @@ type meta struct {
 }
 
 type options struct {
-	asc             bool
 	ceiling         int
 	comment         string
 	includeArchived bool
@@ -94,7 +93,6 @@ type options struct {
 	includeLocked   bool
 	useTemplate     bool
 	query           string
-	sort            string
 	endpoint        flagutil.Strings
 	graphqlEndpoint string
 	token           string

--- a/robots/issue-creator/sources/triage-filer.go
+++ b/robots/issue-creator/sources/triage-filer.go
@@ -46,7 +46,6 @@ type TriageFiler struct {
 	topClustersCount int
 	windowDays       int
 
-	nextSync    time.Time
 	latestStart int64
 
 	creator *creator.IssueCreator


### PR DESCRIPTION
Replace deprecated `deadcode` with `unused` lint check from `golangci-lint`
Resolution to https://github.com/kubernetes/test-infra/issues/27759