### PR TITLE
Add External Secret Operator configs

### DIFF
--- a/config/jobs/.yamllint.conf
+++ b/config/jobs/.yamllint.conf
@@ -5,3 +5,5 @@ rules:
   document-start: disable
   comments: disable
   line-length: disable
+  colons:
+    level: warning

--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -32,6 +32,9 @@ update-plugins: get-cluster-credentials
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run=client -o yaml | kubectl replace configmap plugins -f -
 
 deploy-prow: get-cluster-credentials
+	kubectl apply -f ./cluster/external-secrets-eso/crds/
+	kubectl apply -f ./cluster/external-secrets-eso/
+
 	kubectl apply --server-side=true -f ./cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
 	kubectl apply -f ./cluster/
 

--- a/config/prow/cluster/external-secrets-eso/cert-controller-deployment.yaml
+++ b/config/prow/cluster/external-secrets-eso/cert-controller-deployment.yaml
@@ -1,0 +1,47 @@
+---
+# Source: external-secrets/templates/cert-controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets-eso-cert-controller
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-cert-controller
+      app.kubernetes.io/instance: external-secrets-eso
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: external-secrets-cert-controller
+        app.kubernetes.io/instance: external-secrets-eso
+    spec:
+      serviceAccountName: external-secrets-cert-controller
+      containers:
+        - name: cert-controller
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - certcontroller
+          - --crd-requeue-interval=5m
+          - --service-name=external-secrets-eso-webhook
+          - --service-namespace=default
+          - --secret-name=external-secrets-eso-webhook
+          - --secret-namespace=default
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: metrics
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /readyz
+            initialDelaySeconds: 20
+            periodSeconds: 5

--- a/config/prow/cluster/external-secrets-eso/cert-controller-rbac.yaml
+++ b/config/prow/cluster/external-secrets-eso/cert-controller-rbac.yaml
@@ -1,0 +1,78 @@
+---
+# Source: external-secrets/templates/cert-controller-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-eso-cert-controller
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - "apiextensions.k8s.io"
+    resources:
+    - "customresourcedefinitions"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - "admissionregistration.k8s.io"
+    resources:
+    - "validatingwebhookconfigurations"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "endpoints"
+    verbs:
+    - "list"
+    - "get"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "events"
+    verbs:
+    - "create"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "patch"
+---
+# Source: external-secrets/templates/cert-controller-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-eso-cert-controller
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-eso-cert-controller
+subjects:
+  - name: external-secrets-cert-controller
+    namespace: "default"
+    kind: ServiceAccount

--- a/config/prow/cluster/external-secrets-eso/cert-controller-serviceaccount.yaml
+++ b/config/prow/cluster/external-secrets-eso/cert-controller-serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: external-secrets/templates/cert-controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-cert-controller
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm

