### PR TITLE
make pull-kubebuilder-e2e-k8s-1-25-0 mandatory

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   - name: pull-kubebuilder-e2e-k8s-1-25-0
     decorate: true
     always_run: true
-    optional: true
+    optional: false
     path_alias: sigs.k8s.io/kubebuilder
     branches:
       - ^master$

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
   - name: pull-kubebuilder-e2e-k8s-1-24-1
     decorate: true
     always_run: true
-    optional: true
+    optional: false
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$
@@ -82,7 +82,7 @@ presubmits:
   - name: pull-kubebuilder-e2e-k8s-1-23-3
     decorate: true
     always_run: true
-    optional: true
+    optional: false
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$


### PR DESCRIPTION
**Description of the change:**
make `pull-kubebuilder-e2e-k8s-1-xx-0` tests mandatory instead of `optional`

**Motivation for the change:**
At issue https://github.com/kubernetes-sigs/kubebuilder/pull/3077, the **k8s-ci-robot** merged the pulled request even though testing failed, as detailed here: https://github.com/kubernetes-sigs/kubebuilder/pull/3077#issuecomment-1317613311

* Fixes https://github.com/kubernetes-sigs/kubebuilder/issues/3083