### PR TITLE
Removing capz-windows-containerd-1.25 because it is actually testing master

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -537,41 +537,6 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
-- annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
-    testgrid-dashboards: sig-release-1.25-informing, sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-containerd-1.25
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    repo: cluster-api-provider-azure
-  interval: 3h
-  labels:
-    preset-azure-cred-only: "true"
-    preset-capz-containerd-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common-main: "true"
-    preset-capz-windows-parallel: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  name: ci-kubernetes-e2e-capz-master-containerd-windows-1-25
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
-      name: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

This job was running against master and isn't needed
From 
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-1-25/1590309331801214976/build-log.txt

KernelVersion:10.0.17763.3406,OSImage:Windows Server 2019 Datacenter,ContainerRuntimeVersion:containerd://1.6.8,KubeletVersion:v1.26.0-alpha.3.469+c288251818d9d3,KubeProxyVersion:v1.26.0-alpha.3.469+c288251818d9d3,OperatingSystem:windows,Architecture:amd64,}

This job is correctly testing Windows v1.25 branch
https://testgrid.k8s.io/sig-windows-signal#capz-e2e-windows-containerd-1.25

