### PR TITLE
Add labels to pull-aws-ebs-csi-driver-test-helm-chart presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -7,6 +7,8 @@ presubmits:
     - gh-pages
     labels:
       preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230105-c1beb6cf98-master


### PR DESCRIPTION
The ` pull-aws-ebs-csi-driver-test-helm-chart` presubmit job  fails with 
```
Unable to locate credentials. You can configure credentials by running "aws configure".
```

Example:
- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/1467/pull-aws-ebs-csi-driver-test-helm-chart/1612579413470220288

This PR adds the appropriate labels to supply the credentials.

Signed-off-by: torredil <torredil@amazon.com>