### PR TITLE
Update kubekins/krte to Go 1.19.5

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -56,9 +56,3 @@ variants:
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
-  '1.22':
-    CONFIG: '1.22'
-    GO_VERSION: 1.16.15
-    K8S_RELEASE: stable-1.22
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -15,44 +15,44 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: latest-1.26
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable-1.24
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: 1.19.4
+    GO_VERSION: 1.19.5
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
- Update kubekins/krte to Go 1.19.5
- drop 1.22 config due to release 1.22 is EOL

/assign @saschagrunert @xmudrii @dims @liggitt @justaugustus 
cc @kubernetes/release-engineering 