### PR TITLE
Run post job for website image if cloudbuild file changes

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
@@ -7,7 +7,7 @@ postsubmits:
         testgrid-tab-name: post-website-push-image-k8s-website-hugo
       decorate: true
       run_if_changed: >-
-        ^(Dockerfile|Makefile|netlify\.toml|\.dockerignore)$
+        ^(Dockerfile|Makefile|netlify\.toml|\.dockerignore|cloudbuild\.yaml)$
       branches:
         - ^main$
       spec:


### PR DESCRIPTION
Looks like we forgot to account for changes to cloudbuild.yaml... if this file changes, then we should re-run the push image job

Signed-off-by: Davanum Srinivas <davanum@gmail.com>