### PR TITLE
Upgrade sig-storage-lib-external-provisioner.yaml to golang:1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: golang:1.17.1
+      - image: golang:1.19
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: golang:1.17.1
+      - image: golang:1.19
         command:
         - make
         args:


### PR DESCRIPTION
Sidecar release PR https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/132 failed, the env should be at least 1.18.