### PR TITLE
Clone pull-kubernetes-e2e-gce-alpha-features and modify for containerd/main

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1585,50 +1585,52 @@ presubmits:
   #     Until then, this job complements pull-kubernetes-e2e-gce-alpha-features by running inplace pod resize e2e tests
   #     full-spectrum against containerd/main which has the necessary CRI support.
   - name: pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
-    cluster: k8s-infra-prow-build
-    always_run: false
     optional: true
-    skip_report: false
+    always_run: false
     run_if_changed: '^(pkg\/kubelet\/kuberuntime\/|test\/e2e\/node/)'
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    annotations:
-      testgrid-dashboards: sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-gce-cluster-e2e-inplace-pod-resize-containerd-main-v2
-      description: Executes inplace pod resize e2e tests with containerd/main and cgroupv2
+    skip_report: false
+    branches:
+    # TODO(releng): Remove once repo default branch has been renamed
+    - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-kubelet-gce-cluster-e2e-inplace-pod-resize-containerd-main-v2
+      description: Executes inplace pod resize e2e tests with containerd/main and cgroupv2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-master
         args:
           - "--job=$(JOB_NAME)"
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - --service-account=/etc/service-account/service-account.json
-          - --repo=k8s.io/release
-          - --repo=github.com/containerd/containerd=main
           - --root=/go/src
+          - --repo=github.com/containerd/containerd=main
+          - --repo=k8s.io/kubernetes=$(PULL_REFS)
+          - --repo=k8s.io/release
           - --upload=gs://kubernetes-jenkins/pr-logs
+          - --service-account=/etc/service-account/service-account.json
           - --timeout=180
           - --scenario=kubernetes_e2e
           - -- # end bootstrap args, scenario args below
-          - --check-leaked-resources
-          - --cluster=
           - --ginkgo-parallel=1
+          - --build=quick
+          - --cluster=
           - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
-          - --build=quick
           - --extract=local
-          - --gcp-zone=us-west1-b
           - --gcp-node-image=gci
-          - --gcp-nodes=1
+          - --gcp-zone=us-west1-b
           - --provider=gce
+          - --gcp-nodes=1
+          - --runtime-config=api/all=true
+          - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-inplace-pod-resize-containerd-main-v2
           - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\]
           - --timeout=150m
         resources:


### PR DESCRIPTION
The previous change still failed on missing k8s artifacts. An example of this failure is here: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/102884/pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2/1591093802267840512/build-log.txt

This PR attempts to clone nearly all the fields in pull-kubernetes-e2e-gce-alpha-features and add containerd/main specific fields to it.