### PR TITLE
Revert "install kubetest2 from source"

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -108,7 +108,10 @@ RUN if [ -n "${KIND_VERSION}" ]; then \
 # install kubetest2 binaries if a version is provided
 ARG KUBETEST2_VERSION
 RUN if [ -n "${KUBETEST2_VERSION}" ]; then \
-    go install sigs.k8s.io/kubetest2/...@"${KUBETEST2_VERSION}" \
+    wget -q -O /usr/local/bin/kubetest2.tgz https://storage.googleapis.com/k8s-staging-kubetest2/${KUBETEST2_VERSION}/linux-amd64.tgz && \
+    tar -xzf /usr/local/bin/kubetest2.tgz -C /usr/local/bin && \
+    rm -f /usr/local/bin/kubetest2.tgz && \
+    chmod +x /usr/local/bin/kubetest2*; \
     fi
 
 # configure dockerd to use mirror.gcr.io


### PR DESCRIPTION
This reverts commit cb4f9e1ec8e2049a2fb9989237bb1b4bd9b7c892.

This makes the post submit job to fail

https://prow.k8s.io/log?container=test&id=1618255424887197696&job=post-test-infra-push-kubekins-e2e

```
tep #1:  ---> Running in d79b7ab02149
Step #1: [91m/bin/sh: 1: Syntax error: end of file unexpected (expecting "fi")
Step #1: The command '/bin/sh -c if [ -n "${KUBETEST2_VERSION}" ]; then     go install sigs.k8s.io/kubetest2/...@"${KUBETEST2_VERSION}"     fi' returned a non-zero code: 2
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 2
Step #1: [0m
```