### PR TITLE
Bump go version to 1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.19.3
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.19.3
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.19.3
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: golang:1.19.3
         command:
         - make
         args:


### PR DESCRIPTION
Bump go version to 1.19, otherwise compilation for scheduler-plugins' main branch would fail with errors like `undefined: any`.