### PR TITLE
upload .git to gcb for cloud-provider-gcp

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
@@ -86,4 +86,5 @@ postsubmits:
               - --project=k8s-staging-cloud-provider-gcp
               - --scratch-bucket=gs://k8s-staging-cloud-provider-gcp-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .


### PR DESCRIPTION
It seems the build image script needs to get some git information, maybe the cloudbuild fails because it doesn't have the git information

> If you need the .git directory to be uploaded to your build environment:

> pass the --with-git-dir command-line option to run.sh;
> add an empty .gcloudignore file to your repository. This will override the default values.