### PR TITLE
Don't auto-close triaged issues, require re-triage after 1yr

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -383,7 +383,7 @@ periodics:
     testgrid-tab-name: rotten-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
+    - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
       command:
       - commenter
       args:
@@ -440,7 +440,7 @@ periodics:
     testgrid-tab-name: stale-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
+    - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
       command:
       - commenter
       args:
@@ -604,7 +604,7 @@ periodics:
     testgrid-tab-name: re-triage
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
+    - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
       command:
       - commenter
       args:
@@ -652,7 +652,7 @@ periodics:
     testgrid-tab-name: re-triage-important
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
+    - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
       command:
       - commenter
       args:
@@ -701,7 +701,7 @@ periodics:
     testgrid-tab-name: re-triage-critical
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
+    - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
       command:
       - commenter
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -154,7 +154,8 @@ periodics:
         -label:lifecycle/frozen
         -label:"help wanted"
         -label:"good first issue"
-        -label:"triage/accepted"
+        -label:triage/accepted
+        -label:priority/critical-urgent,priority/important-soon,priority/important-longterm
         label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/github-token/token

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -432,7 +432,7 @@ periodics:
     testgrid-tab-name: rotten-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230116-d4a02a2181
+    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
       command:
       - commenter
       args:
@@ -489,7 +489,7 @@ periodics:
     testgrid-tab-name: stale-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230116-d4a02a2181
+    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
       command:
       - commenter
       args:
@@ -653,7 +653,7 @@ periodics:
     testgrid-tab-name: re-triage
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:commenter:v20230116-d4a02a2181
+    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
       command:
       - commenter
       args:
@@ -699,7 +699,7 @@ periodics:
     testgrid-tab-name: re-triage-important
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:commenter:v20230116-d4a02a2181
+    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
       command:
       - commenter
       args:
@@ -746,7 +746,7 @@ periodics:
     testgrid-tab-name: re-triage-critical
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:commenter:v20230116-d4a02a2181
+    - image: gcr.io/k8s-prow/commenter:v20230124-17d9ffa086
       command:
       - commenter
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -154,6 +154,7 @@ periodics:
         -label:lifecycle/frozen
         -label:"help wanted"
         -label:"good first issue"
+        -label:"triage/accepted"
         label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/github-token/token
@@ -383,10 +384,11 @@ periodics:
         -repo:kubernetes-sigs/kind
         -repo:kubernetes/ingress-nginx
         -label:lifecycle/frozen
-        label:lifecycle/stale
         -label:lifecycle/rotten
         -label:"help wanted"
         -label:"good first issue"
+        -label:"triage/accepted"
+        label:lifecycle/stale
       - --updated=720h
       - --token=/etc/github-token/token
       - --endpoint=http://ghproxy.default.svc.cluster.local
@@ -445,6 +447,7 @@ periodics:
         -label:lifecycle/rotten
         -label:"help wanted"
         -label:"good first issue"
+        -label:"triage/accepted"
       - --updated=2160h
       - --token=/etc/github-token/token
       - --endpoint=http://ghproxy.default.svc.cluster.local

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -529,6 +529,49 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
+- name: ci-k8s-triage-robot-retriage
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Removes the triage/accepted label after 1 year of inactivity
+    testgrid-tab-name: re-triage
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:commenter:v20230116-d4a02a2181
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        -repo:kubernetes-sigs/kind
+        label:triage/accepted
+      - --updated=8760h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=This issue or PR has not been updated in over 1 year, and should be re-triaged.
+
+        You can:
+        - Confirm that this issue or PR is still relevant with `/triage accepted` (org members only)
+        - Close this issue or PR with `/close`
+
+        For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
 - name: issue-creator
   interval: 24h
   cluster: k8s-infra-prow-build-trusted

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -362,14 +362,14 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
-- name: ci-k8s-triage-robot-rotten
+- name: ci-k8s-triage-robot-rotten-issues
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
-    testgrid-tab-name: rotten
+    testgrid-tab-name: rotten-issues
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
@@ -381,6 +381,7 @@ periodics:
         org:kubernetes-sigs
         org:kubernetes-client
         org:kubernetes-csi
+        is:issue
         -repo:kubernetes-sigs/kind
         -repo:kubernetes/ingress-nginx
         -label:lifecycle/frozen
@@ -393,16 +394,16 @@ periodics:
       - --token=/etc/github-token/token
       - --endpoint=http://ghproxy.default.svc.cluster.local
       - |-
-        --comment=The Kubernetes project currently lacks enough active contributors to adequately respond to all issues and PRs.
+        --comment=The Kubernetes project currently lacks enough active contributors to adequately respond to all issues.
 
-        This bot triages issues and PRs according to the following rules:
+        This bot triages un-triaged issues according to the following rules:
         - After 90d of inactivity, `lifecycle/stale` is applied
         - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
         - After 30d of inactivity since `lifecycle/rotten` was applied, the issue is closed
 
         You can:
