### PR TITLE
Add support for stable4 marker to config-rotator

### DIFF
--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -160,6 +160,7 @@ const (
 	markerStableOne   = "k8s-stable1"
 	markerStableTwo   = "k8s-stable2"
 	markerStableThree = "k8s-stable3"
+	markerStableFour  = "k8s-stable4"
 )
 
 var allowedMarkers = []string{
@@ -168,6 +169,7 @@ var allowedMarkers = []string{
 	markerStableOne,
 	markerStableTwo,
 	markerStableThree,
+	markerStableFour,
 }
 
 func getMarker(s string) string {
@@ -195,6 +197,8 @@ func updateGenericVersionMarker(s string) string {
 		newMarker = markerStableTwo
 	case markerStableTwo:
 		newMarker = markerStableThree
+	case markerStableThree:
+		newMarker = markerStableFour
 	default:
 		newMarker = marker
 	}

--- a/releng/config-rotator/main_test.go
+++ b/releng/config-rotator/main_test.go
@@ -61,6 +61,14 @@ func TestUpdateGenericVersionMarker(t *testing.T) {
 			want: "--extra-version-markers=k8s-stable3",
 		},
 		{
+			name: "k8s-stable3",
+			args: args{
+				s:      "--extra-version-markers=k8s-stable3",
+				marker: markerStableTwo,
+			},
+			want: "--extra-version-markers=k8s-stable4",
+		},
+		{
 			name: "noReplace",
 			args: args{
 				s:      "no-replace",


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

This commit adds support for the `stable4` version maker to the config-rotator tool. This is a follow-up from #28084 to ensure that jobs using the `stable3` version marker are properly rotated.

/assign @justaugustus @jeremyrickard @cici37
cc: @kubernetes/release-engineering 