### PR TITLE
Add the redhat-openshift-release-4.12-interop Dashboard to Testgrid

### DIFF
--- a/config/testgrids/openshift/groups.yaml
+++ b/config/testgrids/openshift/groups.yaml
@@ -3,6 +3,7 @@ dashboard_groups:
   - redhat-assisted-installer
   - redhat-hypershift
   - redhat-openshift-informing
+  - redhat-openshift-release-4.12-interop
   - redhat-openshift-ocp-release-3.11-informing
   - redhat-openshift-ocp-release-4.1-blocking
   - redhat-openshift-ocp-release-4.1-informing

--- a/config/testgrids/openshift/redhat-openshift-interop.yaml
+++ b/config/testgrids/openshift/redhat-openshift-interop.yaml
@@ -1,5 +1,5 @@
 test_groups:
-- name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
+- name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412-INTEROP-POC
   gcs_prefix: origin-ci-test/logs/periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
   days_of_results: 60
 
@@ -7,7 +7,7 @@ dashboards:
 - name: redhat-openshift-release-4.12-interop
   dashboard_tab:
   - name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
-    test_group_name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
+    test_group_name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412-INTEROP-POC
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:

--- a/config/testgrids/openshift/redhat-openshift-interop.yaml
+++ b/config/testgrids/openshift/redhat-openshift-interop.yaml
@@ -1,13 +1,13 @@
 test_groups:
-- name: periodic-ci-windup-windup_integration_test-mtr-mtr-scenario
-  gcs_prefix: origin-ci-test/logs/periodic-ci-windup-windup_integration_test-mtr-mtr-scenario
+- name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
+  gcs_prefix: origin-ci-test/logs/periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
   days_of_results: 60
 
 dashboards:
 - name: redhat-openshift-release-4.12-interop
   dashboard_tab:
-  - name: mtr-operator-latest
-    test_group_name: periodic-ci-windup-windup_integration_test-mtr-mtr-scenario
+  - name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
+    test_group_name: periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:

--- a/config/testgrids/openshift/redhat-openshift-interop.yaml
+++ b/config/testgrids/openshift/redhat-openshift-interop.yaml
@@ -1,0 +1,14 @@
+test_groups:
+- name: periodic-ci-windup-windup_integration_test-mtr-mtr-scenario
+  gcs_prefix: origin-ci-test/logs/periodic-ci-windup-windup_integration_test-mtr-mtr-scenario
+  days_of_results: 60
+
+dashboards:
+- name: redhat-openshift-release-4.12-interop
+  dashboard_tab:
+  - name: mtr-operator-latest
+    test_group_name: periodic-ci-windup-windup_integration_test-mtr-mtr-scenario
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>


### PR DESCRIPTION
The RedHat CSPI QE team is working on migrating our interoperability tests to Prow/OpenShift CI. We would like to report our results to a separate interop dashboard in Testgrid. I am trying to create this dashboard and populate it with an existing Prow job, periodic-ci-rhpit-interop-tests-master-ocp-412-quay37-interop-quay-tests-aws-ipi-ocp412, as a proof of concept in our migration effort.

Please let me know if there is anything I am missing in this PR.