### PR TITLE
kOps: Replace t6g instances with t4g

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1047,7 +1047,7 @@ def generate_presubmits_network_plugins():
             k8s_version = '1.22'
         extra_flags = ['--node-size=t3.large']
         if 'arm64' in distro:
-            extra_flags = ["--node-size=t6g.large"]
+            extra_flags = ["--node-size=t4g.large"]
         results.append(
             presubmit_test(
                 distro=distro,

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -671,7 +671,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --validation-wait=20m \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -787,7 +787,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -851,7 +851,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -915,7 +915,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -979,7 +979,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -1043,7 +1043,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -1107,7 +1107,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -3061,7 +3061,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -3125,7 +3125,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -3189,7 +3189,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -3253,7 +3253,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -3317,7 +3317,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -3381,7 +3381,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -5335,7 +5335,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -5399,7 +5399,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -5463,7 +5463,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -5527,7 +5527,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -5591,7 +5591,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -5655,7 +5655,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -7609,7 +7609,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -7673,7 +7673,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -7737,7 +7737,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -7801,7 +7801,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -7865,7 +7865,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -7929,7 +7929,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -9379,7 +9379,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -9443,7 +9443,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -10641,7 +10641,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -10705,7 +10705,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -10769,7 +10769,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -10833,7 +10833,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -10897,7 +10897,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -10961,7 +10961,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -15435,7 +15435,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -15499,7 +15499,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -15563,7 +15563,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -15627,7 +15627,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -15691,7 +15691,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -15755,7 +15755,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -15819,7 +15819,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -15883,7 +15883,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -15947,7 +15947,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -16011,7 +16011,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -16075,7 +16075,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -19604,7 +19604,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -19668,7 +19668,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -19732,7 +19732,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -19796,7 +19796,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -19860,7 +19860,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -19924,7 +19924,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -19988,7 +19988,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -20052,7 +20052,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -20116,7 +20116,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -20180,7 +20180,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -20244,7 +20244,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -23773,7 +23773,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -23837,7 +23837,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -23901,7 +23901,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -23965,7 +23965,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -24029,7 +24029,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -24093,7 +24093,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -24157,7 +24157,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -24221,7 +24221,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -24285,7 +24285,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -24349,7 +24349,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -24413,7 +24413,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -27942,7 +27942,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -28006,7 +28006,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -28070,7 +28070,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -28134,7 +28134,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -28198,7 +28198,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -28262,7 +28262,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -28326,7 +28326,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -28390,7 +28390,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -28454,7 +28454,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -28518,7 +28518,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -28582,7 +28582,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -31229,7 +31229,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -31293,7 +31293,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -31357,7 +31357,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -31421,7 +31421,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -33627,7 +33627,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -33691,7 +33691,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -33755,7 +33755,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --validation-wait=20m \
@@ -33819,7 +33819,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -33883,7 +33883,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -33947,7 +33947,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -34011,7 +34011,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -34075,7 +34075,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.24/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -34139,7 +34139,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -34203,7 +34203,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -34267,7 +34267,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.25/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -227,7 +227,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-arm64-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-arm64-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --validation-wait=20m \
@@ -426,7 +426,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-arm64-hvm' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --topology=private --bastion --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-arm64-hvm' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --topology=private --bastion --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --validation-wait=20m \
@@ -493,7 +493,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3402.1.0-arm64-hvm' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --topology=private --bastion --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-beta-3417.1.0-arm64-hvm' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --topology=private --bastion --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --validation-wait=20m \

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -684,7 +684,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='075585003325/Flatcar-beta-3402.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='075585003325/Flatcar-beta-3417.1.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -134,7 +134,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-amazonvpc-ipv6
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-cni-calico
     branches:
     - master
@@ -166,7 +166,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=calico --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=calico --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -192,7 +192,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
@@ -266,7 +266,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-calico-ipv6
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "canal"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "canal"}
   - name: pull-kops-e2e-cni-canal
     branches:
     - master
@@ -298,7 +298,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=canal --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=canal --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -324,7 +324,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: canal
@@ -332,7 +332,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-canal
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-cni-cilium
     branches:
     - master
@@ -364,7 +364,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=cilium --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=cilium --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -390,7 +390,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -464,7 +464,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-cilium-ipv6
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-etcd"}
   - name: pull-kops-e2e-cni-cilium-etcd
     branches:
     - master
@@ -495,7 +495,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -521,7 +521,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium-etcd
@@ -529,7 +529,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-cilium-etcd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
   - name: pull-kops-e2e-cni-cilium-eni
     branches:
     - master
@@ -560,7 +560,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -586,7 +586,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium-eni
@@ -594,7 +594,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-cilium-eni
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "flannel"}
   - name: pull-kops-e2e-cni-flannel
     branches:
     - master
@@ -626,7 +626,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=flannel --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=flannel --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -652,7 +652,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: flannel
@@ -660,7 +660,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-flannel
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kube-router"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kube-router"}
   - name: pull-kops-e2e-cni-kuberouter
     branches:
     - master
@@ -692,7 +692,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=kube-router --container-runtime=containerd --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20221118' --channel=alpha --networking=kube-router --container-runtime=containerd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -718,7 +718,7 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t6g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kube-router


### PR DESCRIPTION
```
Error: nodes-ap-southeast-2a.spec.machineType: Invalid value: "t6g.large": machine type "t6g.large" is invalid:
describing instance type "t6g.large" in region "ap-southeast-2": InvalidInstanceType:
The following supplied instance types do not exist: [t6g.large]
```

/cc @johngmyers @rifelpet 