### PR TITLE
jobs: bump timeout for ci-k8sio-audit

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: ci-k8sio-audit
-  interval: 2h
+  interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1


### PR DESCRIPTION
The job is pretty consistently timing out now and I'm getting tired of the alert spam
<img width="1152" alt="Screen Shot 2022-10-21 at 2 38 43 PM" src="https://user-images.githubusercontent.com/49258/197292711-a6a98598-7876-4420-87c2-d0871601d297.png">

This is kicking the can down the road, if we look at the longer term via bigquery/google sheets:
```
SELECT
  started,
  elapsed,
FROM 
  `k8s-gubernator.build.all`
WHERE
  job="ci-k8sio-audit"
ORDER BY
  started DESC
```
<img width="915" alt="Screen Shot 2022-10-21 at 2 39 28 PM" src="https://user-images.githubusercontent.com/49258/197292802-9c0ffedd-4ca0-4065-a306-058d3c142f40.png">
