### PR TITLE
releng: bump kpromo version to v3.4.6

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
         command:
         - /kpromo
         args:
@@ -42,7 +42,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
         command:
         - /kpromo
         args:
@@ -85,7 +85,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
         command:
         - /kpromo
         args:
@@ -40,7 +40,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
         command:
         - /kpromo
         args:
@@ -110,7 +110,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
       command:
       - /kpromo
       args:
@@ -148,7 +148,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.5-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.6-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
This PR bumps image promoter jobs to v3.4.6.

Part of https://github.com/kubernetes-sigs/promo-tools/issues/643

/cc: @puerco @Verolop @cpanato @saschagrunert 



Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>