-        - Mark this issue or PR as fresh with `/remove-lifecycle rotten`
-        - Close this issue or PR with `/close`
+        - Mark this issue as fresh with `/remove-lifecycle rotten`
+        - Close this issue with `/close`
         - Offer to help out with [Issue Triage][1]
 
         Please send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
@@ -421,14 +422,131 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
-- name: ci-k8s-triage-robot-stale
+- name: ci-k8s-triage-robot-rotten-prs
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Adds lifecycle/rotten to stale PRs after 30d of inactivity
+    testgrid-tab-name: rotten-prs
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20230116-d4a02a2181
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        is:pr
+        -repo:kubernetes-sigs/kind
+        -repo:kubernetes/ingress-nginx
+        -label:lifecycle/frozen
+        -label:lifecycle/rotten
+        label:lifecycle/stale
+      - --updated=720h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=The Kubernetes project currently lacks enough active contributors to adequately respond to all PRs.
+
+        This bot triages PRs according to the following rules:
+        - After 90d of inactivity, `lifecycle/stale` is applied
+        - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
+        - After 30d of inactivity since `lifecycle/rotten` was applied, the PR is closed
+
+        You can:
+        - Mark this PR as fresh with `/remove-lifecycle rotten`
+        - Close this PR with `/close`
+        - Offer to help out with [Issue Triage][1]
+
+        Please send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
+
+        /lifecycle rotten
+
+        [1]: https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-stale-issues
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/stale to issues after 90d of inactivity
-    testgrid-tab-name: stale
+    testgrid-tab-name: stale-issues
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20230116-d4a02a2181
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        is:issue
+        -repo:kubernetes-sigs/kind
+        -repo:kubernetes/ingress-nginx
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+        -label:"help wanted"
+        -label:"good first issue"
+        -label:"triage/accepted"
+      - --updated=2160h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=The Kubernetes project currently lacks enough contributors to adequately respond to all issues.
+
+        This bot triages un-triaged issues according to the following rules:
+        - After 90d of inactivity, `lifecycle/stale` is applied
+        - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
+        - After 30d of inactivity since `lifecycle/rotten` was applied, the issue is closed
+
+        You can:
+        - Mark this issue as fresh with `/remove-lifecycle stale`
+        - Close this issue with `/close`
+        - Offer to help out with [Issue Triage][1]
+
+        Please send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
+
+        /lifecycle stale
+
+        [1]: https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-stale-prs
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Adds lifecycle/stale to PRs after 90d of inactivity
+    testgrid-tab-name: stale-prs
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
@@ -445,24 +563,20 @@ periodics:
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten
-        -label:"help wanted"
-        -label:"good first issue"
-        -label:"triage/accepted"
       - --updated=2160h
       - --token=/etc/github-token/token
       - --endpoint=http://ghproxy.default.svc.cluster.local
       - |-
-        --comment=The Kubernetes project currently lacks enough contributors to adequately respond to all issues and PRs.
+        --comment=The Kubernetes project currently lacks enough contributors to adequately respond to all PRs.
 
-        This bot triages issues and PRs according to the following rules:
+        This bot triages PRs according to the following rules:
         - After 90d of inactivity, `lifecycle/stale` is applied
         - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
-        - After 30d of inactivity since `lifecycle/rotten` was applied, the issue is closed
+        - After 30d of inactivity since `lifecycle/rotten` was applied, the PR is closed
 
         You can:
-        - Mark this issue or PR as fresh with `/remove-lifecycle stale`
-        - Mark this issue or PR as rotten with `/lifecycle rotten`
-        - Close this issue or PR with `/close`
+        - Mark this PR as fresh with `/remove-lifecycle stale`
+        - Close this PR with `/close`
         - Offer to help out with [Issue Triage][1]
 
         Please send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -664,15 +664,112 @@ periodics:
         org:kubernetes-csi
         -repo:kubernetes-sigs/kind
         label:triage/accepted
+        -label:priority/important-soon
+        -label:priority/critical-urgent
+        is:issue
       - --updated=8760h
       - --token=/etc/github-token/token
       - --endpoint=http://ghproxy.default.svc.cluster.local
       - |-
-        --comment=This issue or PR has not been updated in over 1 year, and should be re-triaged.
+        --comment=This issue has not been updated in over 1 year, and should be re-triaged.
 
         You can:
