### PR TITLE
update janitor broken tests due to python version mismatch

### DIFF
--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -56,14 +56,14 @@ def parse_project(path):
     return None
 
 
-def clean_project(project, hours=24, dryrun=False, ratelimit=None, filt=None):
+def clean_project(project, hours=24, dryrun=False, ratelimit=None, filt=None, python='python3'):
     """Execute janitor for target GCP project """
     # Multiple jobs can share the same project, woooo
     if project in CHECKED:
         return
     CHECKED.add(project)
 
-    cmd = ['python', test_infra('boskos/cmd/janitor/gcp_janitor.py'), '--project=%s' % project]
+    cmd = [python, test_infra('boskos/cmd/janitor/gcp_janitor.py'), '--project=%s' % project]
     cmd.append('--hour=%d' % hours)
     if dryrun:
         cmd.append('--dryrun')


### PR DESCRIPTION
Resolves the failed tests from:
https://storage.googleapis.com/kubernetes-jenkins/logs/maintenance-pull-janitor/1583203111210586112/build-log.txt

Due to:
https://github.com/kubernetes/test-infra/pull/27784

/hold
