### PR TITLE
Update project number env var to match the sync script

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -42,7 +42,7 @@ periodics:
       command:
       - ./release-team/hack/sync-bug-triage-github-project-beta.sh
       env:
-        - name: GITHUB_PROJECT_BETA_NUMBER
+        - name: PROJECT_NUMBER
           value: "80"
         - name: GITHUB_TOKEN
           valueFrom:


### PR DESCRIPTION
The `sync-bug-triage-github-project-beta.sh` has the environment variable as `PROJECT_NUMBER`.

Signed-off-by: Heba Elayoty <hebaelayoty@gmail.com>