### PR TITLE
capz: new AKS job, less frequent “full E2E” periodicity

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -176,7 +176,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -205,4 +205,38 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-full-main
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-e2e-aks-main
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: main
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-1.24
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "AKS cluster"
+        - name: GINKGO_SKIP
+          value: ""
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-aks-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
This PR introduces a new `periodic-cluster-api-provider-azure-e2e-aks-main` periodic job against capz @ main.

In addition, while we debug flaky jobs on the `periodic-cluster-api-provider-azure-e2e-full-main` job, we are reducing the periodicity to every 24 hours to economize infra given this net new AKS job.