### PR TITLE
releng: promote cici37 to branch manager

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -224,6 +224,7 @@ aliases:
   #   k/test-infra jobs and overall CI Signal
   #
   release-engineering-approvers:
+    - cici37 # Release Manager
     - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - jeremyrickard # SIG Chair / RelEng subproject owner / Release Manager
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
@@ -233,6 +234,7 @@ aliases:
     - Verolop # SIG Technical Lead / RelEng subproject owner / Release Manager
     - xmudrii # Release Manager
   release-engineering-reviewers:
+    - cici37 # Release Manager
     - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - jeremyrickard # SIG Chair / RelEng subproject owner / Release Manager
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager


### PR DESCRIPTION
Accompanying GitHub team membership changes to https://github.com/kubernetes/sig-release/issues/2152, https://github.com/kubernetes/sig-release/pull/2156

Promote cici37 to Branch Manager
/hold until https://github.com/kubernetes/sig-release/pull/2156 merges.

/assign @jeremyrickard
/cc https://github.com/orgs/kubernetes/teams/release-managers
/milestone v1.27
/priority important-soon