### PR TITLE
Add CAPZ storage account keys to preset

### DIFF
--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -30,6 +30,23 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: azure-capz-sa-cred
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-upstream
+  data:
+  - key: azure-capz-sa-cred
+    name: credentials
+    version: latest
+  template:
+    data:
+      serviceAccountSigningPub: <%= JSON.parse(data.credentials).serviceAccountSigningPub %>
+      serviceAccountSigningKey: <%= JSON.parse(data.credentials).serviceAccountSigningKey %>
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: azure-secrets-store-cred
   namespace: test-pods
 spec:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -918,6 +918,16 @@ presets:
   env:
   - name: AZURE_CREDENTIALS
     value: /etc/azure-cred/credentials
+  - name: SERVICE_ACCOUNT_SIGNING_PUB
+    valueFrom:
+      secretKeyRef:
+        name: azure-capz-sa-cred
+        key: serviceAccountSigningPub
+  - name: SERVICE_ACCOUNT_SIGNING_KEY
+    valueFrom:
+      secretKeyRef:
+        name: azure-capz-sa-cred
+        key: serviceAccountSigningKey
   - name: AZURE_SSH_PUBLIC_KEY_FILE
     value: /etc/azure-ssh/azure-ssh-pub
   - name: REGISTRY
@@ -954,6 +964,16 @@ presets:
   env:
     - name: AZURE_CREDENTIALS
       value: /etc/azure-cred/credentials
+    - name: SERVICE_ACCOUNT_SIGNING_PUB
+      valueFrom:
+        secretKeyRef:
+          name: azure-capz-sa-cred
+          key: serviceAccountSigningPub
+    - name: SERVICE_ACCOUNT_SIGNING_KEY
+      valueFrom:
+        secretKeyRef:
+          name: azure-capz-sa-cred
+          key: serviceAccountSigningKey
   volumes:
     - name: azure-cred
       secret:


### PR DESCRIPTION
This PR adds service account keys for use with Workload Identity (as documented [here](https://azure.github.io/azure-workload-identity/docs/installation/self-managed-clusters/service-account-key-generation.html)) in the CAPZ project CI, as part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2936.

I have already required secret in the `kubernetes-upstream` GCP project.

/assign @aramase @sonasingh46 