### PR TITLE
track the status of decoratd jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -96,7 +96,7 @@ presubmits:
         - --warnings=duplicate-job-refs
         - --warnings=unknown-fields-all
         - --warnings=non-decorated-jobs
-        - --warnings valid-decoration-config
+        - --warnings=valid-decoration-config
     annotations:
       testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -72,6 +72,33 @@ presubmits:
         - --warnings=unknown-fields-all
     annotations:
       testgrid-dashboards: presubmits-test-infra
+  - name: pull-test-infra-prow-checkconfig-loose
+    optional: true
+    decorate: true
+    skip_report: true
+    run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/checkconfig:v20230124-17d9ffa086
+        command:
+        - checkconfig
+        args:
+        - --config-path=config/prow/config.yaml
+        - --job-config-path=config/jobs
+        - --plugin-config=config/prow/plugins.yaml
+        - --warnings=mismatched-tide-lenient
+        - --warnings=tide-strict-branch
+        - --warnings=needs-ok-to-test
+        - --warnings=validate-owners
+        - --warnings=missing-trigger
+        - --warnings=validate-urls
+        - --warnings=unknown-fields
+        - --warnings=duplicate-job-refs
+        - --warnings=unknown-fields-all
+        - --warnings=non-decorated-jobs
+        - --warnings valid-decoration-config
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration
     branches:
     - master


### PR DESCRIPTION
The job enables the `checkconfig` options to warn on decorated jobs

```
       - --warnings=non-decorated-jobs
        - --warnings valid-decoration-config
 ```

 is kept optional and not reporting, but will give us a place to track when new jobs using bootstraputils are added