### PR TITLE
do not run unsupported tests on kind-ipv6

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -556,7 +556,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ProxyTerminatingEndpoints)\]|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|DualStack
       command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
Failing job 

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20IPv6,%20master%20%5Bnon-serial%5D