### PR TITLE
Remove `kpromo cip --threads` flag from jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -48,11 +48,6 @@ postsubmits:
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --use-prow-manifest-diff
         - --confirm
-        # TODO: these are *not* threads 🤷‍♂️
-        # https://www.geeksforgeeks.org/golang-goroutine-vs-thread/
-        #
-        # this should probably be a multiple of cores below
-        - --threads=28
         env:
         - name: GOMAXPROCS
           value: "7"
@@ -156,11 +151,6 @@ periodics:
       - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - --confirm
-      # TODO: these are *not* threads 🤷‍♂️
-      # https://www.geeksforgeeks.org/golang-goroutine-vs-thread/
-      #
-      # this should probably be a multiple of cores below
-      - --threads=28
       env:
       - name: GOMAXPROCS
         value: "7"


### PR DESCRIPTION
The flag is not used anywhere so we can remove it.

Refers to https://github.com/kubernetes-sigs/promo-tools/pull/665

cc @kubernetes/release-engineering 