### PR TITLE
Adding push-image job to windows-service-proxy images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-windows-svc-proxy.yaml
+++ b/config/jobs/image-pushing/k8s-staging-windows-svc-proxy.yaml
@@ -1,0 +1,21 @@
+postsubmits:
+  kubernetes-sigs/windows-service-proxy:
+    - name: post-windows-service-proxy-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-windows-push-images, sig-k8s-infra-gcb
+        testgrid-tab-name: post-windows-service-proxy-push-images
+      decorate: true
+      branches:
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20221010-3da4a9c21a
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-windows-svc-proxy
+              - --scratch-bucket=gs://k8s-staging-windows-svc-proxy-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Part of https://github.com/kubernetes-sigs/windows-service-proxy/issues/7

https://github.com/kubernetes/k8s.io/pull/4613 added the k8s.gcr.io staging images 
https://github.com/kubernetes-sigs/windows-service-proxy/pull/9 added image building make targets for pushing to the staging bucket

/sig windows
/assign @jsturtevant @knabben 