### PR TITLE
releng: Fix build job generic version markers

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -155,7 +155,7 @@ periodics:
       - --allow-dup
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-stable3
+      - --extra-version-markers=k8s-stable2
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -155,7 +155,7 @@ periodics:
       - --allow-dup
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-stable2
+      - --extra-version-markers=k8s-stable1
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -155,7 +155,7 @@ periodics:
       - --allow-dup
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=latest-1.26
+      - --extra-version-markers=k8s-beta
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""


### PR DESCRIPTION
Continues https://github.com/kubernetes/test-infra/pull/28049.

Generic version markers should match the designations in https://github.com/kubernetes/test-infra/blob/d164f804c3351dd6923ceb6afeac6382937df9b3/releng/test_config.yaml#L377-L401

The missing link in https://github.com/kubernetes/test-infra/pull/28049#pullrequestreview-1188634918 is the `k8s-beta` version marker, which is the marker that is used between the time that a branch is cut and the release goes GA.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @jeremyrickard @puerco @xmudrii @cici37 
cc: @kubernetes/release-engineering @kubernetes/release-team-leads 
ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859