### PR TITLE
Added (at)bobbypage to the list of reviewers and finished clean up

### DIFF
--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -2,6 +2,7 @@
 
 reviewers:
   - bart0sh
+  - bobbypage
   - derekwaynecarr
   - endocrimes
   - sjenning

--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -2,6 +2,7 @@
 
 reviewers:
   - bart0sh
+  - bobbypage
   - derekwaynecarr
   - endocrimes
   - sjenning

--- a/jobs/e2e_node/OWNERS
+++ b/jobs/e2e_node/OWNERS
@@ -2,15 +2,13 @@
 
 reviewers:
 - bart0sh
+- bobbypage
 - ConnorDoyle
 - derekwaynecarr
 - dims
 - endocrimes
-- karan
 - klueska
-- MHBauer
 - tallclair
-- vpickard
 - sjenning
 - SergeyKanzhelev
 approvers:


### PR DESCRIPTION
/sig node
/kind cleanup

This PR is two parter:

- Leftover clean up from: https://github.com/kubernetes/test-infra/pull/24916 (one OWNERS file was forgotten there)
- Adding @bobbypage as a reviewer. 

@bobbypage is already a reviewer for SIG Node, this is just extending the reviewership to this repository. I run numbers and this is definitely something @bobbypage is doing already:

```
~/src/k8s.io/test-infra/jobs/e2e_node$ /usr/local/google/home/skanzhelev/go/bin/maintainers prune --repository-devstats=kubernetes/test-infra
WARN: GOPATH not setRunning script : 12-16-2022 07:40:11
Processed /usr/local/google/home/skanzhelev/src/k8s.io/test-infra/jobs/e2e_node/OWNERS
Found 0 unique aliases
Found 14 unique users
..........
>>>>> Contributions from kubernetes/test-infra devstats repo and kubernetes/kubernetes github repo : 10
>>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
dims : 620 : 944 
SergeyKanzhelev : 214 : 155 
bobbypage : 197 : 100 
endocrimes : 145 : 118 
```
