### PR TITLE
Bump node machine type for scalability benchmark

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -958,7 +958,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-size=n1-standard-96
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-standard-4
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=1
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
The benchmark is currently [failing](https://testgrid.k8s.io/sig-scalability-benchmarks#gce-benchmark-requests-1) because of a change in perf-tests that increased CPU requests of a benchmark pod. This PR will fix the test by bumping the node machine type. Thus, the benchmark pod will be schedulable.

/assign @mborsz 