### PR TITLE
Allow pod to be restarted if it is deleted while running

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -430,6 +430,10 @@ spec:
                   the job is evicted. If this field is unspecified or false, a new
                   pod will be created to replace the evicted one.
                 type: boolean
+              restart_on_unexpected_deletion:
+                description: RestartOnUnxpectedDeletion indicates that the ProwJob should be
+                  recreated if it is deleted unexpectedly (e.g. by node shutdown)
+                type: boolean
               extra_refs:
                 description: ExtraRefs are auxiliary repositories that need to be
                   cloned, determined from config

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -177,6 +177,12 @@ type ProwJobSpec struct {
 	// concurrency is selected from these two.
 	// +kubebuilder:validation:Minimum=0
 	MaxConcurrency int `json:"max_concurrency,omitempty"`
+	// RestartOnUnxpectedDeletion indicates that the ProwJob should be restarted
+	// if the pod that is executing the job is deleted before the test container
+	// could finish.  If this field is true, a new pod will be created to replace
+	// the deleted one.  If not, the pod will be marked failed with a message
+	// "Pod got deleted unexpectedly"
+	RestartOnUnxpectedDeletion bool `json:"restart_on_unexpected_deletion,omitempty"`
 	// ErrorOnEviction indicates that the ProwJob should be completed and given
 	// the ErrorState status if the pod that is executing the job is evicted.
 	// If this field is unspecified or false, a new pod will be created to replace

--- a/prow/cmd/deck/static/api/prow.ts
+++ b/prow/cmd/deck/static/api/prow.ts
@@ -98,6 +98,7 @@ export interface ProwJobSpec {
   context?: string;
   rerun_command?: string;
   max_concurrency?: number;
+  restart_on_unexpected_deletion?: boolean;
   error_on_eviction?: boolean;
   pod_spec?: PodSpec;
   build_spec?: object;

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -41,7 +41,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"gopkg.in/robfig/cron.v2"
+	cron "gopkg.in/robfig/cron.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -106,6 +106,12 @@ type JobBase struct {
 	//   nil: results in config.PodNamespace (aka pod default)
 	//   empty: results in config.ProwJobNamespace (aka same as prowjob)
 	Namespace *string `json:"namespace,omitempty"`
+	// RestartOnUnxpectedDeletion indicates that the ProwJob should be restarted
+	// if the pod that is executing the job is deleted before the test container
+	// could finish.  If this field is true, a new pod will be created to replace
+	// the deleted one.  If not, the pod will be marked failed with a message
+	// "Pod got deleted unexpectedly"
+	RestartOnUnxpectedDeletion bool `json:"restart_on_unexpected_deletion,omitempty"`
 	// ErrorOnEviction indicates that the ProwJob should be completed and given
 	// the ErrorState status if the pod that is executing the job is evicted.
 	// If this field is unspecified or false, a new pod will be created to replace


### PR DESCRIPTION
I propose here that pods that are deleted while running should be allowed to go away and be restarted rather than failing with a mysterious error.

This makes the behavior in this case similar to what will happen if the pod is evicted, in an unknown state, or deleted where there is no finalizer so the pod can disappear because the sync loop runs.

This includes a small refactoring to clean up some duplicated code and make each case of deleting a pod log a distinct message so they can be told apart in the logs.

See also https://github.com/kubernetes/test-infra/issues/28499

