### PR TITLE
Make run_before_merge field emptiable 

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -175,7 +175,7 @@ type Presubmit struct {
 	// Brancher matches.
 	// This is used when a prowjob is so expensive that it's not ideal to run on
 	// every single push from all PRs.
-	RunBeforeMerge bool `json:"run_before_merge"`
+	RunBeforeMerge bool `json:"run_before_merge,omitempty"`
 
 	Brancher
 


### PR DESCRIPTION
Allow having run_before_merge field not mentioned in presubmit job definitions, as it makes it more backwards compatible with existing prow jobs definition.
We had tried updating to the newest test-infra version in openshift CI, but it leads to a lot of changes which can be avoided: https://github.com/openshift/ci-tools/pull/3139