### PR TITLE
Re-enable sanity tests in pd driver

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -25,7 +25,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e
       description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
-    always_run: false
+    always_run: true
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
Re-enabling sanity tests in pd after fixing backoff flake in https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1094