### PR TITLE
Add docker config file needed for Windows private registry

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -122,6 +122,7 @@ periodics:
     preset-capz-containerd-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
+    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -166,6 +167,7 @@ periodics:
     preset-capz-windows-2019: "true"
     preset-capz-containerd-latest: "true"
     preset-capz-serial-slow: "true"
+    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -208,6 +210,7 @@ periodics:
     preset-azure-cred-only: "true"
     preset-capz-windows-common-main: "true"
     preset-capz-containerd-latest: "true"
+    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -250,6 +253,7 @@ periodics:
     preset-capz-containerd-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
+    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
The sig-windows scripts require the private registry configuration file for the private image configuration:

`./capz/run-capz-e2e.sh: line 155: DOCKER_CONFIG_FILE: unbound variable`

/sig windows
/assign @marosset @claudiubelu 