### PR TITLE
updates for dynamic resource allocation being alpha in 1.26

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -1,0 +1,40 @@
+periodics:
+  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
+  # on a kind cluster with containerd updated to a version with CDI support.
+  - name: ci-kind-dra
+    interval: 6h
+    annotations:
+      testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-kind-dra
+      testgrid-alert-email: patrick.ohly@intel.com
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220928-cd48f52a16-master
+        command:
+        - runner.sh
+        args:
+        - /bin/sh
+        - -xc
+        - >
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
+          test/e2e/dra/kind-build-image.sh dra/node:latest &&
+          kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest &&
+          trap 'kind export logs "${ARTIFACTS}/kind"' EXIT &&
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation
+
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1245,7 +1245,7 @@ presubmits:
     # Not relevant for most PRs.
     always_run: false
     # This covers most of the code related to dynamic resource allocation.
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/
+    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/
     # The tests might still be flaky or this job might get triggered accidentally for
     # an unrelated PR.
     optional: true

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
     - sig-node-containerd
     - sig-node-cri-o
     - sig-node-cos
+    - sig-node-dynamic-resource-allocation
     - sig-node-presubmits
     # These dashboards are for out-of-tree SIG Node projects
     - sig-node-cadvisor
@@ -62,5 +63,11 @@ dashboards:
     base_options: width=10
 
 - name: sig-node-cos
+- name: sig-node-dynamic-resource-allocation
+  dashboard_tab:
+  - name: pull-kind-dra
+    test_group_name: pull-kubernetes-kind-dra
+    alert_options:
+      alert_mail_to_addresses: patrick.ohly@intel.com
 - name: sig-node-presubmits
 - name: sig-node-image-pushes


### PR DESCRIPTION
We have one new directory to watch ("resourceclaimtemplate") for the presubmit job and can now run a periodic job. Both get added to a new "sig-node/sig-node-dynamic-resource-allocation" tab.