### PR TITLE
capz: remove 1.22-1.23, add 1.25-1.26 upgrade job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,49 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-22-1-23-main
-  interval: 24h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230125-972f786877-1.25
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.22"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.23"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.3-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.6"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7300m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-22-1-23
-
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-23-1-24-main
   interval: 24h
   decorate: true
@@ -73,9 +29,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.24"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.3-0"
+          value: "3.5.6-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.6"
+          value: "v1.9.3"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -117,9 +73,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.25"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.3-0"
+          value: "3.5.6-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.6"
+          value: "v1.9.3"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -131,3 +87,47 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-24-1-25
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-25-1-26-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230125-972f786877-1.25
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.25"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.26"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.6-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.9.3"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-periodic-upgrade-main-1-25-1-26


### PR DESCRIPTION
This PR updates CAPZ upgrade job specs so that we're testing the currently supported 1.25-->1.26 path, but no longer testing the EOL 1.22-->1.23 path.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3055