### PR TITLE
Add State to Milestone type

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -802,7 +802,7 @@ func (f *FakeClient) ListMilestones(org, repo string) ([]github.Milestone, error
 	defer f.lock.RUnlock()
 	milestones := []github.Milestone{}
 	for k, v := range f.MilestoneMap {
-		milestones = append(milestones, github.Milestone{Title: k, Number: v})
+		milestones = append(milestones, github.Milestone{Title: k, Number: v, State: "open"})
 	}
 	return milestones, nil
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -1260,6 +1260,7 @@ type GenericCommentEvent struct {
 type Milestone struct {
 	Title  string `json:"title"`
 	Number int    `json:"number"`
+	State  string `json:"state"`
 }
 
 // RepositoryCommit represents a commit in a repo.


### PR DESCRIPTION
This is a tiny PR which adds `State` to `Milestone` type.
It would allow me to reuse the `MilestoneClient` in milestone checker tool, which should handle milestones depending on their state 😄 
According to the github docs you find the `state` property in the responses of all methods using the `Milestone` type, so it can be used consistently.
- [ref milestones](https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28)
- [ref issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue)
- [ref PRs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request)