### PR TITLE
CAPZ: run conformance PR jobs when test suite changes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -251,6 +251,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
+    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-conformance.sh'
     decorate: true
     decoration_config:
       timeout: 4h
@@ -284,6 +285,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-conformance.sh'
     decoration_config:
       timeout: 4h
     max_concurrency: 5
@@ -316,6 +318,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
+    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-conformance.sh'
     decorate: true
     decoration_config:
       timeout: 4h


### PR DESCRIPTION
Repair item from recent regression that could have been caught in a PR test: run all the conformance jobs when `test/e2e`, `templates/test`, or `scripts/ci-conformance.sh` change.