### PR TITLE
Update 1.23 ci to go1.19.4

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -52,7 +52,7 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: 1.17.13
+    GO_VERSION: 1.19.4
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Replay of https://github.com/kubernetes/test-infra/pull/28289 for 1.23

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates 1.23 branch CI to use go1.19.4

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2822

#### Does this PR introduce a user-facing change?

```release-note
release-1.23 CI updated to go1.19.4
```

/assign @cpanato @puerco @dims
/hold for 1.24 post-submit signal on https://github.com/kubernetes/kubernetes/pull/113956