### PR TITLE
Update github username for oncall script

### DIFF
--- a/experiment/slack-oncall-updater/main.go
+++ b/experiment/slack-oncall-updater/main.go
@@ -32,7 +32,7 @@ import (
 // and clicking "Copy user ID".
 var githubToSlack = map[string]string{
 	"amwat":          "U9B1P2UGP",
-	"benkazemi":      "U03B4SNKVRT",
+	"benjaminkazemi": "U03B4SNKVRT",
 	"bentheelder":    "U1P7T516X",
 	"chaodaig":       "U010XUQ9VPE",
 	"chases2":        "UJ9R0FWD6",


### PR DESCRIPTION
Should fix this issue with the slack-oncall-updater script:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-update-slack-oncall/1593310604930584576
```
+ go run ./experiment/slack-oncall-updater --token-path=/etc/slack-token/token
2022/11/17 18:31:26 Current oncallers: map[google-build-admin:benjaminkazemi scalability:mborsz testinfra:listx]
attachment
2022/11/[17](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-update-slack-oncall/1593310604930584576#1:build-log.txt%3A17) [18](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-update-slack-oncall/1593310604930584576#1:build-log.txt%3A18):31:26 Failed to get Slack ID for GitHub user "benjaminkazemi"
2022/11/17 18:31:26 Rotation "scalability" does not yet have a Group ID, skipping ...
2022/11/17 18:31:26 listx's slack ID: UFCU8S8P3
[20](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-update-slack-oncall/1593310604930584576#1:build-log.txt%3A20)22/11/17 18:31:26 Adding slack user UFCU8S8P3 to slack usergroup SGLF0GUQH
2022/11/17 18:31:26 Failed to update some rotation(s)
```