### PR TITLE
temporarily pin bootstrap base image in kubekins-e2e, prevent autobumping

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -21,7 +21,7 @@ extraFiles:
   - "config/jobs/README.md"
   - "releng/generate_tests.py"
   - "releng/test_config.yaml"
-  - "images/kubekins-e2e/Dockerfile"
+  #- "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"
 prefixes:
   - name: "k8s-testimages images"

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,10 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-staging-test-infra/bootstrap:v20230124-61b36115b7
+# gcr.io/k8s-staging-test-infra/bootstrap:v20230124-61b36115b7
+# except the autobumber will ignore the digest-only version
+# we will resume autobumping later when python2 vs 3 is sorted out
+FROM gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
until we sort out python2 vs 3 and being ready for debian buster

we need to do that soon, but we don't want any surprises in the meantime.