### PR TITLE
update sig-release team jobs with bug triage

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -24,3 +24,28 @@ periodics:
             secretKeyRef:
               name: k8s-release-enhancements-triage-github-token
               key: token
+- name: periodic-sync-bug-triage-github-project-beta-1-27
+  interval: 3h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: sig-release-release-team-periodics
+    description: Periodically syncs the opted-in k/k issues on the Bug Triage Tracking GitHub Beta Project Board
+  extra_refs:
+  - org: kubernetes
+    repo: sig-release
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+      command:
+      - ./release-team/hack/sync-bug-triage-github-project-beta.sh
+      env:
+        - name: GITHUB_PROJECT_BETA_NUMBER
+          value: "80"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: k8s-release-bug-triage-github-token
+              key: token


### PR DESCRIPTION
Update sig-release team jobs with bug triage one. 

Signed-off-by: Heba Elayoty <hebaelayoty@gmail.com>