### PR TITLE
node: Update image for gpu plugin job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -448,6 +448,11 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
+      # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+      # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
+      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+      - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
+      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
The
https://testgrid.k8s.io/sig-node-containerd#e2e-cos-device-plugin-gpu is
failing, but the
https://testgrid.k8s.io/sig-release-master-blocking#gce-device-plugin-gpu-master
is passing. The main difference appears to be the COS version. The GPU
installer verison has dependencies on the COS version, so let's align
the COS versions.

Fixes https://github.com/kubernetes/kubernetes/issues/113480

Signed-off-by: David Porter <porterdavid@google.com>
