### PR TITLE
ci: separarte pull-containerd-node-e2e for 1.5 branch

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -77,7 +77,7 @@ presubmits:
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
 
-  - name: pull-containerd-release-1.5-node-e2e
+  - name: pull-containerd-node-e2e-1-5
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -96,14 +96,14 @@ presubmits:
       path_alias: k8s.io/test-infra
     annotations:
       testgrid-dashboards: sig-node-containerd
-      testgrid-tab-name: pull-containerd-release-1.5-node-e2e
+      testgrid-tab-name: pull-containerd-node-e2e-1-5
       description: run node e2e tests
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - name: pull-containerd-node-e2e
+      - name: pull-containerd-node-e2e-1-5
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
         env:
         - name: USE_TEST_INFRA_LOG_DUMPING

--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -70,7 +70,7 @@ presubmits:
           --deployment=node
           --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
-          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
           --node-tests=true
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
@@ -121,7 +121,7 @@ presubmits:
           --deployment=node
           --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
-          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
           --node-tests=true
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
@@ -174,7 +174,7 @@ presubmits:
           --deployment=node
           --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
-          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
           --node-tests=true
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'

--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -31,7 +31,6 @@ presubmits:
     decorate: true
     branches:
     - main
-    - release/1.5
     - release/1.6
     decoration_config:
       timeout: 100m
@@ -47,6 +46,57 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-containerd
       testgrid-tab-name: pull-containerd-node-e2e
+      description: run node e2e tests
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - name: pull-containerd-node-e2e
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221024-d0c013ee2d-master
+        env:
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: "true"
+        command:
+        - sh
+        - -c
+        - >
+          runner.sh
+          ./test/build.sh
+          &&
+          cd ${GOPATH}/src/k8s.io/kubernetes
+          &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --deployment=node
+          --gcp-project=cri-c8d-pr-node-e2e
+          --gcp-zone=us-central1-f
+          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          --node-tests=true
+          --provider=gce
+          '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
+          --timeout=65m
+          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+
+  - name: pull-containerd-release-1.5-node-e2e
+    always_run: true
+    max_concurrency: 8
+    decorate: true
+    branches:
+    - release/1.5
+    decoration_config:
+      timeout: 100m
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.25
+      path_alias: k8s.io/kubernetes
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    annotations:
+      testgrid-dashboards: sig-node-containerd
+      testgrid-tab-name: pull-containerd-release-1.5-node-e2e
       description: run node e2e tests
     labels:
       preset-service-account: "true"

--- a/jobs/e2e_node/containerd/containerd-main-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-main-presubmit/env
@@ -6,3 +6,4 @@ CONTAINERD_PKG_PREFIX: 'containerd-cni'
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
 CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
   BinaryName = "/home/containerd/usr/local/sbin/runc"
+CONTAINERD_SYSTEMD_CGROUP: 'true'


### PR DESCRIPTION
containerd v1.5.x supports CRI v1alpha2, the API that was available at the time of release for containerd v1.5.
containerd v1.6.x has support for both CRI v1alpha2 and v1; and is being designated a long term support release.

kubelet master is removing support for CRI v1alpha2, this action has the effect of forcing kubernetes master(and kubernetes r.next+) users to move up to containerd v1.6.x where both CRI v1 and v1alpha2 is supported.

Therefore we need to separate out the `pull-containerd-node-e2e` job for containerd 1.5 branch, so that patches can still be made to 1.5 branch till its EOL. Instead of running against kubernetes master, it will run against k8s release-1.25 branch (the last release which supports CRI v1alpha2)

Ref: https://github.com/kubernetes/kubernetes/pull/110618

Signed-off-by: Akhil Mohan <makhil@vmware.com>