### PR TITLE
capv: Add verify-gen job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -176,6 +176,25 @@ presubmits:
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Verifies the CRDs have been updated
 
+  - name: pull-cluster-api-provider-vsphere-verify-gen
+    always_run: false
+    run_if_changed: '^((apis|config|contrib|controllers|packaging|pkg|templates)/|Makefile|go\.mod|go\.sum)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-1.24
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify-gen
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-gen
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies generated files are up to date
+
   - name: pull-cluster-api-provider-vsphere-test
     branches:
     # The script this job runs is not in all branches.


### PR DESCRIPTION
This adds a job presubmit job for CAPV which ensures generated files are up to date.

The main thing I want to ensure we verify is **flavors** (following https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1618), however it's probably useful to verify **everything** we generate.

**NOTE:** Does this addition make `pull-cluster-api-provider-vsphere-verify-crds` redundant?

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1682.