### PR TITLE
[sig-windows-networking] Add AKS 1.25 with AzureCNI prowjobs

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -61,12 +61,18 @@ dashboards:
   - name: ltsc2022-containerd-flannel-sdnoverlay-stable
     description: Runs Windows (LTSC 2022 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
-  - name: aks-ltsc2019-azurecni
-    description: Runs Kubernetes E2E tests on an AKS deployment (latest version) with LTSC 2019 nodes and AzureCNI.
-    test_group_name: aks-e2e-ltsc2019-azurecni
-  - name: aks-ltsc2022-azurecni
-    description: Runs Kubernetes E2E tests on an AKS deployment (latest version) with LTSC 2022 nodes and AzureCNI.
-    test_group_name: aks-e2e-ltsc2022-azurecni
+  - name: aks-ltsc2019-azurecni-1.24
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.24 release) with LTSC 2019 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2019-azurecni-1.24
+  - name: aks-ltsc2022-azurecni-1.24
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.24 release) with LTSC 2022 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2022-azurecni-1.24
+  - name: aks-ltsc2019-azurecni-1.25
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.25 release) with LTSC 2019 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2019-azurecni-1.25
+  - name: aks-ltsc2022-azurecni-1.25
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.25 release) with LTSC 2022 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2022-azurecni-1.25
 - name: sig-windows-containerd-runtime-signal
   dashboard_tab:
   - name: win-2019-containerd-master-integration
@@ -100,10 +106,14 @@ test_groups:
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
 # AKS with AzureCNI test groups
-- name: aks-e2e-ltsc2019-azurecni
-  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni
-- name: aks-e2e-ltsc2022-azurecni
-  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni
+- name: aks-e2e-ltsc2019-azurecni-1.24
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.24
+- name: aks-e2e-ltsc2022-azurecni-1.24
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.24
+- name: aks-e2e-ltsc2019-azurecni-1.25
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.25
+- name: aks-e2e-ltsc2022-azurecni-1.25
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.25
 # Containerd Runtime integration test groups
 - name: integration-containerd-windows-ltsc2019
   gcs_prefix: containerd-integration/logs/windows-ltsc2019


### PR DESCRIPTION
Add two more test groups for the AKS with AzureCNI 1.25 release testing.

Also, reuse existing AKS with AzureCNI prowjobs for 1.24 release testing. Everything was properly renamed in the `sig-windows-networking` Prow infrastructure to accommodate for this change.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>