### PR TITLE
Add DIND label to kueue E2E test job

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
@@ -42,6 +42,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kueue-test-e2e-main
       description: "Run kueue end to end tests"
+    labels:
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master


### PR DESCRIPTION
The test needs this label to be able to create a kind cluster with Docker-in-docker.