### PR TITLE
Change e2e ingress job

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -125,7 +125,9 @@ postsubmits:
         - --env=VERSION=$(PULL_BASE_REF)
         - --env=REGISTRY=gcr.io/k8s-ingress-image-push
         - make
-        - push-e2e
+        - all-push
+        - ALL_ARCH='amd64 arm64'
+        - CONTAINER_BINARIES="e2e-test"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Use both arm64 & amd64 archs to build
e2e-test images for k8s ingress job.

Signed-off-by: Elina Akhmanova <elinka@google.com>