### PR TITLE
`deck`: only filter out hidden repos, rather than the entire tide query

### DIFF
--- a/prow/cmd/deck/tide_test.go
+++ b/prow/cmd/deck/tide_test.go
@@ -128,6 +128,9 @@ func TestFilter(t *testing.T) {
 				{
 					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
 				},
+				{
+					Orgs: []string{"kubernetes-test"},
+				},
 			},
 			pools: []tide.Pool{
 				{Org: "kubernetes", Repo: "test-infra"},
@@ -147,6 +150,15 @@ func TestFilter(t *testing.T) {
 			expectedQueries: []config.TideQuery{
 				{
 					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver"},
+				},
+				{
+					Orgs: []string{"kubernetes-test"},
 				},
 			},
 			expectedPools: []tide.Pool{
@@ -310,6 +322,12 @@ func TestFilter(t *testing.T) {
 			expectedQueries: []config.TideQuery{
 				{
 					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver"},
 				},
 			},
 			expectedPools: []tide.Pool{
@@ -674,6 +692,12 @@ func TestFilter(t *testing.T) {
 			expectedQueries: []config.TideQuery{
 				{
 					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver"},
 				},
 			},
 			expectedPools: []tide.Pool{


### PR DESCRIPTION
If we filter out a `tide` query due to it containing one or more hidden repos, we should check again without those repos. We don't want to filter out the entire query in case there are more repos/orgs that aren't hidden. There are many more details in the linked issue.

For: https://github.com/kubernetes/test-infra/issues/28459