### PR TITLE
kubekins-e2e: Bump Go version to 1.20rc1 for canary jobs

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.20rc1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Bumping kubekins-e2e go version to 1.20rc1 for canary jobs.

Ref https://github.com/kubernetes/kubernetes/pull/114502#issuecomment-1362959418