### PR TITLE
Stop warning `#release-management` for Dependabot

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -406,16 +406,12 @@ slack:
     - k8s-ci-robot
   - repos:
     - kubernetes/sig-release
-    channels:
-    - release-management
-    exempt_users:
-    - k8s-ci-robot
-  - repos:
     - kubernetes/release
     channels:
     - release-management
     exempt_users:
     - k8s-ci-robot
+    - dependabot[bot]
   - repos:
     - kubernetes/k8s.io
     channels:


### PR DESCRIPTION
We now exclude dependabot to stop notifying the `#release-managment` Slack channel, because branch creation is intentional for dependency updates.

cc @kubernetes/release-managers 