### PR TITLE
Topology Manager and Memory manager e2e tests on multi-NUMA machines

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1026,7 +1026,7 @@ presubmits:
             - --
             - --deployment=node
             - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-multi-numa.yaml
             - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
             - --node-tests=true
             - --provider=gce

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -586,7 +586,7 @@ presubmits:
             - --
             - --deployment=node
             - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-multi-numa.yaml
             - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
             - --node-tests=true
             - --provider=gce
@@ -651,7 +651,7 @@ presubmits:
         - --parallelism=1
         - --focus-regex=\[Feature:TopologyManager\]
         - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config-serial-multi-numa.yaml
   - name: pull-kubernetes-node-kubelet-serial-hugepages
     cluster: k8s-infra-prow-build
     always_run: false

--- a/jobs/e2e_node/image-config-serial-multi-numa.yaml
+++ b/jobs/e2e_node/image-config-serial-multi-numa.yaml
@@ -1,0 +1,15 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-2204-1-24-v20220623
+    project: ubuntu-os-gke-cloud
+    # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager node e2e tests.
+    machine: n2d-standard-32
+  cos-stable1:
+    image_family: cos-89-lts # deprecated after March 2023 (https://cloud.google.com/container-optimized-os/docs/release-notes)
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager node e2e tests.
+    machine: n2d-standard-32

--- a/jobs/e2e_node/image-config-serial-multi-numa.yaml
+++ b/jobs/e2e_node/image-config-serial-multi-numa.yaml
@@ -5,11 +5,11 @@ images:
   ubuntu:
     image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
-    # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager node e2e tests.
+    # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager and Memory manager node e2e tests.
     machine: n2d-standard-32
   cos-stable1:
     image_family: cos-89-lts # deprecated after March 2023 (https://cloud.google.com/container-optimized-os/docs/release-notes)
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
-    # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager node e2e tests.
+    # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager and Memory manager node e2e tests.
     machine: n2d-standard-32


### PR DESCRIPTION
As Topology Manager and Memory Manager are both candidates for GA graduation, it is important to make sure that
e2e tests are not skipped due to lack of multi-NUMA machines in the test infrastructure.

This PR proposes a new job definition `image-config-serial-multi-numa.yaml` with image config specifying `n2d-standard-32` as machine. Both Topology Manager and memory manager then subsequently refer to this file for execution of e2e test on multi-numa machines.

Issue: https://github.com/kubernetes/test-infra/issues/28211.