### PR TITLE
use ubuntu from gke cloud in node e2e

### DIFF
--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -3,8 +3,8 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: ubuntu-2204-lts
-    project: ubuntu-os-cloud
+    image_family: pipeline-1-25
+    project: ubuntu-os-gke-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -1,7 +1,7 @@
 images:
   ubuntu:
-    image_family: ubuntu-2204-lts
-    project: ubuntu-os-cloud
+    image_family: pipeline-1-25
+    project: ubuntu-os-gke-cloud
     machine: n1-standard-2 # These tests need a lot of memory
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable2:


### PR DESCRIPTION
use ubuntu images from gke cloud as public ubuntu images in `ubuntu-os-cloud` does not have containerd preinstalled. Using `pipeline-1-25`, so the we get ubuntu with cgroupv2 enabled by default

Signed-off-by: Akhil Mohan <makhil@vmware.com>