### PR TITLE
Upgrade kubekins-e2e image to master

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -50,7 +50,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-master
             command:
               - runner.sh
               - ./scripts/ci-entrypoint.sh


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

Old image doesn't have go 1.19.
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cloud-provider-azure/2778/pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-24/1592786817881477120/build-log.txt