### PR TITLE
testgrids: remove bunk CRI-O links

### DIFF
--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -57,12 +57,6 @@ test_groups:
   num_columns_recent: 3
   num_failures_to_alert: 1
 
-# CRI-O
-- name: test_pull_request_crio_e2e_fedora
-  gcs_prefix: origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_fedora
-- name: test_pull_request_crio_e2e_rhel
-  gcs_prefix: origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel
-
 #
 # Start dashboards
 #

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -33,22 +33,6 @@ dashboards:
       base_options: width=10
 
 - name: sig-node-cri-o
-  dashboard_tab:
-    - name: crio-e2e-fedora
-      test_group_name: test_pull_request_crio_e2e_fedora
-      open_test_template:
-        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>.txt
-      results_url_template:
-        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
-      base_options: width=10
-    - name: crio-e2e-rhel
-      test_group_name: test_pull_request_crio_e2e_rhel
-      open_test_template:
-        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>.txt
-      results_url_template:
-        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
-      base_options: width=10
-
 - name: sig-node-cri-tools
 - name: sig-node-node-feature-discovery
 - name: sig-node-kernel-module-management


### PR DESCRIPTION
the last run seems to be from 12/31, and the links go nowhere

fixes https://github.com/kubernetes/test-infra/issues/26712

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>