### PR TITLE
use kube-proxy default minSyncPeriod on scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -165,7 +165,8 @@ presets:
   - name: KUBEPROXY_TEST_ARGS
     # TODO(#74011): Remove metrics-bind-address if the default is set.
     # FeatureGate added in #110268 v1.26
-    value: "--profiling --metrics-bind-address=0.0.0.0 --feature-gates=MinimizeIPTablesRestore=true"
+    # TODO(#114229): Use default kube-proxy minSyncPeriod of 1s, remove when last supported version is v1.27
+    value: "--profiling --metrics-bind-address=0.0.0.0 --iptables-min-sync-period=1s --feature-gates=MinimizeIPTablesRestore=true"
   - name: SCHEDULER_TEST_ARGS
     value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
   # Reduce logs verbosity.


### PR DESCRIPTION
iptables performance improved a lot since 2017, we had a 10s minSyncPeriod in kube-proxy by default to avoid the performance problems.

Before rolling out changes and move from 10s to 1s as minSyncPeriod we should study the impact of this change on all the scalability jobs.

xref: https://github.com/kubernetes/kubernetes/pull/114229

This will make this flag also run on old versions IIUIC as suggested by @wojtek-t https://github.com/kubernetes/kubernetes/pull/114229#issuecomment-1334849412

