### PR TITLE
capo: add e2e full test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
           env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
+          - name: E2E_GINKGO_FOCUS
+            value: "\\[PR-Blocking\\]"
           command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -120,3 +122,50 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-conformance-test
+  - name: pull-cluster-api-provider-openstack-e2e-full-test
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
+          env:
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
+          # The PR-Blocking tests are run as in pull-cluster-api-provider-openstack-e2e-test
+          # so we skip them here and run only the rest.
+          - name: E2E_GINKGO_SKIP
+            value: "\\[PR-Blocking\\]"
+          # These tests can use more than 2 machines per cluster and even 2 clusters
+          # per test for clusterctl upgrade tests, so we limit the parallel jobs
+          # to avoid capacity issues.
+          - name: E2E_GINKGO_PARALLEL
+            value: "1"
+          command:
+          - "runner.sh"
+          - "./scripts/ci-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      testgrid-tab-name: pr-e2e-full-test


### PR DESCRIPTION
This adds a job for "e2e full" (similar to what [CAPI has](https://github.com/kubernetes/test-infra/blob/b27527630f6d4c0f2787f0362efd54c4cab5fbd6/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml#L222-L256)) and makes the default e2e focus on PR-Blocking tests (again [similar to CAPI](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml#L120-L150)).

The point it not to change the behavior of current tests, but to allow adding more tests that doesn't need to run all the time.

x-ref:

- Tag current tests as PR-Blocking: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1390
- Add more e2e tests that would be part of the e2e full: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1371

Don't merge before https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1390 !
/hold