### PR TITLE
capz: update approvers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -1,15 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- alexeldeib
 - CecileRobertMichon
-- devigned
 - jackfrancis
 - mboersma
-- shysank
+- marosset
+- jsturtevant
 reviewers:
 - Jont828
-- jsturtevant
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
This PR updates the capz approvers list:

Removes emeritus members:

- @alexeldeib 
- @shysank 
- @devigned 

Adds active test maintainers:

- @marosset 
- @jsturtevant 