### PR TITLE
Fix the pull-kubernetes-node-kubelet-serial-pod-disruption-conditions configuration

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1677,9 +1677,8 @@ presubmits:
             - --
             - --deployment=node
             - --gcp-zone=us-west1-b
-            - --node-test-args=--feature-gates=PodDisruptionConditions=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
-
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+            - '--node-test-args=--feature-gates=PodDisruptionConditions=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
             - --test_args=--nodes=1 --timeout=180m --skip="" --focus="\[NodeFeature:PodDisruptionConditions\]"


### PR DESCRIPTION
The configuration does not work currently as indicated by this build: [https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/113908/pull-kubernetes[…]e-kubelet-serial-pod-disruption-conditions/1592428673930104832/](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/113908/pull-kubernetes-node-kubelet-serial-pod-disruption-conditions/1592428673930104832/)

This is an attempt to fix it by using the same serial config as another configuration which works (`pull-kubernetes-node-kubelet-serial-containerd`)
`/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml`