### PR TITLE
Set privileged securityContext for helm chart tester presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -17,6 +17,8 @@ presubmits:
         args:
         - make
         - test-helm-chart
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver
       testgrid-tab-name: test-helm-chart


### PR DESCRIPTION
Fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/1467/pull-aws-ebs-csi-driver-test-helm-chart/1615513988823519232

Signed-off-by: torredil <torredil@amazon.com>