### PR TITLE
delete 100% failing job - maintenance-pull-scale-janitor

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -74,29 +74,3 @@ periodics:
     testgrid-dashboards: sig-testing-maintenance
     testgrid-tab-name: pull-janitor
     description: Deletes old GCP resources from presubmit jobs
-
-- interval: 1h
-  name: maintenance-pull-scale-janitor
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - args:
-      - --bare
-      - --timeout=60
-      - --service-account=/etc/service-account/service-account.json
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_janitor
-      - --
-      - --mode=scale
-      - --ratelimit=5
-      env:
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-experimental
-      resources:
-        requests:
-          cpu: 5
-          memory: "8Gi"
-  annotations:
-    testgrid-dashboards: sig-testing-maintenance
-    testgrid-tab-name: pull-scale-janitor
-    description: Deletes old GCP resources from scalability presubmit jobs


### PR DESCRIPTION
See the sea of red here:
https://prow.k8s.io/?job=maintenance-pull-scale-janitor

The job started failing after this landed:
https://github.com/kubernetes/test-infra/pull/26364/files#diff-60b9ed841d8938462a60d39bceeea19854cd175ee9a3f21a3f2446989a5f6e9aL102-L189

/assign @jupblb @wojtek-t 
/sig scalability

Signed-off-by: Davanum Srinivas <davanum@gmail.com>