### PR TITLE
kettle: combine failure message and backtrace

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -188,7 +188,18 @@ def parse_junit(xml):
         time = float(child_node.attrib.get('time') or 0) #time val can be ''
         failure_text = None
         for param in child_node.findall('failure'):
-            failure_text = param.text or param.attrib.get('message', 'No Failure Message Found')
+            msg_attribute = param.attrib.get('message')
+            msg_data = param.text
+            if msg_attribute and msg_data:
+                # Use both. With Ginkgo V2, the attribute contains the failure message
+                # and the data contains the stack backtrace. We could leave out the
+                # stack backtrace, but the function names in it might be useful
+                # to distinguish different unrelated failures that happen to have the
+                # same message.
+                failure_text = msg_attribute + "\n" + msg_data
+            else:
+                # Use whatever we have, with a default if both are unset.
+                failure_text = msg_attribute or msg_data or 'No Failure Message Found'
         skipped = child_node.findall('skipped')
         return time, failure_text, skipped
 


### PR DESCRIPTION
Ginkgo v2 started splitting the information about a failure into the XML attribute (failure message) and data (stack backtrace). Kettle used to pick only the data, with the result that go.k8s.io/triage only showed the backtrace.

It's debatable whether the backtrace is relevant for triaging. It was used in the past and it might help to distinguish failures with the same message but a different origin, so now both are stored again.

Fixes: https://github.com/kubernetes/test-infra/issues/27829