### PR TITLE
add periodic job to build nightly images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
@@ -88,3 +88,38 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - --with-git-dir
               - .
+
+periodics:
+  - name: periodic-cloud-provider-gcp-push-images
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-storage-image-build, sig-k8s-infra-gcb
+    decorate: true
+    interval: 24h # nightly
+    extra_refs:
+      # This also becomes the current directory for run.sh and thus
+      # the cloud image build.
+      - org: kubernetes
+        repo: cloud-provider-gcp
+        base_ref: master
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20221010-3da4a9c21a
+          command:
+            - /run.sh
+          env:
+            # We need to emulate a pull job for the cloud build to work the same
+            # way as it usually does.
+            - name: PULL_BASE_REF
+              value: master
+            - name: GIT_TAG
+              value: nightly
+          args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-cloud-provider-gcp
+              - --scratch-bucket=gs://k8s-staging-cloud-provider-gcp-gcb
+              - --env-passthrough=PULL_BASE_REF,GIT_TAG
+              - --with-git-dir
+              - .


### PR DESCRIPTION
It will create a nightly images with the latest sources
This is easy to use for setting up a periodic job that test nightly ccm against nightly kubernetes, to provide signal