-        - Confirm that this issue or PR is still relevant with `/triage accepted` (org members only)
-        - Close this issue or PR with `/close`
+        - Confirm that this issue is still relevant with `/triage accepted` (org members only)
+        - Close this issue with `/close`
+
+        For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-retriage-important
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Removes the triage/accepted label on important issues after 3 months of inactivity
+    testgrid-tab-name: re-triage-important
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:commenter:v20230116-d4a02a2181
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        -repo:kubernetes-sigs/kind
+        label:triage/accepted
+        label:priority/important-soon
+        is:issue
+      - --updated=2160h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=This issue is labeled with `priority/important-soon` but has not been updated in over 90 days, and should be re-triaged.
+        Important-soon issues must be staffed and worked on either currently, or very soon, ideally in time for the next release.
+
+        You can:
+        - Confirm that this issue is still relevant with `/triage accepted` (org members only)
+        - Deprioritize it with `/priority important-longterm` or `/priority backlog`
+        - Close this issue with `/close`
+
+        For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-retriage-critical
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Removes the triage/accepted label on critical issues after 1 month of inactivity
+    testgrid-tab-name: re-triage-critical
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:commenter:v20230116-d4a02a2181
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:kubernetes
+        org:kubernetes-sigs
+        org:kubernetes-client
+        org:kubernetes-csi
+        -repo:kubernetes-sigs/kind
+        label:triage/accepted
+        label:priority/critical-urgent
+        is:issue
+      - --updated=2160h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - |-
+        --comment=This issue is labeled with `priority/critical-urgent` but has not been updated in over 30 days, and should be re-triaged.
+        Critical-urgent issues must be actively worked on as someone's top priority right now.
+
+        You can:
+        - Confirm that this issue is still relevant with `/triage accepted` (org members only)
+        - Deprioritize it with `/priority {important-soon, important-longterm, backlog}`
+        - Close this issue with `/close`
 
         For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
       - --template

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -245,56 +245,6 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
-- name: ci-k8s-triage-robot-freezer
-  interval: 1h
-  cluster: k8s-infra-prow-build-trusted
-  decorate: true
-  annotations:
-    testgrid-dashboards: sig-contribex-k8s-triage-robot
-    description: Freezes important triaged bug issues
-    testgrid-tab-name: freeze
-  spec:
-    containers:
-    - image: gcr.io/k8s-prow/commenter:v20230207-1f583294de
-      command:
-      - commenter
-      args:
-      - |-
-        --query=org:kubernetes
-        org:kubernetes-sigs
-        org:kubernetes-client
-        org:kubernetes-csi
-        -repo:kubernetes-sigs/kind
-        -repo:kubernetes/ingress-nginx
-        -label:lifecycle/frozen
-        label:lifecycle/rotten
-        label:kind/bug
-        label:triage/accepted
-        label:priority/critical-urgent,priority/important-soon,priority/important-longterm
-        is:issue
-        is:open
-      - --token=/etc/github-token/token
-      - --endpoint=http://ghproxy.default.svc.cluster.local
-      - |-
-        --comment=The issue has been marked as an important bug and triaged.
-        Such issues are automatically marked as frozen when hitting the rotten state
-        to avoid missing important bugs.
-
-        Please send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
-
-        /lifecycle frozen
-      - --template
-      - --ceiling=10
-      - --confirm
-      volumeMounts:
-      - name: token
-        mountPath: /etc/github-token
-    volumes:
-    - name: token
-      secret:
-        secretName: k8s-triage-robot-github-token
-
-
 - name: ci-k8s-triage-robot-retester
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
   cluster: k8s-infra-prow-build-trusted

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -678,6 +678,8 @@ periodics:
         - Close this issue with `/close`
 
         For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
+
+        /remove-triage accepted
       - --template
       - --ceiling=10
       - --confirm
@@ -725,6 +727,8 @@ periodics:
         - Close this issue with `/close`
 
         For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
+
+        /remove-triage accepted
       - --template
       - --ceiling=10
       - --confirm
@@ -772,6 +776,8 @@ periodics:
         - Close this issue with `/close`
 
         For more details on the triage process, see https://www.kubernetes.dev/docs/guide/issue-triage/
+
+        /remove-triage accepted
       - --template
       - --ceiling=10
       - --confirm


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/103151

This PR makes the following workflow changes (separate commits):
1. **Don't auto-close triaged issues, don't mark triaged issues as stale/rotten** - Triaged issues have already been vetted by an org member as being relevant and having sufficient information. By ignoring triaged issues for lifecycle changes, this should reduce a lot of unnecessary churn & friction for maintainers.
2. **Require issues to be retriaged when untouched for a set amount of time** - This essentially adds a new lifecycle stage with a much greater (1 year vs 90 days) window. The idea is that the project changes a lot in 1 year, and it makes sense for issues that have been untouched for that amount of time to be retriaged, to ensure they are still relevant. Note that once the triage label is removed, the regular stale/rotten/closed lifecycle checks kick back in.
    - `critical-urgent` - retriage after 30 days of inactivity
    - `important-soon` - retriage after 90 days of inactivity
    - `important-longterm` and `backlog` - retriage after 1 year of inactivity
3. **Don't auto-close important issues** - Issues labeled with `priority/critical-urgent`, `priority/important-soon` or `priority/important-longterm` will no longer be auto-closed from the `lifecycle/rotten` state.
4. **Remove the job that marks important triaged issues as frozen** - This is redundant with the changes in (1) and (3).

/hold
for comment

/sig contributor-experience