### PR TITLE
Add variable `USE_LOCAL_KIND_REGISTRY` to CAPZ presubmit job

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -935,7 +935,9 @@ presets:
   env:
     - name: REGISTRY
       value: capzci.azurecr.io
-    - name: LOCAL_ONLY
+    - name: LOCAL_ONLY # This variable is used for backwards compatability, can be removed once CAPZ v1.7.0+ is used in all jobs
+      value: "false"
+    - name: USE_LOCAL_KIND_REGISTRY
       value: "false"
 - labels:
     preset-azure-cred-only: "true"


### PR DESCRIPTION
Add variable `USE_LOCAL_KIND_REGISTRY` based on this [CAPZ PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2823)
