### PR TITLE
fix hash typo

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -20,7 +20,7 @@ FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
 # gcr.io/k8s-staging-test-infra/bootstrap:v20230124-61b36115b7
 # except the autobumber will ignore the digest-only version
 # we will resume autobumping later when python2 vs 3 is sorted out
-FROM gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26
+FROM gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26d
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
it was pinned but there was a typo

```
docker pull gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26d
gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26d: Pulling from k8s-staging-test-infra/bootstrap
ac7f2e1c7586: Pull complete 
825e3480d907: Pull complete 
```

causing the postsubmit job to fail
```
Step #1:  ---> dc530fa1c5ce
Step #1: Step 3/39 : FROM gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26
Step #1: invalid checksum digest length
Finished Step #1
ERROR
```
https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e