### PR TITLE
kueue updated end to end tests

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
@@ -52,7 +52,8 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test-e2e-kind
+        - kind-image-build
+        - test-e2e
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
PR kubernetes-sigs/kueue#441 updates target `test-e2e-kind` to `test-e2e` for handling running e2e tests for existing clusters. So for these tests to run here we need to run `kind-image-build` before we run `test-e2e`