### PR TITLE
Revert "Tide for Gerrit: post-filter to ensure PRs are truly submittable"

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -602,10 +602,7 @@ func (h *gerritInstanceHandler) QueryChangesForProject(log logrus.FieldLogger, p
 
 	var opt gerrit.QueryChangeOptions
 	opt.Query = append(opt.Query, strings.Join(append(additionalFilters, "project:"+project), "+"))
-	// Gerrit query by default doesn't include all fields, add necessary fields
-	// according to
-	// https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html.
-	opt.AdditionalFields = []string{"SUBMITTABLE", "CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
+	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
 
 	log = log.WithFields(logrus.Fields{"query": opt.Query, "additional_fields": opt.AdditionalFields})
 	var start int

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -157,21 +157,14 @@ func TestQuery(t *testing.T) {
 				"foo1": {
 					"bar1": {
 						gerrit.ChangeInfo{
-							Number:      1,
-							Project:     "bar1",
-							Mergeable:   true,
-							Submittable: true,
+							Number:  1,
+							Project: "bar1",
 						},
 					},
 				},
 			},
 			expect: map[string]CodeReviewCommon{
-				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
-					Number:      1,
-					Project:     "bar1",
-					Mergeable:   true,
-					Submittable: true,
-				}, "foo1"),
+				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar1"}, "foo1"),
 			},
 		},
 		{
@@ -190,65 +183,37 @@ func TestQuery(t *testing.T) {
 				"foo1": {
 					"bar1": {
 						gerrit.ChangeInfo{
-							Number:      1,
-							Project:     "bar1",
-							Mergeable:   true,
-							Submittable: true,
+							Number:  1,
+							Project: "bar1",
 						},
 					},
 					"bar2": {
 						gerrit.ChangeInfo{
-							Number:      2,
-							Project:     "bar2",
-							Mergeable:   true,
-							Submittable: true,
+							Number:  2,
+							Project: "bar2",
 						},
 					},
 				},
 				"foo2": {
 					"bar3": {
 						gerrit.ChangeInfo{
-							Number:      1,
-							Project:     "bar3",
-							Mergeable:   true,
-							Submittable: true,
+							Number:  1,
+							Project: "bar3",
 						},
 					},
 					"bar4": {
 						gerrit.ChangeInfo{
-							Number:      2,
-							Project:     "bar4",
-							Mergeable:   true,
-							Submittable: true,
+							Number:  2,
+							Project: "bar4",
 						},
 					},
 				},
 			},
 			expect: map[string]CodeReviewCommon{
-				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
-					Number:      1,
-					Project:     "bar1",
-					Mergeable:   true,
-					Submittable: true,
-				}, "foo1"),
-				"foo1/bar2#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
-					Number:      2,
-					Project:     "bar2",
-					Mergeable:   true,
-					Submittable: true,
-				}, "foo1"),
-				"foo2/bar3#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
-					Number:      1,
-					Project:     "bar3",
-					Mergeable:   true,
-					Submittable: true,
-				}, "foo2"),
-				"foo2/bar4#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{
-					Number:      2,
-					Project:     "bar4",
-					Mergeable:   true,
-					Submittable: true,
-				}, "foo2"),
+				"foo1/bar1#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar1"}, "foo1"),
+				"foo1/bar2#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 2, Project: "bar2"}, "foo1"),
+				"foo2/bar3#1": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 1, Project: "bar3"}, "foo2"),
+				"foo2/bar4#2": *CodeReviewCommonFromGerrit(&gerrit.ChangeInfo{Number: 2, Project: "bar4"}, "foo2"),
 			},
 		},
 		{


### PR DESCRIPTION
This reverts commit 71b554f28de783f517ccf622bf85e9e7b3c2ba97.

Unfortunately the logic to [compute mergability is disabled by default](https://www.gerritcodereview.com/3.4.html#ismergeable-predicate-is-disabled-per-default) due to performance reasons so enabling this broke some of our users. Lets wait until either:
- We properly document this gerrit repo configuration requirement and give users time to update their gerrit config. This may not be viable for all users for performance reasons.
- The gerrit query results become reliable.

In the meantime, Tide should not be configured to be opt-in by default on repos and the "prow-auto-submit" label should be required. This seems to mitigate the problems with search indexing by triggering a reindex when the label is added. (Much like how we comment on PRs when GitHub's search index becomes corrupted.)

/assign @listx 
/cc @chaodaiG 
/kind bug
/sig testing