### PR TITLE
capo: only run PR-Blocking e2e tests in periodics and postsubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -24,6 +24,8 @@ periodics:
       env:
       - name: "BOSKOS_HOST"
         value: "boskos.test-pods.svc.cluster.local"
+      - name: E2E_GINKGO_FOCUS
+        value: "\\[PR-Blocking\\]"
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
@@ -21,6 +21,8 @@ postsubmits:
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
+        - name: E2E_GINKGO_FOCUS
+          value: "\\[PR-Blocking\\]"
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/28082 I missed that we run the e2e tests as postsubmits and periodics also. It was never the intention to change the behavior of these tests, i.e. they should continue running only the PR-Blocking e2e tests.