### PR TITLE
add aojea as top approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+- aojea # lead
 - BenTheElder # lead
 - spiffxp # chair
 - stevekuznetsov # chair
@@ -8,6 +9,7 @@ reviewers:
 - cjwagner # oncall, lead
 - mpherman2 # oncall
 approvers:
+- aojea # lead
 - BenTheElder # lead
 - spiffxp # chair
 - stevekuznetsov # chair


### PR DESCRIPTION
I want to have it just as last resort in EU timezone, and also to have some help on things like this

https://github.com/kubernetes/test-infra/pull/28229#issuecomment-1347642040

is well known a lot of approvers are not very active and is frustrating to have simple PRs hanging weeks because of that