### PR TITLE
Fix evented_pleg ci job to get away from `--gcp-project-type=node-e2e-project`

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -768,7 +768,6 @@ presubmits:
             - -- # end bootstrap args, scenario args below
             - --deployment=node
             - --env=KUBE_SSH_USER=core
-            - --gcp-project-type=node-e2e-project
             - --gcp-zone=us-west1-b
             - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --feature-gates=EventedPLEG=true" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
             - --node-tests=true

--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -10,6 +10,13 @@
   "storage": {
     "files": [
       {
+        "path": "/etc/ssh-key-secret/ssh-public",
+        "contents": {
+          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"


### PR DESCRIPTION
Commit 1: Fix evented_pleg ci job to get away from `--gcp-project-type=node-e2e-project`
From the references of the following merged PRs, the above parameter may not be required to run the evented-pleg feature enabled node-e2e ci job.
Ref:
  1. https://github.com/kubernetes/test-infra/pull/28458
  2. https://github.com/kubernetes/test-infra/pull/23777

Commit 2: Inject SSH key for evented_pleg CRI-O presubmit job    

1. Observed the `Permission denied` [issue](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e/1615698705770352640) in the evented_pleg presubmit job.
2. Injecting the SSH key might resolve the issue according to the following PR reference 
https://github.com/kubernetes/test-infra/pull/25814

Signed-off-by: Sai Ramesh Vanka svanka@redhat.com