### PR TITLE
update containerd release 1.5 image to cos-93

### DIFF
--- a/jobs/e2e_node/containerd/containerd-release-1.5/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.5/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.5/env"
   cos-stable:
-    image_family: cos-89-lts
+    image_family: cos-93-lts
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.5/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
update containerd release 1.5 job image to use cos-93 stable. The image is set at cos-93 since later versions of cos images have cgroupv2.

Signed-off-by: Akhil Mohan <makhil@vmware.com>