### PR TITLE
capz: Group v1beta1 periodics by release

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.5.yaml
@@ -1,0 +1,103 @@
+periodics:
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-5
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.5
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230104-fac78883b2-1.25
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Cluster API E2E tests"
+        - name: GINKGO_SKIP
+          value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-5
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-5
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.5
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230104-fac78883b2-1.25
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Workload cluster creation"
+        - name: GINKGO_SKIP
+          value: \[Managed Kubernetes\]
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-5
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-5
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.5
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230104-fac78883b2-1.25
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: \[Managed Kubernetes\]
+        - name: GINKGO_SKIP
+          value: ""
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-5
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.6.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-6
   decorate: true
   decoration_config:
     timeout: 4h
@@ -29,10 +29,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-v1beta1
+    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-6
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.1 (v1beta1)
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts
+    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.6 (v1beta1)
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-6
   decorate: true
   decoration_config:
     timeout: 4h
@@ -65,10 +65,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1
+    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-6
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.1 (v1beta1)
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1
+    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.6 (v1beta1)
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-6
   decorate: true
   decoration_config:
     timeout: 4h
@@ -100,7 +100,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-6
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-v1beta1
   decorate: true
@@ -134,9 +134,9 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-6
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-6
   decorate: true
   decoration_config:
     timeout: 4h
@@ -168,107 +168,5 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-minus-1
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  interval: 24h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.6
-      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
-      command:
-        - runner.sh
-      args:
-        - ./scripts/ci-e2e.sh
-      env:
-        - name: GINKGO_FOCUS
-          value: "Cluster API E2E tests"
-        - name: GINKGO_SKIP
-          value: "\\[K8s-Upgrade\\]|API Version Upgrade"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-minus-1
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-v1beta1-minus-1
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  interval: 72h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.6
-      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
-      command:
-        - runner.sh
-      args:
-        - ./scripts/ci-e2e.sh
-      env:
-        - name: GINKGO_FOCUS
-          value: "Workload cluster creation"
-        - name: GINKGO_SKIP
-          value: \[Managed Kubernetes\]
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1-minus-1
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-minus-1
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  interval: 72h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.6
-      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
-      command:
-        - runner.sh
-      args:
-        - ./scripts/ci-e2e.sh
-      env:
-        - name: GINKGO_FOCUS
-          value: \[Managed Kubernetes\]
-        - name: GINKGO_SKIP
-          value: ""
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-minus-1
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-6
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
- Split v1beta1 periodic jobs into release-1.6 and release-1.5 jobs
- Updates the job names and dashboard group names, adds 'release-x.y' suffix

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2967