### PR TITLE
prow: deck can now correctly abort jobs

### DIFF
--- a/config/prow/cluster/deck_rbac.yaml
+++ b/config/prow/cluster/deck_rbac.yaml
@@ -22,6 +22,8 @@ rules:
   - watch
   # Required when deck runs with `--rerun-creates-job=true`
   - create
+  # Required to abort jobs
+  - patch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Before this change, deck will raise an error when a user tries to abort a job:

> Could not patch aborted job: prowjobs.prow.k8s.io “e088e0a4-64bf-11ed-a9da-1a21e662034e” is forbidden: User “system:serviceaccount:default:deck” cannot patch resource “prowjobs” in API group “prow.k8s.io” in the namespace “default”.

I'm not sure if there are other places that need this too, so please kindly let me know.