### PR TITLE
[k8s.io/cloud-provider-gcp] Add cloud-provider-gcp-verify-up-to-date

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -95,3 +95,26 @@ presubmits:
             echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
           fi;
           kubetest2 gce -v 2 --repo-root "${REPO_ROOT}" --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+  - name: cloud-provider-gcp-verify-up-to-date
+    always_run: true
+    optional: true
+    decorate: true
+    path_alias: k8s.io/cloud-provider-gcp
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: provider-gcp-presubmits
+      description: Run verify scripts on kubernetes/cloud-provider-gcp.
+      testgrid-num-columns-recent: '30'
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221207-9bb38b7b14-master
+          command:
+            - runner.sh
+          args:
+          - "/bin/bash"
+          - "-c"
+          - export BAZEL_VERSION=5.3.0;
+            /workspace/test-infra/images/kubekins-e2e/install-bazel.sh;
+            ./tools/verify-up-to-date.sh


### PR DESCRIPTION
Add optional presubmits that run `tools/verify-up-to-date.sh` to prevent regression in libraries