### PR TITLE
sig-network-policy-api prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/network-policy-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/network-policy-api/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - abhiraut
+  - rikatz
+  - astoycos
+  - Dyanngg

--- a/config/jobs/kubernetes-sigs/network-policy-api/network-policy-api-config.yaml
+++ b/config/jobs/kubernetes-sigs/network-policy-api/network-policy-api-config.yaml
@@ -1,0 +1,45 @@
+presubmits:
+  kubernetes-sigs/network-policy-api:
+  - name: pull-network-policy-api-verify
+    annotations:
+      testgrid-dashboards: sig-network-policy-api
+      testgrid-tab-name: verify
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    path_alias: sigs.k8s.io/network-policy-api
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+        command:
+          # generic runner script, handles DIND, bazelrc for caching, etc.
+          - runner.sh
+        args:
+          - make
+          - verify
+  - name: pull-network-policy-api-crd-e2e
+    annotations:
+      testgrid-dashboards: sig-network-policy-api
+      testgrid-tab-name: crd-e2e
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    path_alias: sigs.k8s.io/network-policy-api
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - crd-e2e
+          # docker-in-docker needs privileged mode.
+          securityContext:
+            privileged: true

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -7,6 +7,7 @@ dashboard_groups:
     - sig-network-ingress-gce-e2e
     - sig-network-ingress-nginx
     - sig-network-gateway-api
+    - sig-network-policy-api
     - sig-network-ingress-controller-conformance
     - sig-network-kind
 
@@ -94,5 +95,6 @@ dashboards:
 - name: sig-network-ingress-gce-e2e
 - name: sig-network-ingress-nginx
 - name: sig-network-gateway-api
+- name: sig-network-policy-api
 - name: sig-network-ingress-controller-conformance
 - name: sig-network-kind


### PR DESCRIPTION
Related to: https://github.com/kubernetes-sigs/network-policy-api/pull/47

This is to resolve https://github.com/kubernetes-sigs/network-policy-api/issues/37

Originally we were going to do gh actions but decided after some discussion to follow other sigs, and create prow jobs.

This is my first contribution to a k8s project, so I'm near certain I've done something wrong. Feel free to tell me heh.