### PR TITLE
Pubsub logs raw payload before processing(should revert)

### DIFF
--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -370,7 +370,9 @@ func (s *Subscriber) handleMessage(msg messageInterface, subscription string, al
 		"pubsub-subscription": subscription,
 		"pubsub-id":           msg.getID()})
 	s.Metrics.MessageCounter.With(prometheus.Labels{subscriptionLabel: subscription}).Inc()
-	l.Info("Received message")
+	// TODO(chaodaiG): logging payload for debugging purpose, remove once the
+	// bug is fixed.
+	l.WithField("payload", string(msg.getPayload())).Debug("Received message")
 	eType, err := extractFromAttribute(msg.getAttributes(), ProwEventType)
 	if err != nil {
 		l.WithError(err).Error("failed to read message")


### PR DESCRIPTION
Seeing very strange behavior that is hard to debug, include one more log to help debug, will revert once the bug is fixed