### PR TITLE
Revert "Add CAPZ storage account keys to preset"

### DIFF
--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -30,23 +30,6 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: azure-capz-sa-cred
-  namespace: test-pods
-spec:
-  backendType: gcpSecretsManager
-  projectId: kubernetes-upstream
-  data:
-  - key: azure-capz-sa-cred
-    name: credentials
-    version: latest
-  template:
-    data:
-      serviceAccountSigningPub: <%= JSON.parse(data.credentials).serviceAccountSigningPub %>
-      serviceAccountSigningKey: <%= JSON.parse(data.credentials).serviceAccountSigningKey %>
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: azure-secrets-store-cred
   namespace: test-pods
 spec:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -918,16 +918,6 @@ presets:
   env:
   - name: AZURE_CREDENTIALS
     value: /etc/azure-cred/credentials
-  - name: SERVICE_ACCOUNT_SIGNING_PUB
-    valueFrom:
-      secretKeyRef:
-        name: azure-capz-sa-cred
-        key: serviceAccountSigningPub
-  - name: SERVICE_ACCOUNT_SIGNING_KEY
-    valueFrom:
-      secretKeyRef:
-        name: azure-capz-sa-cred
-        key: serviceAccountSigningKey
   - name: AZURE_SSH_PUBLIC_KEY_FILE
     value: /etc/azure-ssh/azure-ssh-pub
   - name: REGISTRY
@@ -964,16 +954,6 @@ presets:
   env:
     - name: AZURE_CREDENTIALS
       value: /etc/azure-cred/credentials
-    - name: SERVICE_ACCOUNT_SIGNING_PUB
-      valueFrom:
-        secretKeyRef:
-          name: azure-capz-sa-cred
-          key: serviceAccountSigningPub
-    - name: SERVICE_ACCOUNT_SIGNING_KEY
-      valueFrom:
-        secretKeyRef:
-          name: azure-capz-sa-cred
-          key: serviceAccountSigningKey
   volumes:
     - name: azure-cred
       secret:


### PR DESCRIPTION
This reverts commit 5631370c845e05173bb86f9fb4abd67e8fb90aa0 from #28261.

As best I can tell, since this commit was [deployed to production](https://kubernetes.slack.com/archives/CQP3RC68Y/p1671192573764219) in the morning of Dec. 16, [all CAPZ](https://prow.k8s.io/?job=pull-cluster-api-provider-azure-e2e), image-builder, and windows-testing jobs have begun timing out after 15 minutes with this log:

> Failed to open /logs/process-log.txt

Looking at the prow dashboard after a job has been started, we see this type of error:

> Log not found: container "test" in pod "53dac965-7d82-11ed-9d33-9e6a96971cd1" is waiting to start: CreateContainerConfigError

