### PR TITLE
sig-scalability: Enable contention profiling for control plane components

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
@@ -47,7 +47,7 @@ presubmits:
         - --provider=gce
         - --tear-down-previous
         - # TODO(pohly@): Custom overrides, clean up after finishing the tests.
-        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=1000 --kube-api-burst=1000
+        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=1000 --kube-api-burst=1000
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/adhoc/run-e2e-test.sh
         - --timeout=100m

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -91,8 +91,8 @@ periodics:
       args:
       - --cluster=gce-golang
       - --env=CL2_LOAD_TEST_THROUGHPUT=50
-      - --env=KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
-      - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
+      - --env=KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=200 --kube-api-burst=200
+      - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=200 --kube-api-burst=200
       - --env=DEPLOY_GCI_DRIVER=false
       - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --extract=gs://k8s-infra-scale-golang-builds/ci/latest-1.23.txt

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -325,8 +325,8 @@ periodics:
       - --provider=gce
       - --metadata-sources=cl2-metadata.json
       - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0
-      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
-      - --env=SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
+      - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
       - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
       - --test=false
       - --test_args=--ginkgo.focus=xxxx

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -17,6 +17,8 @@ presets:
   # Turn on profiling for various components.
   - name: ETCD_TEST_ARGS
     value: "--enable-pprof"
+  - name: APISERVER_TEST_ARGS
+    value: "--profiling --contention-profiling"
   # Number of bytes of an additional nodes objects annotation in a kubemark
   # cluster. The annotation label is added to make nodes objects sizes similar
   # to regular cluster nodes.
@@ -24,9 +26,9 @@ presets:
     value: 15000
   # Increase throughput in Kubemark master components and turn on profiling.
   - name: KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS
-    value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
   - name: KUBEMARK_SCHEDULER_TEST_ARGS
-    value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
   # Reduce logs verbosity
   - name: TEST_CLUSTER_LOG_LEVEL
     value: "--v=2"
@@ -153,8 +155,10 @@ presets:
   # increase throughput in master components.
   - name: ETCD_EXTRA_ARGS
     value: "--enable-pprof"
+  - name: APISERVER_TEST_ARGS
+    value: "--profiling --contention-profiling"
   - name: CONTROLLER_MANAGER_TEST_ARGS
-    value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
   - name: KUBELET_TEST_ARGS
     value: "--enable-debugging-handlers --kube-api-qps=100 --kube-api-burst=100"
   - name: NODE_KUBELET_TEST_ARGS
@@ -166,7 +170,7 @@ presets:
     # TODO(#74011): Remove metrics-bind-address if the default is set.
     value: "--profiling --metrics-bind-address=0.0.0.0"
   - name: SCHEDULER_TEST_ARGS
-    value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
   # Reduce logs verbosity.
   - name: TEST_CLUSTER_LOG_LEVEL
     value: --v=2
@@ -299,8 +303,10 @@ presets:
   # increase throughput in master components and Kubelet.
   - name: ETCD_EXTRA_ARGS
     value: "--enable-pprof"
+  - name: APISERVER_TEST_ARGS
+    value: "--profiling --contention-profiling"
   - name: CONTROLLER_MANAGER_TEST_ARGS
-    value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
   # Bump max pods per node in Kubelet, because there are more than 10
   # system pods in 1-node cluster.
   - name: MAX_PODS_PER_NODE
@@ -310,7 +316,7 @@ presets:
   - name: KUBEPROXY_TEST_ARGS
     value: "--profiling"
   - name: SCHEDULER_TEST_ARGS
-    value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
   # Reduce logs verbosity.
   - name: TEST_CLUSTER_LOG_LEVEL
     value: --v=2

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -274,14 +274,14 @@ presubmits:
         - --env=CL2_DELETE_TEST_THROUGHPUT=50
         - --env=CL2_RATE_LIMIT_POD_CREATION=false
         # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
+        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
         # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.
         # TODO(#1311): Clean this up after the experiment - it should allow
         #   to hugely decrease pod-startup-latency across the whole test.
         #   Given that individual controllers have separate QPS limits, we allow
         #   scheduler to keep up with the load from deployment, daemonset and job
         #   performing pod creations at once.
-        - --env=SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
+        - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
         # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
         - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
         - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
@@ -726,14 +726,14 @@ presubmits:
         - --env=CL2_DELETE_TEST_THROUGHPUT=50
         - --env=CL2_RATE_LIMIT_POD_CREATION=false
         # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
+        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
         # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.
         # TODO(#1311): Clean this up after the experiment - it should allow
         #   to hugely decrease pod-startup-latency across the whole test.
         #   Given that individual controllers have separate QPS limits, we allow
         #   scheduler to keep up with the load from deployment, daemonset and job
         #   performing pod creations at once.
-        - --env=SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
+        - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
         # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
         - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
         - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -32,7 +32,7 @@ periodics:
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-node-size=e2-small
@@ -108,14 +108,14 @@ periodics:
       - --env=CL2_DELETE_TEST_THROUGHPUT=50
       - --env=CL2_RATE_LIMIT_POD_CREATION=false
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
       # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.
       # TODO(#1311): Clean this up after the experiment - it should allow
       #   to hugely decrease pod-startup-latency across the whole test.
       #   Given that individual controllers have separate QPS limits, we allow
       #   scheduler to keep up with the load from deployment, daemonset and job
       #   performing pod creations at once.
-      - --env=SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
+      - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
       # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true


### PR DESCRIPTION
This PR enables contention profiling for components other than `etcd`. 

Note: this is a follow-up from https://github.com/kubernetes/perf-tests/pull/2181, I realised that mutex profiling isn't enabled by the `--profiling` flag (as opposed to the `--enable-pprof` flag of `etcd`, that adds all possible pprof handlers).

/sig scalability
/kind cleanup
/assign @wojtek-t @marseel 