### PR TITLE
fix CAPZ AKS v1beta1 presubmit regex

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -191,7 +191,7 @@ presubmits:
           - ./scripts/ci-e2e.sh
         env:
           - name: GINKGO_FOCUS
-            value: \[[Managed Kubernetes\\]
+            value: \[Managed Kubernetes\]
           - name: GINKGO_SKIP
             value: ""
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
CI flags this regex as invalid: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/3052/pull-cluster-api-provider-azure-e2e-aks-v1beta1/1615724554854862848#1:build-log.txt%3A487

This change updates it to match its other instances.