### PR TITLE
add dind labels

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
@@ -42,6 +42,9 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kueue-test-e2e-main
       description: "Run kueue end to end tests"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master


### PR DESCRIPTION
For adding Kueue e2e tests, we discovered a bug in our setup.  

To use docker-in-docker, we need to set some labels.  

We got the following error when using this config:

> ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
make: *** [Makefile:182: image-build] Error 1

We are aiming to enable https://github.com/kubernetes-sigs/kueue/tree/main/test/e2e to run in prow.