### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/experiment/bumpmonitoring/main_test.go
+++ b/experiment/bumpmonitoring/main_test.go
@@ -86,13 +86,7 @@ func TestFindConfigToUpdate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", tc.name)
-			if err != nil {
-				t.Fatalf("Failed creating temp dir: %v", err)
-			}
-			t.Cleanup(func() {
-				os.RemoveAll(tmpDir)
-			})
+			tmpDir := t.TempDir()
 			srcRootDir, dstRootDir := seedTempDir(t, tmpDir, tc.srcNodes, tc.dstNodes)
 			c := client{
 				srcPath: srcRootDir,
@@ -160,13 +154,7 @@ func TestCopyFiles(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", tc.name)
-			if err != nil {
-				t.Fatalf("Failed creating temp dir: %v", err)
-			}
-			t.Cleanup(func() {
-				os.RemoveAll(tmpDir)
-			})
+			tmpDir := t.TempDir()
 			srcRootDir, dstRootDir := seedTempDir(t, tmpDir, tc.srcNodes, tc.dstNodes)
 			c := client{
 				srcPath: srcRootDir,

--- a/greenhouse/diskcache/cache_test.go
+++ b/greenhouse/diskcache/cache_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -87,11 +86,7 @@ func TestPathToKeyKeyToPath(t *testing.T) {
 // test stateful cache methods
 func TestCacheStorage(t *testing.T) {
 	// create a cache in a tempdir
-	dir, err := os.MkdirTemp("", "cache-tests")
-	if err != nil {
-		t.Fatalf("Failed to create tempdir for tests! %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	cache := NewCache(dir)
 
 	// sanity checks
@@ -99,7 +94,7 @@ func TestCacheStorage(t *testing.T) {
 		t.Fatalf("Expected DiskRoot to be %v not %v", dir, cache.DiskRoot())
 	}
 	// we haven't put anything yet, so get should return exists == false
-	err = cache.Get("some/key", func(exists bool, contents io.ReadSeeker) error {
+	err := cache.Get("some/key", func(exists bool, contents io.ReadSeeker) error {
 		if exists {
 			t.Fatal("no keys should exist yet!")
 		}

--- a/kubetest/aksengine_test.go
+++ b/kubetest/aksengine_test.go
@@ -189,16 +189,13 @@ func TestStrictJSON(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatalf("failed to create a temporary directory: %v", err)
-			}
+			tempDir := t.TempDir()
 			// Write tc.apiModel to a file so aksEngineDeployer can read it
 			if err := os.WriteFile(path.Join(tempDir, "kubernetes.json"), []byte(tc.apiModel), 0644); err != nil {
 				t.Fatalf("failed to write kubernetes.json: %v", err)
 			}
 			c := getMockAKSEngineDeployer(tempDir)
-			err = c.populateAPIModelTemplate()
+			err := c.populateAPIModelTemplate()
 			if tc.expectedError && err == nil {
 				t.Fatal("expected populateAPIModelTemplate to return an error, but got no error")
 			} else if !tc.expectedError && err != nil {

--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -197,17 +197,7 @@ func Test_logDumperNode_shellToFile(t *testing.T) {
 }
 
 func Test_logDumperNode_dump(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Errorf("error creating temp dir: %v", err)
-		return
-	}
-
-	defer func() {
-		if err := os.RemoveAll(tmpdir); err != nil {
-			t.Errorf("error removing temp dir: %v", err)
-		}
-	}()
+	tmpdir := t.TempDir()
 
 	host1Client := &mockSSHClient{}
 	host1Client.commands = append(host1Client.commands,

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -116,9 +116,9 @@ func TestGetKube(t *testing.T) {
 	} else {
 		defer os.Chdir(o)
 	}
-	if d, err := os.MkdirTemp("", "extract"); err != nil {
-		t.Fatal(err)
-	} else if err := os.Chdir(d); err != nil {
+
+	d := t.TempDir()
+	if err := os.Chdir(d); err != nil {
 		t.Fatal(err)
 	}
 
@@ -266,9 +266,8 @@ func TestExtractStrategies(t *testing.T) {
 	releaseBucket := "k8s-release"
 
 	for _, tc := range cases {
-		if d, err := os.MkdirTemp("", "extract"); err != nil {
-			t.Fatal(err)
-		} else if err := os.Chdir(d); err != nil {
+		d := t.TempDir()
+		if err := os.Chdir(d); err != nil {
 			t.Fatal(err)
 		}
 
@@ -362,9 +361,8 @@ func TestGciExtractStrategy(t *testing.T) {
 	releaseBucket := "k8s-release"
 
 	for _, tc := range cases {
-		if d, err := os.MkdirTemp("", "extract"); err != nil {
-			t.Fatal(err)
-		} else if err := os.Chdir(d); err != nil {
+		d := t.TempDir()
+		if err := os.Chdir(d); err != nil {
 			t.Fatal(err)
 		}
 

--- a/kubetest/main_test.go
+++ b/kubetest/main_test.go
@@ -68,13 +68,7 @@ func TestWriteMetadata(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		topDir, err := os.MkdirTemp("", "TestWriteMetadata")
-
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		defer os.RemoveAll(topDir) // Stack up all the cleanups
+		topDir := t.TempDir()
 
 		dumpDir := filepath.Join(topDir, "artifacts")
 		if err := os.Mkdir(dumpDir, 0755); err != nil {

--- a/prow/clonerefs/run_test.go
+++ b/prow/clonerefs/run_test.go
@@ -40,29 +40,16 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	srcRoot, err := os.MkdirTemp("", "clonerefs_unittest")
-	if err != nil {
-		t.Fatalf("Error while creating temp dir: %v.", err)
-	}
-	defer os.RemoveAll(srcRoot)
+	srcRoot := t.TempDir()
 
-	oauthTokenDir, err := os.MkdirTemp("", "oauth")
-	if err != nil {
-		t.Fatalf("Error while creating oauth token dir: %v.", err)
-	}
-	defer os.RemoveAll(oauthTokenDir)
-
+	oauthTokenDir := t.TempDir()
 	oauthTokenFilePath := filepath.Join(oauthTokenDir, "oauth-token")
 	oauthTokenValue := []byte("12345678")
 	if err := os.WriteFile(oauthTokenFilePath, oauthTokenValue, 0644); err != nil {
 		t.Fatalf("Error while create oauth token file: %v", err)
 	}
 
-	githubAppDir, err := os.MkdirTemp("", "github-app")
-	if err != nil {
-		t.Fatalf("Error while creating github app dir: %v.", err)
-	}
-	defer os.RemoveAll(githubAppDir)
+	githubAppDir := t.TempDir()
 	githubAppPrivateKeyFilePath := filepath.Join(githubAppDir, "private-key.pem")
 	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -689,11 +689,7 @@ presubmits:
 		tc := testcases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			// Set up config files
-			root, err := os.MkdirTemp("", fmt.Sprintf("TestValidateUnknownFieldsAll-%s_*", tc.name))
-			if err != nil {
-				t.Fatalf("Error creating temp dir: %v.", err)
-			}
-			defer os.RemoveAll(root) // clean up
+			root := t.TempDir()
 
 			prowConfigFile := filepath.Join(root, "config.yaml")
 			if err := os.WriteFile(prowConfigFile, []byte(tc.configContent), 0666); err != nil {
@@ -713,7 +709,7 @@ presubmits:
 				}
 			}
 			// Test validation
-			_, err = config.LoadStrict(prowConfigFile, jobConfigDir, nil, "")
+			_, err := config.LoadStrict(prowConfigFile, jobConfigDir, nil, "")
 			if (err != nil) != tc.expectedErr {
 				if tc.expectedErr {
 					t.Error("Expected an error, but did not receive one.")

--- a/prow/cmd/cm2kc/main_test.go
+++ b/prow/cmd/cm2kc/main_test.go
@@ -64,12 +64,7 @@ func TestGenjobs(t *testing.T) {
 				t.Errorf("Failed reading expected output file %v: %v", outE, err)
 			}
 
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Errorf("Failed creating temp file: %v", err)
-			}
-			defer os.Remove(tmpDir)
-
+			tmpDir := t.TempDir()
 			outA := filepath.Join(tmpDir, "out.yaml")
 
 			os.Args = []string{"cm2kc"}

--- a/prow/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper_test.go
@@ -172,11 +172,7 @@ func writeToFile(t *testing.T, path, content string) {
 }
 
 func TestCallWithWriter(t *testing.T) {
-	dir, err := os.MkdirTemp("", "TestCallWithWriter")
-	if err != nil {
-		t.Errorf("failed to create temp dir '%s': '%v'", dir, err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file1 := filepath.Join(dir, "secret1")
 	file2 := filepath.Join(dir, "secret2")
@@ -274,15 +270,7 @@ func TestGetAssignment(t *testing.T) {
 }
 
 func TestCDToRootDir(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(".", "test-update-references_")
-	if err != nil {
-		t.Fatalf("Failed created tmp dir: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Logf("Failed cleanup tmp dir %q: %v", tmpDir, err)
-		}
-	})
+	tmpDir := t.TempDir()
 	for dir, fps := range map[string][]string{
 		"testdata/dir": {"extra-file"},
 	} {
@@ -326,7 +314,7 @@ func TestCDToRootDir(t *testing.T) {
 			defer os.Chdir(curtDir)
 			defer os.Setenv(envName, curtBuildWorkspaceDir)
 
-			os.Setenv(envName, filepath.Join(curtDir, tc.buildWorkspaceDir))
+			os.Setenv(envName, tc.buildWorkspaceDir)
 			err := cdToRootDir()
 			if tc.expectError && err == nil {
 				t.Errorf("Expected to get an error but the result is nil")

--- a/prow/cmd/generic-autobumper/main_test.go
+++ b/prow/cmd/generic-autobumper/main_test.go
@@ -318,15 +318,7 @@ func (cli *fakeImageBumperCli) TagExists(imageHost, imageName, currentTag string
 }
 
 func TestUpdateReferences(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(".", "test-update-references_")
-	if err != nil {
-		t.Fatalf("Failed created tmp dir: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Logf("Failed cleanup tmp dir %q: %v", tmpDir, err)
-		}
-	})
+	tmpDir := t.TempDir()
 	for dir, fps := range map[string][]string{
 		"testdata/dir/subdir1": {"test1-1.yaml", "test1-2.yaml"},
 		"testdata/dir/subdir2": {"test2-1.yaml"},

--- a/prow/cmd/phaino/local_test.go
+++ b/prow/cmd/phaino/local_test.go
@@ -87,11 +87,7 @@ func TestPathAlias(t *testing.T) {
 }
 
 func TestReadRepo(t *testing.T) {
-	dir, err := os.MkdirTemp("", "read-repo")
-	if err != nil {
-		t.Fatalf("Cannot create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cases := []struct {
 		name      string
@@ -242,11 +238,7 @@ func TestFindRepoFromLocal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "find-repo-"+tc.name)
-			if err != nil {
-				t.Fatalf("Cannot create temp dir: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			tc.dirs = append(tc.dirs, tc.wd)
 			for _, d := range tc.dirs {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -290,11 +290,7 @@ deck:
 	}
 	for _, tc := range testCases {
 		// save the config
-		spyglassConfigDir, err := os.MkdirTemp("", "spyglassConfig")
-		if err != nil {
-			t.Fatalf("fail to make tempdir: %v", err)
-		}
-		defer os.RemoveAll(spyglassConfigDir)
+		spyglassConfigDir := t.TempDir()
 
 		spyglassConfig := filepath.Join(spyglassConfigDir, "config.yaml")
 		if err := os.WriteFile(spyglassConfig, []byte(tc.spyglassConfig), 0666); err != nil {
@@ -3260,11 +3256,7 @@ postsubmits:
 		t.Run(tc.name, func(t *testing.T) {
 
 			// save the config
-			prowConfigDir, err := os.MkdirTemp("", "prowConfig")
-			if err != nil {
-				t.Fatalf("fail to make tempdir: %v", err)
-			}
-			defer os.RemoveAll(prowConfigDir)
+			prowConfigDir := t.TempDir()
 
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
 			if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
@@ -3280,11 +3272,7 @@ postsubmits:
 
 			jobConfig := ""
 			if len(tc.jobConfigs) > 0 {
-				jobConfigDir, err := os.MkdirTemp("", "jobConfig")
-				if err != nil {
-					t.Fatalf("fail to make tempdir: %v", err)
-				}
-				defer os.RemoveAll(jobConfigDir)
+				jobConfigDir := t.TempDir()
 
 				// cover both job config as a file & a dir
 				if len(tc.jobConfigs) == 1 {
@@ -3466,12 +3454,8 @@ bar_jobs.yaml`,
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			jobConfigDir, err := os.MkdirTemp("", "jobConfig")
-			if err != nil {
-				t.Fatalf("fail to make tempdir: %v", err)
-			}
-			defer os.RemoveAll(jobConfigDir)
-			err = os.Mkdir(filepath.Join(jobConfigDir, "subdir"), 0777)
+			jobConfigDir := t.TempDir()
+			err := os.Mkdir(filepath.Join(jobConfigDir, "subdir"), 0777)
 			if err != nil {
 				t.Fatalf("fail to make subdir: %v", err)
 			}
@@ -3625,11 +3609,7 @@ func TestSecretAgentLoading(t *testing.T) {
 	changedTokenValue := "121f3cb3e7f70feeb35f9204f5a988d7292c7ba0"
 
 	// Creating a temporary directory.
-	secretDir, err := os.MkdirTemp("", "secretDir")
-	if err != nil {
-		t.Fatalf("fail to create a temporary directory: %v", err)
-	}
-	defer os.RemoveAll(secretDir)
+	secretDir := t.TempDir()
 
 	// Create the first temporary secret.
 	firstTempSecret := filepath.Join(secretDir, "firstTempSecret")
@@ -3732,11 +3712,7 @@ github_reporter:
 
 	for _, tc := range testCases {
 		// save the config
-		prowConfigDir, err := os.MkdirTemp("", "prowConfig")
-		if err != nil {
-			t.Fatalf("fail to make tempdir: %v", err)
-		}
-		defer os.RemoveAll(prowConfigDir)
+		prowConfigDir := t.TempDir()
 
 		prowConfig := filepath.Join(prowConfigDir, "config.yaml")
 		if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
@@ -4272,11 +4248,7 @@ tide:
 
 	for _, tc := range testCases {
 		// save the config
-		prowConfigDir, err := os.MkdirTemp("", "prowConfig")
-		if err != nil {
-			t.Fatalf("fail to make tempdir: %v", err)
-		}
-		defer os.RemoveAll(prowConfigDir)
+		prowConfigDir := t.TempDir()
 
 		prowConfig := filepath.Join(prowConfigDir, "config.yaml")
 		if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {

--- a/prow/entrypoint/run_test.go
+++ b/prow/entrypoint/run_test.go
@@ -149,15 +149,7 @@ func TestOptions_Run(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", testCase.name)
-			if err != nil {
-				t.Errorf("%s: error creating temp dir: %v", testCase.name, err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Errorf("%s: error cleaning up temp dir: %v", testCase.name, err)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			options := Options{
 				AlwaysZero:  testCase.alwaysZero,

--- a/prow/gcsupload/run_test.go
+++ b/prow/gcsupload/run_test.go
@@ -203,15 +203,7 @@ func TestOptions_AssembleTargets(t *testing.T) {
 				BuildID: "build",
 			}
 
-			tmpDir, err := os.MkdirTemp("", testCase.name)
-			if err != nil {
-				t.Errorf("%s: error creating temp dir: %v", testCase.name, err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Errorf("%s: error cleaning up temp dir: %v", testCase.name, err)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			for _, testPath := range testCase.paths {
 				if strings.HasSuffix(testPath, "/") {

--- a/prow/gerrit/client/syncer_test.go
+++ b/prow/gerrit/client/syncer_test.go
@@ -45,11 +45,7 @@ func (o fakeOpener) Writer(ctx context.Context, path string, _ ...io.WriterOptio
 
 func TestSyncTime(t *testing.T) {
 
-	dir, err := os.MkdirTemp("", "fake-gerrit-value")
-	if err != nil {
-		t.Fatalf("Could not create temp file: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	path := filepath.Join(dir, "value.txt")
 	var noCreds string
 	ctx := context.Background()
@@ -206,11 +202,7 @@ func TestSyncTimeThreadSafe(t *testing.T) {
 }
 
 func TestNewProjectAddition(t *testing.T) {
-	dir, err := os.MkdirTemp("", "fake-gerrit-value")
-	if err != nil {
-		t.Fatalf("Could not create temp file: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	path := filepath.Join(dir, "value.txt")
 
 	testTime := time.Now().Add(-time.Minute)

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -719,15 +719,10 @@ func TestCommandsForRefs(t *testing.T) {
 
 func TestGitHeadTimestamp(t *testing.T) {
 	fakeTimestamp := 987654321
-	fakeGitDir, err := makeFakeGitRepo(fakeTimestamp)
+	fakeGitDir, err := makeFakeGitRepo(t, fakeTimestamp)
 	if err != nil {
 		t.Errorf("error creating fake git dir: %v", err)
 	}
-	defer func() {
-		if err := os.RemoveAll(fakeGitDir); err != nil {
-			t.Errorf("error cleaning up fake git dir: %v", err)
-		}
-	}()
 
 	var testCases = []struct {
 		name        string
@@ -794,11 +789,8 @@ func TestGitHeadTimestamp(t *testing.T) {
 }
 
 // makeFakeGitRepo creates a fake git repo with a constant digest and timestamp.
-func makeFakeGitRepo(fakeTimestamp int) (string, error) {
-	fakeGitDir, err := os.MkdirTemp("", "fakegit")
-	if err != nil {
-		return "", err
-	}
+func makeFakeGitRepo(t *testing.T, fakeTimestamp int) (string, error) {
+	fakeGitDir := t.TempDir()
 	cmds := [][]string{
 		{"git", "init"},
 		{"git", "config", "user.email", "test@test.test"},

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1187,11 +1187,7 @@ func TestExpandAliases(t *testing.T) {
 }
 
 func TestSaveSimpleConfig(t *testing.T) {
-	dir, err := os.MkdirTemp("", "simpleConfig")
-	if err != nil {
-		t.Errorf("unexpected error when creating temp dir")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	tests := []struct {
 		name     string
@@ -1243,11 +1239,7 @@ reviewers:
 }
 
 func TestSaveFullConfig(t *testing.T) {
-	dir, err := os.MkdirTemp("", "fullConfig")
-	if err != nil {
-		t.Errorf("unexpected error when creating temp dir")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	tests := []struct {
 		name     string

--- a/prow/sidecar/run_test.go
+++ b/prow/sidecar/run_test.go
@@ -114,15 +114,7 @@ func TestWait(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", tc.name)
-			if err != nil {
-				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Errorf("%s: error cleaning up temp dir: %v", tc.name, err)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			var entries []wrapper.Options
 
@@ -222,15 +214,7 @@ func TestWaitParallelContainers(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", tc.name)
-			if err != nil {
-				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Errorf("%s: error cleaning up temp dir: %v", tc.name, err)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			var entries []wrapper.Options
 
@@ -361,15 +345,7 @@ func TestCombineMetadata(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", tc.name)
-			if err != nil {
-				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Errorf("%s: error cleaning up temp dir: %v", tc.name, err)
-				}
-			}()
+			tmpDir := t.TempDir()
 			var entries []wrapper.Options
 
 			for i, m := range tc.pieces {
@@ -479,15 +455,7 @@ func TestLogReaders(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", tc.name)
-			if err != nil {
-				t.Errorf("%s: error creating temp dir: %v", tc.name, err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Errorf("%s: error cleaning up temp dir: %v", tc.name, err)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			for name, log := range tc.processLogs {
 				p := path.Join(tmpDir, name)
@@ -546,13 +514,7 @@ func TestSideCarLogsUpload(t *testing.T) {
 	logrus.Info(testString)
 	var once sync.Once
 
-	localOutputDir, err := os.MkdirTemp("", "testdir")
-	if err != nil {
-		t.Errorf("Unable to create temp dir: %v", err)
-	}
-	defer func() {
-		os.RemoveAll(localOutputDir)
-	}()
+	localOutputDir := t.TempDir()
 
 	options := Options{
 		GcsOptions: &gcsupload.Options{

--- a/testgrid/pkg/configurator/configurator/client_test.go
+++ b/testgrid/pkg/configurator/configurator/client_test.go
@@ -46,11 +46,7 @@ func Test_announceChanges(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			directory, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatalf("Error in creating temporary dir: %v", err)
-			}
-			defer os.RemoveAll(directory)
+			directory := t.TempDir()
 
 			file, err := os.CreateTemp(directory, "1*.yaml")
 			if err != nil {

--- a/triage/summarize/summarize_test.go
+++ b/triage/summarize/summarize_test.go
@@ -137,12 +137,7 @@ func failOnMismatchedTestSlices(t *testing.T, want []test, got []test) {
 
 func TestSummarize(t *testing.T) {
 	// Setup
-	tmpdir, err := os.MkdirTemp("", "summarize_test_*")
-	if err != nil {
-		t.Errorf("Could not create temporary directory: %s", err)
-		return
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Save the old working directory
 	olddir, err := os.Getwd()


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatalf("unexpected error %v", err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```