### PR TITLE
kOps: Increase timeout for golangci-lint pre-submit to 15m

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -290,7 +290,7 @@ presubmits:
       preset-service-account: "true"
     decorate: true
     decoration_config:
-      timeout: 10m
+      timeout: 15m
     path_alias: k8s.io/kops
     spec:
       containers:


### PR DESCRIPTION
/cc @olemarkus @johngmyers 