### PR TITLE
NO MERGE: break a unit test intentionally

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -3755,7 +3755,7 @@ func TestRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
 			jobSpec: &prowapi.ProwJobSpec{
 				Refs: &prowapi.Refs{Org: "my-default-org", Repo: "my-default-repo"},
 			},
-			expected: &prowapi.RerunAuthConfig{GitHubUsers: []string{"clarketm"}},
+			expected: nil,
 		},
 		{
 			name:     "no refs return wildcard empty string match",


### PR DESCRIPTION
To follow up
https://kubernetes.slack.com/archives/CDECRSC5U/p1667574020181019?thread_ts=1667414271.624479&cid=CDECRSC5U

and make a case for https://github.com/orgs/community/discussions/38290

This PR should be listed in 
https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+is%3Aopen+status%3Afailure
but it does not.

/cc nobody