### PR TITLE
Add jobs for the `stable4` version marker

### DIFF
--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -163,6 +163,45 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
 
+  # stable4
+  ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-default:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseInforming: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseInforming: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-betaapis:
+    interval: 24h
+    args:
+    - --env=KUBE_PROXY_DAEMONSET=true
+    - --env=ENABLE_POD_PRIORITY=true
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+    - --runtime-config=api/beta=true
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+
 # The following settings are used by cluster e2e tests.
 
 common:


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

This commit updates `test_config.yaml` with jobs for the `stable4` version marker. This commit is currently NOOP because we already have those jobs and we already generated jobs for 1.26, but this ensures that our scripts will NOT delete `stable4` jobs when generating the new jobs (e.g. for 1.27).

The added `stable4` jobs were copied from the `stable3` jobs. I ran the job generation locally and there's no diff for the `stable4` jobs in terms of commands, args, and env. We can also always adjust the added jobs later if needed.

/assign @justaugustus @jeremyrickard @cici37
cc: @kubernetes/release-engineering 