### PR TITLE
Report the correct field and fix typo in log messages.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -457,6 +457,8 @@ func contextsToStrings(contexts []Context) []string {
 	for _, c := range contexts {
 		names = append(names, string(c.Context))
 	}
+        // Sorting names improves readability of logs and simplifies unit tests.
+	sort.Strings(names)
 	return names
 }
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -803,7 +803,7 @@ func unsuccessfulContexts(contexts []Context, cc contextChecker, log *logrus.Ent
 		"total_context_count":  len(contexts),
 		"context_names":        contextsToStrings(contexts),
 		"failed_context_count": len(failed),
-		"failed_context_names": contextsToStrings(contexts),
+		"failed_context_names": contextsToStrings(failed),
 	}).Debug("Filtered out failed contexts")
 	return failed
 }
@@ -1524,7 +1524,7 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 			continue
 		}
 		filteredPRs = append(filteredPRs, pr)
-		log.WithField("num_possible_presubmit", len(presubmitsForPull)).Debug("Found possible preseubmits")
+		log.WithField("num_possible_presubmit", len(presubmitsForPull)).Debug("Found possible presubmits")
 
 		for _, ps := range presubmitsForPull {
 			if !ps.ContextRequired() {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/test-infra/issues/27847
  
The `failed_context_names` field incorrectly reports the `context_names` in the log messages. This change is made to report the correct field in the log message.