### PR TITLE
CAPI: Retain LGTM through squash

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -239,6 +239,7 @@ lgtm:
   - kubernetes/kubernetes
   - kubernetes/website
   - kubernetes-sigs/node-feature-discovery
+  - kubernetes-sigs/cluster-api
   store_tree_hash: true
 
 blockades:


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add retaining lgtm through squash to the Cluster API repo.

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/7697