### PR TITLE
Add Fedosin to cluster-api-operator owners

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/OWNERS
@@ -2,7 +2,9 @@
 
 reviewers:
 - JoelSpeed
-- alexander-demichev
+- alexander-demicev
+- Fedosin
 approvers:
 - JoelSpeed
-- alexander-demichev
+- alexander-demicev
+- Fedosin


### PR DESCRIPTION
Also fix a typo for alexander-demicev as the github account is https://github.com/alexander-demicev