### PR TITLE
releng: Don't delete jobs for branches that may be in maintenance mode

### DIFF
--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -33,6 +33,8 @@ BRANCH_JOB_DIR = "../config/jobs/kubernetes/sig-release/release-branch-jobs"
 max_config_count = 4
 min_config_count = 3
 
+suffixes = ['beta', 'stable1', 'stable2', 'stable3']
+
 class ToolError(Exception):
     pass
 
@@ -83,7 +85,6 @@ def delete_stale_branch(branch_path, current_version):
 
 def rotate_files(rotator_bin, branch_path, current_version):
     print("Rotating files...")
-    suffixes = ['beta', 'stable1', 'stable2', 'stable3']
     for i in range(0, 3):
         filename = '%d.%d.yaml' % (current_version[0], current_version[1] - i)
         from_suffix = suffixes[i]
@@ -112,7 +113,6 @@ def update_generated_config(path, latest_version):
         config = yaml.round_trip_load(f)
 
     v = latest_version
-    suffixes = ['beta', 'stable1', 'stable2', 'stable3']
     for i, s in enumerate(suffixes):
         vs = "%d.%d" % (v[0], v[1] + 1 - i)
         markers = config['k8sVersions'][s]

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -30,7 +30,7 @@ TEST_CONFIG_YAML = "test_config.yaml"
 JOB_CONFIG = "../config/jobs"
 BRANCH_JOB_DIR = "../config/jobs/kubernetes/sig-release/release-branch-jobs"
 
-max_config_count = 4
+max_config_count = 5
 min_config_count = 3
 
 suffixes = ['beta', 'stable1', 'stable2', 'stable3']

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -85,7 +85,7 @@ def delete_stale_branch(branch_path, current_version):
 
 def rotate_files(rotator_bin, branch_path, current_version):
     print("Rotating files...")
-    for i in range(0, 3):
+    for i in range(max_config_count - 1):
         filename = '%d.%d.yaml' % (current_version[0], current_version[1] - i)
         from_suffix = suffixes[i]
         to_suffix = suffixes[i+1]
@@ -154,7 +154,7 @@ def main():
     print("Current version: %d.%d" % (version[0], version[1]))
 
     files = get_config_files(branch_job_dir_abs)
-    if len(files) == 4:
+    if len(files) > max_config_count:
         print("There should be a maximum of %s release branch configs." % max_config_count)
         print("Deleting the oldest config before rotation...")
 

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -33,7 +33,7 @@ BRANCH_JOB_DIR = "../config/jobs/kubernetes/sig-release/release-branch-jobs"
 max_config_count = 5
 min_config_count = 3
 
-suffixes = ['beta', 'stable1', 'stable2', 'stable3']
+suffixes = ['beta', 'stable1', 'stable2', 'stable3', 'stable4']
 
 class ToolError(Exception):
     pass


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859:

This PR makes a few changes to the script for generating release branches:
- Move `suffixes` to outer scope
- Use config counts variables for iterators
- Expand `max_config_count` to 5 
- Expand `suffixes` to include `stable4`

This should ensure that when we generate release branches that we don't delete jobs for branches that may be in maintenance mode.

Here's an example of the script causing friction in that scenario: https://github.com/kubernetes/test-infra/pull/28022, https://github.com/kubernetes/test-infra/pull/28049

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @jeremyrickard @xmudrii @cici37 
cc: @kubernetes/release-engineering 
