### PR TITLE
Allow go-canary jobs to run on release branches

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -43,8 +43,6 @@ presubmits:
     cluster: k8s-infra-prow-build
     path_alias: "k8s.io/kubernetes"
     decorate: true
-    skip_branches:
-    - release-\d+.\d+ # per-release job
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -38,8 +38,6 @@ presubmits:
     always_run: false
     skip_report: false
     decorate: true
-    skip_branches:
-    - release-\d+.\d+ # per-release job
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -73,8 +73,6 @@ presubmits:
       testgrid-dashboards: sig-release-releng-informing, sig-testing-canaries
     decorate: true
     cluster: k8s-infra-prow-build
-    skip_branches:
-    - release-\d+.\d+ # per-release job
     labels:
       preset-service-account: "true"
     always_run: false

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -49,8 +49,6 @@ presubmits:
     always_run: false
     skip_report: false
     decorate: true
-    skip_branches:
-    - release-\d+.\d+ # per-release job
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'


### PR DESCRIPTION
As we look to start testing bumping go minor versions on release branches, it is useful to be able to trigger unit / verify / integration / dependency CI jobs on latest go in release branches as well.

Since they only run when explicitly invoked (all have `always_run: false`), and we don't actually clone these per branch (despite the comment in the configs), skip_branches isn't needed

xref:
* https://github.com/kubernetes/kubernetes/pull/113956
* https://github.com/kubernetes/kubernetes/pull/113983
* https://github.com/kubernetes/release/issues/2822