--- a/config/prow/cluster/external-secrets-eso/crds/clusterexternalsecret.yaml
+++ b/config/prow/cluster/external-secrets-eso/crds/clusterexternalsecret.yaml
@@ -1,0 +1,379 @@
+---
+# Source: external-secrets/templates/crds/clusterexternalsecret.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: clusterexternalsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - externalsecrets
+    kind: ClusterExternalSecret
+    listKind: ClusterExternalSecretList
+    plural: clusterexternalsecrets
+    shortNames:
+      - ces
+    singular: clusterexternalsecret
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshInterval
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterExternalSecret is the Schema for the clusterexternalsecrets API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.
+              properties:
+                externalSecretName:
+                  description: The name of the external secrets to be created defaults to the name of the ClusterExternalSecret
+                  type: string
+                externalSecretSpec:
+                  description: The spec for the ExternalSecrets to be created
+                  properties:
+                    data:
+                      description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                      items:
+                        description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                        properties:
+                          remoteRef:
+                            description: ExternalSecretDataRemoteRef defines Provider data location.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                type: string
+                              key:
+                                description: Key is the key used in the Provider, mandatory
+                                type: string
+                              metadataPolicy:
+                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                type: string
+                              property:
+                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                type: string
+                              version:
+                                description: Used to select a specific version of the Provider value, if supported
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          secretKey:
+                            type: string
+                        required:
+                          - remoteRef
+                          - secretKey
+                        type: object
+                      type: array
+                    dataFrom:
+                      description: DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order
+                      items:
+                        properties:
+                          extract:
+                            description: Used to extract multiple key/value pairs from one secret
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                type: string
+                              key:
+                                description: Key is the key used in the Provider, mandatory
+                                type: string
+                              metadataPolicy:
+                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                type: string
+                              property:
+                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                type: string
+                              version:
+                                description: Used to select a specific version of the Provider value, if supported
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          find:
+                            description: Used to find secrets based on tags or regular expressions
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                type: string
+                              name:
+                                description: Finds secrets based on the name.
+                                properties:
+                                  regexp:
+                                    description: Finds secrets base
+                                    type: string
+                                type: object
+                              path:
+                                description: A root path to start the find operations.
+                                type: string
+                              tags:
+                                additionalProperties:
+                                  type: string
+                                description: Find secrets based on tags.
+                                type: object
+                            type: object
+                          rewrite:
+                            description: Used to rewrite secret Keys after getting them from the secret Provider Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                            items:
+                              properties:
+                                regexp:
+                                  description: Used to rewrite with regular expressions. The resulting key will be the output of a regexp.ReplaceAll operation.
+                                  properties:
+                                    source:
+                                      description: Used to define the regular expression of a re.Compiler.
+                                      type: string
+                                    target:
+                                      description: Used to define the target pattern of a ReplaceAll operation.
+                                      type: string
+                                  required:
+                                    - source
+                                    - target
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    refreshInterval:
+                      default: 1h
+                      description: RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.
+                      type: string
+                    secretStoreRef:
+                      description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                      properties:
+                        kind:
+                          description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                          type: string
+                        name:
+                          description: Name of the SecretStore resource
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    target:
+                      default:
+                        creationPolicy: Owner
+                        deletionPolicy: Retain
+                      description: ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.
+                      properties:
+                        creationPolicy:
+                          default: Owner
+                          description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                          enum:
+                            - Owner
+                            - Orphan
+                            - Merge
+                            - None
+                          type: string
+                        deletionPolicy:
+                          default: Retain
+                          description: DeletionPolicy defines rules on how to delete the resulting Secret Defaults to 'Retain'
+                          enum:
+                            - Delete
+                            - Merge
+                            - Retain
+                          type: string
+                        immutable:
+                          description: Immutable defines if the final secret will be immutable
+                          type: boolean
+                        name:
+                          description: Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource
+                          type: string
+                        template:
+                          description: Template defines a blueprint for the created Secret resource.
+                          properties:
+                            data:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            engineVersion:
+                              default: v2
+                              type: string
+                            metadata:
+                              description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            templateFrom:
+                              items:
+                                maxProperties: 1
+                                minProperties: 1
+                                properties:
+                                  configMap:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                    required:
+                                      - items
+                                      - name
+                                    type: object
+                                  secret:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                    required:
+                                      - items
+                                      - name
+                                    type: object
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                    - secretStoreRef
+                  type: object
+                namespaceSelector:
+                  description: The labels to select by to find the Namespaces to create the ExternalSecrets in.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                refreshTime:
+                  description: The time in which the controller should reconcile it's objects and recheck namespaces for labels.
+                  type: string
+              required:
+                - externalSecretSpec
+                - namespaceSelector
+              type: object
+            status:
+              description: ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                failedNamespaces:
+                  description: Failed namespaces are the namespaces that failed to apply an ExternalSecret
+                  items:
+                    description: ClusterExternalSecretNamespaceFailure represents a failed namespace deployment and it's reason.
+                    properties:
+                      namespace:
+                        description: Namespace is the namespace that failed when trying to apply an ExternalSecret
+                        type: string
+                      reason:
+                        description: Reason is why the ExternalSecret failed to apply to the namespace
+                        type: string
+                    required:
+                      - namespace
+                    type: object
+                  type: array
+                provisionedNamespaces:
+                  description: ProvisionedNamespaces are the namespaces where the ClusterExternalSecret has secrets
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-eso-webhook
+          namespace: "default"
+          path: /convert

