### PR TITLE
Bump CAPZ to release-1.7 for CCM jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -45,7 +45,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -70,7 +70,8 @@ presubmits:
             - name: KUBERNETES_VERSION
               value: "latest"
             - name: CLUSTER_TEMPLATE
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+              # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+              value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: AZURE_LOADBALANCER_SKU
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL
@@ -161,7 +162,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes
@@ -221,7 +222,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -273,7 +274,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -298,7 +299,8 @@ presubmits:
             - name: KUBERNETES_VERSION
               value: "latest"
             - name: CLUSTER_TEMPLATE
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+              # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+              value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: AZURE_LOADBALANCER_SKU
               value: "Standard"
             - name: ENABLE_MULTI_SLB
@@ -358,7 +360,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.6
+      base_ref: release-1.7
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -392,7 +394,8 @@ periodics:
         - name: CLUSTER_PROVISIONING_TOOL
           value: "capz"
         - name: CLUSTER_TEMPLATE
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
+          # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+          value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz
@@ -412,7 +415,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.6
+      base_ref: release-1.7
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -515,7 +518,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.6
+      base_ref: release-1.7
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -573,7 +576,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -634,7 +637,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -704,7 +707,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -766,7 +769,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.6
+      base_ref: release-1.7
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -796,7 +799,8 @@ periodics:
         - name: KUBERNETES_VERSION
           value: "latest"
         - name: CLUSTER_TEMPLATE
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+          # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+          value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
         - name: AZURE_LOADBALANCER_SKU
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL
@@ -820,7 +824,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -858,7 +862,8 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "1"
       - name: CLUSTER_TEMPLATE
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+        value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL
@@ -884,7 +889,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -923,7 +928,8 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "1"
       - name: CLUSTER_TEMPLATE
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+        value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL
@@ -951,7 +957,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -990,7 +996,8 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "1"
       - name: CLUSTER_TEMPLATE
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
+        # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+        value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL
@@ -1016,7 +1023,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.6
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes
@@ -1054,7 +1061,8 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "1"
       - name: CLUSTER_TEMPLATE
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+        value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/master/tests/calico-crs/manifest/cluster-api/linux-vmss-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "1"
               - name: CLUSTER_TEMPLATE
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+              # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+                value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
               - name: K8S_FEATURE_GATES
@@ -97,7 +98,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -153,7 +154,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "1"
               - name: CLUSTER_TEMPLATE
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+                value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
       annotations:
@@ -95,7 +96,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -151,7 +152,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "1"
               - name: CLUSTER_TEMPLATE
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+                value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL
@@ -97,7 +98,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -157,7 +158,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "1"
               - name: CLUSTER_TEMPLATE
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO: change this back to kubernetes-sigs/cloud-provider-azure/master branch once https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995 merges.
+                value: https://raw.githubusercontent.com/CecileRobertMichon/cloud-provider-azure/calico-crs/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL
@@ -97,7 +98,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -157,7 +158,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:


### PR DESCRIPTION
This PR updates CAPZ to release-1.7 for all kubernetes-sigs/cloud-provider-azure jobs.

Some of these jobs rely on `CLUSTER_TEMPLATE` files that need to be updated to work with this release. These are getting updated in https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995.

Plan is to:

1) merge this PR to both update the CAPZ version to 1.7 and update the templates to use the ones from my fork/branch
2) Verify everything works as expected
3) merge https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2995/files
4) make another PR in test-infra to change the templates back to the master branch