### PR TITLE
Enable using EPS for endpoint updates

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -54,6 +54,7 @@ presets:
             - --log_file=/var/log/glbc.log
             - --enable-finalizer-add
             - --enable-finalizer-remove
+            - --enable-endpoint-slices
             - --default-backend-service=kube-system/default-http-backend
             - --kubeconfig=/etc/srv/kubernetes/l7-lb-controller/kubeconfig
             - --sync-period=600s


### PR DESCRIPTION
* GLBC will use EPS for NEGs instead of Endpoints.


/assign @aojea 