### PR TITLE
node: Disable In Place Resize CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1375,71 +1375,72 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: gcp-kubelet-credential-provider
     description: "tests feature gcp kubelet image credential provider"
-- name: ci-cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce
-  interval: 24h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=180
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
-      - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
-      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
-      - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=1
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --image-family=cos-stable
-      - --image-project=cos-cloud
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
-      - --timeout=150m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: cos-cgroupv2-inplace-pod-resize-containerd-e2e
-    description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v2
-- name: ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce
-  interval: 48h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=180
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
-      - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
-      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
-      - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=1
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --image-family=cos-stable
-      - --image-project=cos-cloud
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
-      - --timeout=150m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: cos-cgroupv1-inplace-pod-resize-containerd-e2e
-    description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v1
+# Enable inplace-pod-resize after https://github.com/kubernetes/kubernetes/pull/102884 is merged.
+#- name: ci-cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce
+  #interval: 24h
+  #labels:
+    #preset-service-account: "true"
+    #preset-k8s-ssh: "true"
+    #preset-e2e-containerd: "true"
+  #spec:
+    #containers:
+    #- args:
+      #- --repo=github.com/containerd/containerd=main
+      #- --timeout=180
+      #- --scenario=kubernetes_e2e
+      #- --
+      #- --check-leaked-resources
+      #- --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
+      #- --env=ENABLE_POD_SECURITY_POLICY=true
+      #- --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+      #- --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+      #- --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
+      #- --extract=ci/latest
+      #- --gcp-node-image=gci
+      #- --gcp-nodes=1
+      #- --gcp-zone=us-west1-b
+      #- --ginkgo-parallel=30
+      #- --image-family=cos-stable
+      #- --image-project=cos-cloud
+      #- --provider=gce
+      #- --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
+      #- --timeout=150m
+      #image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
+  #annotations:
+    #testgrid-dashboards: sig-node-containerd
+    #testgrid-tab-name: cos-cgroupv2-inplace-pod-resize-containerd-e2e
+    #description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v2
+#- name: ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce
+  #interval: 48h
+  #labels:
+    #preset-service-account: "true"
+    #preset-k8s-ssh: "true"
+    #preset-e2e-containerd: "true"
+  #spec:
+    #containers:
+    #- args:
+      #- --repo=github.com/containerd/containerd=main
+      #- --timeout=180
+      #- --scenario=kubernetes_e2e
+      #- --
+      #- --check-leaked-resources
+      #- --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
+      #- --env=ENABLE_POD_SECURITY_POLICY=true
+      #- --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+      #- --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+      #- --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
+      #- --extract=ci/latest
+      #- --gcp-node-image=gci
+      #- --gcp-nodes=1
+      #- --gcp-zone=us-west1-b
+      #- --ginkgo-parallel=30
+      #- --image-family=cos-stable
+      #- --image-project=cos-cloud
+      #- --provider=gce
+      #- --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
+      #- --timeout=150m
+      #image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-master
+  #annotations:
+    #testgrid-dashboards: sig-node-containerd
+    #testgrid-tab-name: cos-cgroupv1-inplace-pod-resize-containerd-e2e
+    #description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v1


### PR DESCRIPTION
Disabling in place resize tests until
https://github.com/kubernetes/kubernetes/pull/102884 is merged. This
can't be tested in CI until the PR is merged, so these tests are not
needed currently. Until the PR is merged, we have the
`pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2` to provide
coverage of the feature.

Signed-off-by: David Porter <porterdavid@google.com>
