### PR TITLE
approvers: Correct name for IsAutoApproveUnownedSubfolders feature

### DIFF
--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -435,12 +435,12 @@ func TestIsApproved(t *testing.T) {
 		"d":       {},
 	}
 	tests := []struct {
-		testName               string
-		filenames              []string
-		allowFolderCreationMap map[string]bool
-		currentlyApproved      sets.String
-		testSeed               int64
-		isApproved             bool
+		testName                        string
+		filenames                       []string
+		autoApproveUnownedSubfoldersMap map[string]bool
+		currentlyApproved               sets.String
+		testSeed                        int64
+		isApproved                      bool
 	}{
 		{
 			testName:          "Empty PR",
@@ -506,53 +506,53 @@ func TestIsApproved(t *testing.T) {
 			isApproved:        true,
 		},
 		{
-			testName:               "File in folder with AllowFolderCreation does not get approved",
-			filenames:              []string{"a/test.go"},
-			allowFolderCreationMap: map[string]bool{"a": true},
-			isApproved:             false,
+			testName:                        "File in folder with AutoApproveUnownedSubfolders does not get approved",
+			filenames:                       []string{"a/test.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"a": true},
+			isApproved:                      false,
 		},
 		{
-			testName:               "Subfolder in folder with AllowFolderCreation gets approved",
-			filenames:              []string{"a/new-folder/test.go"},
-			allowFolderCreationMap: map[string]bool{"a": true},
-			isApproved:             true,
+			testName:                        "Subfolder in folder with AutoApproveUnownedSubfolders gets approved",
+			filenames:                       []string{"a/new-folder/test.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"a": true},
+			isApproved:                      true,
 		},
 		{
-			testName:               "Subfolder in folder with AllowFolderCreation whose ownersfile has no approvers gets approved",
-			filenames:              []string{"d/new-folder/test.go"},
-			allowFolderCreationMap: map[string]bool{"d": true},
-			isApproved:             true,
+			testName:                        "Subfolder in folder with AutoApproveUnownedSubfolders whose ownersfile has no approvers gets approved",
+			filenames:                       []string{"d/new-folder/test.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"d": true},
+			isApproved:                      true,
 		},
 		{
-			testName:               "Subfolder in folder with AllowFolderCreation and other unapproved file does not get approved",
-			filenames:              []string{"b/unapproved.go", "a/new-folder/test.go"},
-			allowFolderCreationMap: map[string]bool{"a": true},
-			isApproved:             false,
+			testName:                        "Subfolder in folder with AutoApproveUnownedSubfolders and other unapproved file does not get approved",
+			filenames:                       []string{"b/unapproved.go", "a/new-folder/test.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"a": true},
+			isApproved:                      false,
 		},
 		{
-			testName:               "Subfolder in folder with AllowFolderCreation and approved file, approved",
-			filenames:              []string{"b/approved.go", "a/new-folder/test.go"},
-			allowFolderCreationMap: map[string]bool{"a": true},
-			currentlyApproved:      sets.NewString(bApprovers.List()[0]),
-			isApproved:             true,
+			testName:                        "Subfolder in folder with AutoApproveUnownedSubfolders and approved file, approved",
+			filenames:                       []string{"b/approved.go", "a/new-folder/test.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"a": true},
+			currentlyApproved:               sets.NewString(bApprovers.List()[0]),
+			isApproved:                      true,
 		},
 		{
-			testName:               "Nested subfolder in folder with AllowFolderCreation gets approved",
-			filenames:              []string{"a/new-folder/child/grandchild/test.go"},
-			allowFolderCreationMap: map[string]bool{"a": true},
-			isApproved:             true,
+			testName:                        "Nested subfolder in folder with AutoApproveUnownedSubfolders gets approved",
+			filenames:                       []string{"a/new-folder/child/grandchild/test.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"a": true},
+			isApproved:                      true,
 		},
 		{
-			testName:               "Change in folder with Owners whose parent has AllowFolderCreation does not get approved",
-			filenames:              []string{"a/d/new-file.go"},
-			allowFolderCreationMap: map[string]bool{"a": true},
-			isApproved:             false,
+			testName:                        "Change in folder with Owners whose parent has AutoApproveUnownedSubfolders does not get approved",
+			filenames:                       []string{"a/d/new-file.go"},
+			autoApproveUnownedSubfoldersMap: map[string]bool{"a": true},
+			isApproved:                      false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap, func(fr *FakeRepo) { fr.autoApproveUnownedSubfolders = test.allowFolderCreationMap }), seed: test.testSeed, log: logrus.WithField("plugin", "some_plugin")})
+			testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap, func(fr *FakeRepo) { fr.autoApproveUnownedSubfolders = test.autoApproveUnownedSubfoldersMap }), seed: test.testSeed, log: logrus.WithField("plugin", "some_plugin")})
 			for approver := range test.currentlyApproved {
 				testApprovers.AddApprover(approver, "REFERENCE", false)
 			}

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -187,7 +187,7 @@ func (o Owners) GetOwnersSet() sets.String {
 	var newFilenames []string
 	for _, toApprove := range o.filenames {
 		ownersFile := o.repo.FindApproverOwnersForFile(toApprove)
-		// If the ownersfile for toApprove is in the parent folder and has AllowFolderCreation enabled, we purge
+		// If the ownersfile for toApprove is in the parent folder and has IsAutoApproveUnownedSubfolders enabled, we purge
 		// the file from our filenames list, because it doesn't need approval
 		if strings.Contains(filepath.Dir(filepath.Dir(toApprove)), ownersFile) && o.repo.IsAutoApproveUnownedSubfolders(ownersFile) {
 			continue


### PR DESCRIPTION
The AutoApproveUnownedSubfolders feature was called AllowFolderCreation initially, but was changed later as a result of bikeshedding the name. Seems like the name change did not propagate into the tests, this commit changes that.

See https://github.com/kubernetes/test-infra/pull/20743#discussion_r570503889 on name change discussions.

/assign @alvaroaleman @petr-muller 