### PR TITLE
Remove unused volume from cluster-api-operator config

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -118,21 +118,12 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cluster-lifecycle-github-token
         env:
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
               name: cluster-lifecycle-github-token
               key: cluster-lifecycle-github-token
-      volumes:
-      - name: cluster-lifecycle-github-token
-        secret:
-          secretName: cluster-lifecycle-github-token
-          items:
-          - key: cluster-lifecycle-github-token
-            path: cluster-lifecycle-github-token
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-e2e-main


### PR DESCRIPTION
Currently CI fails with `Pod can not be created: create pod test-pod ... ].volumeMounts[0].mountPath: Required value`.