### PR TITLE
Reduce frequency of sig-windows release jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
@@ -11,7 +11,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 3h
+  interval: 24h
   labels:
     preset-azure-cred: "true"
     preset-azure-windows: "true"
@@ -108,7 +108,7 @@ periodics:
     testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.23
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     description: Runs SIG-Windows release serial tests on K8s 1.23 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- interval: 3h
+- interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-1-23-windows
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -12,7 +12,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-1-24
-  interval: 3h
+  interval: 24h
   decorate: true
   decoration_config:
     timeout: 4h0m0s

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -12,7 +12,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-containerd-windows-1-25
-  interval: 3h
+  interval: 24h
   decorate: true
   decoration_config:
     timeout: 4h0m0s

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -20,7 +20,7 @@ periodics:
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
-  interval: 3h
+  interval: 24h
   labels:
     preset-azure-cred-only: "true"
     preset-capz-containerd-latest: "true"


### PR DESCRIPTION
The release branches for sig-windows don't get updated frequently, so we only need to run them each day.

/sig windows
/assign @marosset 