### PR TITLE
capz: graduate AKS tests from exp, make required

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -158,14 +158,14 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-csi-migration-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-e2e-exp
+  - name: pull-cluster-api-provider-azure-e2e-aks
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    always_run: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 4h
-    run_if_changed: '^((exp)\/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)|test\/e2e\/config|managed.*\.go|aks|^azure\/services\/agentpools\/'
+    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
+    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
@@ -183,7 +183,7 @@ presubmits:
           - ./scripts/ci-e2e.sh
         env:
           - name: GINKGO_FOCUS
-            value: \[EXPERIMENTAL\]
+            value: \[Managed Kubernetes\]
           - name: GINKGO_SKIP
             value: ""
         # docker-in-docker needs privileged mode
@@ -191,7 +191,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: capz-pr-e2e-exp-main
+      testgrid-tab-name: capz-pr-e2e-aks-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
@@ -130,39 +130,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-windows-dockershim-v1alpha4
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-e2e-exp-v1alpha4
-    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    always_run: false
-    optional: true
-    decorate: true
-    run_if_changed: '^((exp)\/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)|managed.*\.go|aks|^azure\/services\/agentpools\/'
-    max_concurrency: 5
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-    branches:
-    - ^release-0.5$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220727-f055b40439-1.21
-        command:
-          - runner.sh
-        args:
-          - ./scripts/ci-e2e.sh
-        env:
-          - name: GINKGO_FOCUS
-            value: ".*AKS.*"
-          - name: GINKGO_SKIP
-            value: ""
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: capz-pr-e2e-exp-v1alpha4
-      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e-v1alpha4
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -166,14 +166,14 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-windows-dockershim-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-e2e-exp-v1beta1
+  - name: pull-cluster-api-provider-azure-e2e-aks-v1beta1
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    always_run: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 4h
-    run_if_changed: '^((exp)\/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)|managed.*\.go|aks|^azure\/services\/agentpools\/'
+    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
+    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
@@ -191,7 +191,7 @@ presubmits:
           - ./scripts/ci-e2e.sh
         env:
           - name: GINKGO_FOCUS
-            value: \[EXPERIMENTAL\]
+            value: \[[Managed Kubernetes\\]
           - name: GINKGO_SKIP
             value: ""
         # docker-in-docker needs privileged mode
@@ -199,7 +199,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: capz-pr-e2e-exp-v1beta1
+      testgrid-tab-name: capz-pr-e2e-aks-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e-v1beta1
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"


### PR DESCRIPTION
This PR renames the soon-to-be-graduated-from-experimental AKS E2E jobs in CAPZ so that they are clearly marked "aks", instead of "exp".

We also promote the tests to be required for merging, with the equivalent criteria to the self-managed "e2e" job.

We also remove the legacy v1alpha4 AKS test so as not to confuse any users that the experimental v1alpha4 implementation of AKS is encouraged for further use.

This PR is related to the CAP PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2959. We can merge these test changes immediately to signify near term AKS graduation in CAPZ (once https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2959 lands in CAPZ main this test config will not work at all due to the removed `EXPERIMENTAL` test description in that PR, so we either want to merge these test-infra changes synchronously with https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2959, or merge the test-infra changes in advance to be safe.

Finally, the test description and required critiera changes have also been applied to the v1beta1 and v1beta1-minus-1 jobs. Strictly speaking we won't be landing a concrete "graduated" implementation until v1.8.0. I'm promoting making these changes in advance because the v1beta1 tests are a moving feast as versions make forward progress, and it will help to clarify the CAPZ project priority of supporting AKS scenarios to not suggest in our public test dashboard further "experimental" association w/ the AKS surface area.