### PR TITLE
apiserver-network-proxy: support release-0.0 branch.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-apiserver-network-proxy.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apiserver-network-proxy.yaml
@@ -9,6 +9,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
+        - ^release-.+$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
Releasing v0.0.34 tags built from release-0.0 branch is blocked on this.

Related: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/445