### PR TITLE
ci: Update COS version for containerd jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1037,7 +1037,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-97-lts
+      - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1069,7 +1069,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-97-lts
+      - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8

--- a/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
@@ -1,5 +1,5 @@
 images:
   cos-stable:
-    image_family: cos-97-lts
+    image_family: cos-stable
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2-serial.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2-serial.yaml
@@ -1,7 +1,6 @@
 images:
   cos-stable:
-    # Using cos-beta to pick up cgroupv2 enabled by default as of cos-beta-97-16919-0-3.
-    image_family: cos-beta
+    image_family: cos-stable
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos-stable:
-    image_family: cos-97-lts
+    image_family: cos-stable
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
@@ -5,7 +5,7 @@ images:
     machine: n1-standard-16  # node performance tests will be skipped on smaller machines
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos-stable:
-    image_family: cos-97-lts
+    image_family: cos-stable
     project: cos-cloud
     machine: n1-standard-16 # node performance tests will be skipped on smaller machines
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
@@ -1,5 +1,5 @@
 images:
   cos-stable:
-    image_family: cos-97-lts
+    image_family: cos-stable
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:
-    image_family: cos-97-lts
+    image_family: cos-stable
     project: cos-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
Bump containerd jobs image family to use cos-stable. cos-stable currently points to COS M101.

I suggest we point image-family to use cos-stable, so we will always use the latest stable version of COS so that the version does not get stale and we don't need to manually update the job config.

Signed-off-by: David Porter <porterdavid@google.com>