### PR TITLE
Remove unneeded v1alpha4 job for CAPZ

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha4.yaml
@@ -32,40 +32,6 @@ periodics:
     testgrid-tab-name: capz-periodic-conformance-v1alpha4
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-0.5 (v1alpha4)
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1alpha4
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  interval: 24h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-0.5
-      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220727-f055b40439-1.21
-      command:
-        - runner.sh
-      args:
-        - ./scripts/ci-e2e.sh
-      env:
-        - name: GINKGO_FOCUS
-          value: "Cluster API E2E tests"
-        - name: GINKGO_SKIP
-          value: "\\[K8s-Upgrade\\]"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1alpha4
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-full-v1alpha4
   decorate: true
   decoration_config:


### PR DESCRIPTION
Removes unneeded job based on [this CAPZ issue](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2927)