### PR TITLE
mark e2e tests as mandatory

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
@@ -36,7 +36,6 @@ presubmits:
   - name: pull-kueue-test-e2e-main-1-23
     always_run: true
     decorate: true
-    optional: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
@@ -63,7 +62,6 @@ presubmits:
   - name: pull-kueue-test-e2e-main-1-24
     always_run: true
     decorate: true
-    optional: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
@@ -90,7 +88,6 @@ presubmits:
   - name: pull-kueue-test-e2e-main-k8-1-25
     always_run: true
     decorate: true
-    optional: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling


### PR DESCRIPTION
Since we figured out the flakiness with our e2e tests and they have been running on PRs for a few weeks, we want to enable them as required jobs.  

This will enable required e2e tests for K8 1.23, 1.24 and 1.25