--- a/config/prow/cluster/external-secrets-eso/crds/clustersecretstore.yaml
+++ b/config/prow/cluster/external-secrets-eso/crds/clustersecretstore.yaml
@@ -1,0 +1,2430 @@
+---
+# Source: external-secrets/templates/crds/clustersecretstore.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: clustersecretstores.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - externalsecrets
+    kind: ClusterSecretStore
+    listKind: ClusterSecretStoreList
+    plural: clustersecretstores
+    shortNames:
+      - css
+    singular: clustersecretstore
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+      deprecated: true
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                controller:
+                  description: 'Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property'
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    alibaba:
+                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      properties:
+                        auth:
+                          description: AlibabaAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        endpoint:
+                          type: string
+                        regionID:
+                          description: Alibaba Region to be used for the provider
+                          type: string
+                      required:
+                        - auth
+                        - regionID
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        auth:
+                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          properties:
+                            jwt:
+                              description: Authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the SecretManager provider will assume
+                          type: string
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                          type: string
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          properties:
+                            clientId:
+                              description: The Azure clientId of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          type: string
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              valueMap:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              version:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - data
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              properties:
+                                clusterLocation:
+                                  type: string
+                                clusterName:
+                                  type: string
+                                clusterProjectID:
+                                  type: string
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - clusterLocation
+                                - clusterName
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                      type: object
+                    gitlab:
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          properties:
+                            secretRef:
+                              properties:
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                serviceAccount:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using Hashi provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  type: string
+                                roleId:
+                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  type: string
+                                secretRef:
+                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - roleId
+                                - secretRef
+                              type: object
+                            cert:
+                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            jwt:
+                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified.
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  type: string
+                                role:
+                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  type: string
+                                secretRef:
+                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  type: string
+                                role:
+                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  type: string
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                username:
+                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        forwardInconsistent:
+                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        namespace:
+                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          type: string
+                        path:
+                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          type: string
+                        readYourWrites:
+                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        version:
+                          default: v2
+                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                retrySettings:
+                  description: Used to configure http retries if failed
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                conditions:
+                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  items:
+                    description: ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.
+                    properties:
+                      namespaceSelector:
+                        description: Choose namespace using a labelSelector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: Choose namespaces by name
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                controller:
+                  description: 'Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property'
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    alibaba:
+                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      properties:
+                        auth:
+                          description: AlibabaAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        endpoint:
+                          type: string
+                        regionID:
+                          description: Alibaba Region to be used for the provider
+                          type: string
+                      required:
+                        - auth
+                        - regionID
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        auth:
+                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          properties:
+                            jwt:
+                              description: Authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the SecretManager provider will assume
+                          type: string
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                          type: string
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          properties:
+                            clientId:
+                              description: The Azure clientId of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        environmentType:
+                          default: PublicCloud
+                          description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          type: string
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    doppler:
+                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Doppler API
+                          properties:
+                            secretRef:
+                              properties:
+                                dopplerToken:
+                                  description: The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - dopplerToken
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        config:
+                          description: Doppler config (required if not using a Service Token)
+                          type: string
+                        format:
+                          description: Format enables the downloading of secrets as a file (string)
+                          enum:
+                            - json
+                            - dotnet-json
+                            - env
+                            - yaml
+                            - docker
+                          type: string
+                        nameTransformer:
+                          description: Environment variable compatible name transforms that change secret names to a different format
+                          enum:
+                            - upper-camel
+                            - camel
+                            - lower-snake
+                            - tf-var
+                            - dotnet-env
+                          type: string
+                        project:
+                          description: Doppler project (required if not using a Service Token)
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              valueMap:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              version:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - data
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              properties:
+                                clusterLocation:
+                                  type: string
+                                clusterName:
+                                  type: string
+                                clusterProjectID:
+                                  type: string
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - clusterLocation
+                                - clusterName
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                      type: object
+                    gitlab:
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        environment:
+                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          type: string
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            containerAuth:
+                              description: IBM Container-based auth with IAM Trusted Profile.
+                              properties:
+                                iamEndpoint:
+                                  type: string
+                                profile:
+                                  description: the IBM Trusted Profile
+                                  type: string
+                                tokenLocation:
+                                  description: Location the token is mounted on the pod
+                                  type: string
+                              required:
+                                - profile
+                              type: object
+                            secretRef:
+                              properties:
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    onepassword:
+                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          properties:
+                            secretRef:
+                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              properties:
+                                connectTokenSecretRef:
+                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - connectTokenSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        connectHost:
+                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          type: string
+                        vaults:
+                          additionalProperties:
+                            type: integer
+                          description: Vaults defines which OnePassword vaults to search in which order
+                          type: object
+                      required:
+                        - auth
+                        - connectHost
+                        - vaults
+                      type: object
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    senhasegura:
+                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      properties:
+                        auth:
+                          description: Auth defines parameters to authenticate in senhasegura
+                          properties:
+                            clientId:
+                              type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          required:
+                            - clientId
+                            - clientSecretSecretRef
+                          type: object
+                        ignoreSslCertificate:
+                          default: false
+                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          type: boolean
+                        module:
+                          description: Module defines which senhasegura module should be used to get secrets
+                          type: string
+                        url:
+                          description: URL of senhasegura
+                          type: string
+                      required:
+                        - auth
+                        - module
+                        - url
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using Hashi provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  type: string
+                                roleId:
+                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  type: string
+                                secretRef:
+                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - roleId
+                                - secretRef
+                              type: object
+                            cert:
+                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            jwt:
+                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: 'Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead'
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: 'Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.'
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  type: string
+                                role:
+                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  type: string
+                                secretRef:
+                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  type: string
+                                role:
+                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  type: string
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                username:
+                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        forwardInconsistent:
+                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        namespace:
+                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          type: string
+                        path:
+                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          type: string
+                        readYourWrites:
+                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        version:
+                          default: v2
+                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                    yandexcertificatemanager:
+                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                refreshInterval:
+                  description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                  type: integer
+                retrySettings:
+                  description: Used to configure http retries if failed
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-eso-webhook
+          namespace: "default"
+          path: /convert

