### PR TITLE
TRT-604: Add option to populate test failure risk analysis for comments

### DIFF
--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -61,6 +61,8 @@ type options struct {
 	kubernetes             prowflagutil.KubernetesOptions
 	github                 prowflagutil.GitHubOptions
 	instrumentationOptions prowflagutil.InstrumentationOptions
+
+	storage prowflagutil.StorageClientOptions
 }
 
 func (o *options) Validate() error {
@@ -113,7 +115,7 @@ func gatherOptions() options {
 
 	fs.BoolVar(&o.skipReport, "skip-report", false, "Whether or not to ignore report with githubClient")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub/Kubernetes/Jenkins.")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.instrumentationOptions, &o.config} {
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.instrumentationOptions, &o.config, &o.storage} {
 		group.AddFlags(fs)
 	}
 	fs.Parse(os.Args[1:])
@@ -196,7 +198,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	c, err := jenkins.NewController(prowJobClient, jc, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport)
+	c, err := jenkins.NewController(prowJobClient, jc, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport, o.storage)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to instantiate Jenkins controller.")
 	}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -992,6 +992,17 @@ type JenkinsOperator struct {
 	LabelSelector labels.Selector `json:"-"`
 }
 
+type TestFailureRiskAnalysisConfig struct {
+	// Enabled controls the inclusion of a risk summary column in the failure report comment table.
+	Enabled bool `json:"enabled,omitempty"`
+	// SummaryLocator is an optional string representing a regex identifying the json file within the list of artifacts that
+	// contains the summary value.
+	SummaryLocator string `json:"summary_locator,omitempty"`
+	// SummaryValuePath is an optional string with a comma separated list of keys representing the path to the value within the summary json file that
+	// represents the overall risk for the test failure.
+	SummaryValuePath string `json:"summary_value_path,omitempty"`
+}
+
 // GitHubReporter holds the config for report behavior in github.
 type GitHubReporter struct {
 	// JobTypesToReport is used to determine which type of prowjob
@@ -1006,6 +1017,8 @@ type GitHubReporter struct {
 	// comments is only sent when all jobs from current SHA are finished. Status
 	// contexts will still be written.
 	SummaryCommentRepos []string `json:"summary_comment_repos,omitempty"`
+
+	TestFailureRiskAnalysis TestFailureRiskAnalysisConfig `json:"test_failure_risk_analysis,omitempty"`
 }
 
 // Sinker is config for the sinker controller.

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -525,6 +525,17 @@ github_reporter:
     # contexts will still be written.
     summary_comment_repos:
       - ""
+    test_failure_risk_analysis:
+        # Enabled controls the inclusion of a risk summary column in the failure report comment table.
+        enabled: true
+
+        # SummaryLocator is an optional string representing a regex identifying the json file within the list of artifacts that
+        # contains the summary value.
+        summary_locator: ' '
+
+        # SummaryValuePath is an optional string with a comma separated list of keys representing the path to the value within the summary json file that
+        # represents the overall risk for the test failure.
+        summary_value_path: ' '
 horologium:
     # TickInterval is the interval in which we check if new jobs need to be
     # created. Defaults to one minute.

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -102,7 +102,7 @@ func TestShouldReport(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewReporter(nil, nil, tc.reportAgent, nil)
+			c := NewReporter(nil, nil, tc.reportAgent, nil, nil)
 			if r := c.ShouldReport(context.Background(), logrus.NewEntry(logrus.StandardLogger()), &tc.pj); r == tc.report {
 				return
 			}
@@ -132,6 +132,7 @@ func TestPresumitReportingLocks(t *testing.T) {
 			}
 		},
 		v1.ProwJobAgent(""),
+		nil,
 		nil,
 	)
 

--- a/prow/external-plugins/refresh/main.go
+++ b/prow/external-plugins/refresh/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
@@ -48,6 +49,8 @@ type options struct {
 	prowURL                string
 
 	webhookSecretFile string
+
+	storage prowflagutil.StorageClientOptions
 }
 
 func (o *options) Validate() error {
@@ -71,7 +74,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 	fs.StringVar(&o.prowURL, "prow-url", "", "Prow frontend URL.")
-	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions, &o.config} {
+	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions, &o.config, &o.storage} {
 		group.AddFlags(fs)
 	}
 	fs.Parse(os.Args[1:])
