### PR TITLE
Kueue k8 release testing

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-informing.yaml
@@ -1105,6 +1105,5 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.6-s390x
   name: promote-release-openshift-machine-os-content-e2e-aws-4.6-s390x
-- days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4-to-4.5-to-4.6-ci
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4-to-4.5-to-4.6-ci
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4-to-4.5-to-4.6-ci

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.13-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.13-informing.yaml
@@ -73,14 +73,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws
+    name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws
+    test_group_name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -100,14 +100,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp
+    name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp
+    test_group_name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp-ovn
   name: redhat-openshift-okd-release-4.13-informing
 test_groups:
 - days_of_results: 60
@@ -117,8 +117,8 @@ test_groups:
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-okd-4.13-e2e-vsphere-upi
   name: periodic-ci-openshift-release-master-okd-4.13-e2e-vsphere-upi
 - days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws
-  name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws-ovn
+  name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-aws-ovn
 - days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp
-  name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp-ovn
+  name: periodic-ci-openshift-release-master-okd-4.13-upgrade-from-okd-4.12-e2e-upgrade-gcp-ovn


### PR DESCRIPTION
Allow Kueue to run e2e tests with Kubernetes versions 1.23, 1.24 and 1.25.  

Closes https://github.com/kubernetes-sigs/kueue/issues/461