### PR TITLE
Update kubekins image to 1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
@@ -13,7 +13,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
       command:
         - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
         imagePullPolicy: Always
         resources:
           requests:
@@ -37,7 +37,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
@@ -57,7 +57,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
         imagePullPolicy: Always
         env:
         - name: "IBMCLOUD_API_KEY"
@@ -81,7 +81,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
         command:
         - "./scripts/ci-build.sh"
         resources:
@@ -101,7 +101,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
           command:
             - "make"
             - "verify"
@@ -121,7 +121,7 @@ presubmits:
       - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
         command:
           - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221109-489d560851-1.25
         command:
           - runner.sh
         args:


### PR DESCRIPTION
This PR updates Kubekins image to v1.25
Needed by: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/962