### PR TITLE
Specify CSI hostpath version to master for canary jobs

### DIFF
--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -392,6 +392,8 @@ presubmits:
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -383,7 +383,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -392,6 +392,8 @@ presubmits:
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -383,7 +383,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -392,6 +392,8 @@ presubmits:
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -383,7 +383,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -392,6 +392,8 @@ presubmits:
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -383,7 +383,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -514,6 +514,8 @@ EOF
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -505,7 +505,7 @@ EOF
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "$(expand_tests "$tests")"
         - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -392,6 +392,8 @@ presubmits:
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -383,7 +383,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -392,6 +392,8 @@ presubmits:
           value: "canary"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
         # ... but the RBAC rules only when testing on master.
         # The other jobs test against the unmodified deployment for
         # that Kubernetes version, i.e. with the original RBAC rules.

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -383,7 +383,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "master"
+          value: "latest"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         - name: CSI_PROW_BUILD_JOB


### PR DESCRIPTION
Explicitly set `CSI_PROW_DRIVER_VERSION` to `master` for canary prow jobs. 
Follow up to https://github.com/kubernetes/test-infra/pull/28307