### PR TITLE
Change behavior of setting job queue concurrency to 0

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -673,9 +673,10 @@ type Plank struct {
 
 	// JobQueueConcurrencies is an optional field used to define job queue max concurrency.
 	// Each job can be assigned to a specific queue which has its own max concurrency,
-	// independent from the job's name. An example use case would be easier
-	// scheduling of jobs using boskos resources. This mechanism is separate from
-	// ProwJob's MaxConcurrency setting.
+	// independent from the job's name. Setting the concurrency to 0 will block any job
+	// from being triggered. Setting the concurrency to a negative value will remove the
+	// limit. An example use case would be easier scheduling of jobs using boskos resources.
+	// This mechanism is separate from ProwJob's MaxConcurrency setting.
 	JobQueueConcurrencies map[string]int `json:"job_queue_capacities,omitempty"`
 }
 

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -1035,9 +1035,10 @@ plank:
 
     # JobQueueConcurrencies is an optional field used to define job queue max concurrency.
     # Each job can be assigned to a specific queue which has its own max concurrency,
-    # independent from the job's name. An example use case would be easier
-    # scheduling of jobs using boskos resources. This mechanism is separate from
-    # ProwJob's MaxConcurrency setting.
+    # independent from the job's name. Setting the concurrency to 0 will block any job
+    # from being triggered. Setting the concurrency to a negative value will remove the
+    # limit. An example use case would be easier scheduling of jobs using boskos resources.
+    # This mechanism is separate from ProwJob's MaxConcurrency setting.
     job_queue_capacities:
         "": 0
 

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -2001,9 +2001,15 @@ func TestMaxConcurency(t *testing.T) {
 			ExpectedResult: true,
 		},
 		{
-			Name:                  "Job queue concurency 0 always runs",
+			Name:                  "Job queue concurency 0 never runs",
 			ProwJob:               prowapi.ProwJob{Spec: prowapi.ProwJobSpec{JobQueueName: "queue"}},
 			JobQueueConcurrencies: map[string]int{"queue": 0},
+			ExpectedResult:        false,
+		},
+		{
+			Name:                  "Job queue concurency -1 always runs",
+			ProwJob:               prowapi.ProwJob{Spec: prowapi.ProwJobSpec{JobQueueName: "queue"}},
+			JobQueueConcurrencies: map[string]int{"queue": -1},
 			ExpectedResult:        true,
 		},
 		{

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -815,6 +815,9 @@ func (r *reconciler) canExecuteConcurrentlyPerQueue(ctx context.Context, pj *pro
 		return false, fmt.Errorf("failed to match queue name '%s' with Plank configuration", queueName)
 	}
 	if queueConcurrency == 0 {
+		return false, nil
+	}
+	if queueConcurrency < 0 {
 		return true, nil
 	}
 


### PR DESCRIPTION
Previously setting this value to 0 meant that there is no limit on how many jobs may be executed concurrently. This does not make much sense as this should be achieved by simply not configuring the job queue.

Instead, the new behavior will prevent any job from being executed. This is especially useful when temporarily stopping workloads when no resources are available.

/assign @mborsz @cjwagner 