### PR TITLE
releng 1.26: Add 1.26 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -435,6 +435,7 @@ milestone_applier:
     master: v1.26
   kubernetes/kubernetes:
     master: v1.26
+    release-1.26: v1.26
     release-1.25: v1.25
     release-1.24: v1.24
     release-1.23: v1.23


### PR DESCRIPTION
releng: Add 1.26 and remove 1.22 milestone_applier rules
1.26 rc.0 cut issue:https://github.com/kubernetes/sig-release/issues/2087
Slack thread: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1668515860735989
/hold

/sig release
/area release-eng
/assign @jeremyrickard  @puerco
cc: https://github.com/orgs/kubernetes/teams/release-engineering