### PR TITLE
cri-tools: streamline review `/approve` `/lgtm` behavior

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -88,6 +88,7 @@ approve:
   - kubernetes-sigs/boskos
   - kubernetes-sigs/cluster-api-provider-digitalocean
   - kubernetes-sigs/cluster-api-provider-gcp
+  - kubernetes-sigs/cri-tools
   - kubernetes-sigs/downloadkubernetes
   - kubernetes-sigs/e2e-framework
   - kubernetes-sigs/promo-tools
@@ -208,6 +209,7 @@ lgtm:
   - kubernetes-sigs/controller-runtime
   - kubernetes-sigs/cluster-api-provider-digitalocean
   - kubernetes-sigs/cluster-api-provider-gcp
+  - kubernetes-sigs/cri-tools
   - kubernetes-sigs/downloadkubernetes
   - kubernetes-sigs/e2e-framework
   - kubernetes-sigs/etcdadm


### PR DESCRIPTION
We now use automatic `lgtm` on successful review  as well as set `require_self_approval: false` and `ignore_review_state: false`.

@feiskyer PTAL