### PR TITLE
feat: add ignore invitees option to peribolos

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1075,7 +1075,11 @@ func configureTeamAndMembers(opt options, client github.Client, githubTeams map[
 	if !opt.fixTeamMembers {
 		logrus.Infof("Skipping %s member configuration", name)
 	} else if err = configureTeamMembers(client, orgName, gt, team, opt.ignoreInvitees); err != nil {
-		return fmt.Errorf("failed to update %s members: %w", name, err)
+		if opt.confirm {
+			return fmt.Errorf("failed to update %s members: %w", name, err)
+		}
+		logrus.WithError(err).Warnf("failed to update %s members: %s", name, err)
+		return nil
 	}
 
 	for childName, childTeam := range team.Children {

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -57,6 +57,7 @@ type options struct {
 	fixTeams          bool
 	fixTeamRepos      bool
 	fixRepos          bool
+	ignoreInvitees    bool
 	ignoreSecretTeams bool
 	allowRepoArchival bool
 	allowRepoPublish  bool
@@ -83,6 +84,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	flags.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
 	flags.StringVar(&o.dump, "dump", "", "Output current config of this org if set")
 	flags.BoolVar(&o.dumpFull, "dump-full", false, "Output current config of the org as a valid input config file instead of a snippet")
+	flags.BoolVar(&o.ignoreInvitees, "ignore-invitees", false, "Do not compare missing members with active invitations (compatibility for GitHub Enterprise)")
 	flags.BoolVar(&o.ignoreSecretTeams, "ignore-secret-teams", false, "Do not dump or update secret teams if set")
 	flags.BoolVar(&o.fixOrg, "fix-org", false, "Change org metadata if set")
 	flags.BoolVar(&o.fixOrgMembers, "fix-org-members", false, "Add/remove org members if set")
@@ -784,7 +786,7 @@ type inviteClient interface {
 
 func orgInvitations(opt options, client inviteClient, orgName string) (sets.String, error) {
 	invitees := sets.String{}
-	if !opt.fixOrgMembers && !opt.fixTeamMembers {
+	if (!opt.fixOrgMembers && !opt.fixTeamMembers) || opt.ignoreInvitees {
 		return invitees, nil
 	}
 	is, err := client.ListOrgInvitations(orgName)
@@ -1072,7 +1074,7 @@ func configureTeamAndMembers(opt options, client github.Client, githubTeams map[
 	// Configure team members
 	if !opt.fixTeamMembers {
 		logrus.Infof("Skipping %s member configuration", name)
-	} else if err = configureTeamMembers(client, orgName, gt, team); err != nil {
+	} else if err = configureTeamMembers(client, orgName, gt, team, opt.ignoreInvitees); err != nil {
 		return fmt.Errorf("failed to update %s members: %w", name, err)
 	}
 
@@ -1234,7 +1236,7 @@ func teamInvitations(client teamMembersClient, orgName, teamSlug string) (sets.S
 }
 
 // configureTeamMembers will add/update people to the appropriate role on the team, and remove anyone else.
-func configureTeamMembers(client teamMembersClient, orgName string, gt github.Team, team org.Team) error {
+func configureTeamMembers(client teamMembersClient, orgName string, gt github.Team, team org.Team, ignoreInvitees bool) error {
 	// Get desired state
 	wantMaintainers := sets.NewString(team.Maintainers...)
 	wantMembers := sets.NewString(team.Members...)
@@ -1259,9 +1261,12 @@ func configureTeamMembers(client teamMembersClient, orgName string, gt github.Te
 		haveMaintainers.Insert(m.Login)
 	}
 
-	invitees, err := teamInvitations(client, orgName, gt.Slug)
-	if err != nil {
-		return fmt.Errorf("failed to list %s(%s) invitees: %w", gt.Slug, gt.Name, err)
+	invitees := sets.String{}
+	if !ignoreInvitees {
+		invitees, err = teamInvitations(client, orgName, gt.Slug)
+		if err != nil {
+			return fmt.Errorf("failed to list %s(%s) invitees: %w", gt.Slug, gt.Name, err)
+		}
 	}
 
 	adder := func(user string, super bool) error {

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -1270,24 +1270,21 @@ func TestConfigureTeamMembers(t *testing.T) {
 		slug           string
 	}{
 		{
-			name:           "fail when listing fails",
-			slug:           "some-slug",
-			ignoreInvitees: false,
-			err:            true,
+			name: "fail when listing fails",
+			slug: "some-slug",
+			err:  true,
 		},
 		{
-			name:           "fail when removal fails",
-			members:        sets.NewString("fail"),
-			ignoreInvitees: false,
-			err:            true,
+			name:    "fail when removal fails",
+			members: sets.NewString("fail"),
+			err:     true,
 		},
 		{
 			name: "fail when add fails",
 			team: org.Team{
 				Maintainers: []string{"fail"},
 			},
-			ignoreInvitees: false,
-			err:            true,
+			err: true,
 		},
 		{
 			name: "some of everything",
@@ -1300,7 +1297,6 @@ func TestConfigureTeamMembers(t *testing.T) {
 			remove:         sets.NewString("drop-maintainer", "drop-member"),
 			addMembers:     sets.NewString("new-member"),
 			addMaintainers: sets.NewString("new-maintainer"),
-			ignoreInvitees: false,
 		},
 		{
 			name: "do not reinvitee invitees",
@@ -1310,7 +1306,6 @@ func TestConfigureTeamMembers(t *testing.T) {
 			},
 			invitees:       sets.NewString("invited-maintainer", "invited-member"),
 			addMaintainers: sets.NewString("newbie"),
-			ignoreInvitees: false,
 		},
 		{
 			name: "do not remove pending invitees",
@@ -1318,10 +1313,9 @@ func TestConfigureTeamMembers(t *testing.T) {
 				Maintainers: []string{"keep-maintainer"},
 				Members:     []string{"invited-member"},
 			},
-			maintainers:    sets.NewString("keep-maintainer"),
-			invitees:       sets.NewString("invited-member"),
-			remove:         sets.String{},
-			ignoreInvitees: false,
+			maintainers: sets.NewString("keep-maintainer"),
+			invitees:    sets.NewString("invited-member"),
+			remove:      sets.String{},
 		},
 		{
 			name: "ignore invitees",

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -1327,11 +1327,13 @@ func TestConfigureTeamMembers(t *testing.T) {
 			name: "ignore invitees",
 			team: org.Team{
 				Maintainers: []string{"keep-maintainer"},
-				Members:     []string{"invited-member"},
+				Members:     []string{"keep-member", "new-member"},
 			},
 			maintainers:    sets.NewString("keep-maintainer"),
+			members:        sets.NewString("keep-member"),
 			invitees:       sets.String{},
 			remove:         sets.String{},
+			addMembers:     sets.NewString("new-member"),
 			ignoreInvitees: true,
 		},
 	}


### PR DESCRIPTION
**What this PR change:**

Add a new Flag `--ignore-invitees` in peribolos to make it compatible for GitHub Enterprise.

**Why is this needed:**

Make peribolos compatible with GitHub Enterprise.

This PR resolve issue #27769