### PR TITLE
[kubernetes-sigs/secrets-store-csi-driver#1091]add optional presubmit for alibabacloud provider with secrets-store-csi

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -536,6 +536,45 @@ presubmits:
       description: "Run e2e test with akeyless provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
 
+  - name: pull-secrets-store-csi-driver-e2e-alibabacloud
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    always_run: false
+    optional: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+      - ^main$
+      - ^release-*
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # Sets up the alibabacloud parameters used for testing
+      preset-alibabacloud-secrets-store-creds: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - >-
+              make e2e-bootstrap e2e-helm-deploy e2e-alibabacloud
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4"
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-alibabacloud
+      description: "Run e2e test with alibabacloud provider for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
+
   # release jobs
   - name: release-secrets-store-csi-driver-e2e-aws
     decorate: true

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
@@ -25,3 +25,16 @@ presets:
       secretKeyRef:
         name: akeyless-test-cred
         key: credentials
+- labels:
+    preset-alibabacloud-secrets-store-creds: "true"
+  env:
+    - name: ALIBABACLOUD_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: alibabacloud-test-cred
+          key: credentials-ak
+    - name: ALIBABACLOUD_ACCESS_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: alibabacloud-test-cred
+          key: credentials-sk

--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -17,6 +17,19 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: alibabacloud-test-cred
+  namespace: test-pods
+spec:
+  backendType: alicloudSecretsManager
+  data:
+    - key: alibabacloud-test-ak
+      name: credentials-ak
+    - key: alibabacloud-test-sk
+      name: credentials-sk
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: azure-cred
   namespace: test-pods
 spec:


### PR DESCRIPTION
PR adds:
1. optional presubmit testing for alibabacloud provider with secrets-store-csi
2. external secret in order to use it in alibabacloud provider tests