### PR TITLE
Add build=quick parameter to pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2 job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1606,17 +1606,19 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-master
         args:
-          - --repo=github.com/containerd/containerd=main
-          - --root=/go/src
           - "--job=$(JOB_NAME)"
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--service-account=/etc/service-account/service-account.json"
-          - "--upload=gs://kubernetes-jenkins/pr-logs"
-          - "--timeout=180"
+          - --service-account=/etc/service-account/service-account.json
+          - --repo=k8s.io/release
+          - --repo=github.com/containerd/containerd=main
+          - --root=/go/src
+          - --upload=gs://kubernetes-jenkins/pr-logs
+          - --timeout=180
           - --scenario=kubernetes_e2e
           - -- # end bootstrap args, scenario args below
           - --check-leaked-resources
           - --cluster=
+          - --ginkgo-parallel=1
           - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -1627,6 +1629,8 @@ presubmits:
           - --gcp-node-image=gci
           - --gcp-nodes=1
           - --provider=gce
+          - --runtime-config=api/all=true
+          - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
           - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\]
           - --timeout=150m
         resources:
@@ -1636,3 +1640,5 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+        securityContext:
+          privileged: true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1599,6 +1599,9 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-master
@@ -1618,6 +1621,7 @@ presubmits:
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
+          - --build=quick
           - --extract=local
           - --gcp-zone=us-west1-b
           - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1629,8 +1629,6 @@ presubmits:
           - --gcp-node-image=gci
           - --gcp-nodes=1
           - --provider=gce
-          - --runtime-config=api/all=true
-          - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
           - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\]
           - --timeout=150m
         resources:


### PR DESCRIPTION
It looks like with extract=local, we need build=quick. This PR brings the fix.