### PR TITLE
fix pull-containerd-node-e2e-1-5

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -121,12 +121,12 @@ presubmits:
           --deployment=node
           --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
-          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
           --node-tests=true
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
-          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.5-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
 
   - name: pull-containerd-sandboxed-node-e2e
     always_run: false

--- a/jobs/e2e_node/containerd/containerd-release-1.5-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.5-presubmit/env
@@ -1,0 +1,8 @@
+CONTAINERD_TEST: 'true'
+CONTAINERD_LOG_LEVEL: 'debug'
+CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
+CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"

--- a/jobs/e2e_node/containerd/containerd-release-1.5-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.5-presubmit/image-config-presubmit.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-stable:
+    image_family: cos-93-lts
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.5-presubmit/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
- add separate image config file for containerd-1.5 presubmit. This is because the containerd-main-presubmit uses cos-stable image which uses systemd cgroup driver which is not configured in container 1.5. Therefore, containerd-1.5 job will use cos-93 image (cgroupv1) in presubmit jobs.

Signed-off-by: Akhil Mohan <makhil@vmware.com>