### PR TITLE
Enable only InPlacePodVerticalScaling feature for inplace-pod-resize CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1417,10 +1417,8 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,APIServerTracing=false
+      - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_PROXY_DAEMONSET=true
-      - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
@@ -1432,7 +1430,7 @@ periodics:
       - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-master
   annotations:
@@ -1453,10 +1451,8 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,APIServerTracing=false
+      - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_PROXY_DAEMONSET=true
-      - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
@@ -1468,7 +1464,7 @@ periodics:
       - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-master
   annotations:


### PR DESCRIPTION
The current inplace-pod-resize-containerd-main-e2e-gce have never had a successful run (at this time, apiserver does not 
become reachable, logs provide a few clues (below), root-cause unknown at this time.

Another approach was to look at the difference between `cos-cgroupv2-containerd-e2e-gce` and `cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce` jobs. One "material" difference that stands out is AllAlpha=true + containerd/main. 

I have locally tested containerd-main with InPlacePodVerticalScaling=true. So let's try this out to see if it fares better (which would confirm one of the other alpha features is tripping over containerd main and we are not the blocker)


```bash
I1110 13:25:47.825812       9 healthz.go:261] informer-sync,poststarthook/rbac/bootstrap-roles,poststarthook/scheduling/bootstrap-system-priority-classes,poststarthook/priority-and-fairness-config-producer,poststarthook/built-in-resources-storage-version-updater,autoregister-completion check failed: readyz
[-]informer-sync failed: 2 informers not started yet: [*v1alpha1.ValidatingAdmissionPolicy *v1alpha1.ValidatingAdmissionPolicyBinding]
[-]poststarthook/rbac/bootstrap-roles failed: not finished
[-]poststarthook/scheduling/bootstrap-system-priority-classes failed: not finished
[-]poststarthook/priority-and-fairness-config-producer failed: not finished
[-]poststarthook/built-in-resources-storage-version-updater failed: not finished
[-]autoregister-completion failed: missing APIService: [v1. v1.admissionregistration.k8s.io v1.apiextensions.k8s.io v1.apps v1.authentication.k8s.io v1.authorization.k8s.io v1.autoscaling v1.batch v1.certificates.k8s.io v1.coordination.k8s.io v1.discovery.k8s.io v1.events.k8s.io v1.networking.k8s.io v1.node.k8s.io v1.policy v1.rbac.authorization.k8s.io v1.scheduling.k8s.io v1.storage.k8s.io v1beta1.storage.k8s.io v1beta2.flowcontrol.apiserver.k8s.io v1beta3.flowcontrol.apiserver.k8s.io v2.autoscaling]
```

```bash
I1110 13:25:47.922669       9 httplog.go:132] "HTTP" verb="POST" URI="/apis/apiregistration.k8s.io/v1/apiservices" latency="445.102µs" userAgent="kube-apiserver/v1.26.0 (linux/amd64) kubernetes/70e73a6" audit-ID="b7730587-5816-4de5-a4c8-b1b9bfd09a0e" srcIP="[::1]:37212" apf_pl="exempt" apf_fs="exempt" apf_execution_time="247.273µs" resp=503 statusStack=<
	
	goroutine 5307 [running]:
	k8s.io/apiserver/pkg/server/httplog.(*respLogger).recordStatus(0xc0068e24d0, 0xc0082aa780?)
		vendor/k8s.io/apiserver/pkg/server/httplog/httplog.go:320 +0x105
	k8s.io/apiserver/pkg/server/httplog.(*respLogger).WriteHeader(0xc0068e24d0, 0xc00696fce0?)
		vendor/k8s.io/apiserver/pkg/server/httplog/httplog.go:300 +0x25
	k8s.io/apiserver/pkg/server/filters.(*baseTimeoutWriter).WriteHeader(0xc0082aa7b0, 0x1f7?)
		vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:239 +0x1c8
	k8s.io/apiserver/pkg/endpoints/filters.(*auditResponseWriter).WriteHeader(0xc006959080, 0xc00696fce0?)
		vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:258 +0x3c
	k8s.io/apiserver/pkg/endpoints/handlers/responsewriters.(*deferredResponseWriter).Write(0xc006959200, {0xc006b7cc30, 0xbd, 0xc3})
		vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go:243 +0x642
	k8s.io/apimachinery/pkg/runtime/serializer/protobuf.(*Serializer).doEncode(0xc0000cd600, {0x583dc60?, 0xc00697e6e0?}, {0x582b420, 0xc006959200}, {0x582ac80?, 0x7f374a0?})
		vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go:228 +0x5b3
	k8s.io/apimachinery/pkg/runtime/serializer/protobuf.(*Serializer).encode(0xc0000cd600, {0x583dc60, 0xc00697e6e0}, {0x582b420, 0xc006959200}, {0x582ac80?, 0x7f374a0?})
		vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go:181 +0x13d
	k8s.io/apimachinery/pkg/runtime/serializer/protobuf.(*Serializer).Encode(0x0?, {0x583dc60?, 0xc00697e6e0?}, {0x582b420?, 0xc006959200?})
		vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go:174 +0x3b
	k8s.io/apimachinery/pkg/runtime/serializer/versioning.(*codec).doEncode(0xc00697e8c0, {0x583dc60, 0xc00697e6e0}, {0x582b420, 0xc006959200}, {0x0?, 0x0?})
		vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go:268 +0xd45
	k8s.io/apimachinery/pkg/runtime/serializer/versioning.(*codec).encode(0xc00697e8c0, {0x583dc60, 0xc00697e6e0}, {0x582b420, 0xc006959200}, {0x0?, 0x0?})
		vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go:214 +0x167
	k8s.io/apimachinery/pkg/runtime/serializer/versioning.(*codec).Encode(0x585b418?, {0x583dc60?, 0xc00697e6e0?}, {0x582b420?, 0xc006959200?})
		vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go:207 +0x33
	k8s.io/apiserver/pkg/endpoints/handlers/responsewriters.SerializeObject({0x4eeaf42, 0x23}, {0x7fb2ca180cf8, 0xc00697e8c0}, {0x585a048?, 0xc0040aaec0}, 0xc00698f100, 0x1f7, {0x583dc60, 0xc00697e6e0})
		vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go:111 +0xa87
	k8s.io/apiserver/pkg/endpoints/handlers/responsewriters.WriteObjectNegotiated.func2()
		vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go:292 +0x21d
	k8s.io/apiserver/pkg/endpoints/request.(*durationTracker).Track(0xc0082aa630, 0xc0068d0680)
		vendor/k8s.io/apiserver/pkg/endpoints/request/webhook_duration.go:75 +0x93
	k8s.io/apiserver/pkg/endpoints/request.TrackSerializeResponseObjectLatency({0x585b418?, 0xc0082aa960?}, 0xc0068d0680)
		vendor/k8s.io/apiserver/pkg/endpoints/request/webhook_duration.go:216 +0x5e
	k8s.io/apiserver/pkg/endpoints/handlers/responsewriters.WriteObjectNegotiated({0x5859d78, 0xc000e4a800}, {0x5859fe8, 0x7f374a0}, {{0xc00d1304e6?, 0xa0?}, {0xc00d1304fd?, 0x4ed0aa?}}, {0x585a048, 0xc0040aaec0}, ...)
		vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go:288 +0x789
	k8s.io/apiserver/pkg/endpoints/handlers/responsewriters.ErrorNegotiated({0x582aae0?, 0xc00697e640?}, {0x5859d78, 0xc000e4a800}, {{0xc00d1304e6?, 0x4c1d400?}, {0xc00d1304fd?, 0xc008f50330?}}, {0x585a048, 0xc0040aaec0}, ...)
		vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go:329 +0x285
	k8s.io/apiserver/pkg/endpoints/filters.WithStorageVersionPrecondition.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filters/storageversion.go:110 +0x735
	net/http.HandlerFunc.ServeHTTP(0x4b1c2e0?, {0x585a048?, 0xc0040aaec0?}, 0xb1fb8a?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x1ca
	net/http.HandlerFunc.ServeHTTP(0x585b418?, {0x585a048?, 0xc0040aaec0?}, 0x4?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filters.WithAuthorization.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filters/authorization.go:64 +0x4f4
	net/http.HandlerFunc.ServeHTTP(0x8ca745?, {0x585a048?, 0xc0040aaec0?}, 0xc0003a6d70?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x190
	net/http.HandlerFunc.ServeHTTP(0x4b1c2e0?, {0x585a048?, 0xc0040aaec0?}, 0xb1fb8a?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x1ca
	net/http.HandlerFunc.ServeHTTP(0xc008e35840?, {0x585a048?, 0xc0040aaec0?}, 0x40dc27?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/server/filters.WithPriorityAndFairness.func2.9()
		vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:292 +0xf6
	k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle.func2()
		vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go:191 +0x1e7
	k8s.io/apiserver/pkg/util/flowcontrol.immediateRequest.Finish(...)
		vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go:968
	k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle(0xc00035d2c0, {0x585b418?, 0xc0082aa960}, {0xc0068e2420?, {0x585c410?, 0xc00112b680?}}, 0xc003796940?, 0x1?, 0xc0082aa7e0?, 0xc0022a89b0)
		vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go:179 +0x782
	k8s.io/apiserver/pkg/server/filters.WithPriorityAndFairness.func2({0x585a048?, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:295 +0xceb
	net/http.HandlerFunc.ServeHTTP(0x8ca745?, {0x585a048?, 0xc0040aaec0?}, 0xc0003a6d70?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x190
	net/http.HandlerFunc.ServeHTTP(0x4b1c2e0?, {0x585a048?, 0xc0040aaec0?}, 0xb1fb8a?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x1ca
	net/http.HandlerFunc.ServeHTTP(0x0?, {0x585a048?, 0xc0040aaec0?}, 0xc00c93a240?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filters.WithImpersonation.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go:50 +0x21c
	net/http.HandlerFunc.ServeHTTP(0x8ca745?, {0x585a048?, 0xc0040aaec0?}, 0xc0003a6d70?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x190
	net/http.HandlerFunc.ServeHTTP(0x4b1c2e0?, {0x585a048?, 0xc0040aaec0?}, 0xb1fb8a?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1({0x585a048, 0xc0040aaec0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x1ca
	net/http.HandlerFunc.ServeHTTP(0x585c4f0?, {0x585a048?, 0xc0040aaec0?}, 0xc00084b3e0?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filters.WithAudit.func1({0x585a048?, 0xc0040aaea0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:115 +0x47c
	net/http.HandlerFunc.ServeHTTP(0x8ca745?, {0x585a048?, 0xc0040aaea0?}, 0xc0003a6d70?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x585a048, 0xc0040aaea0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x190
	net/http.HandlerFunc.ServeHTTP(0x4b1c2e0?, {0x585a048?, 0xc0040aaea0?}, 0xb1fb8a?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackCompleted.func1({0x585a048, 0xc0040aaea0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x1ca
	net/http.HandlerFunc.ServeHTTP(0x585b418?, {0x585a048?, 0xc0040aaea0?}, 0x5813800?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x585a048, 0xc0040aaea0}, 0xc00698f100)
		vendor/k8s.io/apiserver/pkg/endpoints/filters/authentication.go:80 +0x622
	net/http.HandlerFunc.ServeHTTP(0x585b418?, {0x585a048?, 0xc0040aaea0?}, 0x58136f0?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x585a048, 0xc0040aaea0}, 0xc00698ee00)
		vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:94 +0x383
	net/http.HandlerFunc.ServeHTTP(0x0?, {0x585a048?, 0xc0040aaea0?}, 0xc00ca76780?)
		/usr/local/go/src/net/http/server.go:2109 +0x2f
	k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1()
		vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:115 +0x70
	created by k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP
		vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:101 +0x1d8
 > addedInfo=<
	
	logging error output: "k8s\x00\n\f\n\x02v1\x12\x06Status\x12\xa4\x01\n\x06\n\x00\x12\x00\x1a\x00\x12\aFailure\x1azwait for storage version registration to complete for resource: apiservices.apiregistration.k8s.io, last seen error: <nil>\"\x12ServiceUnavailable0\xf7\x03\x1a\x00\"\x00"
 >
E1110 13:25:47.923035       9 autoregister_controller.go:195] v1.coordination.k8s.io failed with : wait for storage version registration to complete for resource: apiservices.apiregistration.k8s.io, last seen error: <nil>
```