@@ -107,6 +110,7 @@ func main() {
 		configAgent:    configAgent,
 		ghc:            githubClient,
 		log:            log,
+		storage:        o.storage,
 	}
 
 	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)

--- a/prow/github/report/analysis/risk_analysis.go
+++ b/prow/github/report/analysis/risk_analysis.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	pkgio "k8s.io/test-infra/prow/io"
+	lenses "k8s.io/test-infra/prow/spyglass/lenses/common"
+)
+
+const TestFailureSummaryFilePrefix = "risk-analysis"
+
+var DefaultAnalysisPath = []string{"OverallRisk", "Level", "Name"}
+
+func CreateRiskAnalysisFn(cfg config.Config, storage prowflagutil.StorageClientOptions) ProwJobFailureRiskAnalysis {
+	var raFn ProwJobFailureRiskAnalysis
+	{
+		raFn = func(pj prowapi.ProwJob) (ProwJobFailureRisk, error) {
+			raCfg := config.Config{
+				JobConfig:  cfg.JobConfig,
+				ProwConfig: cfg.ProwConfig,
+			}
+			asf := GetDefaultRiskAnalysisSummaryFile()
+			if len(cfg.GitHubReporter.TestFailureRiskAnalysis.SummaryLocator) > 0 {
+				r, err := regexp.Compile(cfg.GitHubReporter.TestFailureRiskAnalysis.SummaryLocator)
+
+				if err != nil {
+					logrus.WithError(err).Errorf("Error compiling analyze-test-failure-summary-locator: %s.  Using default", cfg.GitHubReporter.TestFailureRiskAnalysis.SummaryLocator)
+				} else {
+					asf = r
+				}
+			}
+
+			ap := DefaultAnalysisPath
+			if len(cfg.GitHubReporter.TestFailureRiskAnalysis.SummaryValuePath) > 0 {
+				p := strings.Split(cfg.GitHubReporter.TestFailureRiskAnalysis.SummaryValuePath, ",")
+				if len(p) < 1 {
+					logrus.Errorf("Error parsing analyze-test-failure-summary-path: %s.  Using default", cfg.GitHubReporter.TestFailureRiskAnalysis.SummaryValuePath)
+				} else {
+					ap = p
+				}
+			}
+			ra, err := InitRiskAnalysis(raCfg, storage, asf, ap)
+
+			if err != nil {
+				return ProwJobFailureRiskUnknown, err
+			}
+
+			return ra.ProwJobFailureRiskAnalysisDefault(pj)
+		}
+	}
+
+	return raFn
+}
+
+func GetDefaultRiskAnalysisSummaryFile() *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("%s.*.json", TestFailureSummaryFilePrefix))
+}
+
+func InitRiskAnalysis(cfg config.Config, storage prowflagutil.StorageClientOptions, filename *regexp.Regexp, analysisPath []string) (*RiskAnalysis, error) {
+	ctx := context.TODO()
+	opener, err := pkgio.NewOpener(ctx, storage.GCSCredentialsFile, storage.S3CredentialsFile)
+	if err != nil {
+		logrus.WithError(err).Error("Error creating opener")
+		return &RiskAnalysis{}, err
+	}
+
+	return &RiskAnalysis{
+		config:            &cfg,
+		opener:            opener,
+		filename:          filename,
+		bucketInitializer: newBlobStorageBucket,
+		analysisPath:      analysisPath,
+	}, nil
+}
+
+func (ra RiskAnalysis) ProwJobFailureRiskAnalysisDefault(pj prowapi.ProwJob) (ProwJobFailureRisk, error) {
+
+	// doesn't really matter since we are using staticFetcher
+	prowKey := pj.Spec.Job + "/" + pj.Status.BuildID
+
+	staticFetcher := &StaticProwJobFetcher{prowJob: pj}
+	configGetter := func() *config.Config {
+		return ra.config
+	}
+	// we have to get the bucket name from the gcsKey so we can get the StorageProvider from there as well
+	_, gcsKey, err := lenses.ProwToGCS(staticFetcher, configGetter, prowKey)
+
+	if err != nil {
+		logrus.WithError(err).Error("Error converting prow to gcs")
+		return ProwJobFailureRiskUnknown, err
+	}
+
+	sp, bucketName, root, err := parseGCSKey(gcsKey)
+
+	if err != nil {
+		return ProwJobFailureRiskUnknown, err
+	}
+
+	riskAnalysisResult := ra.findRiskAnalysisData(sp, bucketName, root, ra.filename, ra.config, ra.opener)
+
+	if len(riskAnalysisResult) > 0 {
+
+		// for now we take the first one
+		return extractRiskAnalysis(riskAnalysisResult[0].Data, ra.analysisPath), nil
+	}
+
+	// default
+	return ProwJobFailureRiskUnknown, nil
+}
+
+func extractRiskAnalysis(analysis map[string]any, path []string) ProwJobFailureRisk {
+
+	if len(path) > 0 {
+		value := analysis
+		for i, key := range path {
+
+			if value == nil || value[key] == nil {
+				break
+			}
+
+			if i < (len(path) - 1) {
+				value = value[key].(map[string]any)
+			} else {
+				return FindProwJobFailureRiskLevel(value[key].(string))
+			}
+		}
+	}
+
+	return ProwJobFailureRiskUnknown
+}
+
+func (ra RiskAnalysis) findRiskAnalysisData(storageProvider, bucketName, root string, filename *regexp.Regexp, config *config.Config, opener pkgio.Opener) []RiskAnalysisResult {
+
+	bucket, err := ra.bucketInitializer(bucketName, storageProvider, config, opener)
+
+	if err != nil {
+		logrus.WithError(err).Errorf("Error getting bucket: %s", bucketName)
+		return nil
+	}
+
+	ctx := context.TODO()
+	files, err := bucket.listAll(ctx, root)
+
+	if err != nil {
+		logrus.WithError(err).Errorf("Error getting file list for path: %s/%s", bucketName, root)
+		return nil
+	}
+
+	for _, name := range files {
+
+		// we match on the first found filename
+		// technically there could be multiples
+		// we support returning array but quit after the first one for now
+		if filename.MatchString(name) {
+			var data map[string]any
+			err = readJSON(ctx, bucket, name, &data)
+
+			// if we had an error keep looking, or bail?
+			if err != nil {
+				logrus.WithError(err).Errorf("Error reading file: %s/%s", bucketName, name)
+			} else {
+				return []RiskAnalysisResult{{Name: name, Data: data}}
+			}
+		}
+	}
+
+	// we didn't find any  ...
+	logrus.Warn("No match for risk analysis data.")
+	return nil
+}
+
+// newBlobStorageBucket validates the bucketName and returns a new instance of blobStorageBucket.
+func newBlobStorageBucket(bucketName, storageProvider string, config *config.Config, opener pkgio.Opener) (storageBucket, error) {
+	if err := config.ValidateStorageBucket(bucketName); err != nil {
+		return blobStorageBucket{}, fmt.Errorf("could not instantiate storage bucket: %w", err)
+	}
+	return blobStorageBucket{bucketName, storageProvider, opener}, nil
+}
+
+func (bucket blobStorageBucket) readObject(ctx context.Context, key string) ([]byte, error) {
+	u := url.URL{
+		Scheme: bucket.storageProvider,
+		Host:   bucket.name,
+		Path:   key,
+	}
+	rc, err := bucket.Opener.Reader(ctx, u.String())
+	if err != nil {
+		return nil, fmt.Errorf("creating reader for object %s: %w", key, err)
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+// reads specified JSON file in to `data`
+func readJSON(ctx context.Context, bucket storageBucket, key string, data interface{}) error {
+	rawData, err := bucket.readObject(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", key, err)
+	}
+	err = json.Unmarshal(rawData, &data)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", key, err)
+	}
+	return nil
+}
+
+// Lists all keys with given prefix.
+func (bucket blobStorageBucket) listAll(ctx context.Context, prefix string) ([]string, error) {
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
+	it, err := bucket.Opener.Iterator(ctx, fmt.Sprintf("%s://%s/%s", bucket.storageProvider, bucket.name, prefix), "")
+	if err != nil {
+		return nil, err
+	}
+
+	keys := []string{}
+	for {
+		attrs, err := it.Next(ctx)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return keys, err
+		}
+		keys = append(keys, attrs.Name)
+	}
+	return keys, nil
+}
+
+func parseGCSKey(gcsKey string) (storageProvider, bucketName, root string, err error) {
+	// remove any leading '/'
+	p := strings.TrimPrefix(gcsKey, "/")
+	// examples for p:
+	// "/gs/ci-test/pr-logs/pull/27486/pull-ci-test-origin-master-e2e-aws-ovn-single-node-upgrade/1584099588365406208"
+
+	s := strings.SplitN(p, "/", 3)
+	if len(s) < 3 {
+		err = fmt.Errorf("invalid path (expected either <storage-type>/<bucket-name>/<storage-path>): %v", gcsKey)
+		return
+	}
+	storageProvider = s[0]
+	bucketName = s[1]
+	root = s[2] // `root` is the root "directory" prefix for this job's results
+
+	if bucketName == "" {
+		err = fmt.Errorf("missing bucket name: %v", gcsKey)
+		return
+	}
+	if root == "" {
+		err = fmt.Errorf("invalid path for job: %v", gcsKey)
+		return
+	}
+
+	return
+}

