### PR TITLE
Try doubling memory to avoid OOMs on UMC tests

### DIFF
--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-periodics.yaml
@@ -17,10 +17,10 @@ periodics:
         resources:
           requests:
             cpu: 1
-            memory: "512Mi"
+            memory: "1Gi"
           limits:
             cpu: 1
-            memory: "1Gi"
+            memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-instrumentation-usage-metrics-collector
     testgrid-tab-name: periodic-test

--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
@@ -30,10 +30,10 @@ presubmits:
         resources:
           requests:
             cpu: 1
-            memory: "512Mi"
+            memory: "1Gi"
           limits:
             cpu: 1
-            memory: "1Gi"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-instrumentation-usage-metrics-collector
       testgrid-tab-name: pr-test


### PR DESCRIPTION
Might fix https://github.com/kubernetes-sigs/usage-metrics-collector/issues/8 https://github.com/kubernetes-sigs/usage-metrics-collector/issues/20