### PR TITLE
Fix pull config for pod-disruption-conditions

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1707,11 +1707,11 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230117-50d6df3625-master
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 4
+              memory: 6Gi
             requests:
-              cpu: 2
-              memory: 2Gi
+              cpu: 4
+              memory: 6Gi
           args:
             - --root=/go/src
             - "--job=$(JOB_NAME)"


### PR DESCRIPTION
This is an attempt to fix the configuration which currently fails. This is an example failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/113908/pull-kubernetes-node-kubelet-serial-pod-disruption-conditions/1616139121749659648/.

A similar symptom was reported here which makes it likely that we are hitting OOM killer in this case: https://forum.golangbridge.org/t/go-build-exits-with-signal-killed/513

I have confirmed that the memory use gets very close to 2Gi by running the tests from my local machine using `kubekins-e2e`.

This will also align the limits & requests for the resources as for all other configurations in `sig-node-presubmit.yaml`.
