### PR TITLE
Allow config-sharding of Slack reporter configs

### DIFF
--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1933,7 +1933,15 @@ func TestValidateAdditionalProwConfigIsInOrgRepoDirectoryStructure(t *testing.T)
 	const validGlobalConfig = `
 sinker:
   exclude_clusters:
-    - default`
+    - default
+slack_reporter_configs:
+  '*':
+    channel: '#general-announcements'
+    job_states_to_report:
+      - failure
+      - error
+	  - success
+	report_template: Job {{.Spec.Job}} ended with status {{.Status.State}}.`
 	const validOrgConfig = `
 branch-protection:
   orgs:
@@ -1941,7 +1949,14 @@ branch-protection:
       protect: true
 tide:
   merge_method:
-    my-org: squash`
+    my-org: squash
+slack_reporter_configs:
+  my-org:
+    channel: '#my-org-announcements'
+    job_states_to_report:
+      - failure
+      - error
+    report_template: Job {{.Spec.Job}} needs my-org maintainers attention.`
 	const validRepoConfig = `
 branch-protection:
   orgs:
@@ -1951,7 +1966,13 @@ branch-protection:
           protect: true
 tide:
   merge_method:
-    my-org/my-repo: squash`
+    my-org/my-repo: squash
+slack_reporter_configs:
+  my-org/my-repo:
+    channel: '#my-repo-announcements'
+    job_states_to_report:
+      - failure
+    report_template: Job {{.Spec.Job}} needs my-repo maintainers attention.`
 	const validGlobalPluginsConfig = `
 blunderbuss:
   max_request_count: 2

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1498,6 +1498,23 @@ type SlackReporter struct {
 // Use `org/repo`, `org` or `*` as key and an `SlackReporter` struct as value.
 type SlackReporterConfigs map[string]SlackReporter
 
+func (cfg SlackReporterConfigs) mergeFrom(additional *SlackReporterConfigs) error {
+	if additional == nil {
+		return nil
+	}
+
+	var errs []error
+	for orgOrRepo, slackReporter := range *additional {
+		if _, alreadyConfigured := cfg[orgOrRepo]; alreadyConfigured {
+			errs = append(errs, fmt.Errorf("config for org or repo %s passed more than once", orgOrRepo))
+			continue
+		}
+		cfg[orgOrRepo] = slackReporter
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
 func (cfg SlackReporterConfigs) GetSlackReporter(refs *prowapi.Refs) SlackReporter {
 	if refs == nil {
 		return cfg["*"]
@@ -1512,6 +1529,11 @@ func (cfg SlackReporterConfigs) GetSlackReporter(refs *prowapi.Refs) SlackReport
 	}
 
 	return cfg["*"]
+}
+
+func (cfg SlackReporterConfigs) HasGlobalConfig() bool {
+	_, exists := cfg["*"]
+	return exists
 }
 
 func (cfg *SlackReporter) DefaultAndValidate() error {
@@ -3154,19 +3176,26 @@ func StringsToOrgRepos(vs []string) []OrgRepo {
 // If you extend this, please also extend HasConfigFor accordingly.
 func (pc *ProwConfig) mergeFrom(additional *ProwConfig) error {
 	emptyReference := &ProwConfig{
-		BranchProtection: additional.BranchProtection,
-		Tide:             Tide{TideGitHubConfig: TideGitHubConfig{MergeType: additional.Tide.MergeType, Queries: additional.Tide.Queries}},
+		BranchProtection:     additional.BranchProtection,
+		Tide:                 Tide{TideGitHubConfig: TideGitHubConfig{MergeType: additional.Tide.MergeType, Queries: additional.Tide.Queries}},
+		SlackReporterConfigs: additional.SlackReporterConfigs,
 	}
 
 	var errs []error
 	if diff := cmp.Diff(additional, emptyReference); diff != "" {
-		errs = append(errs, fmt.Errorf("only 'branch-protection', 'tide.merge_method' and 'tide.queries' may be set via additional config, all other fields have no merging logic yet. Diff: %s", diff))
+		errs = append(errs, fmt.Errorf("only 'branch-protection', 'slack_reporter_configs', 'tide.merge_method' and 'tide.queries' may be set via additional config, all other fields have no merging logic yet. Diff: %s", diff))
 	}
 	if err := pc.BranchProtection.merge(&additional.BranchProtection); err != nil {
 		errs = append(errs, fmt.Errorf("failed to merge branch protection config: %w", err))
 	}
 	if err := pc.Tide.mergeFrom(&additional.Tide); err != nil {
 		errs = append(errs, fmt.Errorf("failed to merge tide config: %w", err))
+	}
+
+	if pc.SlackReporterConfigs == nil {
+		pc.SlackReporterConfigs = additional.SlackReporterConfigs
+	} else if err := pc.SlackReporterConfigs.mergeFrom(&additional.SlackReporterConfigs); err != nil {
+		errs = append(errs, fmt.Errorf("failed to merge slack-reporter config: %w", err))
 	}
 
 	return utilerrors.NewAggregate(errs)
@@ -3253,16 +3282,30 @@ func (pc *ProwConfig) HasConfigFor() (global bool, orgs sets.String, repos sets.
 		repos.Insert(query.Repos...)
 	}
 
+	for orgOrRepo := range pc.SlackReporterConfigs {
+		if orgOrRepo == "*" {
+			// configuration for "*" is globally available
+			continue
+		}
+
+		if strings.Contains(orgOrRepo, "/") {
+			repos.Insert(orgOrRepo)
+		} else {
+			orgs.Insert(orgOrRepo)
+		}
+	}
+
 	return global, orgs, repos
 }
 
 func (pc *ProwConfig) hasGlobalConfig() bool {
-	if pc.BranchProtection.ProtectTested != nil || pc.BranchProtection.AllowDisabledPolicies != nil || pc.BranchProtection.AllowDisabledJobPolicies != nil || pc.BranchProtection.ProtectReposWithOptionalJobs != nil || isPolicySet(pc.BranchProtection.Policy) {
+	if pc.BranchProtection.ProtectTested != nil || pc.BranchProtection.AllowDisabledPolicies != nil || pc.BranchProtection.AllowDisabledJobPolicies != nil || pc.BranchProtection.ProtectReposWithOptionalJobs != nil || isPolicySet(pc.BranchProtection.Policy) || pc.SlackReporterConfigs.HasGlobalConfig() {
 		return true
 	}
 	emptyReference := &ProwConfig{
-		BranchProtection: pc.BranchProtection,
-		Tide:             Tide{TideGitHubConfig: TideGitHubConfig{MergeType: pc.Tide.MergeType, Queries: pc.Tide.Queries}},
+		BranchProtection:     pc.BranchProtection,
+		Tide:                 Tide{TideGitHubConfig: TideGitHubConfig{MergeType: pc.Tide.MergeType, Queries: pc.Tide.Queries}},
+		SlackReporterConfigs: pc.SlackReporterConfigs,
 	}
 	return cmp.Diff(pc, emptyReference) != ""
 }

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -8313,7 +8313,106 @@ tide:
     - another/repo
   status_update_period: 1m0s
   sync_period: 1m0s
-`},
+`,
+		},
+		{
+			name:       "Additional slack reporter config gets merged in",
+			prowConfig: "config_version_sha: abc",
+			supplementalProwConfigs: []string{
+				`
+slack_reporter_configs:
+  my-org:
+    channel: '#channel'
+    job_states_to_report:
+    - failure
+    - error
+    job_types_to_report:
+    - periodic
+    report_template: Job {{.Spec.Job}} ended with state {{.Status.State}}.
+  my-org/my-repo:
+    channel: '#other-channel'
+    report_template: Job {{.Spec.Job}} ended with state {{.Status.State}}.
+`,
+			},
+			expectedProwConfig: `branch-protection: {}
+config_version_sha: abc
+deck:
+  spyglass:
+    gcs_browser_prefixes:
+      '*': ""
+    gcs_browser_prefixes_by_bucket:
+      '*': ""
+    size_limit: 100000000
+  tide_update_period: 10s
+default_job_timeout: 24h0m0s
+gerrit:
+  ratelimit: 5
+  tick_interval: 1m0s
+github:
+  link_url: https://github.com
+github_reporter:
+  job_types_to_report:
+  - presubmit
+  - postsubmit
+horologium: {}
+in_repo_config:
+  allowed_clusters:
+    '*':
+    - default
+log_level: info
+managed_webhooks:
+  auto_accept_invitation: false
+  respect_legacy_global_token: false
+plank:
+  max_goroutines: 20
+  pod_pending_timeout: 10m0s
+  pod_running_timeout: 48h0m0s
+  pod_unscheduled_timeout: 5m0s
+pod_namespace: default
+prowjob_namespace: default
+push_gateway:
+  interval: 1m0s
+  serve_metrics: false
+sinker:
+  max_pod_age: 24h0m0s
+  max_prowjob_age: 168h0m0s
+  resync_period: 1h0m0s
+  terminated_pod_ttl: 24h0m0s
+slack_reporter_configs:
+  my-org:
+    channel: '#channel'
+    job_states_to_report:
+    - failure
+    - error
+    job_types_to_report:
+    - periodic
+    report_template: Job {{.Spec.Job}} ended with state {{.Status.State}}.
+  my-org/my-repo:
+    channel: '#other-channel'
+    report_template: Job {{.Spec.Job}} ended with state {{.Status.State}}.
+status_error_link: https://github.com/kubernetes/test-infra/issues
+tide:
+  context_options: {}
+  max_goroutines: 20
+  status_update_period: 1m0s
+  sync_period: 1m0s
+`,
+		},
+		{
+			name:       "Additional slack reporter config with duplication errors",
+			prowConfig: "config_version_sha: abc",
+			supplementalProwConfigs: []string{
+				`
+slack_reporter_configs:
+  my-org:
+    channel: '#channel'`,
+				`
+slack_reporter_configs:
+  my-org:
+    channel: '#other-channel'`,
+			},
+			expectedErrorSubstr: "config for org or repo my-org passed more than once",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -8486,6 +8585,7 @@ func TestHasConfigFor(t *testing.T) {
 			name: "Any non-empty config with empty branchprotection and Tide properties is considered global",
 			resultGenerator: func(fuzzedConfig *ProwConfig) (toCheck *ProwConfig, exceptGlobal bool, expectOrgs sets.String, expectRepos sets.String) {
 				fuzzedConfig.BranchProtection = BranchProtection{}
+				fuzzedConfig.SlackReporterConfigs = SlackReporterConfigs{}
 				fuzzedConfig.Tide.MergeType = nil
 				fuzzedConfig.Tide.Queries = nil
 				return fuzzedConfig, true, nil, nil
@@ -8569,6 +8669,7 @@ func TestHasConfigFor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				fuzzedConfig := &ProwConfig{}
+				fuzzedConfig.SlackReporterConfigs = SlackReporterConfigs{}
 				fuzzer.Fuzz(fuzzedConfig)
 
 				fuzzedAndManipulatedConfig, expectIsGlobal, expectOrgs, expectRepos := tc.resultGenerator(fuzzedConfig)
@@ -8676,6 +8777,12 @@ func TestProwConfigMergingProperties(t *testing.T) {
 				*pc = ProwConfig{Tide: Tide{TideGitHubConfig: TideGitHubConfig{Queries: pc.Tide.Queries}}}
 			},
 		},
+		{
+			name: "SlackReporter configurations",
+			makeMergeable: func(pc *ProwConfig) {
+				*pc = ProwConfig{SlackReporterConfigs: pc.SlackReporterConfigs}
+			},
+		},
 	}
 
 	expectedProperties := []struct {
@@ -8758,6 +8865,11 @@ func TestProwConfigMergingProperties(t *testing.T) {
 				}
 				i++
 			},
+			func(config *SlackReporterConfigs, c fuzz.Continue) {
+				for _, reporter := range *config {
+					c.Fuzz(reporter)
+				}
+			},
 		)
 
 	// Do not parallelize, the PRNG used by the fuzzer is not threadsafe
@@ -8769,6 +8881,7 @@ func TestProwConfigMergingProperties(t *testing.T) {
 
 					for i := 0; i < 100; i++ {
 						fuzzedConfig := &ProwConfig{}
+						fuzzedConfig.SlackReporterConfigs = map[string]SlackReporter{}
 						fuzzer.Fuzz(fuzzedConfig)
 
 						tc.makeMergeable(fuzzedConfig)


### PR DESCRIPTION
Do the same as we support for branch-protection and tide parameters.
Basically it should enable having a global configuration at the top (annotated with '*') and all other organizations' / repositories' configurations should come in their respective configuration location.