### PR TITLE
capz: remove CSI migration test for EOL'd 1.22

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -120,44 +120,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-optional-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-e2e-csi-migration
-    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 4h
-    max_concurrency: 5
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-    branches:
-    - ^main$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230124-157bf4e62c-1.25
-        command:
-          - runner.sh
-        args:
-          - ./scripts/ci-e2e.sh
-        env:
-          - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.22"
-          - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "stable-1.23"
-          - name: GINKGO_FOCUS
-            value: \[CSI Migration\]
-          - name: GINKGO_SKIP
-            value: ""
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: capz-pr-e2e-csi-migration-main
-      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-aks
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false


### PR DESCRIPTION
This PR removes the k8s 1.22-specific upgrade test that migrates to CSI. As 1.22 is EOL, we no longer need this automated test coverage.

Relates to https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3055