### PR TITLE
Re-enable ci-cri-containerd-e2e-cos-gce-alpha-features with Alpha fea…

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -487,36 +487,35 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos
-# TODO (https://github.com/kubernetes/test-infra/issues/26127) consider restoring once we will figure out the right set of alpha features.
-# - interval: 2h
-#   name: ci-cri-containerd-e2e-cos-gce-alpha-features
-#   labels:
-#     preset-service-account: "true"
-#     preset-k8s-ssh: "true"
-#     preset-e2e-containerd: "true"
-#     preset-e2e-containerd-image-load: "true"
-#   spec:
-#     containers:
-#     - args:
-#       - --repo=github.com/containerd/containerd=main
-#       - --timeout=200
-#       - --scenario=kubernetes_e2e
-#       - --
-#       - --check-leaked-resources
-#       - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
-#       - --env=KUBE_PROXY_DAEMONSET=true
-#       - --env=ENABLE_POD_PRIORITY=true
-#       - --extract=ci/latest
-#       - --gcp-node-image=gci
-#       - --gcp-zone=us-west1-b
-#       - --provider=gce
-#       - --runtime-config=api/all=true
-#       - --test_args=--ginkgo.focus=\[Feature:()\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|Feature:SCTPConnectivity --minStartupPods=8
-#       - --timeout=180m
-#       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-master
-#   annotations:
-#     testgrid-dashboards: sig-node-cos
-#     testgrid-tab-name: e2e-cos-alpha-features
+- interval: 2h
+  name: ci-cri-containerd-e2e-cos-gce-alpha-features
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+    preset-e2e-containerd-image-load: "true"
+  spec:
+    containers:
+    - args:
+      - --repo=github.com/containerd/containerd=main
+      - --timeout=200
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
+      - --env=KUBE_PROXY_DAEMONSET=true
+      - --env=ENABLE_POD_PRIORITY=true
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --runtime-config=api/all=true
+      - --test_args=--ginkgo.focus=\[Feature:(GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|StorageVersionAPI|PodPreset|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|RetroactiveDefaultStorageClass|ReadWriteOncePod)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
+      - --timeout=180m
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+  annotations:
+    testgrid-dashboards: sig-node-cos
+    testgrid-tab-name: e2e-cos-alpha-features
 
 - name: ci-kubernetes-node-kubelet-containerd-eviction
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
…ture tests


The test job was removed because there was no clear set of Alpha feature tests. This PR re-enables the test job with the tests specified in https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L362