### PR TITLE
CAPZ: retain LGTM through squash

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -240,6 +240,7 @@ lgtm:
   - kubernetes/website
   - kubernetes-sigs/node-feature-discovery
   - kubernetes-sigs/cluster-api
+  - kubernetes-sigs/cluster-api-provider-azure
   store_tree_hash: true
 
 blockades:


### PR DESCRIPTION
Signed-off-by: dtzar [david.tesar@microsoft.com](mailto:david.tesar@microsoft.com)

Add retaining lgtm through squash to the Cluster API provider Azure repo.