### PR TITLE
Fix pull job config for containerd cgroupv2 and cgroupv1 jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1379,6 +1379,8 @@ presubmits:
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=github.com/containerd/containerd=main
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=200
         - --scenario=kubernetes_e2e
         - --
@@ -1421,6 +1423,8 @@ presubmits:
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=github.com/containerd/containerd=main
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=200
         - --scenario=kubernetes_e2e
         - --
@@ -1463,6 +1467,8 @@ presubmits:
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=github.com/containerd/containerd=main
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=260
         - --scenario=kubernetes_e2e
         - --
@@ -1505,6 +1511,8 @@ presubmits:
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=github.com/containerd/containerd=main
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=90
         - --scenario=kubernetes_e2e
         - --
@@ -1548,6 +1556,8 @@ presubmits:
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=github.com/containerd/containerd=main
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=90
         - --scenario=kubernetes_e2e
         - --


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/27853

Copy and paste error before didn't add these flags and as a result we are missing artifacts uploaded for these newly added pull jobs. Add the flags following pattern of the other jobs.

Signed-off-by: David Porter <porterdavid@google.com>