### PR TITLE
Point ci-kubernetes-build jobs to correct version markers

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -223,7 +223,7 @@ periodics:
       - --
       - --release=kubernetes-release-dev
       - --allow-dup
-      - --extra-version-markers=k8s-stable3
+      - --extra-version-markers=k8s-stable4
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-staging-test-infra/bootstrap:v20221021-5771e8efb3
       name: ""
@@ -265,7 +265,7 @@ periodics:
       - --allow-dup
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-stable3
+      - --extra-version-markers=k8s-stable4
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -155,7 +155,7 @@ periodics:
       - --allow-dup
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-master
+      - --extra-version-markers=k8s-stable1
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""


### PR DESCRIPTION
We have an issue with `ci-kubernetes-build` jobs for release branches pointing to incorrect version markers:

* `ci-kubernetes-build-1.25` job is pointing to the `k8s-master` version maker, but instead should point to `k8s-stable1`
  * That's because `ci-kubernetes-build` (master job) is already pointing to the `k8s-master` version marker
* `ci-kubernetes-build-1.22` job is pointing to the `k8s-stable3` version marker, but instead should point to `k8s-stable4`
  * That's because `ci-kubernetes-build-1.23` is already pointing to the `k8s-stable3` version marker

Note: I'm not sure do we need to adjust any other jobs.

This PR is supposed to fix https://github.com/kubernetes/kubernetes/issues/113762

cc @kubernetes/release-engineering 
/hold
to discuss the fix with other Release Managers