### PR TITLE
Handle change to kOps settings

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
@@ -44,7 +44,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=spec.cloudConfig.awsEBSCSIDriver.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=spec.cloudProvider.aws.ebsCSIDriver.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \


### PR DESCRIPTION
This broke due to kubernetes/kops#14810

kOps enables EBS CSI by default for k8s 1.22 and higher