### PR TITLE
Disable sanity tests for pd driver

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -25,7 +25,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e
       description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
-    always_run: true
+    always_run: false
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
I'm seeing a potential flake on Sunny's PR in https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1092 so disabling it to be safe until I can investigate further.

This is a follow up to https://github.com/kubernetes/test-infra/pull/28127