### PR TITLE
Updating SIG-Windows 1.26/master jobs to use CAPZ@release-1.6 instead  of master

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -90,7 +90,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: main
+    base_ref: release-1.6
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
@@ -426,7 +426,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: main
+    base_ref: release-1.6
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: windows-testing

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -543,7 +543,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: main
+  - base_ref: release-1.6
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Fixes: https://github.com/kubernetes/kubernetes/issues/114213

/assign @CecileRobertMichon @jackfrancis @leonardpahlke 

There was an accidental regression in CAPZ which prevented the Windows test clusters to provision.
More details in https://kubernetes.slack.com/archives/CEX9HENG7/p1669827404622189