### PR TITLE
Log error from API call when failing to add users.

### DIFF
--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1420,6 +1420,10 @@ func TestRequestReview(t *testing.T) {
 		if len(merr.Users) != 1 || merr.Users[0] != "not-a-collaborator" {
 			t.Errorf("Expected [not-a-collaborator], not %v", merr.Users)
 		}
+		expErr := "could not request a PR review from the following user(s): not-a-collaborator; status code 422 not one of [201], body: ."
+		if merr.Error() != expErr {
+			t.Errorf("Expected error string %q, not %q", expErr, merr.Error())
+		}
 	} else {
 		t.Errorf("Expected MissingUsers error")
 	}
@@ -1428,6 +1432,10 @@ func TestRequestReview(t *testing.T) {
 	} else if merr, ok := err.(MissingUsers); ok {
 		if len(merr.Users) != 1 || merr.Users[0] != "notk8s/team1" {
 			t.Errorf("Expected [notk8s/team1], not %v", merr.Users)
+		}
+		expErr := "could not request a PR review from the following user(s): notk8s/team1; team notk8s/team1 is not part of k8s org."
+		if merr.Error() != expErr {
+			t.Errorf("Expected error string %q, not %q", expErr, merr.Error())
 		}
 	} else {
 		t.Errorf("Expected MissingUsers error")

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -152,6 +152,7 @@ func handle(h *handler) error {
 				if len(msg) == 0 {
 					return nil
 				}
+				h.log.Printf("Failed to add %s to %s/%s#%d: %s", h.userType, org, repo, e.Number, mu.Error())
 				if err := h.gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg)); err != nil {
 					return fmt.Errorf("comment err: %w", err)
 				}


### PR DESCRIPTION
See https://github.com/kubernetes/test-infra/issues/28357; we don't have any details in the logs right now when there's an unprocessable entity (422 status code) on trying to request review from users, which makes the linked issue hard to debug.