### PR TITLE
Fix typo in variable name

### DIFF
--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -365,7 +365,7 @@ func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, callBack func(), o
 	var lock sync.Mutex
 	var threads sync.WaitGroup
 	threads.Add(len(o.clusterConfigs))
-	for buildCluserName, buildClusterConfig := range o.clusterConfigs {
+	for buildClusterName, buildClusterConfig := range o.clusterConfigs {
 		go func(name string, config rest.Config) {
 			defer threads.Done()
 			mgr, err := manager.New(&config, options)
@@ -377,7 +377,7 @@ func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, callBack func(), o
 				return
 			}
 			res[name] = mgr
-		}(buildCluserName, buildClusterConfig)
+		}(buildClusterName, buildClusterConfig)
 	}
 	threads.Wait()
 


### PR DESCRIPTION
Noticed this typo when browsing the code, thought I'd make a little contribution to fix it
