### PR TITLE
Add presubmit job for branch release-1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.24.yaml
@@ -1,0 +1,55 @@
+# sigs.k8s.io/scheduler-plugins presubmits
+presubmits:
+  kubernetes-sigs/scheduler-plugins:
+  - name: pull-scheduler-plugins-verify-release-1-24
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.24$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.11
+        command:
+        - make
+        args:
+        - verify
+  - name: pull-scheduler-plugins-verify-build-release-1-24
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.24$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.11
+        command:
+        - make
+        args:
+        - build
+  - name: pull-scheduler-plugins-unit-test-release-1-24
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.24$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.11
+        command:
+        - make
+        args:
+        - unit-test
+  - name: pull-scheduler-plugins-integration-test-release-1-24
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.24$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.11
+        command:
+        - make
+        args:
+        - integration-test


### PR DESCRIPTION
This enables presubmit CI testing for release-1.24 branch of scheduler-plugins repo.