### PR TITLE
config-forker: perform replacement on Command for presubmits and postsubmits

### DIFF
--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -62,6 +62,10 @@ func generatePostsubmits(c config.JobConfig, version string) (map[string][]confi
 					c.Env = fixEnvVars(c.Env, version)
 					c.Image = fixImage(c.Image, version)
 					var err error
+					c.Command, err = performReplacement(c.Command, version, p.Annotations[replacementAnnotation])
+					if err != nil {
+						return nil, fmt.Errorf("%s: %w", postsubmit.Name, err)
+					}
 					c.Args, err = performReplacement(c.Args, version, p.Annotations[replacementAnnotation])
 					if err != nil {
 						return nil, fmt.Errorf("%s: %w", postsubmit.Name, err)
@@ -92,6 +96,10 @@ func generatePresubmits(c config.JobConfig, version string) (map[string][]config
 					c.Env = fixEnvVars(c.Env, version)
 					c.Image = fixImage(c.Image, version)
 					var err error
+					c.Command, err = performReplacement(c.Command, version, p.Annotations[replacementAnnotation])
+					if err != nil {
+						return nil, fmt.Errorf("%s: %w", presubmit.Name, err)
+					}
 					c.Args, err = performReplacement(c.Args, version, p.Annotations[replacementAnnotation])
 					if err != nil {
 						return nil, fmt.Errorf("%s: %w", presubmit.Name, err)

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -535,9 +535,10 @@ func TestGeneratePresubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-master",
-								Args:  []string{"--repo=k8s.io/kubernetes", "--something=foo"},
-								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
+								Image:   "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-master",
+								Command: []string{"--arg1=test", "--something=foo"},
+								Args:    []string{"--repo=k8s.io/kubernetes", "--something=foo"},
+								Env:     []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
 							},
 						},
 					},
@@ -614,9 +615,10 @@ func TestGeneratePresubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-1.15",
-								Args:  []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
-								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
+								Image:   "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-1.15",
+								Command: []string{"--arg1=test", "--something=1.15"},
+								Args:    []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
+								Env:     []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
 							},
 						},
 					},
@@ -685,9 +687,10 @@ func TestGeneratePeriodics(t *testing.T) {
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Image: "gcr.io/k8s-testinfra/kubekins-e2e:blahblahblah-master",
-							Args:  []string{"--repo=k8s.io/kubernetes", "--version=stable"},
-							Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
+							Image:   "gcr.io/k8s-testinfra/kubekins-e2e:blahblahblah-master",
+							Command: []string{"--args1=test", "--version=stable"},
+							Args:    []string{"--repo=k8s.io/kubernetes", "--version=stable"},
+							Env:     []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
 						},
 					},
 				},
@@ -750,9 +753,10 @@ func TestGeneratePeriodics(t *testing.T) {
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Image: "gcr.io/k8s-testinfra/kubekins-e2e:blahblahblah-1.15",
-							Args:  []string{"--repo=k8s.io/kubernetes=release-1.15", "--version=1.15"},
-							Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
+							Image:   "gcr.io/k8s-testinfra/kubekins-e2e:blahblahblah-1.15",
+							Command: []string{"--args1=test", "--version=1.15"},
+							Args:    []string{"--repo=k8s.io/kubernetes=release-1.15", "--version=1.15"},
+							Env:     []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
 						},
 					},
 				},
@@ -831,9 +835,10 @@ func TestGeneratePostsubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-master",
-								Args:  []string{"--repo=k8s.io/kubernetes", "--something=foo"},
-								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
+								Image:   "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-master",
+								Command: []string{"--args1=test", "--something=foo"},
+								Args:    []string{"--repo=k8s.io/kubernetes", "--something=foo"},
+								Env:     []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
 							},
 						},
 					},
@@ -896,9 +901,10 @@ func TestGeneratePostsubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-1.15",
-								Args:  []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
-								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
+								Image:   "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-1.15",
+								Command: []string{"--args1=test", "--something=1.15"},
+								Args:    []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
+								Env:     []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
 							},
 						},
 					},


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

We started performing replacement on Command for periodics in #28090. However, we did it only for periodics and I think that we should do it for presubmits and postsubmits to have consistent behavior.

This commit also adds tests for the command replacements.

/assign @justaugustus @jeremyrickard @cici37
cc: @kubernetes/release-engineering 