### PR TITLE
Use job queue for image promotion jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -35,6 +35,10 @@ postsubmits:
     # into a case where an older manifest PR merge gets run last (after a newer
     # one).
     max_concurrency: 1
+    # Run only 1 of image promotion postsubmit and periodic at the same time.
+    # This is an important step to ensure that we avoid issues of running promotion
+    # twice in parallel, such as double signing images.
+    job_queue_name: "k8sio-image-promo"
     branches:
     - ^main$
     spec:
@@ -128,6 +132,10 @@ periodics:
 - interval: 1h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
+  # Run only 1 of image promotion postsubmit and periodic at the same time.
+  # This is an important step to ensure that we avoid issues of running promotion
+  # twice in parallel, such as double signing images.
+  job_queue_name: "k8sio-image-promo"
   # This name is the "job name", passed in as "--job=NAME" for mkpj.
   name: ci-k8sio-image-promo
   # Enable Pod Utilities.

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -6,6 +6,8 @@ plank:
     '*': https://prow.k8s.io/view/
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 5m
+  job_queue_capacities:
+    'k8sio-image-promo': 1
   default_decoration_config_entries:
   - config:
       timeout: 2h


### PR DESCRIPTION
This PR adds the `k8sio-image-promo` job queue to ensure that we run only one of the image promotion postsubmit and periodic at the same time. We already use `max_concurrency` of one for those jobs, but the purpose of this PR is to ensure that we disallow running promotion twice at the same time (one with postsubmit and another with periodic).

Running the image promotion twice can lead to issues such as double signing images. The promotion itself is idempotent -- copying the image twice will not cause any issue and wouldn't be noticed at all. However, cosign allows an image to be signed multiple times with the same identity. If we run image singing twice, which is what's essentially happening when we run the promotion job two times in parallel, we end up with duplicated signatures for some images.

This can happen often -- promotion for Kubernetes releases can take a lot of time, up to one hour, and even more sometimes. Considering that the image promotion periodic runs once each hour, there's a very high chance it's going to conflict with the postsubmit. This PR should fix this issue.

xref https://github.com/kubernetes/release/issues/2789

/assign @puerco @cpanato @saschagrunert @jeremyrickard @ameukam 
cc @kubernetes/release-engineering @alvaroaleman 
/hold
for discussion