### PR TITLE
feat: add k8s 1.26 to e2e tests in prow

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-24-1
+  - name: pull-kubebuilder-e2e-k8s-1-24-7
     decorate: true
     always_run: true
     optional: false
@@ -97,7 +97,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.24.1"
+          value: "v1.24.7"
         resources:
           requests:
             cpu: 4000m
@@ -105,7 +105,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-24-1
+      testgrid-tab-name: kubebuilder-e2e-1-24-7
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-25-0
+  - name: pull-kubebuilder-e2e-k8s-1-25-3
     decorate: true
     always_run: true
     optional: false
@@ -67,7 +67,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.25.0"
+              value: "v1.25.3"
           resources:
             requests:
               cpu: 4000m
@@ -75,7 +75,7 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-25-0
+      testgrid-tab-name: kubebuilder-e2e-1-25-3
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -19,6 +19,36 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
+  - name: pull-kubebuilder-e2e-k8s-1-26-0
+    decorate: true
+    always_run: true
+    optional: false
+    path_alias: sigs.k8s.io/kubebuilder
+    branches:
+      - ^master$
+      - ^feature/plugins-.+$
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230105-c1beb6cf98-master
+          command:
+            # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
+            - runner.sh
+            # this MUST be a relative directory with "./" or the runner will fail to find the file
+            - ./test_e2e.sh
+          env:
+            - name: KIND_K8S_VERSION
+              value: "v1.26.0"
+          resources:
+            requests:
+              cpu: 4000m
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: kubebuilder-e2e-1-26-0
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
   - name: pull-kubebuilder-e2e-k8s-1-25-0
     decorate: true
     always_run: true

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -109,7 +109,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-23-3
+  - name: pull-kubebuilder-e2e-k8s-1-23-13
     decorate: true
     always_run: true
     optional: false
@@ -127,7 +127,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.23.5"
+          value: "v1.23.13"
         resources:
           requests:
             cpu: 4000m
@@ -135,7 +135,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-23-3
+      testgrid-tab-name: kubebuilder-e2e-1-23-13
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
This adds an e2e test run on 1.26 for Kubebuilder.

This also patches the older 1.25.x, 1.24.x, and 1.23.x cluster versions in existing tests.