### PR TITLE
Add prow jobs for release-1.6 in CAPA

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.6.yaml
@@ -1,0 +1,176 @@
+periodics:
+- name: periodic-cluster-api-provider-aws-e2e-release-1-6
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: release-1.6
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+      command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      env:
+      - name: BOSKOS_HOST
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: AWS_REGION
+        value: "us-west-2"
+      # Parallelize tests
+      - name: GINKGO_ARGS
+        value: "-nodes 20 -skip='\\[ClusterClass\\]'"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 2
+          memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-e2e-release-1-6
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-aws-eks-e2e-release-1-6
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: release-1.6
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+      command:
+        - "runner.sh"
+        - "./scripts/ci-e2e-eks.sh"
+      env:
+      - name: BOSKOS_HOST
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: AWS_REGION
+        value: "us-west-2"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 2
+          memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-eks-e2e-release-1-6
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-aws-e2e-conformance-release-1-6
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-aws
+      base_ref: release-1.6
+      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+        env:
+          - name: BOSKOS_HOST
+            value: "boskos.test-pods.svc.cluster.local"
+          - name: AWS_REGION
+            value: "us-west-2"
+          # Parallelize tests
+          - name: GINKGO_ARGS
+            value: "-nodes 20"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-conformance-release-1-6
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts-release-1-6
+  max_concurrency: 1
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-aws
+      base_ref: release-1.6
+      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+        env:
+          - name: BOSKOS_HOST
+            value: "boskos.test-pods.svc.cluster.local"
+          - name: AWS_REGION
+            value: "us-west-2"
+          - name: E2E_ARGS
+            value: "-kubetest.use-ci-artifacts"
+          # Parallelize tests
+          - name: GINKGO_ARGS
+            value: "-nodes 20"
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9Gi"
+            cpu: 2
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+    testgrid-tab-name: periodic-conformance-release-1-6-k8s-main
+    testgrid-num-columns-recent: '20'
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.6.yaml
@@ -1,0 +1,288 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-aws:
+  - name: pull-cluster-api-provider-aws-test-release-1-6
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+        command:
+        - "./scripts/ci-test.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-test-release-1-6
+  - name: pull-cluster-api-provider-aws-apidiff-release-1-6
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    always_run: true
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-apidiff-release-1-6
+  - name: pull-cluster-api-provider-aws-build-release-1-6
+    always_run: true
+    optional: false
+    decorate: true
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-1.6$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+        command:
+        - "./scripts/ci-build.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-build-release-1-6
+  - name: pull-cluster-api-provider-aws-verify-release-1-6
+    always_run: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+        command:
+        - "runner.sh"
+        - "make"
+        - "verify"
+        # docker-in-docker needs privileged mode
+        securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-verify-release-1-6
+    labels:
+      preset-dind-enabled: "true"
+  # conformance test
+  - name: pull-cluster-api-provider-aws-e2e-conformance-release-1-6
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9Gi"
+              cpu: 2
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-conformance-release-1-6
+      testgrid-num-columns-recent: '20'
+  # conformance test against kubernetes main branch with `kind` + cluster-api-provider-aws
+  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-1-6
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+            - name: E2E_ARGS
+              value: "-kubetest.use-ci-artifacts"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-conformance-release-1-6-k8s-main
+      testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-blocking-release-1-6
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-1.6$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    #run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: E2E_FOCUS
+              value: "\\[PR-Blocking\\]"
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+            # Parallelize tests
+            - name: GINKGO_ARGS
+              value: "-nodes 20"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-quick-e2e-release-1-6
+      testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-release-1-6
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-e2e-release-1-6
+      testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-eks-release-1-6
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.6$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220922-dcf27e1579-1.24
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e-eks.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
+      testgrid-tab-name: pr-e2e-eks-release-1-6
+      testgrid-num-columns-recent: '20'

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -13,6 +13,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-1.3
     - sig-cluster-lifecycle-cluster-api-provider-aws
     - sig-cluster-lifecycle-cluster-api-provider-aws-1.5
+    - sig-cluster-lifecycle-cluster-api-provider-aws-1.6
     - sig-cluster-lifecycle-cluster-api-provider-azure
     - sig-cluster-lifecycle-cluster-api-provider-digitalocean
     - sig-cluster-lifecycle-cluster-api-provider-vsphere
@@ -41,6 +42,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-1.2
 - name: sig-cluster-lifecycle-cluster-api-1.3
 - name: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
+- name: sig-cluster-lifecycle-cluster-api-provider-aws-1.6
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
   dashboard_tab:
     - name: periodic-test-coverage-main


### PR DESCRIPTION
This PR is to add the E2E jobs for CAPA release 1.6.

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3880