### PR TITLE
ci-benchmark-scheduler-perf-master: extend the timeout

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -716,7 +716,7 @@ periodics:
   tags:
   - "perfDashPrefix: scheduler-perf-benchmark"
   - "perfDashJobType: benchmark"
-  interval: 2h
+  interval: 2h30m
   annotations:
     testgrid-dashboards: sig-scalability-benchmarks
     testgrid-tab-name: scheduler-perf
@@ -727,7 +727,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   decoration_config:
-    timeout: 1h55m
+    timeout: 2h25m
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230104-fac78883b2-master
@@ -737,7 +737,7 @@ periodics:
       - ./test/integration/scheduler_perf
       env:
       - name: KUBE_TIMEOUT
-        value: --timeout=1h50m
+        value: --timeout=2h25m
       - name: TEST_PREFIX
         value: BenchmarkPerfScheduling
       # Set the benchtime to a very low value so every test is ran at most once


### PR DESCRIPTION
Issue: https://github.com/kubernetes/kubernetes/issues/114890

Currently, it runs for more than timeout ([ref](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-benchmark-scheduler-perf-master)) and results in these errors. 

```
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:164","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h55m0s timeout","severity":"error","time":"2023-01-05T12:57:03Z"}
{"component":"entrypoint","error":"os: process already finished","file":"k8s.io/test-infra/prow/entrypoint/run.go:242","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Could not interrupt process after timeout","severity":"error","time":"2023-01-05T12:57:03Z"}
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:254","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15m0s grace period","severity":"error","time":"2023-01-05T13:12:04Z"}
{"component":"entrypoint","error":"os: process already finished","file":"k8s.io/test-infra/prow/entrypoint/run.go:256","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Could not kill process after grace period","severity":"error","time":"2023-01-05T13:12:04Z"}
```

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-benchmark-scheduler-perf-master/1610954337838698496/build-log.txt
https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-benchmark-scheduler-perf-master