### PR TITLE
usage-metrics-collector: Remove no-op build job

### DIFF
--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
@@ -30,18 +30,3 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-instrumentation-usage-metrics-collector
       testgrid-tab-name: pr-test
-  - name: pull-usage-metrics-collector-build
-    decorate: true
-    path_alias: sigs.k8s.io/usage-metrics-collector
-    always_run: true
-    optional: false
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230111-cd1b3caf9c-master
-        command:
-        - runner.sh
-        - make
-        - build
-    annotations:
-      testgrid-dashboards: sig-instrumentation-usage-metrics-collector
-      testgrid-tab-name: pr-build


### PR DESCRIPTION
We need to install protoc in the test environment to test this properly, otherwise this just duplicates work done by the test job. Dropping it for now.

/sig instrumentation