### PR TITLE
[WIP] Create a inrepoconfig service that serves inrepoconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/csrf v1.6.2
 	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/schema v1.2.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc

--- a/go.sum
+++ b/go.sum
@@ -513,6 +513,8 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=

--- a/prow/cache/cache_test.go
+++ b/prow/cache/cache_test.go
@@ -47,7 +47,7 @@ func TestGetOrAddSimple(t *testing.T) {
 		}
 	}
 
-	simpleCache, err := NewLRUCache(2)
+	simpleCache, err := NewLRUCache(2, "", nil)
 	if err != nil {
 		t.Error("could not initialize simpleCache")
 	}
@@ -241,7 +241,7 @@ func TestGetOrAddBurst(t *testing.T) {
 		}
 	}
 
-	lruCache, err := NewLRUCache(1000)
+	lruCache, err := NewLRUCache(1000, "", nil)
 	if err != nil {
 		t.Error("could not initialize lruCache")
 	}

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -129,7 +129,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating git client.")
 	}
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, ca, gitClient, o.config.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, ca, gitClient, o.config.InRepoConfigCacheCopies, "", nil)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/cmd/inrepoconfig-server/main.go
+++ b/prow/cmd/inrepoconfig-server/main.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// inrepoconfig-server is a web server that serves purely other Prow components,
+// it's responsible for caching and resolving inrepoconfig files and serving the
+// resolved files via http requests from other components.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/NYTimes/gziphandler"
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/io"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/pjutil"
+
+	"github.com/gorilla/schema"
+
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	configflagutil "k8s.io/test-infra/prow/flagutil/config"
+)
+
+type options struct {
+	port int
+
+	github          prowflagutil.GitHubOptions
+	config          configflagutil.ConfigOptions
+	storage         prowflagutil.StorageClientOptions
+	instrumentation prowflagutil.InstrumentationOptions
+
+	// Gerrit-related options
+	cookiefilePath string
+	// cachefilePath is where cache is stored(potentially in GCS)
+	cachefilePath string
+}
+
+func (o *options) Validate() error {
+	for _, group := range []flagutil.OptionGroup{&o.github, &o.config, &o.storage, &o.instrumentation} {
+		if err := group.Validate(false); err != nil {
+			return err
+		}
+	}
+	if o.cachefilePath == "" {
+		return errors.New("cachefile must be provided")
+	}
+	return nil
+}
+
+func gatherOptions(fs *flag.FlagSet, args ...string) options {
+	var o options
+	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	for _, group := range []flagutil.OptionGroup{&o.github, &o.config, &o.storage, &o.instrumentation} {
+		group.AddFlags(fs)
+	}
+	// Gerrit-related flags
+	fs.StringVar(&o.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile; leave empty for anonymous access or if you are using GitHub")
+	fs.StringVar(&o.cachefilePath, "cachefile", "", "Path to cachefile")
+	fs.Parse(args)
+	return o
+}
+
+type queryParams struct {
+	Type     string   `schema:"type,required"`
+	Org      string   `schema:"org,required"`
+	Repo     string   `schema:"repo,required"`
+	BaseSHA  string   `schema:"base_sha,required"`
+	HeadSHAs []string `schema:"head_shas,required"`
+}
+
+type controller struct {
+	cacheGetter *config.InRepoConfigCacheHandler
+
+	decoder *schema.Decoder
+	l       *logrus.Entry
+}
+
+// newController initializes a controller, constructing git clients for Gerrit
+// and Github.
+func newControler(cacheGetter *config.InRepoConfigCacheHandler) *controller {
+	return &controller{
+		decoder:     schema.NewDecoder(),
+		l:           logrus.WithField("controller", "inrepoconfig-server"),
+		cacheGetter: cacheGetter,
+	}
+}
+
+func main() {
+	if err := realMain(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// realMain is created instead of main, potentially can be used for unit testing
+// purpose.
+func realMain() error {
+	logrusutil.ComponentInit()
+
+	defer interrupts.WaitForGracefulShutdown()
+
+	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	configAgent, err := o.config.ConfigAgent()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+	cfg := configAgent.Config
+
+	// If we are provided credentials for Git hosts, use them. These credentials
+	// hold per-host information in them so it's safe to set them globally.
+	if o.cookiefilePath != "" {
+		cmd := exec.Command("git", "config", "--global", "http.cookiefile", o.cookiefilePath)
+		if err := cmd.Run(); err != nil {
+			logrus.WithError(err).Fatal("unable to set cookiefile")
+		}
+	}
+	gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, false)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Git client.")
+	}
+	opener, err := io.NewOpener(context.Background(), o.storage.GCSCredentialsFile, o.storage.S3CredentialsFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating io.Opener.")
+	}
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies, o.cachefilePath, opener)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
+	}
+
+	c := newControler(cacheGetter)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		msg := fmt.Sprintf("Unsupported path: %v", r.URL)
+		http.Error(w, msg, http.StatusNotFound)
+	})
+	mux.Handle("/inrepoconfig", gziphandler.GzipHandler(handleInrepoconfig(c, cfg)))
+
+	// setup done, actually start the server
+
+	// signal to the world that we are healthy
+	// this needs to be in a separate port as we don't start the
+	// main server with the main mux until we're ready
+	health := pjutil.NewHealthOnPort(o.instrumentation.HealthPort)
+	// signal to the world that we're ready
+	health.ServeReady()
+	server := &http.Server{Addr: fmt.Sprintf(":%d", o.port), Handler: mux}
+	interrupts.ListenAndServe(server, 5*time.Second)
+	return nil
+}
+
+func handleInrepoconfig(c *controller, cfg func() *config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if err := r.ParseForm(); err != nil {
+			respondWithError(c.l, w, fmt.Sprintf("Failed parse request form: %v", err), http.StatusBadRequest)
+			return
+		}
+		var qps queryParams
+		if err := c.decoder.Decode(&qps, r.PostForm); err != nil {
+			respondWithError(c.l, w, fmt.Sprintf("Failed decoding request form into queryParams: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		baseSHAGetter := func() (string, error) { return qps.BaseSHA, nil }
+		var headSHAGetters []func() (string, error)
+		for _, hs := range qps.HeadSHAs {
+			hs := hs
+			headSHAGetters = append(headSHAGetters, func() (string, error) { return hs, nil })
+		}
+
+		var payload []byte
+		var err error
+		switch qps.Type {
+		case "presubmits":
+			presubmits, tmpErr := c.cacheGetter.GetPresubmits(qps.Org+"/"+qps.Repo, baseSHAGetter, headSHAGetters...)
+			if tmpErr != nil {
+				respondWithError(c.l, w, fmt.Sprintf("Failed getting presubmits: %v", err), http.StatusInternalServerError)
+				return
+			}
+			payload, err = json.Marshal(presubmits)
+		case "postsubmits":
+			postsubmits, tmpErr := c.cacheGetter.GetPostsubmits(qps.Org+"/"+qps.Repo, baseSHAGetter, headSHAGetters...)
+			if tmpErr != nil {
+				respondWithError(c.l, w, fmt.Sprintf("Failed getting postsubmits: %v", err), http.StatusInternalServerError)
+				return
+			}
+			payload, err = json.Marshal(postsubmits)
+		}
+
+		if err != nil {
+			respondWithError(c.l, w, fmt.Sprintf("Failed to unmarshal inrepoconfig jobs: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, string(payload))
+	}
+}
+
+func respondWithError(l *logrus.Entry, w http.ResponseWriter, msg string, code int) {
+	l.WithFields(logrus.Fields{"message": msg, "code": code})
+	http.Error(w, msg, code)
+}

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -137,7 +137,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies, "", nil)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/config/cache_test.go
+++ b/prow/config/cache_test.go
@@ -47,7 +47,7 @@ func TestNewInRepoConfigCacheHandler(t *testing.T) {
 
 		fca := &fakeConfigAgent{}
 		cf := &testClientFactory{}
-		cache, err := NewInRepoConfigCacheHandler(invalid, fca, cf, 1)
+		cache, err := NewInRepoConfigCacheHandler(invalid, fca, cf, 1, "", nil)
 
 		if err == nil {
 			t.Fatal("Expected non-nil error, got nil")
@@ -68,7 +68,7 @@ func TestNewInRepoConfigCacheHandler(t *testing.T) {
 
 		fca := &fakeConfigAgent{}
 		cf := &testClientFactory{}
-		cache, err := NewInRepoConfigCacheHandler(valid, fca, cf, 1)
+		cache, err := NewInRepoConfigCacheHandler(valid, fca, cf, 1, "", nil)
 
 		if err != nil {
 			t.Errorf("Expected error 'nil' got '%v'", err.Error())
@@ -87,7 +87,7 @@ func TestNewInRepoConfigCache(t *testing.T) {
 
 		fca := &fakeConfigAgent{}
 		cf := &testClientFactory{}
-		cache, err := NewInRepoConfigCache(invalid, fca, cf)
+		cache, err := NewInRepoConfigCache(invalid, fca, cf, "", nil)
 
 		if err == nil {
 			t.Fatal("Expected non-nil error, got nil")
@@ -108,7 +108,7 @@ func TestNewInRepoConfigCache(t *testing.T) {
 
 		fca := &fakeConfigAgent{}
 		cf := &testClientFactory{}
-		cache, err := NewInRepoConfigCache(valid, fca, cf)
+		cache, err := NewInRepoConfigCache(valid, fca, cf, "", nil)
 
 		if err != nil {
 			t.Errorf("Expected error 'nil' got '%v'", err.Error())
@@ -409,7 +409,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 				},
 			}
 			cf := &testClientFactory{}
-			cache, err := NewInRepoConfigCache(1, fca, cf)
+			cache, err := NewInRepoConfigCache(1, fca, cf, "", nil)
 			if err != nil {
 				t.Fatal("could not initialize cache")
 			}
@@ -827,7 +827,7 @@ func TestGetProwYAMLCachedAndDefaulted(t *testing.T) {
 			cf := &testClientFactory{}
 
 			// Initialize cache. Notice that it relies on a snapshot of the Config with configBefore.
-			cache, err := NewInRepoConfigCacheHandler(10, fca, cf, 10)
+			cache, err := NewInRepoConfigCacheHandler(10, fca, cf, 10, "", nil)
 			if err != nil {
 				t1.Fatal("could not initialize cache")
 			}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -468,7 +468,9 @@ func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCacheHandle
 		10,
 		ca,
 		config.NewInRepoConfigGitCache(cf),
-		1)
+		1,
+		"",
+		nil)
 	if err != nil {
 		t.Errorf("error creating cache: %v", err)
 	}

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -303,7 +303,7 @@ func TestHandleMessage(t *testing.T) {
 			ca.Set(tc.config)
 			fr := fakeReporter{}
 			gitClient, _ := (&flagutil.GitHubOptions{}).GitClientFactory("abc", nil, true)
-			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1)
+			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1, "", nil)
 			s := Subscriber{
 				Metrics:                  NewMetrics(),
 				ProwJobClient:            fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -109,7 +109,7 @@ func NewGerritController(
 		newPoolPending:   make(chan bool),
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(configOptions.InRepoConfigCacheSize, cfgAgent, gc, configOptions.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(configOptions.InRepoConfigCacheSize, cfgAgent, gc, configOptions.InRepoConfigCacheCopies, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating inrepoconfig cache getter: %v", err)
 	}


### PR DESCRIPTION
This is an implementation of the centralized inrepoconfig configuration resolver that aims at solving one of our biggest pain points in Prow right now:
- inrepoconfig requires cloning user repo before figuring out the prowjobs to run, for larger repos the response latency of Prow is at a minimum the cloning time of the repo.
- In the past we had implemented in memory cache for solving this problem, however it still has a bad cold start problem, and multiple Prow components do the same heavy lifting doesn't sound like the best solution.
- At a scale the inrepoconfig processing is very resource consuming, at least disk I/O

This centralized inrepoconfig service will run in cluster and answers requests from other prow components, hopefully:
- no cold start problem
- fast response time