### PR TITLE
Update CSI Proxy postsubmit to run on v1 only

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -20,13 +20,13 @@ postsubmits:
         grace_period: 15m
       branches:
         # For publishing canary images.
-        - ^master$
-        - ^release-
+        - ^master$ # TODO(alexander-ding): when v2 is released, this needs to be switched to point to the v1.x branch
         # For publishing tagged images. Those will only get built once, i.e.
         # existing images are not getting overwritten. A new tag must be set to
-        # trigger another image build. Images are only built for tags that follow
-        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
-        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+        # trigger another image build. Images are only built for v1 tags that follow
+        # the semver format (regex adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)
+        # v2 and beyond are released as a Go library and therefore do not need to be built
+        - ^v1\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
As part of [KEP-3636](https://github.com/kubernetes/enhancements/issues/3636), [CSI Proxy](https://github.com/kubernetes-csi/csi-proxy) will be updated to be a pure Go library and no longer release .exe binaries. The postsubmit job needs to be updated to only trigger for v1 tags and branches containing v1 code.

/cc @mauriciopoppe 