### PR TITLE
crier: remove redundant call to `interrupts.WaitForGracefulShutdown()`

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -151,8 +151,6 @@ func main() {
 
 	o := parseOptions()
 
-	defer interrupts.WaitForGracefulShutdown()
-
 	pprof.Instrument(o.instrumentationOptions)
 
 	configAgent, err := o.config.ConfigAgent()


### PR DESCRIPTION
We started calling `interrupts.WaitForGracefulShutdown()` at the end of `main()` in https://github.com/kubernetes/test-infra/pull/25809. We should keep that line instead of this one because we log "Ended gracefully" there (IOW, this log message doesn't make sense if some error occurs and we never even get to start up the service --- there would be nothing to gracefully shut down to begin with).

/cc @cjwagner @chaodaiG