### PR TITLE
Updated generated test config to include `stable4` tests

### DIFF
--- a/config/testgrids/generated-test-config.yaml
+++ b/config/testgrids/generated-test-config.yaml
@@ -176,3 +176,52 @@ test_groups:
   - configuration_value: master_os_image
   - configuration_value: Commit
   - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-betaapis
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-betaapis
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-default
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-default
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-ingress
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-ingress
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-reboot
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-reboot
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-serial
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-gce-cos-k8sstable4-slow
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable4-slow
+  column_header:
+  - configuration_value: node_os_image
+  - configuration_value: master_os_image
+  - configuration_value: Commit
+  - configuration_value: infra-commit


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

We introduced support for the `stable4` version marker as part of https://github.com/kubernetes/sig-release/issues/2094 and https://github.com/kubernetes/test-infra/pull/28088. However, I think that we forgot to update the generated test config (`config/testgrids/generated-test-config.yaml`) to include jobs that use the `stable4` version marker.

This PR updates `config/testgrids/generated-test-config.yaml` with jobs that use the `stable4` marker.

/assign @justaugustus @jeremyrickard @cici37 
cc: @kubernetes/release-engineering 