### PR TITLE
update pull-cip-verify job to use go 1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -143,7 +143,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
need for https://github.com/kubernetes-sigs/promo-tools/pull/666

/assign @saschagrunert 