### PR TITLE
`generic-autobumper`: unit test and cleanup for PRTitleBody

### DIFF
--- a/experiment/bumpmonitoring/main.go
+++ b/experiment/bumpmonitoring/main.go
@@ -117,8 +117,8 @@ func (c *client) Changes() []func(context.Context) (string, error) {
 }
 
 // PRTitleBody returns the body of the PR, this function runs after each commit
-func (c *client) PRTitleBody() (string, string, error) {
-	return c.title(), c.body(), nil
+func (c *client) PRTitleBody() (string, string) {
+	return c.title(), c.body()
 }
 
 func (c *client) title() string {

--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -96,7 +96,7 @@ type PRHandler interface {
 	Changes() []func(context.Context) (string, error)
 	// PRTitleBody returns the body of the PR, this function runs after all
 	// changes have been executed
-	PRTitleBody() (string, string, error)
+	PRTitleBody() (string, string)
 }
 
 // GitAuthorOptions is specifically to read the author info for a commit
@@ -260,10 +260,7 @@ func processGitHub(ctx context.Context, o *Options, prh PRHandler) error {
 		return fmt.Errorf("push changes to the remote branch: %w", err)
 	}
 
-	summary, body, err := prh.PRTitleBody()
-	if err != nil {
-		return fmt.Errorf("creating PR summary and body: %w", err)
-	}
+	summary, body := prh.PRTitleBody()
 	if o.GitHubBaseBranch == "" {
 		repo, err := gc.GetRepo(o.GitHubOrg, o.GitHubRepo)
 		if err != nil {

--- a/prow/cmd/generic-autobumper/main.go
+++ b/prow/cmd/generic-autobumper/main.go
@@ -94,11 +94,13 @@ func (c *client) Changes() []func(context.Context) (string, error) {
 }
 
 // PRTitleBody returns the body of the PR, this function runs after each commit
-func (c *client) PRTitleBody() (string, string, error) {
+func (c *client) PRTitleBody() (string, string) {
 	body := generatePRBody(c.images, c.o.Prefixes) +
-		getAssignment(c.o.OncallAddress, c.o.OncallGroup, c.o.SkipOncallAssignment, c.o.SelfAssign) + "\n" +
-		c.o.AdditionalPRBody + "\n"
-	return makeCommitSummary(c.o.Prefixes, c.versions), body, nil
+		getAssignment(c.o.OncallAddress, c.o.OncallGroup, c.o.SkipOncallAssignment, c.o.SelfAssign) + "\n"
+	if c.o.AdditionalPRBody != "" {
+		body += c.o.AdditionalPRBody + "\n"
+	}
+	return makeCommitSummary(c.o.Prefixes, c.versions), body
 }
 
 func generatePRBody(images map[string]string, prefixes []prefix) (body string) {


### PR DESCRIPTION
Adding a unit test for `PRTitleBody` as a follow up to: https://github.com/kubernetes/test-infra/pull/28102. It is a fairly simple test as the functions that are called from this one are already tested in depth. I modified the function to not add an extra `\n` when there is no additional body. I also noticed that an error is never returned from the function, or the other one that shares the interface, so I removed it from the signature.