### PR TITLE
Pin OS version for e2e-gce-device-plugin job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -2,12 +2,6 @@ presets:
 - labels:
     preset-ci-gce-device-plugin-gpu: "true"
   env:
-  # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
-  # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-  - name: KUBE_GCE_NODE_IMAGE
-    value: cos-97-16919-189-5
-  - name: KUBE_GCE_NODE_PROJECT
-    value: cos-cloud
   - name: NODE_ACCELERATORS
     value: type=nvidia-tesla-k80,count=2
 
@@ -39,6 +33,11 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
+      # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+      # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b
@@ -75,6 +74,11 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
+      # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+      # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project=k8s-infra-e2e-gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -57,6 +57,9 @@ periodics:
       - --extract=ci/latest-1.22
       - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_CONTAINER_RUNTIME=docker
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-85-13310-1041-9
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -57,6 +57,9 @@ periodics:
       - --extract=ci/latest-1.23
       - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_CONTAINER_RUNTIME=docker
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-85-13310-1041-9
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -56,6 +56,9 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest-1.24
       - --extract-ci-bucket=k8s-release-dev
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-85-13310-1041-9
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -56,6 +56,9 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest-1.25
       - --extract-ci-bucket=k8s-release-dev
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-85-13310-1041-9
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
Explicitly pass the OS version for each e2e-gce-device-plugin job. Pin the job to COS-97 for the latest master version and pin the old OS version (COS-85) for existing release branches.

Fixes https://github.com/kubernetes/kubernetes/issues/113752

Signed-off-by: David Porter <porterdavid@google.com>