### PR TITLE
Use butane generation for `crio.ign`

### DIFF
--- a/jobs/e2e_node/crio/Makefile
+++ b/jobs/e2e_node/crio/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CONTAINER_RUNTIME ?= $(if $(shell which podman 2>/dev/null),podman,docker)
+
+all:
+	$(CONTAINER_RUNTIME) run \
+		-i \
+		--rm \
+		--pull always \
+		-v $(shell pwd):/w -w /w \
+		quay.io/coreos/butane:release \
+		-ps -d templates < templates/crio.yaml > crio.ign

--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -12,6 +12,7 @@
       {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
+          "compression": "",
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
@@ -21,12 +22,12 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/templates/90-disable-auto-updates.toml
+++ b/jobs/e2e_node/crio/templates/90-disable-auto-updates.toml
@@ -1,0 +1,2 @@
+[updates]
+enabled = false

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -1,0 +1,51 @@
+---
+variant: fcos
+version: 1.4.0
+kernel_arguments:
+  should_exist:
+    - systemd.unified_cgroup_hierarchy=0
+storage:
+  files:
+    - path: /etc/zincati/config.d/90-disable-auto-updates.toml
+      contents:
+        local: 90-disable-auto-updates.toml
+      mode: 0644
+systemd:
+  units:
+    - name: dbus-tools-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Download and install dbus-tools.
+        Before=crio-install.service
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/rpm-ostree install \
+          --apply-live \
+          --allow-inactive \
+          dbus-tools
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: crio-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Download and install crio binaries and configurations.
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+          ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+
+        [Install]
+        WantedBy=multi-user.target


### PR DESCRIPTION
Bootstrap the generation infrastructure for the `crio.ign` file. This commit is the base for the follow-up work to auto-generate all other ignition files as well and verify them in CI.

Refers to https://github.com/kubernetes/test-infra/issues/28512

/cc @harche @haircommander @sairameshv
/sig node 