### PR TITLE
Revert "upgrade bootstrap to latest image"

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-staging-test-infra/bootstrap:v20230120-da7bf474ce
+FROM gcr.io/k8s-staging-test-infra/bootstrap:v20221021-5771e8efb3
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
This reverts commit 75034d1d10fc73e038cd5fbf1eeff86a2cc5337c.

bootstrap.py scripts in _this_ repo are still py2, I thought all of test-infra had been updated to py3 already but not here ... >.>