### PR TITLE
node e2e: Eviction test improvements

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -512,11 +512,11 @@ periodics:
       - --
       - --deployment=node
       - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --focus="\[NodeFeature:Eviction\]"
+      - --test_args=--nodes=1 --focus="\[NodeFeature:Eviction\]" --timeout=300m
       - --timeout=300m
       env:
       - name: GOPATH

--- a/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
@@ -1,0 +1,6 @@
+images:
+  cos-stable1:
+    image_family: cos-stable
+    project: cos-cloud
+    machine: n1-standard-2 # These tests need a lot of memory
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init-eviction.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/init-eviction.yaml
+++ b/jobs/e2e_node/containerd/init-eviction.yaml
@@ -1,0 +1,37 @@
+#cloud-config
+
+runcmd:
+  - echo "Test run from /tmp folder, remounting it"
+  - mount /tmp /tmp -o remount,exec,suid
+
+  - echo "Configuring sysctls"
+  - touch /etc/sysctl.d/99-node-e2e-defaults.conf
+  # Increase kernel.pid_max and kernel.threads-max to maximum. This is needed for pid eviction tests, because systemd will set a system wide DefaultTasksMax based on mimunum of these values.
+  # xref: https://github.com/systemd/systemd/commit/3a0f06c41a29b760fe6c3da7529cf595e583aa06
+  # The default values are too low for the pid eviction test.
+  - echo 'kernel.pid_max=4194304' >> /etc/sysctl.d/99-node-e2e-defaults.conf
+  - echo 'kernel.threads-max=4194304' >> /etc/sysctl.d/99-node-e2e-defaults.conf
+  - /usr/lib/systemd/systemd-sysctl
+  - echo "Done configuring sysctls"
+
+  - echo "This will configure built-in containerd for k8s tests. Containerd version is:"
+  - ctr version # current version of containerd
+
+  - echo "Download and install CNI configuration to /home/containerd"
+  - mkdir -p /home/containerd
+  - mount --bind /home/containerd /home/containerd
+  - mount -o remount,exec /home/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
+
+  - echo "Download and install CNI to /home/containerd"
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
+
+  - echo "Set containerd configuration"
+  - mkdir -p /etc/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
+
+  - echo "Restarting containerd"
+  - systemctl restart containerd
+
+  - echo "Configuration complete"


### PR DESCRIPTION
* Use a dedicated node image config file for eviction tests. This is needed because we need some special initialization for eviction tests.

* We need to explicility pass in the timeout for --test_args and which passes the timeout to ginkgo. Otherwise ginkgo default of 1h will be applied. Thanks @CoderSherlock for catching this, xref [slack thread](https://kubernetes.slack.com/archives/C09QZ4DQB/p1666286995270859) 

* Add a new `jobs/e2e_node/containerd/init-evicition.yaml` cloud config file. We configure kernel.pid_max and kernel.threads_max because the defaults are too low for Pid Eviction tests.

After some debugging, of the Pid Eviction test, it seems one of the
issues is it is hitting a low system default pid limit. This is because
the default limit comes from systemd's ThreadsMax property (which is
default) of `pids.max`. ThreadsMax is computed by systemd as min
(kernel.pid_max, kernel.threads-max, /sys/fs/cgroup/pids.max). The
default sysctls values for kernel.pid_max and kernel.threads-max on COS
are too low (32768), so set them to the max value.

```

cos~ # cat /etc/os-release
NAME="Container-Optimized OS"
ID=cos
PRETTY_NAME="Container-Optimized OS from Google"
HOME_URL="https://cloud.google.com/container-optimized-os/docs"
BUG_REPORT_URL="https://cloud.google.com/container-optimized-os/docs/resources/support-policy#contact_us"
GOOGLE_CRASH_ID=Lakitu
GOOGLE_METRICS_PRODUCT_ID=26
KERNEL_COMMIT_ID=79283ceda27c31cf836963f6e10e5e62eeff5acb
VERSION=101
VERSION_ID=101
BUILD_ID=17162.40.52

cos ~ # sysctl kernel.threads-max
kernel.threads-max = 59555
cos~ # sysctl kernel.pid_max
kernel.pid_max = 4194304

## !! This is too low for eviction test !!
cos-dev ~ # systemctl show --property DefaultTasksMax
DefaultTasksMax=8933

## Bumping pid_max and thread-max results in higher DefaultTasksMax

cos~ # touch /etc/sysctl.d/99-node-e2e-defaults.conf
cos~ # echo 'kernel.pid_max=4194304' >> /etc/sysctl.d/99-node-e2e-defaults.conf
cos~ # echo 'kernel.threads-max=4194304' >> /etc/sysctl.d/99-node-e2e-defaults.conf
cos~ # /usr/lib/systemd/systemd-sysctl
cos~ # systemctl show --property DefaultTasksMax
DefaultTasksMax=629145
```


Signed-off-by: David Porter <porterdavid@google.com>