### PR TITLE
releng 1.26: Update kubekins-e2e variants

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -32,10 +32,16 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.26':
+    CONFIG: '1.26'
+    GO_VERSION: 1.19.3
+    K8S_RELEASE: latest-1.26
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
     GO_VERSION: 1.19.3
-    K8S_RELEASE: latest-1.25
+    K8S_RELEASE: stable-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.24':


### PR DESCRIPTION
Update kubekins-e2e variants.yaml with 1.26 config
Update 1.25 kubekins-e2e variant to set K8S_RELEASE to stable-1.25
1.26 rc.0 cut issue:https://github.com/kubernetes/sig-release/issues/2087
Slack thread: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1668515860735989
/hold

/sig release
/area release-eng
/assign @jeremyrickard @puerco 
cc: https://github.com/orgs/kubernetes/teams/release-engineering