--- a/config/prow/cluster/external-secrets-eso/crds/externalsecret.yaml
+++ b/config/prow/cluster/external-secrets-eso/crds/externalsecret.yaml
@@ -1,0 +1,543 @@
+---
+# Source: external-secrets/templates/crds/externalsecret.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: externalsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - externalsecrets
+    kind: ExternalSecret
+    listKind: ExternalSecretList
+    plural: externalsecrets
+    shortNames:
+      - es
+    singular: externalsecret
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshInterval
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+      deprecated: true
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ExternalSecret is the Schema for the external-secrets API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExternalSecretSpec defines the desired state of ExternalSecret.
+              properties:
+                data:
+                  description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                  items:
+                    description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                    properties:
+                      remoteRef:
+                        description: ExternalSecretDataRemoteRef defines Provider data location.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      secretKey:
+                        type: string
+                    required:
+                      - remoteRef
+                      - secretKey
+                    type: object
+                  type: array
+                dataFrom:
+                  description: DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order
+                  items:
+                    description: ExternalSecretDataRemoteRef defines Provider data location.
+                    properties:
+                      conversionStrategy:
+                        default: Default
+                        description: Used to define a conversion Strategy
+                        type: string
+                      key:
+                        description: Key is the key used in the Provider, mandatory
+                        type: string
+                      property:
+                        description: Used to select a specific property of the Provider value (if a map), if supported
+                        type: string
+                      version:
+                        description: Used to select a specific version of the Provider value, if supported
+                        type: string
+                    required:
+                      - key
+                    type: object
+                  type: array
+                refreshInterval:
+                  default: 1h
+                  description: RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.
+                  type: string
+                secretStoreRef:
+                  description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                  properties:
+                    kind:
+                      description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                      type: string
+                    name:
+                      description: Name of the SecretStore resource
+                      type: string
+                  required:
+                    - name
+                  type: object
+                target:
+                  description: ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.
+                  properties:
+                    creationPolicy:
+                      default: Owner
+                      description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                      type: string
+                    immutable:
+                      description: Immutable defines if the final secret will be immutable
+                      type: boolean
+                    name:
+                      description: Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource
+                      type: string
+                    template:
+                      description: Template defines a blueprint for the created Secret resource.
+                      properties:
+                        data:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        engineVersion:
+                          default: v1
+                          description: EngineVersion specifies the template engine version that should be used to compile/execute the template specified in .data and .templateFrom[].
+                          type: string
+                        metadata:
+                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        templateFrom:
+                          items:
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              configMap:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              secret:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                            type: object
+                          type: array
+                        type:
+                          type: string
+                      type: object
+                  type: object
+              required:
+                - secretStoreRef
+                - target
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                refreshTime:
+                  description: refreshTime is the time and date the external secret was fetched and the target secret updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                syncedResourceVersion:
+                  description: SyncedResourceVersion keeps track of the last synced version
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshInterval
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ExternalSecret is the Schema for the external-secrets API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExternalSecretSpec defines the desired state of ExternalSecret.
+              properties:
+                data:
+                  description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                  items:
+                    description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                    properties:
+                      remoteRef:
+                        description: ExternalSecretDataRemoteRef defines Provider data location.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          metadataPolicy:
+                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      secretKey:
+                        type: string
+                    required:
+                      - remoteRef
+                      - secretKey
+                    type: object
+                  type: array
+                dataFrom:
+                  description: DataFrom is used to fetch all properties from a specific Provider data If multiple entries are specified, the Secret keys are merged in the specified order
+                  items:
+                    properties:
+                      extract:
+                        description: Used to extract multiple key/value pairs from one secret
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          metadataPolicy:
+                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      find:
+                        description: Used to find secrets based on tags or regular expressions
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            type: string
+                          name:
+                            description: Finds secrets based on the name.
+                            properties:
+                              regexp:
+                                description: Finds secrets base
+                                type: string
+                            type: object
+                          path:
+                            description: A root path to start the find operations.
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: Find secrets based on tags.
+                            type: object
+                        type: object
+                      rewrite:
+                        description: Used to rewrite secret Keys after getting them from the secret Provider Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                        items:
+                          properties:
+                            regexp:
+                              description: Used to rewrite with regular expressions. The resulting key will be the output of a regexp.ReplaceAll operation.
+                              properties:
+                                source:
+                                  description: Used to define the regular expression of a re.Compiler.
+                                  type: string
+                                target:
+                                  description: Used to define the target pattern of a ReplaceAll operation.
+                                  type: string
+                              required:
+                                - source
+                                - target
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                refreshInterval:
+                  default: 1h
+                  description: RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.
+                  type: string
+                secretStoreRef:
+                  description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                  properties:
+                    kind:
+                      description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`
+                      type: string
+                    name:
+                      description: Name of the SecretStore resource
+                      type: string
+                  required:
+                    - name
+                  type: object
+                target:
+                  default:
+                    creationPolicy: Owner
+                    deletionPolicy: Retain
+                  description: ExternalSecretTarget defines the Kubernetes Secret to be created There can be only one target per ExternalSecret.
+                  properties:
+                    creationPolicy:
+                      default: Owner
+                      description: CreationPolicy defines rules on how to create the resulting Secret Defaults to 'Owner'
+                      enum:
+                        - Owner
+                        - Orphan
+                        - Merge
+                        - None
+                      type: string
+                    deletionPolicy:
+                      default: Retain
+                      description: DeletionPolicy defines rules on how to delete the resulting Secret Defaults to 'Retain'
+                      enum:
+                        - Delete
+                        - Merge
+                        - Retain
+                      type: string
+                    immutable:
+                      description: Immutable defines if the final secret will be immutable
+                      type: boolean
+                    name:
+                      description: Name defines the name of the Secret resource to be managed This field is immutable Defaults to the .metadata.name of the ExternalSecret resource
+                      type: string
+                    template:
+                      description: Template defines a blueprint for the created Secret resource.
+                      properties:
+                        data:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        engineVersion:
+                          default: v2
+                          type: string
+                        metadata:
+                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        templateFrom:
+                          items:
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              configMap:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              secret:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                            type: object
+                          type: array
+                        type:
+                          type: string
+                      type: object
+                  type: object
+              required:
+                - secretStoreRef
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                refreshTime:
+                  description: refreshTime is the time and date the external secret was fetched and the target secret updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                syncedResourceVersion:
+                  description: SyncedResourceVersion keeps track of the last synced version
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-eso-webhook
+          namespace: "default"
+          path: /convert

--- a/config/prow/cluster/external-secrets-eso/crds/secretstore.yaml
+++ b/config/prow/cluster/external-secrets-eso/crds/secretstore.yaml
@@ -1,0 +1,2430 @@
+---
+# Source: external-secrets/templates/crds/secretstore.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: secretstores.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - externalsecrets
+    kind: SecretStore
+    listKind: SecretStoreList
+    plural: secretstores
+    shortNames:
+      - ss
+    singular: secretstore
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+      deprecated: true
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                controller:
+                  description: 'Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property'
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    alibaba:
+                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      properties:
+                        auth:
+                          description: AlibabaAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        endpoint:
+                          type: string
+                        regionID:
+                          description: Alibaba Region to be used for the provider
+                          type: string
+                      required:
+                        - auth
+                        - regionID
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        auth:
+                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          properties:
+                            jwt:
+                              description: Authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the SecretManager provider will assume
+                          type: string
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                          type: string
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          properties:
+                            clientId:
+                              description: The Azure clientId of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          type: string
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              valueMap:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              version:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - data
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              properties:
+                                clusterLocation:
+                                  type: string
+                                clusterName:
+                                  type: string
+                                clusterProjectID:
+                                  type: string
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - clusterLocation
+                                - clusterName
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                      type: object
+                    gitlab:
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          properties:
+                            secretRef:
+                              properties:
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                serviceAccount:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key the value inside of the provider type to use, only used with "Secret" type
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using Hashi provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  type: string
+                                roleId:
+                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  type: string
+                                secretRef:
+                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - roleId
+                                - secretRef
+                              type: object
+                            cert:
+                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            jwt:
+                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified.
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  type: string
+                                role:
+                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  type: string
+                                secretRef:
+                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  type: string
+                                role:
+                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  type: string
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                username:
+                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        forwardInconsistent:
+                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        namespace:
+                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          type: string
+                        path:
+                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          type: string
+                        readYourWrites:
+                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        version:
+                          default: v2
+                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                retrySettings:
+                  description: Used to configure http retries if failed
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                conditions:
+                  description: Used to constraint a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore
+                  items:
+                    description: ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in for a ClusterSecretStore instance.
+                    properties:
+                      namespaceSelector:
+                        description: Choose namespace using a labelSelector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: Choose namespaces by name
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                controller:
+                  description: 'Used to select the correct KES controller (think: ingress.ingressClassName) The KES controller is instantiated with a specific controller name and filters ES based on this property'
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: Kubernetes authenticates with Akeyless by passing the ServiceAccount token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Akeyless. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Akeyless. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: Reference to a Secret that contains the details to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    alibaba:
+                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      properties:
+                        auth:
+                          description: AlibabaAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        endpoint:
+                          type: string
+                        regionID:
+                          description: Alibaba Region to be used for the provider
+                          type: string
+                      required:
+                        - auth
+                        - regionID
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        auth:
+                          description: 'Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          properties:
+                            jwt:
+                              description: Authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the SecretManager provider will assume
+                          type: string
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                          type: string
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type.
+                          properties:
+                            clientId:
+                              description: The Azure clientId of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: 'Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)'
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        environmentType:
+                          default: PublicCloud
+                          description: 'EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud'
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          type: string
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    doppler:
+                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Doppler API
+                          properties:
+                            secretRef:
+                              properties:
+                                dopplerToken:
+                                  description: The DopplerToken is used for authentication. See https://docs.doppler.com/reference/api#authentication for auth token types. The Key attribute defaults to dopplerToken if not specified.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - dopplerToken
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        config:
+                          description: Doppler config (required if not using a Service Token)
+                          type: string
+                        format:
+                          description: Format enables the downloading of secrets as a file (string)
+                          enum:
+                            - json
+                            - dotnet-json
+                            - env
+                            - yaml
+                            - docker
+                          type: string
+                        nameTransformer:
+                          description: Environment variable compatible name transforms that change secret names to a different format
+                          enum:
+                            - upper-camel
+                            - camel
+                            - lower-snake
+                            - tf-var
+                            - dotnet-env
+                          type: string
+                        project:
+                          description: Doppler project (required if not using a Service Token)
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              valueMap:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              version:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - data
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              properties:
+                                clusterLocation:
+                                  type: string
+                                clusterName:
+                                  type: string
+                                clusterProjectID:
+                                  type: string
+                                serviceAccountRef:
+                                  description: A reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - clusterLocation
+                                - clusterName
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                      type: object
+                    gitlab:
+                      description: Gitlab configures this store to sync secrets using Gitlab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        environment:
+                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          type: string
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            containerAuth:
+                              description: IBM Container-based auth with IAM Trusted Profile.
+                              properties:
+                                iamEndpoint:
+                                  type: string
+                                profile:
+                                  description: the IBM Trusted Profile
+                                  type: string
+                                tokenLocation:
+                                  description: Location the token is mounted on the pod
+                                  type: string
+                              required:
+                                - profile
+                              type: object
+                            secretRef:
+                              properties:
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  type: string
+                                namespace:
+                                  description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    onepassword:
+                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          properties:
+                            secretRef:
+                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              properties:
+                                connectTokenSecretRef:
+                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - connectTokenSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        connectHost:
+                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          type: string
+                        vaults:
+                          additionalProperties:
+                            type: integer
+                          description: Vaults defines which OnePassword vaults to search in which order
+                          type: object
+                      required:
+                        - auth
+                        - connectHost
+                        - vaults
+                      type: object
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Oracle Vault. If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    senhasegura:
+                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      properties:
+                        auth:
+                          description: Auth defines parameters to authenticate in senhasegura
+                          properties:
+                            clientId:
+                              type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          required:
+                            - clientId
+                            - clientSecretSecretRef
+                          type: object
+                        ignoreSslCertificate:
+                          default: false
+                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          type: boolean
+                        module:
+                          description: Module defines which senhasegura module should be used to get secrets
+                          type: string
+                        url:
+                          description: URL of senhasegura
+                          type: string
+                      required:
+                        - auth
+                        - module
+                        - url
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using Hashi provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                                  type: string
+                                roleId:
+                                  description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                                  type: string
+                                secretRef:
+                                  description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - roleId
+                                - secretRef
+                              type: object
+                            cert:
+                              description: Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: ClientCert is a certificate to authenticate using the Cert Vault authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing client private key to authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              type: object
+                            jwt:
+                              description: Jwt authenticates with Vault by passing role and JWT token using the JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: Optional ServiceAccountToken specifies the Kubernetes service account for which to request a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: 'Optional audiences field that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Defaults to a single audience `vault` it not specified. Deprecated: use serviceAccountRef.Audiences instead'
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: 'Optional expiration time in seconds that will be used to request a temporary Kubernetes service account token for the service account referenced by `serviceAccountRef`. Deprecated: this will be removed in the future. Defaults to 10 minutes.'
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: 'Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"'
+                                  type: string
+                                role:
+                                  description: Role is a JWT role to authenticate using the JWT/OIDC Vault authentication method
+                                  type: string
+                                secretRef:
+                                  description: Optional SecretRef that refers to a key in a Secret resource containing JWT token to authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: 'Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"'
+                                  type: string
+                                role:
+                                  description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: Optional secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If a name is specified without a key, `token` is the default. If one is not specified, the one bound to the controller will be used.
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: Optional service account field containing the name of a kubernetes ServiceAccount. If the service account is specified, the service account secret token JWT will be used for authenticating with Vault. If the service account selector is not supplied, the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: Ldap authenticates with Vault by passing username/password pair using the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: 'Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"'
+                                  type: string
+                                secretRef:
+                                  description: SecretRef to a key in a Secret resource containing password for the LDAP user used to authenticate with Vault using the LDAP authentication method
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                      type: string
+                                  type: object
+                                username:
+                                  description: Username is a LDAP user name used to authenticate using the LDAP Vault authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in. Can only be defined when used in a ClusterSecretStore.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        forwardInconsistent:
+                          description: ForwardInconsistent tells Vault to forward read-after-write requests to the Vault leader instead of simply retrying within a loop. This can increase performance if the option is enabled serverside. https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        namespace:
+                          description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                          type: string
+                        path:
+                          description: 'Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.'
+                          type: string
+                        readYourWrites:
+                          description: ReadYourWrites ensures isolated read-after-write semantics by providing discovered cluster replication states in each request. More information about eventual consistency in Vault can be found here https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        version:
+                          default: v2
+                          description: Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: PEM encoded CA bundle used to validate webhook server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key the value inside of the provider type to use, only used with "Secret" type
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: Secrets to fill in templates These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                    yandexcertificatemanager:
+                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource, In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                refreshInterval:
+                  description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                  type: integer
+                retrySettings:
+                  description: Used to configure http retries if failed
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-eso-webhook
+          namespace: "default"
+          path: /convert

--- a/config/prow/cluster/external-secrets-eso/deployment.yaml
+++ b/config/prow/cluster/external-secrets-eso/deployment.yaml
@@ -1,0 +1,36 @@
+---
+# Source: external-secrets/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets-eso
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 0 # TODO(chaodaiG): switch to 1 once KES is deprecated.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+      app.kubernetes.io/instance: external-secrets-eso
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: external-secrets
+        app.kubernetes.io/instance: external-secrets-eso
+    spec:
+      serviceAccountName: kubernetes-external-secrets-sa
+      containers:
+        - name: external-secrets
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --concurrent=1
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: metrics

--- a/config/prow/cluster/external-secrets-eso/rbac.yaml
+++ b/config/prow/cluster/external-secrets-eso/rbac.yaml
@@ -1,0 +1,225 @@
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-eso-controller
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "secretstores"
+    - "clustersecretstores"
+    - "externalsecrets"
+    - "clusterexternalsecrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    - "externalsecrets/status"
+    - "externalsecrets/finalizers"
+    - "secretstores"
+    - "secretstores/status"
+    - "secretstores/finalizers"
+    - "clustersecretstores"
+    - "clustersecretstores/status"
+    - "clustersecretstores/finalizers"
+    - "clusterexternalsecrets"
+    - "clusterexternalsecrets/status"
+    - "clusterexternalsecrets/finalizers"
+    verbs:
+    - "update"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts"
+    - "namespaces"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts/token"
+    verbs:
+    - "create"
+  - apiGroups:
+    - ""
+    resources:
+    - "events"
+    verbs:
+    - "create"
+    - "patch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    verbs:
+    - "create"
+    - "update"
+    - "delete"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-eso-view
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - "external-secrets.io"
+    resources:
+      - "externalsecrets"
+      - "secretstores"
+      - "clustersecretstores"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-eso-edit
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - "external-secrets.io"
+    resources:
+      - "externalsecrets"
+      - "secretstores"
+      - "clustersecretstores"
+    verbs:
+      - "create"
+      - "delete"
+      - "deletecollection"
+      - "patch"
+      - "update"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-eso-controller
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-eso-controller
+subjects:
+  - name: external-secrets-eso
+    namespace: "default"
+    kind: ServiceAccount
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-secrets-eso-leaderelection
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    resourceNames:
+    - "external-secrets-controller"
+    verbs:
+    - "get"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "create"
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - "leases"
+    verbs:
+    - "get"
+    - "create"
+    - "update"
+    - "patch"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: external-secrets-eso-leaderelection
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-secrets-eso-leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-eso
+    namespace: "default"

--- a/config/prow/cluster/external-secrets-eso/serviceaccount.yaml
+++ b/config/prow/cluster/external-secrets-eso/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: external-secrets/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-eso
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm

--- a/config/prow/cluster/external-secrets-eso/validatingwebhook.yaml
+++ b/config/prow/cluster/external-secrets-eso/validatingwebhook.yaml
@@ -1,0 +1,65 @@
+---
+# Source: external-secrets/templates/validatingwebhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: secretstore-validate
+  labels:
+    external-secrets.io/component: webhook
+webhooks:
+- name: "validate.secretstore.external-secrets.io"
+  rules:
+  - apiGroups:   ["external-secrets.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["secretstores"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: "default"
+      name: external-secrets-eso-webhook
+      path: /validate-external-secrets-io-v1beta1-secretstore
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+
+- name: "validate.clustersecretstore.external-secrets.io"
+  rules:
+  - apiGroups:   ["external-secrets.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["clustersecretstores"]
+    scope:       "Cluster"
+  clientConfig:
+    service:
+      namespace: "default"
+      name: external-secrets-eso-webhook
+      path: /validate-external-secrets-io-v1beta1-clustersecretstore
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+---
+# Source: external-secrets/templates/validatingwebhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: externalsecret-validate
+  labels:
+    external-secrets.io/component: webhook
+webhooks:
+- name: "validate.externalsecret.external-secrets.io"
+  rules:
+  - apiGroups:   ["external-secrets.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["externalsecrets"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: "default"
+      name: external-secrets-eso-webhook
+      path: /validate-external-secrets-io-v1beta1-externalsecret
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail

--- a/config/prow/cluster/external-secrets-eso/webhook-deployment.yaml
+++ b/config/prow/cluster/external-secrets-eso/webhook-deployment.yaml
@@ -1,0 +1,59 @@
+---
+# Source: external-secrets/templates/webhook-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets-eso-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-webhook
+      app.kubernetes.io/instance: external-secrets-eso
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: external-secrets-webhook
+        app.kubernetes.io/instance: external-secrets-eso
+    spec:
+      hostNetwork: false
+      serviceAccountName: external-secrets-webhook
+      containers:
+        - name: webhook
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - webhook
+          - --port=10250
+          - --dns-name=external-secrets-eso-webhook.default.svc
+          - --cert-dir=/tmp/certs
+          - --check-interval=5m
+          - --healthz-addr=:8081
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: metrics
+            - containerPort: 10250
+              protocol: TCP
+              name: webhook
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /readyz
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          volumeMounts:
+            - name: certs
+              mountPath: /tmp/certs
+              readOnly: true
+      volumes:
+        - name: certs
+          secret:
+            secretName: external-secrets-eso-webhook

--- a/config/prow/cluster/external-secrets-eso/webhook-secret.yaml
+++ b/config/prow/cluster/external-secrets-eso/webhook-secret.yaml
@@ -1,0 +1,14 @@
+---
+# Source: external-secrets/templates/webhook-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-secrets-eso-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+    external-secrets.io/component: webhook

--- a/config/prow/cluster/external-secrets-eso/webhook-service.yaml
+++ b/config/prow/cluster/external-secrets-eso/webhook-service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: external-secrets/templates/webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-secrets-eso-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm
+    external-secrets.io/component: webhook
+spec:
+  type: ClusterIP
+  ports:
+  - port: 443
+    targetPort: 10250
+    protocol: TCP
+    name: webhook
+  selector:
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets-eso

--- a/config/prow/cluster/external-secrets-eso/webhook-serviceaccount.yaml
+++ b/config/prow/cluster/external-secrets-eso/webhook-serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: external-secrets/templates/webhook-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: external-secrets-0.6.1
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets-eso
+    app.kubernetes.io/version: "v0.6.1"
+    app.kubernetes.io/managed-by: Helm

--- a/config/prow/cluster/external_secrets_eso.yaml
+++ b/config/prow/cluster/external_secrets_eso.yaml
@@ -1,132 +1,215 @@
-# This is a place holder for adding kubernetes external secrets, please add the
-# ExternalSecret CR here, separated by `---`.
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: k8s-prow-builds
+spec:
+  provider:
+    gcpsm:
+      projectID: k8s-prow-builds
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: k8s-prow
+spec:
+  provider:
+    gcpsm:
+      projectID: k8s-prow
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: kubernetes-public
+spec:
+  provider:
+    gcpsm:
+      projectID: kubernetes-public
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: k8s-infra-prow-build-trusted
+spec:
+  provider:
+    gcpsm:
+      projectID: k8s-infra-prow-build-trusted
+---
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: service-account
+  name: k8s-prow-build-service-account
   namespace: test-pods
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow-builds
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow-builds               # name of the SecretStore (or kind specified)
+  target:
+    name: service-account  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: default-k8s-build-cluster-service-account-key
-    name: service-account.json
-    version: latest
+  - secretKey: default-k8s-build-cluster-service-account-key  # name of the GCPSM secret key
+    remoteRef:
+      key: service-account.json
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: prometheus-alert-slack-post-prow-alerts-secret-url
   namespace: prow-monitoring
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: prometheus-alert-slack-post-prow-alerts-secret-url  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: prometheus-alert-slack-post-prow-alerts-secret-url
-    name: url
-    version: latest
+  - secretKey: prometheus-alert-slack-post-prow-alerts-secret-url  # name of the GCPSM secret key
+    remoteRef:
+      key: url
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: prometheus-alert-slack-post-testing-ops-secret-url
   namespace: prow-monitoring
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: prometheus-alert-slack-post-testing-ops-secret-url  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: prometheus-alert-slack-post-testing-ops-secret-url
-    name: url
-    version: latest
+  - secretKey: prometheus-alert-slack-post-testing-ops-secret-url  # name of the GCPSM secret key
+    remoteRef:
+      key: url
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: grafana
   namespace: prow-monitoring
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: grafana  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: gke_k8s-prow_us-central1-f_prow__prow-monitoring__grafana
-    name: password
-    version: latest
+  - secretKey: gke_k8s-prow_us-central1-f_prow__prow-monitoring__grafana  # name of the GCPSM secret key
+    remoteRef:
+      key: password
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: k8s-infra-cherrypick-robot-github-token  # The name of the K8s Secret
+  name: k8s-infra-cherrypick-robot-github-token
   namespace: default
 spec:
-  backendType: gcpSecretsManager
-  projectId: kubernetes-public
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: kubernetes-public               # name of the SecretStore (or kind specified)
+  target:
+    name: k8s-infra-cherrypick-robot-github-token  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: k8s-infra-cherrypick-robot-github-token # The name of the GSM Secret
-    name: token                                  # The key to write in the K8s Secret
-    version: latest
+  - secretKey: k8s-infra-cherrypick-robot-github-token  # name of the GCPSM secret key
+    remoteRef:
+      key: token
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: kubeconfig-prow-services
   namespace: test-pods
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: kubeconfig-prow-services  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: gke_k8s-prow_us-central1-f_prow__default__prow-services
-    name: config
-    version: latest
+  - secretKey: gke_k8s-prow_us-central1-f_prow__default__prow-services  # name of the GCPSM secret key
+    remoteRef:
+      key: config
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: kubeconfig-build-test-infra-trusted
   namespace: default
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: kubeconfig-build-test-infra-trusted  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: prow_build_cluster_kubeconfig_test-infra-trusted
-    name: kubeconfig
-    version: latest
+  - secretKey: prow_build_cluster_kubeconfig_test-infra-trusted  # name of the GCPSM secret key
+    remoteRef:
+      key: kubeconfig
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: kubeconfig-build-k8s-prow-builds
   namespace: default
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: kubeconfig-build-k8s-prow-builds  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds
-    name: kubeconfig
-    version: latest
+  - secretKey: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds  # name of the GCPSM secret key
+    remoteRef:
+      key: kubeconfig
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: kubeconfig-build-rules-k8s
   namespace: default
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-prow               # name of the SecretStore (or kind specified)
+  target:
+    name: kubeconfig-build-rules-k8s  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: gke_rules-k8s_us-central1-f_testing__default__build-rules-k8s
-    name: kubeconfig
-    version: latest
+  - secretKey: gke_rules-k8s_us-central1-f_testing__default__build-rules-k8s  # name of the GCPSM secret key
+    remoteRef:
+      key: kubeconfig
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: cluster-api-provider-digitalocean-quayio
   namespace: default
 spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-infra-prow-build-trusted
+  refreshInterval: 10s           # rate SecretManager pulls GCPSM
+  secretStoreRef:
+    kind: SecretStore
+    name: k8s-infra-prow-build-trusted               # name of the SecretStore (or kind specified)
+  target:
+    name: cluster-api-provider-digitalocean-quayio  # name of the k8s Secret to be created
+    creationPolicy: Owner
   data:
-  - key: capdo-quayio-registry-secret
-    name: config.json
-    version: latest
+  - secretKey: capdo-quayio-registry-secret  # name of the GCPSM secret key
+    remoteRef:
+      key: config.json

--- a/config/prow/cluster/external_secrets_eso.yaml
+++ b/config/prow/cluster/external_secrets_eso.yaml
@@ -1,0 +1,132 @@
+# This is a place holder for adding kubernetes external secrets, please add the
+# ExternalSecret CR here, separated by `---`.
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow-builds
+  data:
+  - key: default-k8s-build-cluster-service-account-key
+    name: service-account.json
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: prometheus-alert-slack-post-prow-alerts-secret-url
+  namespace: prow-monitoring
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: prometheus-alert-slack-post-prow-alerts-secret-url
+    name: url
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: prometheus-alert-slack-post-testing-ops-secret-url
+  namespace: prow-monitoring
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: prometheus-alert-slack-post-testing-ops-secret-url
+    name: url
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana
+  namespace: prow-monitoring
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: gke_k8s-prow_us-central1-f_prow__prow-monitoring__grafana
+    name: password
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-infra-cherrypick-robot-github-token  # The name of the K8s Secret
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-infra-cherrypick-robot-github-token # The name of the GSM Secret
+    name: token                                  # The key to write in the K8s Secret
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-prow-services
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: gke_k8s-prow_us-central1-f_prow__default__prow-services
+    name: config
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-test-infra-trusted
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: prow_build_cluster_kubeconfig_test-infra-trusted
+    name: kubeconfig
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-k8s-prow-builds
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds
+    name: kubeconfig
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-rules-k8s
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: gke_rules-k8s_us-central1-f_testing__default__build-rules-k8s
+    name: kubeconfig
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cluster-api-provider-digitalocean-quayio
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build-trusted
+  data:
+  - key: capdo-quayio-registry-secret
+    name: config.json
+    version: latest


### PR DESCRIPTION
Part of #24869 

The goal is to migrate from Kubernetes External Secret to External Secret Operator as the former was announced deprecated and superseded by the latter. This PR adds the configs with the replica set to 0 so it will be no effect.

For code reviewers, this PR consists of two commits:

- Source control External Secret Operator service, deployment that are generated by helm template. Also copy/pasted external secrets that were used by Kubernetes External Secrets.
- Modify the new external secrets file to the format that works with External Secret Operator.
