### PR TITLE
kops: suppress containerd suffix in test names

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -109,7 +109,7 @@ def build_test(cloud='aws',
         suffix += "-k" + k8s_version.replace("1.", "")
     if kops_version:
         suffix += "-ko" + kops_version.replace("1.", "")
-    if container_runtime:
+    if container_runtime and container_runtime != "containerd":
         suffix += "-" + container_runtime
 
     tab = name_override or (f"kops-grid{suffix}")

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -13137,8 +13137,8 @@ periodics:
     testgrid-tab-name: kops-grid-kopeio-u2204-k23-ko24-docker
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k22-containerd
-  cron: '8 1 * * 1'
+- name: e2e-kops-grid-amzn2-k22
+  cron: '4 19 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13197,11 +13197,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k22-containerd
+    testgrid-tab-name: kops-grid-amzn2-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k22-ko23-containerd
-  cron: '39 13 * * 6'
+- name: e2e-kops-grid-amzn2-k22-ko23
+  cron: '1 0 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13260,11 +13260,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-amzn2-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k22-ko24-containerd
-  cron: '40 2 * * 5'
+- name: e2e-kops-grid-amzn2-k22-ko24
+  cron: '46 3 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13323,11 +13323,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-amzn2-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k23-containerd
-  cron: '47 14 * * 0'
+- name: e2e-kops-grid-amzn2-k23
+  cron: '42 21 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13386,11 +13386,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k23-containerd
+    testgrid-tab-name: kops-grid-amzn2-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k23-ko23-containerd
-  cron: '32 6 * * 1'
+- name: e2e-kops-grid-amzn2-k23-ko23
+  cron: '28 5 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13449,11 +13449,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-amzn2-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k23-ko24-containerd
-  cron: '11 17 * * 4'
+- name: e2e-kops-grid-amzn2-k23-ko24
+  cron: '15 22 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13512,11 +13512,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-amzn2-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k24-containerd
-  cron: '4 1 * * 1'
+- name: e2e-kops-grid-amzn2-k24
+  cron: '5 14 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13575,11 +13575,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k24-containerd
+    testgrid-tab-name: kops-grid-amzn2-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k24-ko24-containerd
-  cron: '48 2 * * 5'
+- name: e2e-kops-grid-amzn2-k24-ko24
+  cron: '7 22 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13638,11 +13638,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-amzn2-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-amzn2-k25-containerd
-  cron: '43 14 * * 2'
+- name: e2e-kops-grid-amzn2-k25
+  cron: '11 16 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13701,11 +13701,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-amzn2-k25-containerd
+    testgrid-tab-name: kops-grid-amzn2-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k22-containerd
-  cron: '33 8 * * 2'
+- name: e2e-kops-grid-deb10-k22
+  cron: '49 18 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13764,11 +13764,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k22-containerd
+    testgrid-tab-name: kops-grid-deb10-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k22-ko23-containerd
-  cron: '29 7 * * 1'
+- name: e2e-kops-grid-deb10-k22-ko23
+  cron: '56 13 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13827,11 +13827,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-deb10-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k22-ko24-containerd
-  cron: '2 0 * * 4'
+- name: e2e-kops-grid-deb10-k22-ko24
+  cron: '59 14 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13890,11 +13890,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-deb10-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k23-containerd
-  cron: '26 7 * * 0'
+- name: e2e-kops-grid-deb10-k23
+  cron: '35 20 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13953,11 +13953,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k23-containerd
+    testgrid-tab-name: kops-grid-deb10-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k23-ko23-containerd
-  cron: '30 4 * * 6'
+- name: e2e-kops-grid-deb10-k23-ko23
+  cron: '17 8 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14016,11 +14016,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-deb10-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k23-ko24-containerd
-  cron: '5 11 * * 2'
+- name: e2e-kops-grid-deb10-k23-ko24
+  cron: '58 19 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14079,11 +14079,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-deb10-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k24-containerd
-  cron: '21 16 * * 4'
+- name: e2e-kops-grid-deb10-k24
+  cron: '24 15 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14142,11 +14142,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k24-containerd
+    testgrid-tab-name: kops-grid-deb10-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k24-ko24-containerd
-  cron: '38 8 * * 3'
+- name: e2e-kops-grid-deb10-k24-ko24
+  cron: '58 3 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14205,11 +14205,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-deb10-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-deb10-k25-containerd
-  cron: '58 15 * * 3'
+- name: e2e-kops-grid-deb10-k25
+  cron: '30 1 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14268,11 +14268,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-deb10-k25-containerd
+    testgrid-tab-name: kops-grid-deb10-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k22-containerd
-  cron: '13 18 * * 6'
+- name: e2e-kops-grid-flatcar-k22
+  cron: '58 1 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14332,11 +14332,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k22-containerd
+    testgrid-tab-name: kops-grid-flatcar-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k22-ko23-containerd
-  cron: '42 18 * * 1'
+- name: e2e-kops-grid-flatcar-k22-ko23
+  cron: '48 14 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14396,11 +14396,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-flatcar-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k22-ko24-containerd
-  cron: '17 21 * * 5'
+- name: e2e-kops-grid-flatcar-k22-ko24
+  cron: '19 5 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14460,11 +14460,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-flatcar-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k23-containerd
-  cron: '26 13 * * 6'
+- name: e2e-kops-grid-flatcar-k23
+  cron: '8 23 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14524,11 +14524,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k23-containerd
+    testgrid-tab-name: kops-grid-flatcar-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k23-ko23-containerd
-  cron: '1 9 * * 1'
+- name: e2e-kops-grid-flatcar-k23-ko23
+  cron: '25 3 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14588,11 +14588,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-flatcar-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k23-ko24-containerd
-  cron: '34 14 * * 0'
+- name: e2e-kops-grid-flatcar-k23-ko24
+  cron: '34 16 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14652,11 +14652,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-flatcar-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k24-containerd
-  cron: '45 2 * * 2'
+- name: e2e-kops-grid-flatcar-k24
+  cron: '35 12 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14716,11 +14716,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k24-containerd
+    testgrid-tab-name: kops-grid-flatcar-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k24-ko24-containerd
-  cron: '13 13 * * 2'
+- name: e2e-kops-grid-flatcar-k24-ko24
+  cron: '46 0 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14780,11 +14780,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-flatcar-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-flatcar-k25-containerd
-  cron: '10 5 * * 2'
+- name: e2e-kops-grid-flatcar-k25
+  cron: '9 18 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14844,11 +14844,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flatcar-k25-containerd
+    testgrid-tab-name: kops-grid-flatcar-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k22-containerd
-  cron: '2 7 * * 4'
+- name: e2e-kops-grid-rhel8-k22
+  cron: '17 22 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14907,11 +14907,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k22-containerd
+    testgrid-tab-name: kops-grid-rhel8-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k22-ko23-containerd
-  cron: '13 23 * * 4'
+- name: e2e-kops-grid-rhel8-k22-ko23
+  cron: '56 9 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14970,11 +14970,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-rhel8-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k22-ko24-containerd
-  cron: '34 8 * * 4'
+- name: e2e-kops-grid-rhel8-k22-ko24
+  cron: '11 2 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15033,11 +15033,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-rhel8-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k23-containerd
-  cron: '21 0 * * 5'
+- name: e2e-kops-grid-rhel8-k23
+  cron: '23 0 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15096,11 +15096,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k23-containerd
+    testgrid-tab-name: kops-grid-rhel8-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k23-ko23-containerd
-  cron: '30 20 * * 3'
+- name: e2e-kops-grid-rhel8-k23-ko23
+  cron: '5 20 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15159,11 +15159,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-rhel8-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k23-ko24-containerd
-  cron: '45 3 * * 3'
+- name: e2e-kops-grid-rhel8-k23-ko24
+  cron: '10 7 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15222,11 +15222,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-rhel8-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k24-containerd
-  cron: '22 15 * * 0'
+- name: e2e-kops-grid-rhel8-k24
+  cron: '12 19 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15285,11 +15285,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k24-containerd
+    testgrid-tab-name: kops-grid-rhel8-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k24-ko24-containerd
-  cron: '14 16 * * 5'
+- name: e2e-kops-grid-rhel8-k24-ko24
+  cron: '2 7 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15348,11 +15348,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-rhel8-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-rhel8-k25-containerd
-  cron: '1 16 * * 0'
+- name: e2e-kops-grid-rhel8-k25
+  cron: '58 5 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15411,11 +15411,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-rhel8-k25-containerd
+    testgrid-tab-name: kops-grid-rhel8-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k22-containerd
-  cron: '4 5 * * *'
+- name: e2e-kops-grid-u2004-k22
+  cron: '47 4 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15474,11 +15474,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-u2004-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k22-ko23-containerd
-  cron: '4 6 * * *'
+- name: e2e-kops-grid-u2004-k22-ko23
+  cron: '54 15 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15537,11 +15537,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-u2004-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k22-ko24-containerd
-  cron: '47 9 * * *'
+- name: e2e-kops-grid-u2004-k22-ko24
+  cron: '37 4 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15600,10 +15600,73 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-u2004-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k23-containerd
+- name: e2e-kops-grid-u2004-k23
+  cron: '49 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-u2004-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+- name: e2e-kops-grid-u2004-k23-ko23
   cron: '19 2 * * *'
   labels:
     preset-service-account: "true"
@@ -15632,69 +15695,6 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=kubenet --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k23-ko23-containerd
-  cron: '23 13 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -15726,11 +15726,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-u2004-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k23-ko24-containerd
-  cron: '56 18 * * *'
+- name: e2e-kops-grid-u2004-k23-ko24
+  cron: '52 1 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15789,11 +15789,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-u2004-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k24-containerd
-  cron: '12 21 * * *'
+- name: e2e-kops-grid-u2004-k24
+  cron: '6 1 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15852,11 +15852,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-u2004-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k24-ko24-containerd
-  cron: '11 17 * * *'
+- name: e2e-kops-grid-u2004-k24-ko24
+  cron: '16 1 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15915,11 +15915,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-u2004-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2004-k25-containerd
-  cron: '47 10 * * *'
+- name: e2e-kops-grid-u2004-k25
+  cron: '40 15 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15978,11 +15978,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-u2004-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k22-containerd
-  cron: '27 22 * * 0'
+- name: e2e-kops-grid-u2204-k22
+  cron: '54 21 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16041,11 +16041,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k22-containerd
+    testgrid-tab-name: kops-grid-u2204-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k22-ko23-containerd
-  cron: '17 23 * * 1'
+- name: e2e-kops-grid-u2204-k22-ko23
+  cron: '37 8 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16104,11 +16104,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-u2204-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k22-ko24-containerd
-  cron: '10 16 * * 4'
+- name: e2e-kops-grid-u2204-k22-ko24
+  cron: '58 11 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16167,11 +16167,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-u2204-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k23-containerd
-  cron: '48 1 * * 3'
+- name: e2e-kops-grid-u2204-k23
+  cron: '0 11 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16230,11 +16230,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k23-containerd
+    testgrid-tab-name: kops-grid-u2204-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k23-ko23-containerd
-  cron: '26 4 * * 2'
+- name: e2e-kops-grid-u2204-k23-ko23
+  cron: '20 5 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16293,11 +16293,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-u2204-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k23-ko24-containerd
-  cron: '49 19 * * 0'
+- name: e2e-kops-grid-u2204-k23-ko24
+  cron: '47 6 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16356,11 +16356,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-u2204-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k24-containerd
-  cron: '23 22 * * 1'
+- name: e2e-kops-grid-u2204-k24
+  cron: '7 16 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16419,11 +16419,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k24-containerd
+    testgrid-tab-name: kops-grid-u2204-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k24-ko24-containerd
-  cron: '50 0 * * 1'
+- name: e2e-kops-grid-u2204-k24-ko24
+  cron: '15 14 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16482,11125 +16482,10 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-u2204-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-u2204-k25-containerd
-  cron: '52 17 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=kubenet --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-u2204-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k22-containerd
-  cron: '44 4 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k22-ko23-containerd
-  cron: '30 8 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k22-ko24-containerd
-  cron: '21 23 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k23-containerd
-  cron: '23 19 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k23-ko23-containerd
-  cron: '1 3 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k23-ko24-containerd
-  cron: '6 20 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k24-containerd
-  cron: '52 4 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k24-ko24-containerd
-  cron: '41 15 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k25-containerd
-  cron: '35 19 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k22-containerd
-  cron: '17 13 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k22-ko23-containerd
-  cron: '28 2 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k22-ko24-containerd
-  cron: '47 5 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k23-containerd
-  cron: '22 2 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k23-ko23-containerd
-  cron: '35 9 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k23-ko24-containerd
-  cron: '4 14 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k24-containerd
-  cron: '49 21 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k24-ko24-containerd
-  cron: '19 13 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k25-containerd
-  cron: '42 18 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k22-containerd
-  cron: '14 13 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k22-ko23-containerd
-  cron: '57 8 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k22-ko24-containerd
-  cron: '54 15 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k23-containerd
-  cron: '57 18 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k23-ko23-containerd
-  cron: '26 19 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k23-ko24-containerd
-  cron: '21 12 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k24-containerd
-  cron: '58 13 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k24-ko24-containerd
-  cron: '26 7 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k25-containerd
-  cron: '13 10 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k22-containerd
-  cron: '38 18 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k22-ko23-containerd
-  cron: '16 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k22-ko24-containerd
-  cron: '19 21 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k23-containerd
-  cron: '53 21 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k23-ko23-containerd
-  cron: '7 17 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k23-ko24-containerd
-  cron: '16 22 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k24-containerd
-  cron: '26 10 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k24-ko24-containerd
-  cron: '31 5 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k25-containerd
-  cron: '41 5 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k22-containerd
-  cron: '28 16 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k22-ko23-containerd
-  cron: '25 3 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k22-ko24-containerd
-  cron: '34 12 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k23-containerd
-  cron: '3 23 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k23-ko23-containerd
-  cron: '14 8 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k23-ko24-containerd
-  cron: '37 7 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k24-containerd
-  cron: '12 8 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k24-ko24-containerd
-  cron: '10 4 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k25-containerd
-  cron: '31 23 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k22-containerd
-  cron: '11 11 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k22-ko23-containerd
-  cron: '28 10 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k22-ko24-containerd
-  cron: '3 13 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k23-containerd
-  cron: '24 12 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k23-ko23-containerd
-  cron: '27 17 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k23-ko24-containerd
-  cron: '12 22 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k24-containerd
-  cron: '27 19 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k24-ko24-containerd
-  cron: '31 13 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k25-containerd
-  cron: '36 12 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k22-containerd
-  cron: '6 22 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k22-ko23-containerd
-  cron: '6 12 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k22-ko24-containerd
-  cron: '25 3 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k23-containerd
-  cron: '29 17 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k23-ko23-containerd
-  cron: '1 23 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k23-ko24-containerd
-  cron: '54 8 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k24-containerd
-  cron: '26 22 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k24-ko24-containerd
-  cron: '49 19 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k25-containerd
-  cron: '13 9 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k22-containerd
-  cron: '31 7 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k22-ko23-containerd
-  cron: '32 22 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k22-ko24-containerd
-  cron: '35 1 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k23-containerd
-  cron: '56 0 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k23-ko23-containerd
-  cron: '43 21 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k23-ko24-containerd
-  cron: '40 18 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k24-containerd
-  cron: '15 15 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k24-ko24-containerd
-  cron: '15 9 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k25-containerd
-  cron: '48 8 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k22-containerd
-  cron: '29 18 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k22-ko23-containerd
-  cron: '22 3 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k22-ko24-containerd
-  cron: '37 12 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k23-containerd
-  cron: '46 5 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k23-ko23-containerd
-  cron: '45 0 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k23-ko24-containerd
-  cron: '14 23 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k24-containerd
-  cron: '29 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k24-ko24-containerd
-  cron: '17 4 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k25-containerd
-  cron: '46 21 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k22-containerd
-  cron: '12 0 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k22-ko23-containerd
-  cron: '8 22 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k22-ko24-containerd
-  cron: '11 1 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k23-containerd
-  cron: '51 15 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k23-ko23-containerd
-  cron: '31 5 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k23-ko24-containerd
-  cron: '32 10 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k24-containerd
-  cron: '44 8 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k24-ko24-containerd
-  cron: '3 1 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k25-containerd
-  cron: '39 23 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k22-containerd
-  cron: '2 10 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k22-ko23-containerd
-  cron: '25 23 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k22-ko24-containerd
-  cron: '22 16 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k23-containerd
-  cron: '17 21 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k23-ko23-containerd
-  cron: '2 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k23-ko24-containerd
-  cron: '57 3 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k24-containerd
-  cron: '54 2 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k24-ko24-containerd
-  cron: '54 0 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k25-containerd
-  cron: '21 13 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k22-containerd
-  cron: '41 9 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k22-ko24-containerd
-  cron: '19 17 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k23-containerd
-  cron: '10 6 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k23-ko24-containerd
-  cron: '24 2 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k24-containerd
-  cron: '17 17 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k24-ko24-containerd
-  cron: '43 9 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k25-containerd
-  cron: '18 14 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k22-containerd
-  cron: '4 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko23-containerd
-  cron: '58 20 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko24-containerd
-  cron: '57 19 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k23-containerd
-  cron: '3 21 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k23-ko23-containerd
-  cron: '17 23 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k23-ko24-containerd
-  cron: '18 16 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k24-containerd
-  cron: '20 18 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k24-ko24-containerd
-  cron: '17 19 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k25-containerd
-  cron: '11 5 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k22-containerd
-  cron: '17 3 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k22-ko23-containerd
-  cron: '44 14 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k22-ko24-containerd
-  cron: '39 9 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k23-containerd
-  cron: '54 12 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k23-ko23-containerd
-  cron: '47 5 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k23-ko24-containerd
-  cron: '8 10 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k24-containerd
-  cron: '37 11 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k24-ko24-containerd
-  cron: '11 1 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k25-containerd
-  cron: '34 4 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k22-containerd
-  cron: '57 12 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k22-ko23-containerd
-  cron: '56 5 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k22-ko24-containerd
-  cron: '35 2 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k23-containerd
-  cron: '38 11 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k23-ko23-containerd
-  cron: '51 14 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k23-ko24-containerd
-  cron: '4 9 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k24-containerd
-  cron: '33 20 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k24-ko24-containerd
-  cron: '15 18 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k25-containerd
-  cron: '26 19 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k22-containerd
-  cron: '58 20 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko23-containerd
-  cron: '24 6 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko24-containerd
-  cron: '43 17 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k23-containerd
-  cron: '41 11 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k23-ko23-containerd
-  cron: '51 21 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k23-ko24-containerd
-  cron: '28 10 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k24-containerd
-  cron: '26 12 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k24-ko24-containerd
-  cron: '7 17 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k25-containerd
-  cron: '37 3 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k22-containerd
-  cron: '0 22 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k22-ko23-containerd
-  cron: '13 7 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k22-ko24-containerd
-  cron: '42 16 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k23-containerd
-  cron: '15 9 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k23-ko23-containerd
-  cron: '14 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k23-ko24-containerd
-  cron: '9 11 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k24-containerd
-  cron: '0 6 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k24-ko24-containerd
-  cron: '18 16 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k25-containerd
-  cron: '3 9 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k22-containerd
-  cron: '19 21 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k22-ko23-containerd
-  cron: '12 22 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k22-ko24-containerd
-  cron: '31 17 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k23-containerd
-  cron: '44 2 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k23-ko23-containerd
-  cron: '51 13 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k23-ko24-containerd
-  cron: '8 2 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k24-containerd
-  cron: '59 21 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k24-ko24-containerd
-  cron: '59 9 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k25-containerd
-  cron: '24 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k22-containerd
-  cron: '12 15 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k22-ko23-containerd
-  cron: '13 19 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k22-ko24-containerd
-  cron: '14 4 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k23-containerd
-  cron: '11 16 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k23-ko23-containerd
-  cron: '22 8 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k23-ko24-containerd
-  cron: '49 7 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k24-containerd
-  cron: '4 7 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k24-ko24-containerd
-  cron: '10 12 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.24.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.24'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k24-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k25-containerd
-  cron: '55 0 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.25.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/k8s_version: '1.25'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k25-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k22-containerd
-  cron: '33 22 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k22-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k22-ko23-containerd
-  cron: '43 17 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k22-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k22-ko24-containerd
-  cron: '32 22 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.22.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.22'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k22-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k23-containerd
-  cron: '14 1 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k23-ko23-containerd
-  cron: '36 10 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.23'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k23-ko23-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k23-ko24-containerd
-  cron: '35 5 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable-1.23.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/k8s_version: '1.23'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.24'
-    test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k23-ko24-containerd
-
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k24-containerd
+- name: e2e-kops-grid-u2204-k25
   cron: '45 14 * * 3'
   labels:
     preset-service-account: "true"
@@ -27628,6 +16513,11121 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-u2204-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k22
+  cron: '0 14 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k22-ko23
+  cron: '39 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k22-ko24
+  cron: '56 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k23
+  cron: '46 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k23-ko23
+  cron: '34 1 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k23-ko24
+  cron: '45 10 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k24
+  cron: '49 11 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k24-ko24
+  cron: '5 10 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k25
+  cron: '31 5 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-amzn2-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k22
+  cron: '9 7 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k22-ko23
+  cron: '50 1 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k22-ko24
+  cron: '29 18 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k23
+  cron: '3 17 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k23-ko23
+  cron: '55 20 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k23-ko24
+  cron: '32 23 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k24
+  cron: '4 2 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k24-ko24
+  cron: '12 23 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k25
+  cron: '30 20 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb10-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k22
+  cron: '18 4 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k22-ko23
+  cron: '22 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k22-ko24
+  cron: '57 13 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k23
+  cron: '20 10 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k23-ko23
+  cron: '7 19 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k23-ko24
+  cron: '56 8 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k24
+  cron: '19 17 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k24-ko24
+  cron: '12 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k25
+  cron: '45 7 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k22
+  cron: '13 3 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k22-ko23
+  cron: '2 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k22-ko24
+  cron: '25 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k23
+  cron: '47 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k23-ko23
+  cron: '31 8 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k23-ko24
+  cron: '48 11 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k24
+  cron: '48 14 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k24-ko24
+  cron: '16 19 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k25
+  cron: '34 16 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k22
+  cron: '43 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k22-ko23
+  cron: '48 11 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k22-ko24
+  cron: '3 16 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k23
+  cron: '5 15 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k23-ko23
+  cron: '25 14 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k23-ko24
+  cron: '54 13 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k24
+  cron: '2 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k24-ko24
+  cron: '46 13 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k25
+  cron: '0 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k22
+  cron: '26 16 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k22-ko23
+  cron: '39 20 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k22-ko24
+  cron: '36 7 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k23
+  cron: '48 6 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k23-ko23
+  cron: '22 9 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k23-ko24
+  cron: '37 2 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k24
+  cron: '43 13 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k24-ko24
+  cron: '49 2 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k25
+  cron: '25 3 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k22
+  cron: '14 12 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k22-ko23
+  cron: '31 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k22-ko24
+  cron: '24 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k23
+  cron: '28 18 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k23-ko23
+  cron: '6 21 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k23-ko24
+  cron: '25 14 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k24
+  cron: '59 1 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k24-ko24
+  cron: '1 22 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k25
+  cron: '41 23 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-amzn2-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k22
+  cron: '15 13 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k22-ko23
+  cron: '58 5 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k22-ko24
+  cron: '37 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k23
+  cron: '17 19 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k23-ko23
+  cron: '23 0 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k23-ko24
+  cron: '16 19 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k24
+  cron: '22 8 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k24-ko24
+  cron: '48 19 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k25
+  cron: '8 14 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb10-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k22
+  cron: '53 19 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k22-ko23
+  cron: '36 20 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k22-ko24
+  cron: '35 23 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k23
+  cron: '43 21 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k23-ko23
+  cron: '41 9 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k23-ko24
+  cron: '26 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k24
+  cron: '24 14 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k24-ko24
+  cron: '38 10 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k25
+  cron: '22 8 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k22
+  cron: '11 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k22-ko23
+  cron: '26 9 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k22-ko24
+  cron: '29 10 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k23
+  cron: '53 23 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k23-ko23
+  cron: '31 12 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k23-ko24
+  cron: '52 7 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k24
+  cron: '58 12 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k24-ko24
+  cron: '8 7 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k25
+  cron: '4 2 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k22
+  cron: '25 11 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k22-ko23
+  cron: '56 15 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k22-ko24
+  cron: '27 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k23
+  cron: '31 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k23-ko23
+  cron: '9 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k23-ko24
+  cron: '6 9 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k24
+  cron: '48 6 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k24-ko24
+  cron: '54 1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k25
+  cron: '18 8 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k22
+  cron: '40 18 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k22-ko24
+  cron: '44 11 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k23
+  cron: '38 20 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k23-ko24
+  cron: '53 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k24
+  cron: '5 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k24-ko24
+  cron: '1 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k25
+  cron: '11 1 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k22
+  cron: '16 3 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko23
+  cron: '58 3 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko24
+  cron: '5 0 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k23
+  cron: '26 13 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k23-ko23
+  cron: '43 22 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k23-ko24
+  cron: '48 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k24
+  cron: '53 14 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k24-ko24
+  cron: '56 21 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-amzn2-k25
+  cron: '47 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k22
+  cron: '37 18 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k22-ko23
+  cron: '7 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k22-ko24
+  cron: '48 5 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k23
+  cron: '55 4 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k23-ko23
+  cron: '38 19 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k23-ko24
+  cron: '29 0 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k24
+  cron: '48 23 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k24-ko24
+  cron: '29 0 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb10-k25
+  cron: '42 9 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k22
+  cron: '0 8 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k22-ko23
+  cron: '54 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k22-ko24
+  cron: '29 2 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k23
+  cron: '58 6 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k23-ko23
+  cron: '35 4 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k23-ko24
+  cron: '32 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k24
+  cron: '33 21 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k24-ko24
+  cron: '44 15 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k25
+  cron: '27 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-3374.1.1-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k22
+  cron: '21 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko23
+  cron: '3 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko24
+  cron: '8 1 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k23
+  cron: '15 0 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k23-ko23
+  cron: '6 23 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k23-ko24
+  cron: '25 4 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k24
+  cron: '8 19 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k24-ko24
+  cron: '33 20 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k25
+  cron: '26 5 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k22
+  cron: '55 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k22-ko23
+  cron: '37 12 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k22-ko24
+  cron: '50 7 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k23
+  cron: '1 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k23-ko23
+  cron: '28 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k23-ko24
+  cron: '43 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k24
+  cron: '22 1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k24-ko24
+  cron: '19 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k25
+  cron: '44 23 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k22
+  cron: '38 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k22-ko23
+  cron: '26 19 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k22-ko24
+  cron: '13 8 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k23
+  cron: '20 3 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k23-ko23
+  cron: '27 22 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k23-ko24
+  cron: '8 5 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k24
+  cron: '43 8 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k24-ko24
+  cron: '44 21 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k25
+  cron: '57 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221101.1' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k22
+  cron: '51 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k22-ko23
+  cron: '31 4 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k22-ko24
+  cron: '0 7 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k23
+  cron: '41 15 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k23-ko23
+  cron: '2 17 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k23-ko24
+  cron: '53 2 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k24
+  cron: '2 20 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k24-ko24
+  cron: '57 18 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.24.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.24'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k24-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k25
+  cron: '28 2 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20221004.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.25.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.25'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-amzn2-k25
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k22
+  cron: '18 16 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-deb10-k22
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k22-ko23
+  cron: '30 17 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-deb10-k22-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k22-ko24
+  cron: '33 10 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-deb10-k22-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k23
+  cron: '20 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-deb10-k23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k23-ko23
+  cron: '39 20 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.23'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-deb10-k23-ko23
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k23-ko24
+  cron: '16 7 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.23.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.23'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.24'
+    test.kops.k8s.io/networking: flannel
+    testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-flannel-deb10-k23-ko24
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k24
+  cron: '19 21 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
           --create-args="--image='136693071363/debian-10-amd64-20220911-1135' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
@@ -27660,11 +27660,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k24-containerd
+    testgrid-tab-name: kops-grid-flannel-deb10-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k24-ko24-containerd
-  cron: '28 22 * * 1'
+- name: e2e-kops-grid-flannel-deb10-k24-ko24
+  cron: '4 7 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -27723,11 +27723,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-deb10-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k25-containerd
-  cron: '6 9 * * 2'
+- name: e2e-kops-grid-flannel-deb10-k25
+  cron: '25 3 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -27786,11 +27786,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k25-containerd
+    testgrid-tab-name: kops-grid-flannel-deb10-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k22-containerd
-  cron: '5 13 * * 0'
+- name: e2e-kops-grid-flannel-flatcar-k22
+  cron: '35 3 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -27850,11 +27850,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k22-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k22-ko23-containerd
-  cron: '43 2 * * 0'
+- name: e2e-kops-grid-flannel-flatcar-k22-ko23
+  cron: '51 16 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -27914,11 +27914,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k22-ko24-containerd
-  cron: '4 5 * * 0'
+- name: e2e-kops-grid-flannel-flatcar-k22-ko24
+  cron: '48 3 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -27978,11 +27978,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k23-containerd
-  cron: '46 18 * * 3'
+- name: e2e-kops-grid-flannel-flatcar-k23
+  cron: '21 5 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28042,11 +28042,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k23-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k23-ko23-containerd
-  cron: '48 9 * * 3'
+- name: e2e-kops-grid-flannel-flatcar-k23-ko23
+  cron: '54 21 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28106,11 +28106,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k23-ko24-containerd
-  cron: '27 22 * * 6'
+- name: e2e-kops-grid-flannel-flatcar-k23-ko24
+  cron: '17 6 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28170,11 +28170,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k24-containerd
-  cron: '25 21 * * 3'
+- name: e2e-kops-grid-flannel-flatcar-k24
+  cron: '50 6 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28234,11 +28234,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k24-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k24-ko24-containerd
-  cron: '52 13 * * 0'
+- name: e2e-kops-grid-flannel-flatcar-k24-ko24
+  cron: '53 14 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28298,11 +28298,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-flatcar, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k25-containerd
-  cron: '26 18 * * 2'
+- name: e2e-kops-grid-flannel-flatcar-k25
+  cron: '8 16 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28362,11 +28362,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-flatcar-k25-containerd
+    testgrid-tab-name: kops-grid-flannel-flatcar-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k22-containerd
-  cron: '18 17 * * 1'
+- name: e2e-kops-grid-flannel-rhel8-k22
+  cron: '42 12 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28425,11 +28425,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k22-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k22-ko23-containerd
-  cron: '3 17 * * 4'
+- name: e2e-kops-grid-flannel-rhel8-k22-ko23
+  cron: '34 5 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28488,11 +28488,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k22-ko24-containerd
-  cron: '12 6 * * 3'
+- name: e2e-kops-grid-flannel-rhel8-k22-ko24
+  cron: '1 14 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28551,11 +28551,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k23-containerd
-  cron: '33 14 * * 2'
+- name: e2e-kops-grid-flannel-rhel8-k23
+  cron: '8 10 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28614,11 +28614,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k23-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k23-ko23-containerd
-  cron: '32 10 * * 1'
+- name: e2e-kops-grid-flannel-rhel8-k23-ko23
+  cron: '27 8 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28677,11 +28677,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k23-ko24-containerd
-  cron: '47 5 * * 6'
+- name: e2e-kops-grid-flannel-rhel8-k23-ko24
+  cron: '16 11 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28740,11 +28740,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k24-containerd
-  cron: '42 1 * * 6'
+- name: e2e-kops-grid-flannel-rhel8-k24
+  cron: '7 17 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28803,11 +28803,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k24-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k24-ko24-containerd
-  cron: '52 6 * * 5'
+- name: e2e-kops-grid-flannel-rhel8-k24-ko24
+  cron: '32 3 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28866,11 +28866,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k25-containerd
-  cron: '53 22 * * 5'
+- name: e2e-kops-grid-flannel-rhel8-k25
+  cron: '49 23 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28929,11 +28929,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-rhel8-k25-containerd
+    testgrid-tab-name: kops-grid-flannel-rhel8-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k22-containerd
-  cron: '12 3 * * *'
+- name: e2e-kops-grid-flannel-u2004-k22
+  cron: '48 22 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -28992,11 +28992,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k22-ko23-containerd
-  cron: '6 0 * * *'
+- name: e2e-kops-grid-flannel-u2004-k22-ko23
+  cron: '48 19 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29055,11 +29055,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k22-ko24-containerd
-  cron: '33 15 * * *'
+- name: e2e-kops-grid-flannel-u2004-k22-ko24
+  cron: '35 8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29118,11 +29118,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k23-containerd
-  cron: '55 12 * * *'
+- name: e2e-kops-grid-flannel-u2004-k23
+  cron: '58 0 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29181,11 +29181,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k23-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k23-ko23-containerd
-  cron: '1 19 * * *'
+- name: e2e-kops-grid-flannel-u2004-k23-ko23
+  cron: '45 22 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29244,11 +29244,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k23-ko24-containerd
-  cron: '30 12 * * *'
+- name: e2e-kops-grid-flannel-u2004-k23-ko24
+  cron: '18 5 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29307,11 +29307,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k24-containerd
-  cron: '24 3 * * *'
+- name: e2e-kops-grid-flannel-u2004-k24
+  cron: '9 19 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29370,11 +29370,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k24-ko24-containerd
-  cron: '17 23 * * *'
+- name: e2e-kops-grid-flannel-u2004-k24-ko24
+  cron: '6 5 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29433,11 +29433,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k25-containerd
-  cron: '3 12 * * *'
+- name: e2e-kops-grid-flannel-u2004-k25
+  cron: '23 21 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29496,11 +29496,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-flannel-u2004-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k22-containerd
-  cron: '35 0 * * 0'
+- name: e2e-kops-grid-flannel-u2204-k22
+  cron: '33 23 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29559,11 +29559,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k22-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k22-ko23-containerd
-  cron: '3 1 * * 1'
+- name: e2e-kops-grid-flannel-u2204-k22-ko23
+  cron: '15 4 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29622,11 +29622,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k22-ko24-containerd
-  cron: '48 6 * * 0'
+- name: e2e-kops-grid-flannel-u2204-k22-ko24
+  cron: '36 15 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29685,11 +29685,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k23-containerd
-  cron: '24 7 * * 5'
+- name: e2e-kops-grid-flannel-u2204-k23
+  cron: '47 9 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29748,11 +29748,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k23-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k23-ko23-containerd
-  cron: '20 18 * * 4'
+- name: e2e-kops-grid-flannel-u2204-k23-ko23
+  cron: '18 9 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29811,11 +29811,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k23-ko24-containerd
-  cron: '39 5 * * 3'
+- name: e2e-kops-grid-flannel-u2204-k23-ko24
+  cron: '33 18 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29874,11 +29874,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k24-containerd
-  cron: '19 0 * * 5'
+- name: e2e-kops-grid-flannel-u2204-k24
+  cron: '12 18 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -29937,11 +29937,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k24-ko24-containerd
-  cron: '16 14 * * 6'
+- name: e2e-kops-grid-flannel-u2204-k24-ko24
+  cron: '57 18 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30000,11 +30000,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2204-k25-containerd
-  cron: '52 7 * * 5'
+- name: e2e-kops-grid-flannel-u2204-k25
+  cron: '14 4 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30063,11 +30063,11 @@ periodics:
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-u2204-k25-containerd
+    testgrid-tab-name: kops-grid-flannel-u2204-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k22-containerd
-  cron: '47 15 * * 1'
+- name: e2e-kops-grid-kopeio-amzn2-k22
+  cron: '49 7 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30126,11 +30126,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k22-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k22-ko23-containerd
-  cron: '46 8 * * 3'
+- name: e2e-kops-grid-kopeio-amzn2-k22-ko23
+  cron: '0 3 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30189,11 +30189,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k22-ko24-containerd
-  cron: '49 15 * * 2'
+- name: e2e-kops-grid-kopeio-amzn2-k22-ko24
+  cron: '7 16 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30252,11 +30252,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k23-containerd
-  cron: '44 16 * * 6'
+- name: e2e-kops-grid-kopeio-amzn2-k23
+  cron: '55 17 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30315,11 +30315,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k23-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k23-ko23-containerd
-  cron: '41 11 * * 5'
+- name: e2e-kops-grid-kopeio-amzn2-k23-ko23
+  cron: '21 6 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30378,11 +30378,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k23-ko24-containerd
-  cron: '18 4 * * 3'
+- name: e2e-kops-grid-kopeio-amzn2-k23-ko24
+  cron: '34 13 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30441,11 +30441,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k24-containerd
-  cron: '59 7 * * 6'
+- name: e2e-kops-grid-kopeio-amzn2-k24
+  cron: '32 2 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30504,11 +30504,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k24-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k24-ko24-containerd
-  cron: '21 23 * * 0'
+- name: e2e-kops-grid-kopeio-amzn2-k24-ko24
+  cron: '50 5 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30567,11 +30567,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-amzn2, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k25-containerd
-  cron: '56 8 * * 0'
+- name: e2e-kops-grid-kopeio-amzn2-k25
+  cron: '10 12 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30630,11 +30630,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k25-containerd
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k22-containerd
-  cron: '50 14 * * 1'
+- name: e2e-kops-grid-kopeio-deb10-k22
+  cron: '36 14 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30693,11 +30693,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k22-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k22-ko23-containerd
-  cron: '20 10 * * 4'
+- name: e2e-kops-grid-kopeio-deb10-k22-ko23
+  cron: '9 6 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30756,11 +30756,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k22-ko24-containerd
-  cron: '47 5 * * 4'
+- name: e2e-kops-grid-kopeio-deb10-k22-ko24
+  cron: '58 21 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30819,11 +30819,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k23-containerd
-  cron: '29 1 * * 4'
+- name: e2e-kops-grid-kopeio-deb10-k23
+  cron: '42 0 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30882,11 +30882,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k23-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k23-ko23-containerd
-  cron: '31 1 * * 5'
+- name: e2e-kops-grid-kopeio-deb10-k23-ko23
+  cron: '20 3 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30945,11 +30945,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k23-ko24-containerd
-  cron: '52 6 * * 4'
+- name: e2e-kops-grid-kopeio-deb10-k23-ko24
+  cron: '11 8 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31008,11 +31008,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k24-containerd
-  cron: '18 6 * * 5'
+- name: e2e-kops-grid-kopeio-deb10-k24
+  cron: '17 3 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31071,11 +31071,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k24-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k24-ko24-containerd
-  cron: '15 5 * * 6'
+- name: e2e-kops-grid-kopeio-deb10-k24-ko24
+  cron: '3 0 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31134,11 +31134,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-deb10, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k25-containerd
-  cron: '57 17 * * 1'
+- name: e2e-kops-grid-kopeio-deb10-k25
+  cron: '3 5 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31197,11 +31197,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k25-containerd
+    testgrid-tab-name: kops-grid-kopeio-deb10-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k22-containerd
-  cron: '1 9 * * 0'
+- name: e2e-kops-grid-kopeio-rhel8-k22
+  cron: '40 10 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31260,11 +31260,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k22-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k22-ko23-containerd
-  cron: '0 10 * * 4'
+- name: e2e-kops-grid-kopeio-rhel8-k22-ko23
+  cron: '41 10 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31323,11 +31323,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k22-ko24-containerd
-  cron: '23 21 * * 6'
+- name: e2e-kops-grid-kopeio-rhel8-k22-ko24
+  cron: '50 17 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31386,11 +31386,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k23-containerd
-  cron: '6 22 * * 4'
+- name: e2e-kops-grid-kopeio-rhel8-k23
+  cron: '26 12 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31449,11 +31449,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k23-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k23-ko23-containerd
-  cron: '23 1 * * 1'
+- name: e2e-kops-grid-kopeio-rhel8-k23-ko23
+  cron: '52 23 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31512,11 +31512,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k23-ko24-containerd
-  cron: '44 22 * * 1'
+- name: e2e-kops-grid-kopeio-rhel8-k23-ko24
+  cron: '15 4 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31575,11 +31575,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k24-containerd
-  cron: '37 9 * * 4'
+- name: e2e-kops-grid-kopeio-rhel8-k24
+  cron: '1 15 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31638,11 +31638,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k24-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k24-ko24-containerd
-  cron: '3 13 * * 4'
+- name: e2e-kops-grid-kopeio-rhel8-k24-ko24
+  cron: '15 4 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31701,11 +31701,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-rhel8, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k25-containerd
-  cron: '46 14 * * 6'
+- name: e2e-kops-grid-kopeio-rhel8-k25
+  cron: '7 1 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31764,11 +31764,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k25-containerd
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k22-containerd
-  cron: '55 19 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k22
+  cron: '10 16 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31827,11 +31827,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k22-ko23-containerd
-  cron: '53 11 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k22-ko23
+  cron: '3 4 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31890,11 +31890,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k22-ko24-containerd
-  cron: '34 12 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k22-ko24
+  cron: '24 15 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -31953,11 +31953,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k23-containerd
-  cron: '4 20 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k23
+  cron: '44 6 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32016,11 +32016,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k23-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k23-ko23-containerd
-  cron: '58 8 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k23-ko23
+  cron: '46 17 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32079,11 +32079,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k23-ko24-containerd
-  cron: '41 23 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k23-ko24
+  cron: '45 10 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32142,11 +32142,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k24-containerd
-  cron: '59 11 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k24
+  cron: '19 13 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32205,11 +32205,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k24-ko24-containerd
-  cron: '46 20 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k24-ko24
+  cron: '17 10 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32268,11 +32268,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2004, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k25-containerd
-  cron: '40 4 * * *'
+- name: e2e-kops-grid-kopeio-u2004-k25
+  cron: '21 19 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32331,11 +32331,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2004-k25
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k22-containerd
-  cron: '0 8 * * 1'
+- name: e2e-kops-grid-kopeio-u2204-k22
+  cron: '43 1 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32394,11 +32394,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k22-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k22
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k22-ko23-containerd
-  cron: '40 2 * * 6'
+- name: e2e-kops-grid-kopeio-u2204-k22-ko23
+  cron: '40 11 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32457,11 +32457,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k22-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k22-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k22-ko24-containerd
-  cron: '19 5 * * 1'
+- name: e2e-kops-grid-kopeio-u2204-k22-ko24
+  cron: '11 8 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32520,11 +32520,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k22-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k22-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k23-containerd
-  cron: '15 23 * * 4'
+- name: e2e-kops-grid-kopeio-u2204-k23
+  cron: '21 23 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32583,11 +32583,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k23-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k23-ko23-containerd
-  cron: '55 1 * * 4'
+- name: e2e-kops-grid-kopeio-u2204-k23-ko23
+  cron: '45 22 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32646,11 +32646,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.23, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k23-ko23-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k23-ko23
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k23-ko24-containerd
-  cron: '52 14 * * 2'
+- name: e2e-kops-grid-kopeio-u2204-k23-ko24
+  cron: '50 5 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32709,11 +32709,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.23, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k23-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k23-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k24-containerd
-  cron: '56 16 * * 4'
+- name: e2e-kops-grid-kopeio-u2204-k24
+  cron: '2 20 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32772,11 +32772,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.24", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k24-ko24-containerd
-  cron: '11 13 * * 6'
+- name: e2e-kops-grid-kopeio-u2204-k24-ko24
+  cron: '10 13 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32835,11 +32835,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.24, kops-distro-u2204, kops-grid, kops-k8s-1.24, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k24-ko24-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k24-ko24
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k25-containerd
-  cron: '3 23 * * 4'
+- name: e2e-kops-grid-kopeio-u2204-k25
+  cron: '8 18 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32898,11 +32898,11 @@ periodics:
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k25-containerd
+    testgrid-tab-name: kops-grid-kopeio-u2204-k25
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-gce-u2004-k22-containerd
-  cron: '49 6-23/8 * * *'
+- name: e2e-kops-grid-gce-u2004-k22
+  cron: '39 3-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -32961,11 +32961,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-gce-u2004-k22
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-gce-u2004-k23-containerd
-  cron: '2 1-23/8 * * *'
+- name: e2e-kops-grid-gce-u2004-k23
+  cron: '53 5-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33024,11 +33024,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-u2004-k23-containerd
+    testgrid-tab-name: kops-grid-gce-u2004-k23
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-gce-u2004-k24-containerd
-  cron: '5 6-23/8 * * *'
+- name: e2e-kops-grid-gce-u2004-k24
+  cron: '58 6-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33087,11 +33087,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-gce-u2004-k24
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-grid-gce-u2004-k25-containerd
-  cron: '38 1-23/8 * * *'
+- name: e2e-kops-grid-gce-u2004-k25
+  cron: '8 0-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33150,11 +33150,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-gce-u2004-k25
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-gce-calico-u2004-k22-containerd
-  cron: '41 1-23/8 * * *'
+- name: e2e-kops-grid-gce-calico-u2004-k22
+  cron: '6 3-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33213,11 +33213,11 @@ periodics:
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-calico-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-gce-calico-u2004-k22
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-gce-calico-u2004-k23-containerd
-  cron: '50 6-23/8 * * *'
+- name: e2e-kops-grid-gce-calico-u2004-k23
+  cron: '0 5-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33276,11 +33276,11 @@ periodics:
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-calico-u2004-k23-containerd
+    testgrid-tab-name: kops-grid-gce-calico-u2004-k23
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-gce-calico-u2004-k24-containerd
-  cron: '9 1-23/8 * * *'
+- name: e2e-kops-grid-gce-calico-u2004-k24
+  cron: '3 6-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33339,11 +33339,11 @@ periodics:
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-calico-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-gce-calico-u2004-k24
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-gce-calico-u2004-k25-containerd
-  cron: '50 6-23/8 * * *'
+- name: e2e-kops-grid-gce-calico-u2004-k25
+  cron: '41 0-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33402,11 +33402,11 @@ periodics:
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-calico-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-gce-calico-u2004-k25
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-gce-cilium-u2004-k22-containerd
-  cron: '15 3-23/8 * * *'
+- name: e2e-kops-grid-gce-cilium-u2004-k22
+  cron: '28 1-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33465,11 +33465,11 @@ periodics:
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-cilium-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-gce-cilium-u2004-k22
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-gce-cilium-u2004-k23-containerd
-  cron: '4 4-23/8 * * *'
+- name: e2e-kops-grid-gce-cilium-u2004-k23
+  cron: '46 7-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33528,11 +33528,11 @@ periodics:
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-cilium-u2004-k23-containerd
+    testgrid-tab-name: kops-grid-gce-cilium-u2004-k23
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-gce-cilium-u2004-k24-containerd
-  cron: '23 3-23/8 * * *'
+- name: e2e-kops-grid-gce-cilium-u2004-k24
+  cron: '25 4-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33591,11 +33591,11 @@ periodics:
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-cilium-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-gce-cilium-u2004-k24
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-gce-cilium-u2004-k25-containerd
-  cron: '8 4-23/8 * * *'
+- name: e2e-kops-grid-gce-cilium-u2004-k25
+  cron: '31 2-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33654,11 +33654,11 @@ periodics:
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-cilium-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-gce-cilium-u2004-k25
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "gce"}
-- name: e2e-kops-grid-gce-gce-u2004-k22-containerd
-  cron: '54 5-23/8 * * *'
+- name: e2e-kops-grid-gce-gce-u2004-k22
+  cron: '49 3-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33717,11 +33717,11 @@ periodics:
     test.kops.k8s.io/networking: gce
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-gce-u2004-k22-containerd
+    testgrid-tab-name: kops-grid-gce-gce-u2004-k22
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "gce"}
-- name: e2e-kops-grid-gce-gce-u2004-k23-containerd
-  cron: '57 2-23/8 * * *'
+- name: e2e-kops-grid-gce-gce-u2004-k23
+  cron: '31 5-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33780,11 +33780,11 @@ periodics:
     test.kops.k8s.io/networking: gce
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.23, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-gce-u2004-k23-containerd
+    testgrid-tab-name: kops-grid-gce-gce-u2004-k23
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "gce"}
-- name: e2e-kops-grid-gce-gce-u2004-k24-containerd
-  cron: '42 5-23/8 * * *'
+- name: e2e-kops-grid-gce-gce-u2004-k24
+  cron: '36 6-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33843,11 +33843,11 @@ periodics:
     test.kops.k8s.io/networking: gce
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.24, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-gce-u2004-k24-containerd
+    testgrid-tab-name: kops-grid-gce-gce-u2004-k24
 
 # {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "gce"}
-- name: e2e-kops-grid-gce-gce-u2004-k25-containerd
-  cron: '5 2-23/8 * * *'
+- name: e2e-kops-grid-gce-gce-u2004-k25
+  cron: '46 0-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   decorate: true
@@ -33906,4 +33906,4 @@ periodics:
     test.kops.k8s.io/networking: gce
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-gce-u2004-k25-containerd
+    testgrid-tab-name: kops-grid-gce-gce-u2004-k25


### PR DESCRIPTION
The recently added gce-gce tests have cluster names that are too long.

At this point it isn't necessary to draw attention to the containerd runtime.