### PR TITLE
test: gpu: Bump to COS 97 image

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -5,7 +5,7 @@ presets:
   # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
   # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
   - name: KUBE_GCE_NODE_IMAGE
-    value: cos-85-13310-1041-9
+    value: cos-97-16919-189-5
   - name: KUBE_GCE_NODE_PROJECT
     value: cos-cloud
   - name: NODE_ACCELERATORS


### PR DESCRIPTION
COS-85 is very old OS image and is EoL in September 2022 (see https://cloud.google.com/container-optimized-os/docs/release-notes/). Update to the latest stable LTS version of COS.

We see `CRI v1 runtime API is not implemented for endpoint` in all the nodes (kubelet.log)

Fixes: https://github.com/kubernetes/kubernetes/issues/113625

Also see https://github.com/kubernetes/kubernetes/pull/113632

🤞🏾 

Signed-off-by: Davanum Srinivas <davanum@gmail.com>