### PR TITLE
CAPV: Updates the run interval to 24h instead of 12h

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.3.yaml
@@ -6,7 +6,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 12h
+    interval: 24h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.4.yaml
@@ -6,7 +6,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 12h
+    interval: 24h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere


### PR DESCRIPTION
Since the tests have been pretty stable now, decreasing the interval between two runs to `24h`.

/cc @yastij @lubronzhan @sbueringer 