### PR TITLE
jobs: actually bump ci-k8sio-audit timeout

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
@@ -3,6 +3,8 @@ periodics:
   interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    timeout: 3h
   max_concurrency: 1
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
Related:
- Followup to: https://github.com/kubernetes/test-infra/pull/27802

last commit that tried to do this only bumped interval