### PR TITLE
capz: ensure upgrade test runs on release branches

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -379,7 +379,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
     always_run: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 4h


### PR DESCRIPTION
This PR follows on from https://github.com/kubernetes/test-infra/pull/26905.

Here we set the `pull-cluster-api-provider-azure-e2e-workload-upgrade-v1beta1` job to be required before merging PRs to capz release branches.

Successful runs here predict this is tractable:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2825
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2818