### PR TITLE
Return prow job labels and annotations in tide for Github

### DIFF
--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -418,6 +418,7 @@ func (gi *GitHubProvider) refsForJob(sp subpool, prs []CodeReviewCommon) (prowap
 }
 
 func (gi *GitHubProvider) labelsAndAnnotations(instance string, jobLabels, jobAnnotations map[string]string, changes ...CodeReviewCommon) (labels, annotations map[string]string) {
+	labels, annotations = jobLabels, jobAnnotations
 	return
 }
 


### PR DESCRIPTION
An issue occurs with prowjobs generated by tide not having the correct labels annotations.

This caused an issue in KubeVirt CI as it broke some of the antiaffinity rules due the labels required not being present [1].

This update just returns the job labels and annotations as needed for the github provider.

I think this issue was introduced here - https://github.com/kubernetes/test-infra/pull/27610/commits/96b457527634298cfaa1396302da2954f8319941#diff-c14eb587d77a92863efbdc355f979224da70202b83b8e642f63bc011027cb366R420

[1] https://github.com/kubevirt/project-infra/pull/2416

/cc @cjwagner @chaodaiG 

Signed-off-by: Brian Carey <bcarey@redhat.com>