### PR TITLE
Add `pull-aws-ebs-csi-driver-test-helm-chart` presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -1,5 +1,25 @@
 presubmits:
   kubernetes-sigs/aws-ebs-csi-driver:
+  - name: pull-aws-ebs-csi-driver-test-helm-chart
+    always_run: true
+    decorate: true
+    skip_branches:
+    - gh-pages
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230105-c1beb6cf98-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-helm-chart
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver
+      testgrid-tab-name: test-helm-chart
+      description: aws ebs csi driver test helm chart on pull request
+      testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-verify
     always_run: true
     decorate: true


### PR DESCRIPTION
A new Makefile target was introduced in the aws-ebs-csi-driver project to test Helm chart upgrades. This PR updates the `aws-ebs-csi-driver-presubmits.yaml` config to run the new target on pull requests.

For more context see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1454.

Signed-off-by: torredil <torredil@amazon.com>