### PR TITLE
Tide for Gerrit stop relying on mergeable

### DIFF
--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -225,10 +225,6 @@ func (p *GerritProvider) Query() (map[string]CodeReviewCommon, error) {
 						logger.WithField("id", c.ID).Debug("Change not submittable presented in query results.")
 						continue
 					}
-					if !c.Mergeable {
-						logger.WithField("id", c.ID).Debug("Change not mergeable presented in query results.")
-						continue
-					}
 					submittableChanges = append(submittableChanges, c)
 				}
 				resChan <- changesFromProject{instance: instance, project: projName, changes: submittableChanges}


### PR DESCRIPTION
Inspecting REST response from our Gerrit instance indicated that the mergeable field is missing from the response body, could possibly due to https://www.gerritcodereview.com/3.4.html#ismergeable-predicate-is-disabled-per-default, this resulted in no PR is considered mergeable and Tide stopped working with Gerrit.