### PR TITLE
Extend the branchprotector PR review policy with bypass restrictions

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -765,6 +765,13 @@ branch-protection:
       teams:
       - oncall
       - sres
+    bypass_pull_request_allowances:
+     users:
+     - bypass_bob
+     - bypass_jane
+     teams:
+     - bypass_oncall
+     - bypass_sres
   restrictions:
     apps:
     - content-app
@@ -799,6 +806,10 @@ branch-protection:
 							DismissalRestrictions: github.DismissalRestrictionsRequest{
 								Users: &[]string{"bob", "jane"},
 								Teams: &[]string{"oncall", "sres"},
+							},
+							BypassRestrictions: github.BypassRestrictionsRequest{
+								Users: &[]string{"bypass_bob", "bypass_jane"},
+								Teams: &[]string{"bypass_oncall", "bypass_sres"},
 							},
 						},
 						Restrictions: &github.RestrictionsRequest{
@@ -910,6 +921,13 @@ branch-protection:
       teams:
       - oncall
       - sres
+    bypass_pull_request_allowances:
+      users:
+      - bypass_bob
+      - bypass_jane
+      teams:
+      - bypass_oncall
+      - bypass_sres
   restrictions:
     apps:
     - content-app
@@ -937,6 +955,10 @@ branch-protection:
 						DismissalRestrictions: &github.DismissalRestrictions{
 							Users: []github.User{{Login: "bob"}, {Login: "jane"}},
 							Teams: []github.Team{{Slug: "oncall"}, {Slug: "sres"}},
+						},
+						BypassRestrictions: &github.BypassRestrictions{
+							Users: []github.User{{Login: "bypass_bob"}, {Login: "bypass_jane"}},
+							Teams: []github.Team{{Slug: "bypass_oncall"}, {Slug: "bypass_sres"}},
 						},
 					},
 					Restrictions: &github.Restrictions{
@@ -989,6 +1011,13 @@ branch-protection:
       teams:
       - oncall
       - sres
+    bypass_pull_request_allowances:
+      users:
+      - bypass_bob
+      - bypass_jane
+      teams:
+      - bypass_oncall
+      - bypass_sres
   restrictions:
     teams:
     - config-team
@@ -1014,6 +1043,10 @@ branch-protection:
 						DismissalRestrictions: &github.DismissalRestrictions{
 							Users: []github.User{{Login: "bob"}, {Login: "jane"}},
 							Teams: []github.Team{{Slug: "oncall"}, {Slug: "sres"}},
+						},
+						BypassRestrictions: &github.BypassRestrictions{
+							Users: []github.User{{Login: "bypass_bob"}, {Login: "bypass_jane"}},
+							Teams: []github.Team{{Slug: "bypass_oncall"}, {Slug: "bypass_sres"}},
 						},
 					},
 					Restrictions: &github.Restrictions{
@@ -1751,6 +1784,10 @@ func TestEqualBranchProtection(t *testing.T) {
 						Users: []github.User{{Login: "user"}},
 						Teams: []github.Team{{Slug: "team"}},
 					},
+					BypassRestrictions: &github.BypassRestrictions{
+						Users: []github.User{{Login: "user"}},
+						Teams: []github.Team{{Slug: "team"}},
+					},
 				},
 				Restrictions: &github.Restrictions{
 					Apps:  []github.App{{Slug: "app"}},
@@ -1769,6 +1806,10 @@ func TestEqualBranchProtection(t *testing.T) {
 					RequireCodeOwnerReviews:      true,
 					RequiredApprovingReviewCount: 1,
 					DismissalRestrictions: github.DismissalRestrictionsRequest{
+						Users: &[]string{"user"},
+						Teams: &[]string{"team"},
+					},
+					BypassRestrictions: github.BypassRestrictionsRequest{
 						Users: &[]string{"user"},
 						Teams: &[]string{"team"},
 					},
@@ -1799,6 +1840,10 @@ func TestEqualBranchProtection(t *testing.T) {
 						Users: []github.User{{Login: "user"}},
 						Teams: []github.Team{{Slug: "team"}},
 					},
+					BypassRestrictions: &github.BypassRestrictions{
+						Users: []github.User{{Login: "user"}},
+						Teams: []github.Team{{Slug: "team"}},
+					},
 				},
 				Restrictions: &github.Restrictions{
 					Apps:  []github.App{{Slug: "app"}},
@@ -1817,6 +1862,10 @@ func TestEqualBranchProtection(t *testing.T) {
 					RequireCodeOwnerReviews:      true,
 					RequiredApprovingReviewCount: 1,
 					DismissalRestrictions: github.DismissalRestrictionsRequest{
+						Users: &[]string{"user"},
+						Teams: &[]string{"team"},
+					},
+					BypassRestrictions: github.BypassRestrictionsRequest{
 						Users: &[]string{"user"},
 						Teams: &[]string{"team"},
 					},
@@ -2036,12 +2085,20 @@ func TestEqualRequiredPullRequestReviews(t *testing.T) {
 					Users: []github.User{{Login: "user"}},
 					Teams: []github.Team{{Slug: "team"}},
 				},
+				BypassRestrictions: &github.BypassRestrictions{
+					Users: []github.User{{Login: "user"}},
+					Teams: []github.Team{{Slug: "team"}},
+				},
 			},
 			request: &github.RequiredPullRequestReviewsRequest{
 				DismissStaleReviews:          true,
 				RequireCodeOwnerReviews:      true,
 				RequiredApprovingReviewCount: 1,
 				DismissalRestrictions: github.DismissalRestrictionsRequest{
+					Users: &[]string{"user"},
+					Teams: &[]string{"team"},
+				},
+				BypassRestrictions: github.BypassRestrictionsRequest{
 					Users: &[]string{"user"},
 					Teams: &[]string{"team"},
 				},
@@ -2100,12 +2157,20 @@ func TestEqualRequiredPullRequestReviews(t *testing.T) {
 					Users: []github.User{{Login: "user"}},
 					Teams: []github.Team{{Slug: "team"}},
 				},
+				BypassRestrictions: &github.BypassRestrictions{
+					Users: []github.User{{Login: "user"}},
+					Teams: []github.Team{{Slug: "team"}},
+				},
 			},
 			request: &github.RequiredPullRequestReviewsRequest{
 				DismissStaleReviews:          true,
 				RequireCodeOwnerReviews:      true,
 				RequiredApprovingReviewCount: 1,
 				DismissalRestrictions: github.DismissalRestrictionsRequest{
+					Users: &[]string{"other"},
+					Teams: &[]string{"team"},
+				},
+				BypassRestrictions: github.BypassRestrictionsRequest{
 					Users: &[]string{"other"},
 					Teams: &[]string{"team"},
 				},
@@ -2201,6 +2266,91 @@ func TestEqualDismissalRestrictions(t *testing.T) {
 
 	for _, testCase := range testCases {
 		if actual, expected := equalDismissalRestrictions(testCase.state, testCase.request), testCase.expected; actual != expected {
+			t.Errorf("%s: didn't compute equality correctly, expected %v got %v", testCase.name, expected, actual)
+		}
+	}
+}
+
+func TestEqualBypassRestrictions(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		state    *github.BypassRestrictions
+		request  *github.BypassRestrictionsRequest
+		expected bool
+	}{
+		{
+			name:     "neither set matches",
+			expected: true,
+		},
+		{
+			name:     "request unset doesn't match",
+			state:    &github.BypassRestrictions{},
+			expected: false,
+		},
+		{
+			name: "matching requests work",
+			state: &github.BypassRestrictions{
+				Users: []github.User{{Login: "user"}},
+				Teams: []github.Team{{Slug: "team"}},
+			},
+			request: &github.BypassRestrictionsRequest{
+				Users: &[]string{"user"},
+				Teams: &[]string{"team"},
+			},
+			expected: true,
+		},
+		{
+			name: "user login casing is ignored",
+			state: &github.BypassRestrictions{
+				Users: []github.User{{Login: "User"}, {Login: "OTHer"}},
+				Teams: []github.Team{{Slug: "team"}},
+			},
+			request: &github.BypassRestrictionsRequest{
+				Users: &[]string{"uSer", "oThER"},
+				Teams: &[]string{"team"},
+			},
+			expected: true,
+		},
+		{
+			name: "not matching on users",
+			state: &github.BypassRestrictions{
+				Users: []github.User{{Login: "user"}},
+				Teams: []github.Team{{Slug: "team"}},
+			},
+			request: &github.BypassRestrictionsRequest{
+				Users: &[]string{"other"},
+				Teams: &[]string{"team"},
+			},
+			expected: false,
+		},
+		{
+			name: "not matching on team",
+			state: &github.BypassRestrictions{
+				Users: []github.User{{Login: "user"}},
+				Teams: []github.Team{{Slug: "team"}},
+			},
+			request: &github.BypassRestrictionsRequest{
+				Users: &[]string{"user"},
+				Teams: &[]string{"other"},
+			},
+			expected: false,
+		},
+		{
+			name:     "both unset",
+			request:  &github.BypassRestrictionsRequest{},
+			expected: true,
+		},
+		{
+			name: "partially unset",
+			request: &github.BypassRestrictionsRequest{
+				Teams: &[]string{"team"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if actual, expected := equalBypassRestrictions(testCase.state, testCase.request), testCase.expected; actual != expected {
 			t.Errorf("%s: didn't compute equality correctly, expected %v got %v", testCase.name, expected, actual)
 		}
 	}

--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -85,6 +85,22 @@ func makeDismissalRestrictions(rp *branchprotection.DismissalRestrictions) *gith
 	}
 }
 
+// makeBypassRestrictions renders restrictions into the corresponding GitHub api object.
+//
+// Returns nil when input restrictions is nil.
+// Otherwise Teams and Users are both non-nil (empty list if unset).
+func makeBypassRestrictions(rp *branchprotection.BypassRestrictions) *github.BypassRestrictionsRequest {
+	if rp == nil {
+		return nil
+	}
+	teams := append([]string{}, sets.NewString(rp.Teams...).List()...)
+	users := append([]string{}, sets.NewString(rp.Users...).List()...)
+	return &github.BypassRestrictionsRequest{
+		Teams: &teams,
+		Users: &users,
+	}
+}
+
 // makeRestrictions renders restrictions into the corresponding GitHub api object.
 //
 // Returns nil when input restrictions is nil.
@@ -130,6 +146,10 @@ func makeReviews(rp *branchprotection.ReviewPolicy) *github.RequiredPullRequestR
 	}
 	if rp.DismissalRestrictions != nil {
 		rprr.DismissalRestrictions = *makeDismissalRestrictions(rp.DismissalRestrictions)
+	}
+
+	if rp.BypassRestrictions != nil {
+		rprr.BypassRestrictions = *makeBypassRestrictions(rp.BypassRestrictions)
 	}
 	return &rprr
 }

--- a/prow/cmd/branchprotector/request_test.go
+++ b/prow/cmd/branchprotector/request_test.go
@@ -95,12 +95,20 @@ func TestMakeReviews(t *testing.T) {
 					Users: []string{"fred", "jane"},
 					Teams: []string{"megacorp", "startup"},
 				},
+				BypassRestrictions: &branchprotection.BypassRestrictions{
+					Users: []string{"fred", "jane"},
+					Teams: []string{"megacorp", "startup"},
+				},
 			},
 			expected: &github.RequiredPullRequestReviewsRequest{
 				RequiredApprovingReviewCount: 1,
 				RequireCodeOwnerReviews:      true,
 				DismissStaleReviews:          true,
 				DismissalRestrictions: github.DismissalRestrictionsRequest{
+					Teams: &[]string{"megacorp", "startup"},
+					Users: &[]string{"fred", "jane"},
+				},
+				BypassRestrictions: github.BypassRestrictionsRequest{
 					Teams: &[]string{"megacorp", "startup"},
 					Users: &[]string{"fred", "jane"},
 				},

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -88,11 +88,20 @@ type ReviewPolicy struct {
 	RequireOwners *bool `json:"require_code_owner_reviews,omitempty"`
 	// Approvals overrides the number of approvals required if set (set to 0 to disable)
 	Approvals *int `json:"required_approving_review_count,omitempty"`
+	// BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+	BypassRestrictions *BypassRestrictions `json:"bypass_pull_request_allowances,omitempty"`
 }
 
 // DismissalRestrictions limits who can merge
 // Users and Teams items are appended to parent lists.
 type DismissalRestrictions struct {
+	Users []string `json:"users,omitempty"`
+	Teams []string `json:"teams,omitempty"`
+}
+
+// BypassRestrictions defines who can bypass PR restrictions
+// Users and Teams items are appended to parent lists.
+type BypassRestrictions struct {
 	Users []string `json:"users,omitempty"`
 	Teams []string `json:"teams,omitempty"`
 }
@@ -159,6 +168,7 @@ func mergeReviewPolicy(parent, child *ReviewPolicy) *ReviewPolicy {
 		DismissStale:          selectBool(parent.DismissStale, child.DismissStale),
 		RequireOwners:         selectBool(parent.RequireOwners, child.RequireOwners),
 		Approvals:             selectInt(parent.Approvals, child.Approvals),
+		BypassRestrictions:    mergeBypassRestrictions(parent.BypassRestrictions, child.BypassRestrictions),
 	}
 }
 
@@ -170,6 +180,19 @@ func mergeDismissalRestrictions(parent, child *DismissalRestrictions) *Dismissal
 		return child
 	}
 	return &DismissalRestrictions{
+		Users: unionStrings(parent.Users, child.Users),
+		Teams: unionStrings(parent.Teams, child.Teams),
+	}
+}
+
+func mergeBypassRestrictions(parent, child *BypassRestrictions) *BypassRestrictions {
+	if child == nil {
+		return parent
+	}
+	if parent == nil {
+		return child
+	}
+	return &BypassRestrictions{
 		Users: unionStrings(parent.Users, child.Users),
 		Teams: unionStrings(parent.Teams, child.Teams),
 	}

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -86,6 +86,13 @@ branch-protection:
 
                             # RequiredPullRequestReviews specifies github approval/review criteria.
                             required_pull_request_reviews:
+                                # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+                                bypass_pull_request_allowances:
+                                    teams:
+                                      - ""
+                                    users:
+                                      - ""
+
                                 # DismissStale overrides whether new commits automatically dismiss old reviews if set
                                 dismiss_stale_reviews: false
 
@@ -101,13 +108,6 @@ branch-protection:
 
                                 # Approvals overrides the number of approvals required if set (set to 0 to disable)
                                 required_approving_review_count: 0
-
-                                # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
-                                bypass_pull_request_allowances:
-                                    teams:
-                                      - ""
-                                    users:
-                                      - ""
 
                             # RequiredStatusChecks configures github contexts
                             required_status_checks:
@@ -151,6 +151,13 @@ branch-protection:
 
                     # RequiredPullRequestReviews specifies github approval/review criteria.
                     required_pull_request_reviews:
+                        # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+                        bypass_pull_request_allowances:
+                            teams:
+                              - ""
+                            users:
+                              - ""
+
                         # DismissStale overrides whether new commits automatically dismiss old reviews if set
                         dismiss_stale_reviews: false
 
@@ -166,13 +173,6 @@ branch-protection:
 
                         # Approvals overrides the number of approvals required if set (set to 0 to disable)
                         required_approving_review_count: 0
-
-                        # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
-                        bypass_pull_request_allowances:
-                            teams:
-                              - ""
-                            users:
-                              - ""
 
                     # RequiredStatusChecks configures github contexts
                     required_status_checks:
@@ -200,6 +200,13 @@ branch-protection:
 
             # RequiredPullRequestReviews specifies github approval/review criteria.
             required_pull_request_reviews:
+                # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+                bypass_pull_request_allowances:
+                    teams:
+                      - ""
+                    users:
+                      - ""
+
                 # DismissStale overrides whether new commits automatically dismiss old reviews if set
                 dismiss_stale_reviews: false
 
@@ -215,13 +222,6 @@ branch-protection:
 
                 # Approvals overrides the number of approvals required if set (set to 0 to disable)
                 required_approving_review_count: 0
-
-                # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
-                bypass_pull_request_allowances:
-                    teams:
-                      - ""
-                    users:
-                      - ""
 
             # RequiredStatusChecks configures github contexts
             required_status_checks:
@@ -261,6 +261,13 @@ branch-protection:
 
     # RequiredPullRequestReviews specifies github approval/review criteria.
     required_pull_request_reviews:
+        # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+        bypass_pull_request_allowances:
+            teams:
+              - ""
+            users:
+              - ""
+
         # DismissStale overrides whether new commits automatically dismiss old reviews if set
         dismiss_stale_reviews: false
 
@@ -276,13 +283,6 @@ branch-protection:
 
         # Approvals overrides the number of approvals required if set (set to 0 to disable)
         required_approving_review_count: 0
-
-        # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
-        bypass_pull_request_allowances:
-            teams:
-              - ""
-            users:
-              - ""
 
     # RequiredStatusChecks configures github contexts
     required_status_checks:

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -102,6 +102,13 @@ branch-protection:
                                 # Approvals overrides the number of approvals required if set (set to 0 to disable)
                                 required_approving_review_count: 0
 
+                                # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+                                bypass_pull_request_allowances:
+                                    teams:
+                                      - ""
+                                    users:
+                                      - ""
+
                             # RequiredStatusChecks configures github contexts
                             required_status_checks:
                                 # Contexts appends required contexts that must be green to merge
@@ -160,6 +167,13 @@ branch-protection:
                         # Approvals overrides the number of approvals required if set (set to 0 to disable)
                         required_approving_review_count: 0
 
+                        # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+                        bypass_pull_request_allowances:
+                            teams:
+                              - ""
+                            users:
+                              - ""
+
                     # RequiredStatusChecks configures github contexts
                     required_status_checks:
                         # Contexts appends required contexts that must be green to merge
@@ -201,6 +215,13 @@ branch-protection:
 
                 # Approvals overrides the number of approvals required if set (set to 0 to disable)
                 required_approving_review_count: 0
+
+                # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+                bypass_pull_request_allowances:
+                    teams:
+                      - ""
+                    users:
+                      - ""
 
             # RequiredStatusChecks configures github contexts
             required_status_checks:
@@ -255,6 +276,13 @@ branch-protection:
 
         # Approvals overrides the number of approvals required if set (set to 0 to disable)
         required_approving_review_count: 0
+
+        # BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
+        bypass_pull_request_allowances:
+            teams:
+              - ""
+            users:
+              - ""
 
     # RequiredStatusChecks configures github contexts
     required_status_checks:

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -586,10 +586,17 @@ type RequiredPullRequestReviews struct {
 	DismissStaleReviews          bool                   `json:"dismiss_stale_reviews"`
 	RequireCodeOwnerReviews      bool                   `json:"require_code_owner_reviews"`
 	RequiredApprovingReviewCount int                    `json:"required_approving_review_count"`
+	BypassRestrictions           *BypassRestrictions    `json:"bypass_pull_request_allowances"`
 }
 
 // DismissalRestrictions exposes restrictions in github for an activity to people/teams.
 type DismissalRestrictions struct {
+	Users []User `json:"users,omitempty"`
+	Teams []Team `json:"teams,omitempty"`
+}
+
+// BypassRestrictions exposes bypass option in github for a pull request to people/teams.
+type BypassRestrictions struct {
 	Users []User `json:"users,omitempty"`
 	Teams []Team `json:"teams,omitempty"`
 }
@@ -634,6 +641,7 @@ type RequiredPullRequestReviewsRequest struct {
 	DismissStaleReviews          bool                         `json:"dismiss_stale_reviews"`
 	RequireCodeOwnerReviews      bool                         `json:"require_code_owner_reviews"`
 	RequiredApprovingReviewCount int                          `json:"required_approving_review_count"`
+	BypassRestrictions           BypassRestrictionsRequest    `json:"bypass_pull_request_allowances"`
 }
 
 // DismissalRestrictionsRequest tells github to restrict an activity to people/teams.
@@ -642,6 +650,18 @@ type RequiredPullRequestReviewsRequest struct {
 // This is needed by dismissal_restrictions to distinguish
 // do not restrict (empty object) and restrict everyone (nil user/teams list)
 type DismissalRestrictionsRequest struct {
+	// Users is a list of user logins
+	Users *[]string `json:"users,omitempty"`
+	// Teams is a list of team slugs
+	Teams *[]string `json:"teams,omitempty"`
+}
+
+// BypassRestrictionsRequest tells github to restrict PR bypass activity to people/teams.
+//
+// Use *[]string in order to distinguish unset and empty list.
+// This is needed by bypass_pull_request_allowances to distinguish
+// do not restrict (empty object) and restrict everyone (nil user/teams list)
+type BypassRestrictionsRequest struct {
 	// Users is a list of user logins
 	Users *[]string `json:"users,omitempty"`
 	// Teams is a list of team slugs


### PR DESCRIPTION
The `bypass_pull_request_allowances` configuration will allow users/teams to bypass the PR restrictions for a branch. The option is implemented like the `dismissal_restrictions` PR request review option. Like the dismissal option it supports only teams and users and don't support apps.

An example configuration will look like:
```
branch-protection:
  orgs:
    myOrg:
      repos:
        myRepo:
          branches:
            main:
              required_pull_request_reviews:             
                bypass_pull_request_allowances:
                  users: ["myUser"]
```

I have executed all the unit tests with `go test ./prow/cmd/branchprotector` and manually ran the toll against an test Github repository.

This is an implementation proposal for #28262.