### PR TITLE
move to grid-gcr-mirror-canary to k8s-infra

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
@@ -15,6 +15,7 @@ presets:
 
 periodics:
 - name: e2e-kops-grid-gcr-mirror-canary
+  cluster: k8s-infra-prow-build
   cron: '11 0-23/1 * * *'
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Move grid-gcr-mirror-canary to the community infrastructure.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>