### PR TITLE
[CAPA] Bump k8s version to 1.25 in PR blocking prow job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -183,7 +183,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221207-9bb38b7b14-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221207-9bb38b7b14-1.25
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
Bump k8s version to 1.25 in PR-blocking E2E prow job