### PR TITLE
custom-metrics-apiserver: use --always-make for make verify

### DIFF
--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
@@ -11,6 +11,7 @@ presubmits:
         - make
         args:
         - verify
+        - --always-make
     annotations:
       testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
       testgrid-tab-name: pr-verify


### PR DESCRIPTION
In `custom-metrics-apiserver`'s CI, add option `--always-make` to `make verify`

The objective is to make sure the generated files are up to date, even if their timestamp is greater than `go.mod`'s timestamp.

Cf https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/144