### PR TITLE
py2-3:jenkins/bootstrap decoding byte stream returned by stdout.readline

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -65,6 +65,8 @@ def read_all(end, stream, append):
         if not line:
             return True  # Read everything
         # Strip \n at the end if any. Last line of file may not have one.
+        # decode bytes to string
+        line = line.decode()
         append(line.rstrip('\n'))
         # Is there more on the buffer?
         ret = select.select([stream.fileno()], [], [], 0.1)


### PR DESCRIPTION
Python3 **readline()** _(subprocess stdout )_  returns bytes instead of a string, this PR fixes that.