### PR TITLE
releng: bump kpromo to v3.4.10

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
         command:
         - /kpromo
         args:
@@ -43,7 +43,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
         command:
         - /kpromo
         args:
@@ -87,7 +87,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
         command:
         - /kpromo
         args:
@@ -40,7 +40,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
         command:
         - /kpromo
         args:
@@ -106,7 +106,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
       command:
       - /kpromo
       args:
@@ -144,7 +144,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.9-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Bump image promoter to v3.4.10

/cc @jeremyrickard @xmudrii 

Part of https://github.com/kubernetes-sigs/promo-tools/issues/682

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>