### PR TITLE
Add a daily job to exercise in-place pod resize feature with AllAlpha features enabled

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1367,7 +1367,7 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: gcp-kubelet-credential-provider
     description: "tests feature gcp kubelet image credential provider"
-- name: ci-cos-inplace-pod-resize-containerd-main-e2e-gce
+- name: ci-cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce
   interval: 24h
   labels:
     preset-service-account: "true"
@@ -1377,7 +1377,7 @@ periodics:
     containers:
     - args:
       - --repo=github.com/containerd/containerd=main
-      - --timeout=150
+      - --timeout=180
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
@@ -1388,10 +1388,10 @@ periodics:
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-nodes=4
+      - --gcp-nodes=1
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-97-lts
+      - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
@@ -1399,4 +1399,39 @@ periodics:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
   annotations:
     testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: cos-inplace-pod-resize-containerd-e2e
+    testgrid-tab-name: cos-cgroupv2-inplace-pod-resize-containerd-e2e
+    description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v2
+- name: ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce
+  interval: 48h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+  spec:
+    containers:
+    - args:
+      - --repo=github.com/containerd/containerd=main
+      - --timeout=180
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=ENABLE_POD_SECURITY_POLICY=true
+      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+      - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-nodes=1
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --image-family=cos-stable
+      - --image-project=cos-cloud
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=150m
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: cos-cgroupv1-inplace-pod-resize-containerd-e2e
+    description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v1

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1367,3 +1367,36 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: gcp-kubelet-credential-provider
     description: "tests feature gcp kubelet image credential provider"
+- name: ci-cos-inplace-pod-resize-containerd-main-e2e-gce
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+  spec:
+    containers:
+    - args:
+      - --repo=github.com/containerd/containerd=main
+      - --timeout=150
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=ENABLE_POD_SECURITY_POLICY=true
+      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+      - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-nodes=4
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --image-family=cos-97-lts
+      - --image-project=cos-cloud
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=150m
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: cos-inplace-pod-resize-containerd-e2e


### PR DESCRIPTION
This adds a daily job that runs InPlacePodResize E2E test with a 1-node GCE cluster that has AllAlpha feature gates enabled.

This runs the pod resize test with containerd-main which has added the CRI support needed for in-place pod resize E2E tests to verify that podStatus reflects the resources reported by runtime via the ContainerStatus CRI call.