### PR TITLE
Add presubmits for k8s-sigs/usage-metrics-collector

### DIFF
--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/OWNERS
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ehashman
+  - KnVerey
+  - pmorie
+  - pwittrock

--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
@@ -1,0 +1,44 @@
+presubmits:
+  kubernetes-sigs/usage-metrics-collector:
+  - name: pull-usage-metrics-collector-verify
+    decorate: true
+    path_alias: sigs.k8s.io/usage-metrics-collector
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
+        command:
+        - runner.sh
+        - make
+        - verify
+    annotations:
+      testgrid-dashboards: sig-instrumentation-usage-metrics-collector
+      testgrid-tab-name: pr-verify
+  - name: pull-usage-metrics-collector-test
+    decorate: true
+    path_alias: sigs.k8s.io/usage-metrics-collector
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
+        command:
+        - runner.sh
+        - make
+        - test
+    annotations:
+      testgrid-dashboards: sig-instrumentation-usage-metrics-collector
+      testgrid-tab-name: pr-test
+  - name: pull-usage-metrics-collector-build
+    decorate: true
+    path_alias: sigs.k8s.io/usage-metrics-collector
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
+        command:
+        - runner.sh
+        - make
+        - build
+    annotations:
+      testgrid-dashboards: sig-instrumentation-usage-metrics-collector
+      testgrid-tab-name: pr-build

--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
   - sig-instrumentation-metrics-server
   - sig-instrumentation-custom-metrics-apiserver
   - sig-instrumentation-prometheus-adapter
+  - sig-instrumentation-usage-metrics-collector
 
 dashboards:
 - name: sig-instrumentation-tests
@@ -22,3 +23,4 @@ dashboards:
 - name: sig-instrumentation-metrics-server
 - name: sig-instrumentation-custom-metrics-apiserver
 - name: sig-instrumentation-prometheus-adapter
+- name: sig-instrumentation-usage-metrics-collector


### PR DESCRIPTION
Loosely based on the metrics-server jobs.

/sig instrumentation

Closes https://github.com/kubernetes-sigs/usage-metrics-collector/issues/5