### PR TITLE
Change the release 1.2 upgrade jobs frequency

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
@@ -189,7 +189,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-2
-  interval: 24h
+  interval: 2h
   decorate: true
   decoration_config:
     gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -237,7 +237,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-2
-  interval: 24h
+  interval: 2h
   decorate: true
   decoration_config:
     gcs_credentials_secret: "" # Use workload identity for uploading artifacts


### PR DESCRIPTION
Changes the release-1.2 upgrade job frequency to 2hrs to allow for debugging on the test failures. 
- periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-2
- periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-2

This should be changed back to 24hrs after the issue is addressed.

