### PR TITLE
Remove run_before_merge from the release jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -731,7 +731,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-kops-aws
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -781,7 +780,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -827,7 +825,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-canary
-    run_before_merge: false
     skip_report: true
     spec:
       containers:
@@ -878,7 +875,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -927,7 +923,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -983,7 +978,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1041,7 +1035,6 @@ presubmits:
     max_concurrency: 5
     name: pull-kubernetes-e2e-gce-device-plugin-gpu
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1084,7 +1077,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify-govet-levee
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1138,7 +1130,6 @@ presubmits:
     name: pull-kubernetes-node-e2e-podutil
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1182,7 +1173,6 @@ presubmits:
     name: pull-kubernetes-node-e2e-kubetest2
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1220,7 +1210,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1261,7 +1250,6 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-kubernetes-node-e2e-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1311,7 +1299,6 @@ presubmits:
     name: pull-kubernetes-node-e2e-containerd-kubetest2
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1366,7 +1353,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-gce-100-performance
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1439,7 +1425,6 @@ presubmits:
     name: pull-kubernetes-kubemark-e2e-gce-big
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1504,7 +1489,6 @@ presubmits:
     name: pull-kubernetes-conformance-kind-ipv6-parallel
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: ^test/
     spec:
       containers:
@@ -1540,7 +1524,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-dependencies
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1570,7 +1553,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-files-remake
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: Makefile.generated_files|make-rules
     spec:
       containers:
@@ -1601,7 +1583,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-integration
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1633,7 +1614,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1674,7 +1654,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1719,7 +1698,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1754,7 +1732,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-unit
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1779,7 +1756,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-typecheck
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1809,7 +1785,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -606,7 +606,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-kops-aws
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -656,7 +655,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -702,7 +700,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-canary
-    run_before_merge: false
     skip_report: true
     spec:
       containers:
@@ -752,7 +749,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -807,7 +803,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -864,7 +859,6 @@ presubmits:
     max_concurrency: 5
     name: pull-kubernetes-e2e-gce-device-plugin-gpu
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -907,7 +901,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify-govet-levee
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -951,7 +944,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -991,7 +983,6 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-kubernetes-node-e2e-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1041,7 +1032,6 @@ presubmits:
     name: pull-kubernetes-node-e2e-containerd-kubetest2
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1096,7 +1086,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-gce-100-performance
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1178,7 +1167,6 @@ presubmits:
     name: pull-kubernetes-kubemark-e2e-gce-big
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1257,7 +1245,6 @@ presubmits:
     max_concurrency: 1
     name: pull-kubernetes-kubemark-e2e-gce-scale
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1319,7 +1306,6 @@ presubmits:
     name: pull-kubernetes-conformance-kind-ipv6-parallel
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: ^test/
     spec:
       containers:
@@ -1358,7 +1344,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-dependencies
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1388,7 +1373,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-files-remake
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: Makefile.generated_files|make-rules
     spec:
       containers:
@@ -1419,7 +1403,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-integration
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1451,7 +1434,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1492,7 +1474,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1537,7 +1518,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1572,7 +1552,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-unit
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1597,7 +1576,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-typecheck
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1627,7 +1605,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-update
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1668,7 +1645,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1719,7 +1695,6 @@ presubmits:
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
     path_alias: k8s.io/perf-tests
-    run_before_merge: false
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:
@@ -1787,7 +1762,6 @@ presubmits:
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
     path_alias: k8s.io/perf-tests
-    run_before_merge: false
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -554,7 +554,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-kops-aws
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -604,7 +603,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -650,7 +648,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-canary
-    run_before_merge: false
     skip_report: true
     spec:
       containers:
@@ -700,7 +697,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -755,7 +751,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -812,7 +807,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-serial
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -869,7 +863,6 @@ presubmits:
     max_concurrency: 5
     name: pull-kubernetes-e2e-gce-device-plugin-gpu
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -912,7 +905,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify-govet-levee
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -956,7 +948,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -996,7 +987,6 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-kubernetes-node-e2e-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1046,7 +1036,6 @@ presubmits:
     name: pull-kubernetes-node-e2e-containerd-kubetest2
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1101,7 +1090,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-gce-100-performance
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1184,7 +1172,6 @@ presubmits:
     name: pull-kubernetes-kubemark-e2e-gce-big
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1264,7 +1251,6 @@ presubmits:
     max_concurrency: 1
     name: pull-kubernetes-kubemark-e2e-gce-scale
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1326,7 +1312,6 @@ presubmits:
     name: pull-kubernetes-conformance-kind-ipv6-parallel
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: ^test/
     spec:
       containers:
