### PR TITLE
Updating windows soak tests to use K8s v1.26 clusters

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -22,7 +22,7 @@ presubmits:
       #   path_alias: "k8s.io/perf-tests"
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.4
+        base_ref: release-1.6
         path_alias: "sigs.k8s.io/cluster-api-provider-azure"
         workdir: true
     spec:
@@ -50,7 +50,7 @@ presubmits:
             - name: TEST_WINDOWS
               value: "true"
             - name: KUBERNETES_VERSION
-              value: "v1.23.5"
+              value: "v1.25.3"
             - name: WINDOWS_WORKER_MACHINE_COUNT
               value: "1"
             - name: WORKER_MACHINE_COUNT
@@ -105,7 +105,7 @@ periodics:
         path_alias: "k8s.io/perf-tests"
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: main
+        base_ref: release-1.6
         path_alias: "sigs.k8s.io/cluster-api-provider-azure"
         workdir: true
     spec:
@@ -133,7 +133,7 @@ periodics:
             - name: TEST_WINDOWS
               value: "true"
             - name: KUBERNETES_VERSION
-              value: "v1.23.5"
+              value: "v1.25.3"
             - name: WINDOWS_WORKER_MACHINE_COUNT
               value: "1"
             - name: WORKER_MACHINE_COUNT


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Updating the windows soak jobs to provision K8s v1.26 clusters and targeting CAPZ@release-1.26 for stability

/sig windows

/assign @jsturtevant @CecileRobertMichon @jackfrancis 