--- a/prow/github/report/analysis/risk_analysis_test.go
+++ b/prow/github/report/analysis/risk_analysis_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analysis
+
+import (
+	"context"
+	"fmt"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	pkgio "k8s.io/test-infra/prow/io"
+	"regexp"
+	"testing"
+)
+
+type storageBucketTester struct {
+	listAllResponse    []string
+	listAllError       error
+	readObjectResponse []byte
+	readObjectError    error
+}
+
+func (sbt storageBucketTester) listAll(ctx context.Context, prefix string) ([]string, error) {
+	return sbt.listAllResponse, sbt.listAllError
+}
+
+func (sbt storageBucketTester) readObject(ctx context.Context, key string) ([]byte, error) {
+	return sbt.readObjectResponse, sbt.readObjectError
+}
+
+func initRiskAnalysis(cfg config.Config, filename *regexp.Regexp, sbt storageBucketTester) (*RiskAnalysis, error) {
+
+	var sbi = func(bucketName, storageProvider string, config *config.Config, opener pkgio.Opener) (storageBucket, error) {
+		return sbt, nil
+	}
+
+	return &RiskAnalysis{
+		config: &cfg,
+		//opener: 	opener,
+		filename:          filename,
+		bucketInitializer: sbi,
+		analysisPath:      DefaultAnalysisPath,
+	}, nil
+}
+
+func TestArtifacts(t *testing.T) {
+
+	var testcases = []struct {
+		name         string
+		risk         string
+		expectedRisk string
+	}{
+		{
+			name:         "unknown",
+			risk:         `{"OverallRisk": {"Level": {"Name": "Unknown"}}}`,
+			expectedRisk: "unknown",
+		},
+		{
+			name:         "high",
+			risk:         `{"OverallRisk": {"Level": {"Name": "hiGh"}}}`,
+			expectedRisk: "high",
+		},
+		{
+			name:         "missing",
+			risk:         `{"OverallRiskWrong": {"Level": {"Name": "Unknown"}}}`,
+			expectedRisk: "unknown",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			raFn := func(pj prowapi.ProwJob) (ProwJobFailureRisk, error) {
+
+				raCfg := config.Config{
+					ProwConfig: config.ProwConfig{
+						Plank: config.Plank{
+							JobURLPrefixConfig: map[string]string{"*": "https://prow.ci.test.org/view"},
+						},
+						Deck: config.Deck{},
+					},
+				}
+
+				unknown := tc.risk
+
+				sbt := &storageBucketTester{readObjectResponse: []byte(unknown), readObjectError: nil, listAllResponse: []string{fmt.Sprintf("%s.json", TestFailureSummaryFilePrefix)}}
+
+				ra, err := initRiskAnalysis(raCfg, GetDefaultRiskAnalysisSummaryFile(), *sbt)
+
+				if err != nil {
+					return ProwJobFailureRiskUnknown, err
+				}
+
+				return ra.ProwJobFailureRiskAnalysisDefault(pj)
+			}
+
+			job := &prowapi.ProwJob{Spec: prowapi.ProwJobSpec{Job: "testJob"}, Status: prowapi.ProwJobStatus{BuildID: "99023", URL: "https://prow.ci.test.org/view/gs/ci-test-bucket/pr-logs/pull/27486/pull-ci-test-master-e2e-aws-ovn-single-node-upgrade/1584599988365406208"}}
+			risk, err := raFn(*job)
+
+			if err != nil {
+				t.Errorf("Error initializing risk analysis: %v", err)
+			}
+
+			if risk != ProwJobFailureRisk(tc.expectedRisk) {
+				t.Errorf("Expected risk: %s, received: %s", string(ProwJobFailureRiskUnknown), string(risk))
+			}
+
+		})
+	}
+}

