### PR TITLE
[cloud-provider-gcp] Make cloud-provider-gcp-verify-up-to-date mandatory

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -97,7 +97,6 @@ presubmits:
           kubetest2 gce -v 2 --repo-root "${REPO_ROOT}" --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
   - name: cloud-provider-gcp-verify-up-to-date
     always_run: true
-    optional: true
     decorate: true
     path_alias: k8s.io/cloud-provider-gcp
     labels:


### PR DESCRIPTION
Verified in kubernetes/cloud-provider-gcp#426

/assign @pawbana 

Ref. kubernetes/cloud-provider-gcp#384