### PR TITLE
Deck tide-history understands -review suffix for Gerrit repos

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1515,13 +1515,19 @@ func HandleGitProviderLink(githubHost string, secure bool) http.HandlerFunc {
 				http.Redirect(w, r, "", http.StatusNotFound)
 				return
 			}
+			orgCodeURL, err := gerritsource.CodeRootURL(org)
+			if err != nil {
+				logrus.WithError(err).WithField("cloneURI", repo).Warn("Failed deriving source code URL from cloneURI.")
+				http.Redirect(w, r, "", http.StatusNotFound)
+				return
+			}
 			switch target {
 			case "commit":
-				redirectURL = org + "/" + repo + "/+/" + commit
+				redirectURL = orgCodeURL + "/" + repo + "/+/" + commit
 			case "branch":
-				redirectURL = org + "/" + repo + "/+/refs/heads/" + branch
+				redirectURL = orgCodeURL + "/" + repo + "/+/refs/heads/" + branch
 			case "pr":
-				redirectURL = org + "/c/" + repo + "/+/" + number
+				redirectURL = orgCodeURL + "/c/" + repo + "/+/" + number
 			}
 		} else {
 			scheme := "http"

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1034,22 +1034,22 @@ func TestHandleGitProviderLink(t *testing.T) {
 		},
 		{
 			name:  "gerrit-commit",
-			query: "target=commit&repo='https://foo/bar'&commit=abc123",
-			want:  "https://foo/bar/+/abc123",
+			query: "target=commit&repo='https://foo-review.abc/bar'&commit=abc123",
+			want:  "https://foo.abc/bar/+/abc123",
 		},
 		{
 			name:  "gerrit-branch",
-			query: "target=branch&repo='https://foo/bar'&branch=main",
-			want:  "https://foo/bar/+/refs/heads/main",
+			query: "target=branch&repo='https://foo-review.abc/bar'&branch=main",
+			want:  "https://foo.abc/bar/+/refs/heads/main",
 		},
 		{
 			name:  "gerrit-pr",
-			query: "target=pr&repo='https://foo/bar'&number=2",
-			want:  "https://foo/c/bar/+/2",
+			query: "target=pr&repo='https://foo-review.abc/bar'&number=2",
+			want:  "https://foo.abc/c/bar/+/2",
 		},
 		{
 			name:  "gerrit-invalid",
-			query: "target=invalid&repo='https://foo/bar'&commit=abc123",
+			query: "target=invalid&repo='https://foo-review.abc/bar'&commit=abc123",
 			want:  "/",
 		},
 	}

--- a/prow/gerrit/source/source.go
+++ b/prow/gerrit/source/source.go
@@ -89,3 +89,18 @@ func orgRepo(org, repo string) string {
 	repo = strings.Trim(repo, "/")
 	return org + "/" + repo
 }
+
+// CodeRootURL converts code review URL into source code URL, simply
+// trimming the `-review` suffix from the name of the org.
+//
+// Gerrit URL for sourcecode looks like
+// https://android.googlesource.com, and the code review URL looks like
+// https://android-review.googlesource.com/c/platform/frameworks/support/+/2260382.
+func CodeRootURL(reviewURL string) (string, error) {
+	orgParts := strings.Split(reviewURL, ".")
+	if !strings.HasSuffix(orgParts[0], "-review") {
+		return "", fmt.Errorf("cannot find '-review' suffix from the first part of url %v", orgParts)
+	}
+	orgParts[0] = strings.TrimSuffix(orgParts[0], "-review")
+	return strings.Join(orgParts, "."), nil
+}

--- a/prow/gerrit/source/source_test.go
+++ b/prow/gerrit/source/source_test.go
@@ -193,3 +193,47 @@ func TestOrgRepoFromCloneURI(t *testing.T) {
 		})
 	}
 }
+
+func TestCodeRootURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "base",
+			in:   "https://foo-review.googlesource.com",
+			want: "https://foo.googlesource.com",
+		},
+		{
+			name: "with-repo",
+			in:   "https://foo-review.googlesource.com/bar",
+			want: "https://foo.googlesource.com/bar",
+		},
+		{
+			name:    "invalid",
+			in:      "https://foo.googlesource.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotErr := CodeRootURL(tc.in)
+			if tc.wantErr {
+				if gotErr == nil {
+					t.Fatal("Want error, got nil")
+				}
+				return
+			}
+			if gotErr != nil {
+				t.Fatalf("Want no error, got: %v", gotErr)
+			}
+			if want, got := tc.want, got; want != got {
+				t.Fatalf("Want: %s, got: %s", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Gerrit base URL for codereview and sourcecode differs, for example https://android-review.googlesource.com and https://android.googlesource.com, Deck will have to understand this special logic for it to correctly set URL for links on tide-history page

/cc @cjwagner @listx 