### PR TITLE
Add Milestone environment variable to bug-triage prow job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -44,6 +44,8 @@ periodics:
       env:
         - name: PROJECT_NUMBER
           value: "80"
+        - name: MILESTONE
+          value: "v1.27"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The `sync-bug-triage-github-project-beta.sh` needs the `MILESTONE` environment variable.

Signed-off-by: Heba Elayoty <hebaelayoty@gmail.com>