### PR TITLE
use only cgroupv2 images for gke ubuntu

### DIFF
--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -5,6 +5,9 @@ images:
   ubuntu:
     image_family: pipeline-1-25
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-25
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     machine: n1-standard-2 # These tests need a lot of memory
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable2:

--- a/jobs/e2e_node/containerd/image-config-systemd.yaml
+++ b/jobs/e2e_node/containerd/image-config-systemd.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-25
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable:
     image_family: cos-stable


### PR DESCRIPTION
pipeline-1-25 from gke publishes both cgroupv2 and cgroupv1 images for ubuntu. The cgroupv1 images are suffixed with -cgroupsv1. A regex is used to discard images which have a suffix.

Signed-off-by: Akhil Mohan <makhil@vmware.com>

/hold for review