### PR TITLE
Updating Windows jobs to use CAPZ 1.7

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -74,7 +74,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.5
+      base_ref: release-1.7
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -25,7 +25,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
-  - base_ref: release-1.5
+  - base_ref: release-1.7
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -62,7 +62,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.5
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Now that 1.24 is on golang 1.19 we should be able to update the CAPZ release branch we use to help build the test cluster to a release-1.7

/sig windows
/assign @CecileRobertMichon @jsturtevant 