### PR TITLE
Update the project type for evented-pleg presubmit CI job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -768,6 +768,7 @@ presubmits:
             - -- # end bootstrap args, scenario args below
             - --deployment=node
             - --env=KUBE_SSH_USER=core
+            - --gcp-project-type=node-e2e-project
             - --gcp-zone=us-west1-b
             - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --feature-gates=EventedPLEG=true" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
             - --node-tests=true


### PR DESCRIPTION
Observed some [failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/115028/pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e/1615698705770352640/) in the recently added CI job to run the e2e tests by enabling the evented-pleg feature.
The failure seems to be related to `ssh`ing into the FCOS node instance that is created to run the e2e tests.
Sample Failure log that is observed:
```
W0118 13:16:04.351] I0118 13:16:04.351159    6824 ssh.go:120] Running the command ssh, with args: [-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o LogLevel=ERROR -i /workspace/.ssh/google_compute_engine core@34.168.133.203 -- sudo sh -c 'systemctl list-units  --type=service  --state=running | grep -e containerd -e crio']
W0118 13:17:09.651] E0118 13:17:09.650723    6824 ssh.go:123] failed to run SSH command: out: core@34.168.133.203: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
W0118 13:17:09.651] , err: exit status 255
```
Following are some of the jobs that use this arg `--gcp-project-type=node-e2e-project` and hence added this change that might fix the CI job [failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/115028/pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e/1615698705770352640/). 

- [ci-cos-cgroupv1-containerd-node-e2e](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/containerd.yaml#L168)
- [ci-cgroup-systemd-containerd-node-e2e](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/containerd.yaml#L989)
- [ci-crio-cgroupv1-node-e2e-conformance](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/crio.yaml#L18)
- [ci-crio-cgroupv2-node-e2e-conformance](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/crio.yaml#L212), etc.

Signed-off-by: Sai Ramesh Vanka svanka@redhat.com