### PR TITLE
Explicitly skip SCTPConnectivity tests on network-policy job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -699,7 +699,7 @@ periodics:
       - --provider=gce
       # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
       # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
-      - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|ProxyTerminatingEndpoints)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
+      - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|ProxyTerminatingEndpoints|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
       - --extract=ci/latest
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master


### PR DESCRIPTION
Calico doesn't support SCTP. Previously they were getting skipped by virtue of the fact that those tests were (incorrectly) labeled "Disruptive", but that's being fixed in https://github.com/kubernetes/kubernetes/pull/113335 so now we need to explicitly skip them.

/assign @aojea 