### PR TITLE
Bump gcloud-in-go to go1.19

### DIFF
--- a/images/gcloud-in-go/Dockerfile
+++ b/images/gcloud-in-go/Dockerfile
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE: CHANGE THIS LINE TO FORCE A NEW IMAGE: 20200109
 # Includes go and gcloud
-FROM golang:1.17
+FROM golang:1.19
 
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG

--- a/images/gcloud-in-go/README.md
+++ b/images/gcloud-in-go/README.md
@@ -5,7 +5,7 @@ Use this image when you want to use `go` and `gcloud` in the same job
 ## contents
 
 - base:
-  - golang:1.16
+  - golang:1.19
 - directories:
   - `/workspace` default working dir for `run` commands
 - languages:


### PR DESCRIPTION
Tracked as part of https://github.com/GoogleCloudPlatform/oss-test-infra/issues/1818, but probably won't solve it; the image is already at go1.17.

Pushing anyway since the kubernetes project is using go1.19