### PR TITLE
ci: update containerd presubmit job cos image

### DIFF
--- a/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml
@@ -1,5 +1,5 @@
 images:
   cos-stable:
-    image_family: cos-85-lts
+    image_family: cos-stable
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
update containerd presubmit job cos image to cos-stable as referred in #27879

The following error is seen in pull-containerd-node-e2e job. [Ref](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/containerd_containerd/7479/pull-containerd-node-e2e/1588430294585708544#1:build-log.txt%3A1242)
```
CRI v1 runtime API is not implemented for endpoint
```



Signed-off-by: Akhil Mohan <makhil@vmware.com>