### PR TITLE
secrets-store: remove kubernetes version 1.22 (EOL)

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -377,7 +377,7 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-build
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-23-6
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-23-13
     decorate: true
     decoration_config:
       timeout: 25m
@@ -407,17 +407,17 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.23.6"
+          value: "1.23.13"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-23-6
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.23.6"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-23-13
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.23.13"
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-2
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
     decorate: true
     decoration_config:
       timeout: 25m
@@ -447,17 +447,17 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.24.2"
+          value: "1.24.7"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-2
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.2"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.7"
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-0
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
     decorate: true
     decoration_config:
       timeout: 25m
@@ -487,15 +487,15 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.25.0"
+          value: "1.25.3"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-25-0
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.25.0"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.25.3"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-akeyless
     decorate: true

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -377,46 +377,6 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-build
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-22-9
-    decorate: true
-    decoration_config:
-      timeout: 25m
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/secrets-store-csi-driver
-    branches:
-    - ^main$
-    # e2e-provider is only available in release-1.* branches
-    - ^release-1.*
-    labels:
-      # this is required because we want to run kind in docker
-      preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-master
-        command:
-          - runner.sh
-        args:
-          - bash
-          - -c
-          - >-
-            ./test/scripts/e2e_provider.sh
-        securityContext:
-          privileged: true
-        env:
-        - name: KUBERNETES_VERSION
-          value: "1.22.9"
-        resources:
-          requests:
-            cpu: "4"
-            memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-22-9
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.22.9"
-      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-23-6
     decorate: true
     decoration_config:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Remove Kubernetes version 1.22 from docs and CI since it has reached EOL
- Update Kubernetes versions to latest in CI for supported releases

/assign @tam7t 