### PR TITLE
Re-enable sanity tests for pd driver

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -25,7 +25,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e
       description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
-    always_run: false
+    always_run: true
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
This reverts #26354 to re-enable sanity tests for pd driver now that they have been fixed as of https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/990 