### PR TITLE
Set VOLUME_MODE_CONVERSION_TESTS for provisioner canary job

### DIFF
--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -399,6 +399,7 @@ presubmits:
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -399,6 +399,8 @@ presubmits:
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+        - name: VOLUME_MODE_CONVERSION_TESTS
+          value: "true"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -399,6 +399,7 @@ presubmits:
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -399,6 +399,7 @@ presubmits:
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -521,6 +521,13 @@ EOF
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+$(    if [ "$repo" = "external-provisioner" ]; then
+cat <<EOF2
+        - name: VOLUME_MODE_CONVERSION_TESTS
+          value: "true"
+EOF2
+      fi
+)
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -399,6 +399,7 @@ presubmits:
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -399,6 +399,7 @@ presubmits:
         # that Kubernetes version, i.e. with the original RBAC rules.
         - name: UPDATE_RBAC_RULES
           value: "true"
+
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Needed for https://github.com/kubernetes-csi/external-provisioner/pull/832
This PR enables `VOLUME_MODE_CONVERSION_TESTS` for external-provisioner. 
