### PR TITLE
Add e2e presubmit with RUNNER=kind

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
@@ -61,3 +61,32 @@ presubmits:
       testgrid-num-columns-recent: '30'
     branches:
     - master
+    - release-0.5
+  - name: pull-aws-iam-authenticator-e2e-kind
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - e2e
+        env:
+        - name: RUNNER
+          value: kind
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: provider-aws-iam-authenticator
+      testgrid-tab-name: pull-e2e-kind
+      description: AWS IAM Authenticator end-to-end test on pull request (run on kind)
+      testgrid-num-columns-recent: '30'
+    branches:
+    - master
+    - release-0.5


### PR DESCRIPTION
This adds a presubmit for aws-iam-authenticator with a different test runner.  