### PR TITLE
images/bootsrap: Add symlink to python3

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-gflags \
     python3-pip \
     python3-yaml \
+    python-is-python3 \
     rsync \
     unzip \
     wget \


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/test-infra/pull/28382
  - https://github.com/kubernetes/test-infra/pull/28465

According to https://wiki.debian.org/Python, python 2 has been removed and `python-is-python3` package will create an appropriate symlink to /usr/bin/python3 to support scripts still using the 'python' command.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>