### PR TITLE
Change presubmit names on master to better reflect images

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -12,7 +12,7 @@ presets:
 
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-gce
+  - name: pull-kubernetes-e2e-gce-cos
     always_run: false
     cluster: k8s-infra-prow-build
     skip_branches:
@@ -60,12 +60,12 @@ presubmits:
             memory: 14Gi
         securityContext:
           privileged: true
-  - name: pull-kubernetes-e2e-gce-no-stage
+  - name: pull-kubernetes-e2e-gce-cos-no-stage
     always_run: false
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-gce-no-stage
+      testgrid-tab-name: pull-kubernetes-e2e-gce-cos-no-stage
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -102,7 +102,7 @@ presubmits:
             memory: 14Gi
         securityContext:
           privileged: true
-  - name: pull-kubernetes-e2e-gce-kubetest2
+  - name: pull-kubernetes-e2e-gce-cos-kubetest2
     # explicitly needs /test pull-kubernetes-e2e-gce to run
     always_run: false
     # if at all it is run and fails, don't block the PR
@@ -120,7 +120,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-gce-kubetest2
+      testgrid-tab-name: pull-kubernetes-e2e-gce-cos-kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-experimental
@@ -151,7 +151,7 @@ presubmits:
         - --use-built-binaries # use the kubectl, e2e.test, and ginkgo binaries built during --build as opposed to from a GCS release tarball
 
 
-  - name: pull-kubernetes-e2e-gce-canary
+  - name: pull-kubernetes-e2e-gce-cos-canary
     cluster: k8s-infra-prow-build
     always_run: false
     skip_report: true
@@ -187,7 +187,7 @@ presubmits:
         - --provider=gce
         # Panic if anything mutates a shared informer cache
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-cos-canary
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
         env:
@@ -205,7 +205,7 @@ presubmits:
             cpu: 4
             memory: 14Gi
 
-  - name: pull-kubernetes-e2e-gce-ubuntu-containerd
+  - name: pull-kubernetes-e2e-gce
     cluster: k8s-infra-prow-build
     always_run: true
     skip_branches:
@@ -250,7 +250,7 @@ presubmits:
             - --gcp-zone=us-west1-b
             - --ginkgo-parallel=30
             - --provider=gce
-            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
+            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
             - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
@@ -264,7 +264,7 @@ presubmits:
           securityContext:
             privileged: true
 
-  - name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+  - name: pull-kubernetes-e2e-gce-canary
     cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
@@ -309,7 +309,7 @@ presubmits:
             - --gcp-zone=us-west1-b
             - --ginkgo-parallel=30
             - --provider=gce
-            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
             - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
@@ -323,7 +323,7 @@ presubmits:
           securityContext:
             privileged: true
 
-  - name: pull-kubernetes-e2e-gce-alpha-features
+  - name: pull-kubernetes-e2e-gce-cos-alpha-features
     optional: true
     run_if_changed: '^.*feature.*\.go'
     branches:
@@ -358,7 +358,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --runtime-config=api/all=true
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-cos-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|StorageVersionAPI|PodPreset|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|RetroactiveDefaultStorageClass|ReadWriteOncePod)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
@@ -370,7 +370,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
 
-  - name: pull-kubernetes-e2e-gce-ubuntu-containerd-serial
+  - name: pull-kubernetes-e2e-gce-serial
     cluster: k8s-infra-prow-build
     optional: true
     always_run: false
@@ -416,7 +416,7 @@ presubmits:
             - --gcp-zone=us-west1-b
             - --ginkgo-parallel=1
             - --provider=gce
-            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
+            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-serial
             - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=500m
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1582,7 +1582,7 @@ presubmits:
             memory: 6Gi
 
   #TODO(vinaykul,InPlacePodVerticalScaling): Remove this job once we have updated to a COS OS with containerd >= 1.6.9
-  #     Until then, this job complements pull-kubernetes-e2e-gce-alpha-features by running inplace pod resize e2e tests
+  #     Until then, this job complements pull-kubernetes-e2e-gce-cos-alpha-features by running inplace pod resize e2e tests
   #     full-spectrum against containerd/main which has the necessary CRI support.
   - name: pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
     optional: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -751,6 +751,11 @@ presubmits:
     - release-1.26
     cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-gce-ubuntu-containerd
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -806,6 +811,11 @@ presubmits:
     - release-1.26
     cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
     labels:
       preset-k8s-ssh: "true"
       preset-pull-kubernetes-e2e: "true"
