### PR TITLE
Deck: fix tide gerrit url on tide-history page

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1529,7 +1529,7 @@ func HandleGitProviderLink(githubHost string, secure bool) http.HandlerFunc {
 			case "branch":
 				redirectURL = orgCodeURL + "/" + repo + "/+/refs/heads/" + branch
 			case "pr":
-				redirectURL = orgCodeURL + "/c/" + repo + "/+/" + number
+				redirectURL = org + "/c/" + repo + "/+/" + number
 			}
 		} else {
 			scheme := "http"

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1523,6 +1523,8 @@ func HandleGitProviderLink(githubHost string, secure bool) http.HandlerFunc {
 			}
 			switch target {
 			case "commit":
+				fallthrough
+			case "prcommit":
 				redirectURL = orgCodeURL + "/" + repo + "/+/" + commit
 			case "branch":
 				redirectURL = orgCodeURL + "/" + repo + "/+/refs/heads/" + branch

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1050,7 +1050,7 @@ func TestHandleGitProviderLink(t *testing.T) {
 		{
 			name:  "gerrit-pr",
 			query: "target=pr&repo='https://foo-review.abc/bar'&number=2",
-			want:  "https://foo.abc/c/bar/+/2",
+			want:  "https://foo-review.abc/c/bar/+/2",
 		},
 		{
 			name:  "gerrit-invalid",

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1038,6 +1038,11 @@ func TestHandleGitProviderLink(t *testing.T) {
 			want:  "https://foo.abc/bar/+/abc123",
 		},
 		{
+			name:  "gerrit-commit",
+			query: "target=prcommit&repo='https://foo-review.abc/bar'&commit=abc123",
+			want:  "https://foo.abc/bar/+/abc123",
+		},
+		{
 			name:  "gerrit-branch",
 			query: "target=branch&repo='https://foo-review.abc/bar'&branch=main",
 			want:  "https://foo.abc/bar/+/refs/heads/main",


### PR DESCRIPTION
This PR contains two commits that fix two remaining problems on the tide-history page

/cc @cjwagner @listx 