### PR TITLE
Setting NFD's default PR merge policy to 'squash'.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -798,6 +798,8 @@ tide:
     kubernetes-sigs/service-catalog: squash
     kubernetes-sigs/go-open-service-broker-client: squash
     kubernetes-sigs/minibroker: squash
+    kubernetes-sigs/node-feature-discovery: squash
+    kubernetes-sigs/node-feature-discovery-operator: squash
     kubernetes-sigs/vsphere-csi-driver: squash
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash


### PR DESCRIPTION
Every PR will be squashed to a single commit before

merging regardless of the number of commits in the PR pre-merging.