@@ -1365,7 +1350,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-dependencies
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1399,7 +1383,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-files-remake
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: Makefile.generated_files|make-rules
     spec:
       containers:
@@ -1430,7 +1413,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-integration
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1462,7 +1444,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1503,7 +1484,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1548,7 +1528,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1583,7 +1562,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-unit
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1608,7 +1586,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-typecheck
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1638,7 +1615,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-update
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1679,7 +1655,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1730,7 +1705,6 @@ presubmits:
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
     path_alias: k8s.io/perf-tests
-    run_before_merge: false
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:
@@ -1799,7 +1773,6 @@ presubmits:
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
     path_alias: k8s.io/perf-tests
-    run_before_merge: false
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -615,7 +615,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-kops-aws
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -665,7 +664,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -711,7 +709,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-canary
-    run_before_merge: false
     skip_report: true
     spec:
       containers:
@@ -761,7 +758,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -816,7 +812,6 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -873,7 +868,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-e2e-gce-ubuntu-containerd-serial
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -930,7 +924,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-e2e-gce-cloud-provider-disabled
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -981,7 +974,6 @@ presubmits:
     max_concurrency: 5
     name: pull-kubernetes-e2e-gce-device-plugin-gpu
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1024,7 +1016,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify-govet-levee
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1066,7 +1057,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
     optional: true
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1106,7 +1096,6 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-kubernetes-node-e2e-containerd
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1156,7 +1145,6 @@ presubmits:
     name: pull-kubernetes-node-e2e-containerd-kubetest2
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1211,7 +1199,6 @@ presubmits:
     max_concurrency: 12
     name: pull-kubernetes-e2e-gce-100-performance
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1293,7 +1280,6 @@ presubmits:
     name: pull-kubernetes-kubemark-e2e-gce-big
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1373,7 +1359,6 @@ presubmits:
     max_concurrency: 1
     name: pull-kubernetes-kubemark-e2e-gce-scale
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1435,7 +1420,6 @@ presubmits:
     name: pull-kubernetes-conformance-kind-ipv6-parallel
     optional: true
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     run_if_changed: ^test/
     spec:
       containers:
@@ -1474,7 +1458,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-dependencies
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1507,7 +1490,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-integration
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1539,7 +1521,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1580,7 +1561,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1625,7 +1605,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1660,7 +1639,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-unit
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - command:
@@ -1683,7 +1661,6 @@ presubmits:
     decorate: true
     name: pull-kubernetes-typecheck
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1713,7 +1690,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-update
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1752,7 +1728,6 @@ presubmits:
       preset-service-account: "true"
     name: pull-kubernetes-verify
     path_alias: k8s.io/kubernetes
-    run_before_merge: false
     spec:
       containers:
       - args:
@@ -1801,7 +1776,6 @@ presubmits:
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
     path_alias: k8s.io/perf-tests
-    run_before_merge: false
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:
@@ -1869,7 +1843,6 @@ presubmits:
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
     path_alias: k8s.io/perf-tests
-    run_before_merge: false
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

This PR removes `run_before_merge: false` from the release jobs. I don't _think_ that we need this at all. This property is also removed when generating the release jobs using:

```
make -C releng prepare-release-branch
```

As far as I can tell:
- `run_before_merge` variable is defined here: https://github.com/kubernetes/test-infra/blob/4b1eb2a191d0cbd0d60f431f8084726c572ee77d/prow/config/jobs.go#L174-L178
- the type of this variable is `bool` which means that this variable is `false` by default
- running [code search](https://cs.k8s.io/?q=RunBeforeMerge&i=nope&files=&excludeFiles=&repos=), I don't see that Prow ever sets this variable to true, so it should always stay false. That being said, I don't think we need to explicitly set it to false in the release jobs

/assign @justaugustus @jeremyrickard @cici37
cc: @kubernetes/release-engineering 