### PR TITLE
use the right skip for ipv6

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -556,7 +556,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ProxyTerminatingEndpoints)\]|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|DualStack
+        value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS|ProxyTerminatingEndpoints)\]|Internet.connection|upstream.nameserver|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|DualStack
       command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
I've used the ipv4 regex instead of the IPv6 one, fixing some problem but causing other

Failing job

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20IPv6,%20master%20%5Bnon-serial%5D

an IPv6 job must not run IPv4 tests and just skip them