### PR TITLE
capz: separate self-managed, AKS jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -172,11 +172,11 @@ periodics:
           exit $result
       securityContext:
         privileged: true
-- name: periodic-cluster-api-provider-azure-e2e-full-main
+- name: periodic-cluster-api-provider-azure-e2e-main
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 12h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -198,19 +198,19 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: ""
+          value: \[Managed Kubernetes\]
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-full-main
+    testgrid-tab-name: capz-periodic-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-aks-main
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 1h
+  interval: 12h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -230,7 +230,7 @@ periodics:
         - ./scripts/ci-e2e.sh
       env:
         - name: GINKGO_FOCUS
-          value: "AKS cluster"
+          value: \[Managed Kubernetes\]
         - name: GINKGO_SKIP
           value: ""
       # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1beta1.yaml
@@ -102,7 +102,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-capi-e2e-v1beta1
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-full-v1beta1
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1
   decorate: true
   decoration_config:
     timeout: 4h
@@ -128,13 +128,47 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
+          value: \[Managed Kubernetes\]
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-v1beta1
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.5
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: \[Managed Kubernetes\]
+        - name: GINKGO_SKIP
           value: ""
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-full-v1beta1
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-minus-1
   decorate: true
@@ -170,7 +204,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-minus-1
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-full-v1beta1-minus-1
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-minus-1
   decorate: true
   decoration_config:
     timeout: 4h
@@ -196,11 +230,45 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
+          value: \[Managed Kubernetes\]
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-minus-1
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-minus-1
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.4
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: \[Managed Kubernetes\]
+        - name: GINKGO_SKIP
           value: ""
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-full-v1beta1-minus-1
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-minus-1
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
This PR proposes a new classification of periodic E2E jobs for the capz project:

1. `capz-periodic-e2e-<target branch>` (replaces `capz-periodic-e2e-full-<target branch>`)
2. `capz-periodic-e2e-aks-<target branch>`

The primary justification is that we anticipate a growth of AKS test cluster scenarios, and splitting those scenarios out from the "self-managed" scenarios improves the readability and maintainability of these test jobs in testgrid.

Secondarily, we have observed that the capz E2E implementation has some side-effects when running large number of concurrent ginkgo tests. This allows us to troubleshoot that in the background while preserving the integrity of the underlying test signal.