### PR TITLE
releng: Update kpromo to v3.4.11

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
         command:
         - /kpromo
         args:
@@ -43,7 +43,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
         command:
         - /kpromo
         args:
@@ -87,7 +87,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
         command:
         - /kpromo
         args:
@@ -44,7 +44,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
         command:
         - /kpromo
         args:
@@ -110,7 +110,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
       command:
       - /kpromo
       args:
@@ -152,7 +152,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.10-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Update kpromo to v3.4.11.

Part of https://github.com/kubernetes-sigs/promo-tools/issues/694

/assign @cpanato @puerco @saschagrunert
cc @kubernetes/release-engineering 