### PR TITLE
Remove contention profiling of api-server from gce-master-scale-performance

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -117,7 +117,7 @@ periodics:
       #   performing pod creations at once.
       - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
       # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
-      - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0 --profiling --contention-profiling
+      - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
       - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
       - --test=false


### PR DESCRIPTION
It seems that since we enabled contention profiling of api-server, latency of api calls increased significantly and it introduced some flakiness:
![image](https://user-images.githubusercontent.com/2011575/211339907-8a1c1eb5-fb87-477c-937a-dfa9b93dd4f5.png)
 

This PR removes contention profiling of api-server from gce-master-scale-performance CI job. 