### PR TITLE
plugins/jira: Modify to not replace strings starting with dash

### DIFF
--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -254,7 +254,7 @@ func replaceStringIfNeeded(text, old, new string) string {
 	startingIdx = 0
 	for _, idx := range allOldIdx {
 		result += text[startingIdx:idx]
-		if idx == 0 || (text[idx-1] != '[' && text[idx-1] != '/') && text[idx-1] != '`' && text[idx-1] != '-' {
+		if idx == 0 || strings.Contains("[/`-", string(text[idx-1])) {
 			result += new
 		} else {
 			result += old

--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -223,7 +223,8 @@ func insertLinksIntoLine(line string, issueNames []string, jiraBaseURL string) s
 // replaceStringIfNeeded replaces a string if it is not prefixed by:
 // * `[` which we use as heuristic for "Already replaced",
 // * `/` which we use as heuristic for "Part of a link in a previous replacement",
-// * ``` (backtick) which we use as heuristic for "Inline code".
+// * ``` (backtick) which we use as heuristic for "Inline code",
+// * `-` (dash) to prevent replacing a substring that accidentally matches a JIRA issue.
 // If golang would support back-references in regex replacements, this would have been a lot
 // simpler.
 func replaceStringIfNeeded(text, old, new string) string {
@@ -253,7 +254,7 @@ func replaceStringIfNeeded(text, old, new string) string {
 	startingIdx = 0
 	for _, idx := range allOldIdx {
 		result += text[startingIdx:idx]
-		if idx == 0 || (text[idx-1] != '[' && text[idx-1] != '/') && text[idx-1] != '`' {
+		if idx == 0 || (text[idx-1] != '[' && text[idx-1] != '/') && text[idx-1] != '`' && text[idx-1] != '-' {
 			result += new
 		} else {
 			result += old

--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -254,7 +254,7 @@ func replaceStringIfNeeded(text, old, new string) string {
 	startingIdx = 0
 	for _, idx := range allOldIdx {
 		result += text[startingIdx:idx]
-		if idx == 0 || strings.Contains("[/`-", string(text[idx-1])) {
+		if idx == 0 || !strings.Contains("[/`-", string(text[idx-1])) {
 			result += new
 		} else {
 			result += old

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/andygrunwald/go-jira"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/andygrunwald/go-jira"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -461,6 +460,11 @@ is very important` + "\n``ABC-123`` and `ABC-123` shouldn't be replaced, as well
 			name:     "Multiline codeblock that is denoted through four leading spaces",
 			body:     "I meant to do this test:\r\n\r\n    operator_test.go:1914: failed to read output from pod unique-id-header-test-1: container \"curl\" in pod \"unique-id-header-ABC-123\" is waiting to start: ContainerCreating\r\n\r\n",
 			expected: "I meant to do this test:\r\n\r\n    operator_test.go:1914: failed to read output from pod unique-id-header-test-1: container \"curl\" in pod \"unique-id-header-ABC-123\" is waiting to start: ContainerCreating\r\n\r\n",
+		},
+		{
+			name:     "parts of words starting with a dash are not replaced",
+			body:     "this shouldn't be replaced: whatever-ABC-123 and also inline `whatever-ABC-123`",
+			expected: "this shouldn't be replaced: whatever-ABC-123 and also inline `whatever-ABC-123`",
 		},
 	}
 


### PR DESCRIPTION
In [https://github.com/stackrox/acs-fleet-manager/pull/526](https://github.com/stackrox/acs-fleet-manager/pull/526) bot saw the string acs-stage-dp-01 and decided that the trailing part (dp-01) is a reference to an existing JIRA issue ( [DP-1](https://issues.redhat.com/browse/DP-1) ), and replaced it with a markdown link, resulting in acs-stage-[dp-01](https://issues.redhat.com//browse/dp-01).

This PR fixes this by not replacing a string (which matches a JIRA issue) if it starts with `-` (dash).