### PR TITLE
Add ci-kubernetes-node-e2e-containerd to release-informing

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -34,7 +34,7 @@ periodics:
             cpu: 4
             memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-node-release-blocking, sig-node-containerd
+    testgrid-dashboards: sig-node-release-blocking, sig-node-containerd, sig-release-master-informing
     testgrid-tab-name: ci-node-e2e
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Uses kubetest to run node-e2e tests (+NodeConformance, -Flaky|Slow|Serial)"


### PR DESCRIPTION
We don't have the `NodeConformance` as a signal for sig-release folks, So let's add it as informing first, once we have 🟢 for a few weeks, we can promote it to blocking

See it here on test-grid: https://testgrid.k8s.io/sig-node-containerd#ci-node-e2e

Signed-off-by: Davanum Srinivas <davanum@gmail.com>