### PR TITLE
Tide for Gerrit: post-filter to ensure PRs are truly submittable

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -602,7 +602,10 @@ func (h *gerritInstanceHandler) QueryChangesForProject(log logrus.FieldLogger, p
 
 	var opt gerrit.QueryChangeOptions
 	opt.Query = append(opt.Query, strings.Join(append(additionalFilters, "project:"+project), "+"))
-	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
+	// Gerrit query by default doesn't include all fields, add necessary fields
+	// according to
+	// https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html.
+	opt.AdditionalFields = []string{"SUBMITTABLE", "CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
 
 	log = log.WithFields(logrus.Fields{"query": opt.Query, "additional_fields": opt.AdditionalFields})
 	var start int

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -207,13 +207,31 @@ func (p *GerritProvider) Query() (map[string]CodeReviewCommon, error) {
 				optInByDefault = projFilter.OptInByDefault
 			}
 			go func(projName string, optInByDefault bool) {
+				logger := p.logger.WithFields(logrus.Fields{"instance": instance, "project": projName})
 				changes, err := p.gc.QueryChangesForProject(instance, projName, lastUpdate, p.cfg().Gerrit.RateLimit, gerritQueryParam(optInByDefault))
 				if err != nil {
-					p.logger.WithFields(logrus.Fields{"instance": instance, "project": projName}).WithError(err).Warn("Querying gerrit project for changes.")
+					logger.WithError(err).Warn("Querying gerrit project for changes.")
 					errChan <- fmt.Errorf("failed querying project '%s' from instance '%s': %v", projName, instance, err)
 					return
 				}
-				resChan <- changesFromProject{instance: instance, project: projName, changes: changes}
+				// Appears that `is:submittable` is not guaranteed to always
+				// work, add an extra layer of filtering until the below
+				// mentioned bug is fixed:
+				// Google internal bug reference: 263278725
+				var submittableChanges []gerrit.ChangeInfo
+				for _, c := range changes {
+					c := c
+					if !c.Submittable {
+						logger.WithField("id", c.ID).Debug("Change not submittable presented in query results.")
+						continue
+					}
+					if !c.Mergeable {
+						logger.WithField("id", c.ID).Debug("Change not mergeable presented in query results.")
+						continue
+					}
+					submittableChanges = append(submittableChanges, c)
+				}
+				resChan <- changesFromProject{instance: instance, project: projName, changes: submittableChanges}
 			}(projName, optInByDefault)
 		}
 	}

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -157,14 +157,21 @@ func TestQuery(t *testing.T) {
 				"foo1": {
 					"bar1": {
 						gerrit.ChangeInfo{
-							Number:  1,
-							Project: "bar1",
+							Number:      1,
+							Project:     "bar1",
+							Mergeable:   true,
+							Submittable: true,
 						},
 					},
 				},
 			},
 			expect: map[string]CodeReviewCommon{
-				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar1"}, "foo1"),
+				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
+					Number:      1,
+					Project:     "bar1",
+					Mergeable:   true,
+					Submittable: true,
+				}, "foo1"),
 			},
 		},
 		{
@@ -183,37 +190,65 @@ func TestQuery(t *testing.T) {
 				"foo1": {
 					"bar1": {
 						gerrit.ChangeInfo{
-							Number:  1,
-							Project: "bar1",
+							Number:      1,
+							Project:     "bar1",
+							Mergeable:   true,
+							Submittable: true,
 						},
 					},
 					"bar2": {
 						gerrit.ChangeInfo{
-							Number:  2,
-							Project: "bar2",
+							Number:      2,
+							Project:     "bar2",
+							Mergeable:   true,
+							Submittable: true,
 						},
 					},
 				},
 				"foo2": {
 					"bar3": {
 						gerrit.ChangeInfo{
-							Number:  1,
-							Project: "bar3",
+							Number:      1,
+							Project:     "bar3",
+							Mergeable:   true,
+							Submittable: true,
 						},
 					},
 					"bar4": {
 						gerrit.ChangeInfo{
-							Number:  2,
-							Project: "bar4",
+							Number:      2,
+							Project:     "bar4",
+							Mergeable:   true,
+							Submittable: true,
 						},
 					},
 				},
 			},
 			expect: map[string]CodeReviewCommon{
-				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar1"}, "foo1"),
-				"foo1/bar2#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 2, Project: "bar2"}, "foo1"),
-				"foo2/bar3#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar3"}, "foo2"),
-				"foo2/bar4#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 2, Project: "bar4"}, "foo2"),
+				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
+					Number:      1,
+					Project:     "bar1",
+					Mergeable:   true,
+					Submittable: true,
+				}, "foo1"),
+				"foo1/bar2#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
+					Number:      2,
+					Project:     "bar2",
+					Mergeable:   true,
+					Submittable: true,
+				}, "foo1"),
+				"foo2/bar3#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
+					Number:      1,
+					Project:     "bar3",
+					Mergeable:   true,
+					Submittable: true,
+				}, "foo2"),
+				"foo2/bar4#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
+					Number:      2,
+					Project:     "bar4",
+					Mergeable:   true,
+					Submittable: true,
+				}, "foo2"),
 			},
 		},
 		{


### PR DESCRIPTION
 Appears that `is:submittable` is not guaranteed to always work, add an extra layer of filtering as a workaround until the gerrit is fixed

/cc @cjwagner @listx 