@@ -860,6 +870,11 @@ presubmits:
     - release-1.26
     cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-gce-ubuntu-containerd-serial
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -55,19 +55,28 @@ dashboards:
   - name: pull-kubernetes-conformance-kind-ga-only-parallel
     test_group_name: pull-kubernetes-conformance-kind-ga-only-parallel
     base_options: width=10
-  - name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    test_group_name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    base_options: width=10
   - name: pull-kubernetes-verify-govet-levee
     test_group_name: pull-kubernetes-verify-govet-levee
     base_options: width=10
   - name: pull-kubernetes-files-remake
     test_group_name: pull-kubernetes-files-remake
     base_options: width=10
+  - name: pull-kubernetes-e2e-gce
+    test_group_name: pull-kubernetes-e2e-gce
+    base_options: width=10
+  - name: pull-kubernetes-e2e-gce-ubuntu-containerd
+    test_group_name: pull-kubernetes-e2e-gce-ubuntu-containerd
+    base_options: width=10
 - name: presubmits-kubernetes-nonblocking
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
     test_group_name: pull-kubernetes-e2e-gce-network-proxy-grpc
+    base_options: width=10
+  - name: pull-kubernetes-e2e-gce-cos
+    test_group_name: pull-kubernetes-e2e-gce-cos
+    base_options: width=10
+  - name: pull-kubernetes-e2e-gce-cos-canary
+    test_group_name: pull-kubernetes-e2e-gce-cos-canary
     base_options: width=10
   - name: pull-kubernetes-e2e-gce-canary
     test_group_name: pull-kubernetes-e2e-gce-canary
@@ -87,8 +96,8 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
     test_group_name: pull-kubernetes-e2e-kind-ipvs-dual-canary
     base_options: width=10
-  - name: pull-kubernetes-e2e-gce-alpha-features
-    test_group_name: pull-kubernetes-e2e-gce-alpha-features
+  - name: pull-kubernetes-e2e-gce-cos-alpha-features
+    test_group_name: pull-kubernetes-e2e-gce-cos-alpha-features
     base_options: width=10
   - name: pull-kubernetes-e2e-gce-storage-slow
     test_group_name: pull-kubernetes-e2e-gce-storage-slow

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -26,6 +26,7 @@ jobs:
   kubernetes-jenkins/pr-logs/directory/:
   - pull-kubernetes-conformance-kind-ga-only-parallel
   - pull-kubernetes-dependencies
+  - pull-kubernetes-e2e-gce
   - pull-kubernetes-e2e-gce-100-performance
   - pull-kubernetes-e2e-gce-ubuntu-containerd
   - pull-kubernetes-e2e-kind


### PR DESCRIPTION
Related to https://github.com/kubernetes/test-infra/issues/21430

- "ubuntu-containerd" should be the default (so don't specify it in the name of the CI job)
- When the job does not use ubuntu, then specify what it is using (example `cos` image)

```
config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml

15:   - name: pull-kubernetes-e2e-gce                               => pull-kubernetes-e2e-gce-cos
63:   - name: pull-kubernetes-e2e-gce-no-stage                      => pull-kubernetes-e2e-gce-cos-no-stage
105:  - name: pull-kubernetes-e2e-gce-kubetest2                     => pull-kubernetes-e2e-gce-cos-kubetest2
154:  - name: pull-kubernetes-e2e-gce-canary                        => pull-kubernetes-e2e-gce-cos-canary
208:  - name: pull-kubernetes-e2e-gce-ubuntu-containerd             => pull-kubernetes-e2e-gce
267:  - name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary      => pull-kubernetes-e2e-gce-canary
326:  - name: pull-kubernetes-e2e-gce-alpha-features                => pull-kubernetes-e2e-gce-cos-alpha-features
373:  - name: pull-kubernetes-e2e-gce-ubuntu-containerd-serial      => pull-kubernetes-e2e-gce-serial
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>