--- a/prow/github/report/analysis/types.go
+++ b/prow/github/report/analysis/types.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analysis
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	pkgio "k8s.io/test-infra/prow/io"
+)
+
+type ProwJobFailureRisk string
+
+// Various job failure risk levels.
+const (
+	// HighRisk means the job has a high (e.g. > 98%) success rate and a failure indicates a higher chance of regression.
+	ProwJobFailureRiskHigh ProwJobFailureRisk = "high"
+	// MediumRisk means the job is regularly successful (e.g. > 80%) and a failure indicates potential regression
+	ProwJobFailureRiskMedium ProwJobFailureRisk = "medium"
+	// LowRisk means the job does not have a consistent success profile (e.g. < 80%) so the failure alone can not be relied on as indicator for regression
+	ProwJobFailureRiskLow ProwJobFailureRisk = "low"
+	// UnknownRisk means the risk analysis for this job could not determine a risk level
+	ProwJobFailureRiskUnknown ProwJobFailureRisk = "unknown"
+)
+
+func FindProwJobFailureRiskLevel(in string) ProwJobFailureRisk {
+
+	switch strings.ToLower(in) {
+	case string(ProwJobFailureRiskHigh):
+		return ProwJobFailureRiskHigh
+	case string(ProwJobFailureRiskMedium):
+		return ProwJobFailureRiskMedium
+	case string(ProwJobFailureRiskLow):
+		return ProwJobFailureRiskLow
+	default:
+		return ProwJobFailureRiskUnknown
+	}
+
+}
+
+type ProwJobFailureRiskAnalysis func(pj prowapi.ProwJob) (ProwJobFailureRisk, error)
+
+type StorageBucketInitializer func(bucketName, storageProvider string, config *config.Config, opener pkgio.Opener) (storageBucket, error)
+
+type StaticProwJobFetcher struct {
+	prowJob prowapi.ProwJob
+}
+
+func (j *StaticProwJobFetcher) GetProwJob(job, id string) (prowapi.ProwJob, error) {
+	return j.prowJob, nil
+}
+
+type RiskAnalysis struct {
+	config            *config.Config
+	opener            pkgio.Opener
+	filename          *regexp.Regexp
+	bucketInitializer StorageBucketInitializer
+	analysisPath      []string
+}
+
+type RiskAnalysisResult struct {
+	Name string
+	Data map[string]any
+}
+
+// storageBucket is an abstraction for unit testing
+type storageBucket interface {
+	listAll(ctx context.Context, prefix string) ([]string, error)
+	readObject(ctx context.Context, key string) ([]byte, error)
+}
+
+// blobStorageBucket is our real implementation of storageBucket.
+// Use `newBlobStorageBucket` to instantiate (includes bucket-level validation).
+type blobStorageBucket struct {
+	name            string
+	storageProvider string
+	pkgio.Opener
+}


### PR DESCRIPTION
TRT-604 is part of an effort to analyze risk of regression based on overall success rate of failed tests.  Tests that consistently pass indicate a high risk of regression if they fail during a pr's presubmits.  As the consistency lowers so does the ability to determine risk.

In an effort to draw attention to tests that have failed and are worth reviewing this PR seeks to append a risk column in the PR comments for failed tests, when it is enabled via cmd options.

The default is disabled with no noticeable changes.

When enabled a lookup for a risk analysis summary will be made in the tests artifacts, when found the overall risk for the prow job (highest analyzed risk among the failed tests) will be surfaced in the failed tests summary table.