### PR TITLE
Use `--use-prow-manifest-diff` for `kpromo cip` jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -20,6 +20,7 @@ presubmits:
         args:
         - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --use-prow-manifest-diff
         resources:
           limits:
             cpu: 2
@@ -48,6 +49,7 @@ presubmits:
         args:
         - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --use-prow-manifest-diff
         - --vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -46,6 +46,7 @@ postsubmits:
         args:
         - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --use-prow-manifest-diff
         - --confirm
         # TODO: these are *not* threads 🤷‍♂️
         # https://www.geeksforgeeks.org/golang-goroutine-vs-thread/


### PR DESCRIPTION
This enables to use only the latest diff for `kpromo cip` rather than all manifests.

Refers to https://github.com/kubernetes/k8s.io/issues/4374, https://github.com/kubernetes-sigs/promo-tools/issues/637