### PR TITLE
kubekins-e2e: Bump Go version to go1.20rc2 for go canary

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.20rc1
+    GO_VERSION: 1.20rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Bumps go version to go1.20rc2 for Go canary in order to get early CI signal.

go1.20rc2 announcement: https://groups.google.com/g/golang-dev/c/MtxdaVmTgQk/m/xm6rLPFHAQAJ

/assign @dims 