### PR TITLE
Allow any triage label to remove needs-triage on kustomize repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -789,7 +789,7 @@ require_matching_label:
   repo: kustomize
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 


### PR DESCRIPTION
@natasha41575 @annasong20  I've noticed when doing triage that the `needs-triage` label sometimes gets removed automatically and sometimes does not, whereas the `needs-kind` label works as expected. It turns out this is a Prow configuration option. I see that other repos that use this feature have the same restriction as our current config, but I feel that having it removed regardless of the triage result would better fit our actual workflow. Do you agree?