### PR TITLE
Add CAPZ storage account keys as new preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
@@ -1,0 +1,14 @@
+presets:
+- labels:
+    preset-azure-capz-sa-cred: "true"
+  env:
+  - name: SERVICE_ACCOUNT_SIGNING_PUB
+    valueFrom:
+      secretKeyRef:
+        name: azure-capz-sa-cred
+        key: serviceAccountSigningPub
+  - name: SERVICE_ACCOUNT_SIGNING_KEY
+    valueFrom:
+      secretKeyRef:
+        name: azure-capz-sa-cred
+        key: serviceAccountSigningKey

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -98,6 +98,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
     branches:
     - ^main$
     spec:

--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -30,6 +30,23 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: azure-capz-sa-cred
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-upstream
+  data:
+  - key: azure-capz-sa-cred
+    name: credentials
+    version: latest
+  template:
+    data:
+      serviceAccountSigningPub: <%= JSON.parse(data.credentials).serviceAccountSigningPub %>
+      serviceAccountSigningKey: <%= JSON.parse(data.credentials).serviceAccountSigningKey %>
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: azure-secrets-store-cred
   namespace: test-pods
 spec:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -918,16 +918,6 @@ presets:
   env:
   - name: AZURE_CREDENTIALS
     value: /etc/azure-cred/credentials
-  - name: SERVICE_ACCOUNT_SIGNING_PUB
-    valueFrom:
-      secretKeyRef:
-        name: azure-capz-sa-cred
-        key: serviceAccountSigningPub
-  - name: SERVICE_ACCOUNT_SIGNING_KEY
-    valueFrom:
-      secretKeyRef:
-        name: azure-capz-sa-cred
-        key: serviceAccountSigningKey
   - name: AZURE_SSH_PUBLIC_KEY_FILE
     value: /etc/azure-ssh/azure-ssh-pub
   - name: REGISTRY
@@ -964,16 +954,6 @@ presets:
   env:
     - name: AZURE_CREDENTIALS
       value: /etc/azure-cred/credentials
-    - name: SERVICE_ACCOUNT_SIGNING_PUB
-      valueFrom:
-        secretKeyRef:
-          name: azure-capz-sa-cred
-          key: serviceAccountSigningPub
-    - name: SERVICE_ACCOUNT_SIGNING_KEY
-      valueFrom:
-        secretKeyRef:
-          name: azure-capz-sa-cred
-          key: serviceAccountSigningKey
   volumes:
     - name: azure-cred
       secret:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -918,6 +918,16 @@ presets:
   env:
   - name: AZURE_CREDENTIALS
     value: /etc/azure-cred/credentials
+  - name: SERVICE_ACCOUNT_SIGNING_PUB
+    valueFrom:
+      secretKeyRef:
+        name: azure-capz-sa-cred
+        key: serviceAccountSigningPub
+  - name: SERVICE_ACCOUNT_SIGNING_KEY
+    valueFrom:
+      secretKeyRef:
+        name: azure-capz-sa-cred
+        key: serviceAccountSigningKey
   - name: AZURE_SSH_PUBLIC_KEY_FILE
     value: /etc/azure-ssh/azure-ssh-pub
   - name: REGISTRY
@@ -954,6 +964,16 @@ presets:
   env:
     - name: AZURE_CREDENTIALS
       value: /etc/azure-cred/credentials
+    - name: SERVICE_ACCOUNT_SIGNING_PUB
+      valueFrom:
+        secretKeyRef:
+          name: azure-capz-sa-cred
+          key: serviceAccountSigningPub
+    - name: SERVICE_ACCOUNT_SIGNING_KEY
+      valueFrom:
+        secretKeyRef:
+          name: azure-capz-sa-cred
+          key: serviceAccountSigningKey
   volumes:
     - name: azure-cred
       secret:


### PR DESCRIPTION
This reverts commit eaaf9d925a6e09a32a6979535aef59af4b991394 and re-implements https://github.com/kubernetes/test-infra/pull/28261.

The [secret](https://console.cloud.google.com/security/secret-manager/secret/azure-capz-sa-cred/versions?project=kubernetes-upstream) was created without the required permissions to be used by Prow as an ExternalSecret which caused all Azure tests using the preset to start failing. 

I've added the right permissions to the secret so it should be good now. As extra precaution, I've also moved the new secret to a new preset so it doesn't affect any other existing jobs until we've made sure that it works.