### PR TITLE
Fix the version markers not getting updated when generating new jobs

### DIFF
--- a/releng/README.md
+++ b/releng/README.md
@@ -17,7 +17,6 @@ a future date).
   - [Create a pull request](#create-a-pull-request)
   - [Validate](#validate)
   - [Announce](#announce)
-- [TODOs](#todos)
 
 ## Tools
 
@@ -70,13 +69,5 @@ Examples:
 ### Announce
 
 [Announce in #sig-release and #release-management](https://kubernetes.slack.com/archives/C2C40FMNF/p1565746110248300?thread_ts=1565701466.241200&cid=C2C40FMNF) that this work has been completed.
-
-## TODOs
-
-- [ ] Branch jobs build the wrong marker after new branch job creation
-  
-  e.g., `k8s-master` instead of `k8s-stable1`
-  
-  This suggests that the generic marker suffixes are not being properly replaced.
 
 [branch-manager-handbook]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -130,6 +130,10 @@ func generatePeriodics(conf config.JobConfig, version string) ([]config.Periodic
 					c.Args = fixBootstrapArgs(c.Args, version)
 				}
 				var err error
+				c.Command, err = performReplacement(c.Command, version, p.Annotations[replacementAnnotation])
+				if err != nil {
+					return nil, fmt.Errorf("%s: %w", periodic.Name, err)
+				}
 				c.Args, err = performReplacement(c.Args, version, p.Annotations[replacementAnnotation])
 				if err != nil {
 					return nil, fmt.Errorf("%s: %w", periodic.Name, err)

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -76,12 +76,12 @@ func updateJobBase(j *config.JobBase, old, new string) {
 	for i := range j.Spec.Containers {
 		c := &j.Spec.Containers[i]
 		for j := range c.Args {
-			c.Args[j] = updateString(c.Args[j], old, new)
 			c.Args[j] = updateGenericVersionMarker(c.Args[j])
+			c.Args[j] = updateString(c.Args[j], old, new)
 		}
 		for j := range c.Command {
-			c.Command[j] = updateString(c.Command[j], old, new)
 			c.Command[j] = updateGenericVersionMarker(c.Command[j])
+			c.Command[j] = updateString(c.Command[j], old, new)
 		}
 	}
 }


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

### config-forker changes

config-forker is currently performing replacement only on the job's args. This is causing an issue where the `ci-kubernetes-build` job is not forked properly because it uses `command` instead of `args`. Because of that, forked ci-kubernetes-build jobs are using an incorrect extra version marker. This is now fixed with this commit by ensuring we perform a replacement on both command and args.

### config-rotator changes

We are doing two things when updating version markers in config-rotator:

- run `strings.Replace` to replace all occurrences of the old marker with the new marker
- bump the old marker to the next one by calling `updateGenericVersionMarker`

This brings an issue that we're bumping the version markers for two instead of for one. For example, we bump `k8s-stable1` to `k8s-stable3`.

That's because we first run `strings.Replace("k8s-stable1", "k8s-stable2")` and then we run the `updateGenericVersionMarker` function which also updates the version marker to the next one.

This has never been an issue before because config-forker wasn't properly generating jobs, but that was fixed with a previous commit.

/assign @justaugustus @jeremyrickard @cici37
cc: @kubernetes/release-engineering 