### PR TITLE
Revert "Convert `bootstrap.py` and supporting scripts to python 3

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2016 The Kubernetes Authors.
 #
@@ -53,7 +53,7 @@ import subprocess
 import sys
 import tempfile
 import time
-import urllib.request, urllib.error, urllib.parse
+import urllib2
 
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
@@ -152,7 +152,7 @@ def _call(end, cmd, stdin=None, check=True, output=None, log_failures=True, env=
 
 def ref_has_shas(ref):
     """Determine if a reference specifies shas (contains ':')"""
-    return isinstance(ref, str) and ':' in ref
+    return isinstance(ref, basestring) and ':' in ref
 
 
 def pull_numbers(pull):
@@ -309,7 +309,7 @@ def checkout(call, repo, repo_path, branch, pull, ssh='', git_cache='', clean=Fa
 
 def repos_dict(repos):
     """Returns {"repo1": "branch", "repo2": "pull"}."""
-    return {r: b or p for (r, (b, p)) in list(repos.items())}
+    return {r: b or p for (r, (b, p)) in repos.items()}
 
 
 def start(gsutil, paths, stamp, node_name, version, repos):
@@ -585,7 +585,7 @@ def node():
         try:
             # Try reading the name of the VM we're running on, using the
             # metadata server.
-            os.environ[NODE_ENV] = urllib.request.urlopen(urllib.request.Request(
+            os.environ[NODE_ENV] = urllib2.urlopen(urllib2.Request(
                 'http://169.254.169.254/computeMetadata/v1/instance/name',
                 headers={'Metadata-Flavor': 'Google'})).read()
             os.environ[POD_ENV] = host  # We also want to log this.
@@ -938,7 +938,7 @@ def configure_ssh_key(ssh):
         fp.write(
             '#!/bin/sh\nssh -o StrictHostKeyChecking=no -i \'%s\' -F /dev/null "${@}"\n' % ssh)
     try:
-        os.chmod(fp.name, 0o500)
+        os.chmod(fp.name, 0500)
         had = 'GIT_SSH' in os.environ
         old = os.getenv('GIT_SSH')
         os.environ['GIT_SSH'] = fp.name
@@ -965,7 +965,7 @@ def setup_root(call, root, repos, ssh, git_cache, clean):
     # under the sun assumes $GOPATH/src/k8s.io/kubernetes so... :(
     # after this method is called we've already computed the upload paths
     # etc. so we can just swap it out for the desired path on disk
-    for repo, (branch, pull) in list(repos.items()):
+    for repo, (branch, pull) in repos.items():
         os.chdir(root_dir)
         # for k-s/k these are different, for the rest they are the same
         # TODO(cjwagner,stevekuznetsov): in the integrated
@@ -1130,7 +1130,7 @@ def bootstrap(args):
     if upload:
         gsutil.copy_file(paths.build_log, build_log_path, args.compress)
     if exc_type:
-        raise exc_type(exc_value).with_traceback(exc_traceback)  # pylint: disable=raising-bad-type
+        raise exc_type, exc_value, exc_traceback  # pylint: disable=raising-bad-type
     if not success:
         # TODO(fejta/spxtr): we should distinguish infra and non-infra problems
         # by exit code and automatically retrigger after an infra-problem.

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -653,8 +653,8 @@ class AppendResultTest(unittest.TestCase):
         bootstrap.append_result(gsutil, 'fake_path', build, version, success)
         cache = gsutil.jsons[0][0][1]
         self.assertEqual(1, len(cache))
-        self.assertIn(build, list(cache[0].values()))
-        self.assertIn(version, list(cache[0].values()))
+        self.assertIn(build, cache[0].values())
+        self.assertIn(version, cache[0].values())
 
     def test_passed_is_bool(self):
         build = 123
@@ -1043,7 +1043,7 @@ class FakeFinish(object):
 
 def repo(config):
     repos = bootstrap.Repos()
-    for cur_repo, tup in list(config.items()):
+    for cur_repo, tup in config.items():
         repos[cur_repo] = tup
     return repos
 
@@ -1090,14 +1090,14 @@ class FakeArgs(object):
         self.pull = PULL
         self.repo = [REPO]
         self.extra_job_args = []
-        for key, val in list(kw.items()):
+        for key, val in kw.items():
             if not hasattr(self, key):
                 raise AttributeError(self, key)
             setattr(self, key, val)
 
 
 def test_bootstrap(**kw):
-    if isinstance(kw.get('repo'), str):
+    if isinstance(kw.get('repo'), basestring):
         kw['repo'] = [kw['repo']]
     return bootstrap.bootstrap(FakeArgs(**kw))
 
@@ -1421,7 +1421,7 @@ class IntegrationTest(unittest.TestCase):
             refs.append('%d:%s' % (pr, head_sha()))
         os.chdir('/tmp')
         pull = ','.join(refs)
-        print('--pull', pull)
+        print '--pull', pull
         subprocess.check_call(['ls'])
         test_bootstrap(
             job='fake-pr',

--- a/scenarios/canarypush.py
+++ b/scenarios/canarypush.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -26,8 +26,8 @@ import sys
 
 def check_with_log(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
-    print(subprocess.check_call(cmd), file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
+    print >>sys.stderr, subprocess.check_call(cmd)
 
 def check_no_log(*cmd):
     """Run the command, raising on errors, no logs"""
@@ -38,7 +38,7 @@ def check_no_log(*cmd):
 
 def check_output(*cmd):
     """Log and run the command, return output, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     return subprocess.check_output(cmd)
 
 
@@ -61,9 +61,9 @@ def main(target, buildfile):
             pwd = content_file.read()
 
     if not user or not pwd:
-        print('Logging info not exist', file=sys.stderr)
+        print >>sys.stderr, 'Logging info not exist'
         sys.exit(1)
-    print('Logging in as %r' % user, file=sys.stderr)
+    print >>sys.stderr, 'Logging in as %r' % user
     check_no_log('docker', 'login', '--username=%s' % user, '--password=%s' % pwd)
 
     os.environ.pop('DOCKER_USER', None)

--- a/scenarios/dindind_execute.py
+++ b/scenarios/dindind_execute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2018 The Kubernetes Authors.
 #
@@ -28,7 +28,7 @@ import sys
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 
@@ -40,7 +40,7 @@ def main(envs, cmd):
 
     for env in envs:
         key, val = env.split('=', 1)
-        print('%s=%s' % (key, val), file=sys.stderr)
+        print >>sys.stderr, '%s=%s' % (key, val)
         os.environ[key] = val
     if not cmd:
         raise ValueError(cmd)

--- a/scenarios/execute.py
+++ b/scenarios/execute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -26,7 +26,7 @@ import sys
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 
@@ -34,7 +34,7 @@ def main(envs, cmd):
     """Run script and verify it exits 0."""
     for env in envs:
         key, val = env.split('=', 1)
-        print('%s=%s' % (key, val), file=sys.stderr)
+        print >>sys.stderr, '%s=%s' % (key, val)
         os.environ[key] = val
     if not cmd:
         raise ValueError(cmd)

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -29,12 +29,12 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 def check_output(*cmd):
     """Log and run the command, raising on errors, return output"""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     return subprocess.check_output(cmd)
 
 
@@ -98,7 +98,7 @@ class Bazel(object):
 def upload_string(gcs_path, text):
     """Uploads text to gcs_path"""
     cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
-    print('Run:', cmd, 'stdin=%s'%text, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd, 'stdin=%s'%text
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
     proc.communicate(input=text)
 
@@ -112,7 +112,7 @@ def echo_result(res):
         4:'Build passed, no tests found',
         5:'Interrupted'
     }
-    print(echo_map.get(res, 'Unknown exit code : %s' % res))
+    print echo_map.get(res, 'Unknown exit code : %s' % res)
 
 def get_version():
     """Return kubernetes version"""
@@ -206,7 +206,7 @@ def main(args):
     if args.push or args.release and res == 0:
         version = get_version()
         if not version:
-            print('Kubernetes version missing; not uploading ci artifacts.')
+            print 'Kubernetes version missing; not uploading ci artifacts.'
             res = 1
         else:
             try:

--- a/scenarios/kubernetes_bazel_test.py
+++ b/scenarios/kubernetes_bazel_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -66,7 +66,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         }
 
     def tearDown(self):
-        for _, stub in list(self.boiler.items()):
+        for _, stub in self.boiler.items():
             with stub:  # Leaving with restores things
                 pass
         self.callstack[:] = []

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2016 The Kubernetes Authors.
 #
@@ -28,18 +28,18 @@ import sys
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 def check_no_stdout(*cmd):
     """Log and run the command, suppress stdout & stderr, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     null = open(os.devnull, 'w')
     subprocess.check_call(cmd, stdout=null, stderr=null)
 
 def check_output(*cmd):
     """Log and run the command, raising on errors, return output"""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
 def check_build_exists(gcs, suffix, fast):
@@ -47,7 +47,7 @@ def check_build_exists(gcs, suffix, fast):
         already exists in remote path
     """
     if not os.path.exists('hack/print-workspace-status.sh'):
-        print('hack/print-workspace-status.sh not found, continue', file=sys.stderr)
+        print >>sys.stderr, 'hack/print-workspace-status.sh not found, continue'
         return False
 
     version = ''
@@ -60,7 +60,7 @@ def check_build_exists(gcs, suffix, fast):
             version = match.group(1)
     except subprocess.CalledProcessError as exc:
         # fallback with doing a real build
-        print('Failed to get k8s version, continue: %s' % exc, file=sys.stderr)
+        print >>sys.stderr, 'Failed to get k8s version, continue: %s' % exc
         return False
 
     if version:
@@ -79,8 +79,8 @@ def check_build_exists(gcs, suffix, fast):
             check_no_stdout('gsutil', 'ls', gcs + "/bin")
             return True
         except subprocess.CalledProcessError as exc:
-            print((
-                'gcs path %s (or some files under it) does not exist yet, continue' % gcs), file=sys.stderr)
+            print >>sys.stderr, (
+                'gcs path %s (or some files under it) does not exist yet, continue' % gcs)
     return False
 
 
@@ -88,17 +88,17 @@ def main(args):
     # pylint: disable=too-many-branches
     """Build and push kubernetes.
 
-    This is a python3 port of the kubernetes/hack/jenkins/build.sh script.
+    This is a python port of the kubernetes/hack/jenkins/build.sh script.
     """
     if os.path.split(os.getcwd())[-1] != 'kubernetes':
-        print((
-            'Scenario should only run from either kubernetes directory!'), file=sys.stderr)
+        print >>sys.stderr, (
+            'Scenario should only run from either kubernetes directory!')
         sys.exit(1)
 
     # pre-check if target build exists in gcs bucket or not
     # if so, don't make duplicated builds
     if check_build_exists(args.release, args.suffix, args.fast):
-        print('build already exists, exit', file=sys.stderr)
+        print >>sys.stderr, 'build already exists, exit'
         sys.exit(0)
 
     env = {
@@ -129,7 +129,7 @@ def main(args):
         # with non-public registries.
         check_no_stdout('gcloud', 'auth', 'configure-docker')
 
-    for key, value in list(env.items()):
+    for key, value in env.items():
         os.environ[key] = value
     check('make', 'clean')
     if args.fast:
@@ -137,7 +137,7 @@ def main(args):
     else:
         check('make', 'release')
     output = check_output(args.push_build_script, *push_build_args)
-    print('Push build result: ', output, file=sys.stderr)
+    print >>sys.stderr, 'Push build result: ', output
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -27,7 +27,7 @@ import re
 import shutil
 import subprocess
 import sys
-import urllib.request, urllib.error, urllib.parse
+import urllib2
 import time
 
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
@@ -92,22 +92,22 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 
 def check_output(*cmd):
     """Log and run the command, raising on errors, return output"""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     return subprocess.check_output(cmd)
 
 
 def check_env(env, *cmd):
     """Log and run the command with a specific env, raising on errors."""
-    print('Environment:', file=sys.stderr)
+    print >>sys.stderr, 'Environment:'
     for key, value in sorted(env.items()):
-        print('%s=%s' % (key, value), file=sys.stderr)
-    print('Run:', cmd, file=sys.stderr)
+        print >>sys.stderr, '%s=%s' % (key, value)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd, env=env)
 
 
@@ -220,7 +220,7 @@ class LocalMode(object):
 
     def start(self, args):
         """Starts kubetest."""
-        print('starts with local mode', file=sys.stderr)
+        print >>sys.stderr, 'starts with local mode'
         env = {}
         env.update(self.os_env)
         env.update(self.env_files)
@@ -382,8 +382,8 @@ def set_up_aws(workspace, args, mode, cluster, runner_args):
 def read_gcs_path(gcs_path):
     """reads a gcs path (gs://...) by HTTP GET to storage.googleapis.com"""
     link = gcs_path.replace('gs://', 'https://storage.googleapis.com/')
-    loc = urllib.request.urlopen(link).read()
-    print("Read GCS Path: %s" % loc, file=sys.stderr)
+    loc = urllib2.urlopen(link).read()
+    print >>sys.stderr, "Read GCS Path: %s" % loc
     return loc
 
 def get_shared_gcs_path(gcs_shared, use_shared_build):
@@ -459,7 +459,7 @@ def main(args):
     if args.use_shared_build is not None:
         # find shared build location from GCS
         gcs_path = get_shared_gcs_path(args.gcs_shared, args.use_shared_build)
-        print('Getting shared build location from: '+gcs_path, file=sys.stderr)
+        print >>sys.stderr, 'Getting shared build location from: '+gcs_path
         # retry loop for reading the location
         attempts_remaining = 12
         while True:
@@ -470,10 +470,10 @@ def main(args):
                 args.kubetest_args.append('--extract=' + shared_build_gcs_path)
                 args.build = None
                 break
-            except urllib.error.URLError as err:
-                print('Failed to get shared build location: %s' % err, file=sys.stderr)
+            except urllib2.URLError as err:
+                print >>sys.stderr, 'Failed to get shared build location: %s' % err
                 if attempts_remaining > 0:
-                    print('Waiting 5 seconds and retrying...', file=sys.stderr)
+                    print >>sys.stderr, 'Waiting 5 seconds and retrying...'
                     time.sleep(5)
                 else:
                     raise RuntimeError('Failed to get shared build location too many times!')
@@ -551,7 +551,7 @@ def main(args):
 
     # TODO(fejta): delete this?
     mode.add_os_environment(*(
-        '%s=%s' % (k, v) for (k, v) in list(os.environ.items())))
+        '%s=%s' % (k, v) for (k, v) in os.environ.items()))
 
     mode.add_environment(
       # Boilerplate envs
@@ -709,13 +709,13 @@ def parse_args(args=None):
                 raise ValueError('HOME dir not set!')
             if not args.aws_ssh:
                 args.aws_ssh = '%s/.ssh/kube_aws_rsa' % home
-                print('-aws-ssh key not set. Defaulting to %s' % args.aws_ssh, file=sys.stderr)
+                print >>sys.stderr, '-aws-ssh key not set. Defaulting to %s' % args.aws_ssh
             if not args.aws_pub:
                 args.aws_pub = '%s/.ssh/kube_aws_rsa.pub' % home
-                print('--aws-pub key not set. Defaulting to %s' % args.aws_pub, file=sys.stderr)
+                print >>sys.stderr, '--aws-pub key not set. Defaulting to %s' % args.aws_pub
             if not args.aws_cred:
                 args.aws_cred = '%s/.aws/credentials' % home
-                print('--aws-cred not set. Defaulting to %s' % args.aws_cred, file=sys.stderr)
+                print >>sys.stderr, '--aws-cred not set. Defaulting to %s' % args.aws_cred
     return args
 
 

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -23,7 +23,7 @@ import os
 import shutil
 import string
 import tempfile
-import urllib.request, urllib.error, urllib.parse
+import urllib2
 import unittest
 import time
 
@@ -82,7 +82,7 @@ def fake_bomb(*a, **kw):
 
 def raise_urllib2_error(*_unused, **_unused2):
     """Always raise a urllib2.URLError"""
-    raise urllib.error.URLError("test failure")
+    raise urllib2.URLError("test failure")
 
 def always_kubernetes(*_unused, **_unused2):
     """Always return 'kubernetes'"""
@@ -299,13 +299,13 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
             mode.add_file(temp.name)
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             mode.start([])
-        self.assertIn(('FOO', 'BAR'), self.envs.items())
-        self.assertIn(('WORKSPACE', '/new/workspace'), self.envs.items())
-        self.assertIn(('GOPATH', '/go/path'), self.envs.items())
-        self.assertIn(('USER', 'prow'), self.envs.items())
-        self.assertIn(('GOOS', 'linux'), self.envs.items())
-        self.assertNotIn(('USER', 'jenkins'), self.envs.items())
-        self.assertNotIn(('FOO', 'BAZ'), self.envs.items())
+        self.assertIn(('FOO', 'BAR'), self.envs.viewitems())
+        self.assertIn(('WORKSPACE', '/new/workspace'), self.envs.viewitems())
+        self.assertIn(('GOPATH', '/go/path'), self.envs.viewitems())
+        self.assertIn(('USER', 'prow'), self.envs.viewitems())
+        self.assertIn(('GOOS', 'linux'), self.envs.viewitems())
+        self.assertNotIn(('USER', 'jenkins'), self.envs.viewitems())
+        self.assertNotIn(('FOO', 'BAZ'), self.envs.viewitems())
 
     def test_parse_args_order_agnostic(self):
         args = kubernetes_e2e.parse_args([

--- a/scenarios/kubernetes_execute_bazel.py
+++ b/scenarios/kubernetes_execute_bazel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2018 The Kubernetes Authors.
 #
@@ -31,12 +31,12 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 def call(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     return subprocess.call(cmd)
 
 
@@ -47,7 +47,7 @@ def main(cmd):
     # update bazel caching configuration if enabled
     # TODO(fejta): migrate all jobs to use RBE instead of this
     if os.environ.get('BAZEL_REMOTE_CACHE_ENABLED', 'false') == 'true':
-        print('Bazel remote cache is enabled, generating .bazelrcs ...')
+        print 'Bazel remote cache is enabled, generating .bazelrcs ...'
         # TODO: consider moving this once we've migrated all users
         # of the remote cache to this script
         check(test_infra('images/bootstrap/create_bazel_cache_rcs.sh'))

--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -41,7 +41,7 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 
@@ -101,7 +101,7 @@ PR_PROJECTS = {
 
 def check_predefine_jobs(jobs, ratelimit):
     """Handle predefined jobs"""
-    for project, expire in jobs.items():
+    for project, expire in jobs.iteritems():
         clean_project(project, hours=expire, ratelimit=ratelimit)
 
 def check_ci_jobs():
@@ -110,7 +110,7 @@ def check_ci_jobs():
         config = json.load(fp)
 
     match_re = re.compile(r'--gcp-project=(.+)')
-    for value in list(config.values()):
+    for value in config.values():
         clean_hours = 24
         found = None
         for arg in value.get('args', []):
@@ -123,7 +123,7 @@ def check_ci_jobs():
                 continue
             project = mat.group(1)
             if any(b in project for b in EXEMPT_PROJECTS):
-                print('Project %r is exempted in ci-janitor' % project, file=sys.stderr)
+                print >>sys.stderr, 'Project %r is exempted in ci-janitor' % project
                 continue
             found = project
         if found:
@@ -142,14 +142,14 @@ def main(mode, ratelimit, projects, age, artifacts, filt):
         check_ci_jobs()
 
     # Summary
-    print('Janitor checked %d project, %d failed to clean up.' % (len(CHECKED), len(FAILED)))
-    print(HAS_JUNIT)
+    print 'Janitor checked %d project, %d failed to clean up.' % (len(CHECKED), len(FAILED))
+    print HAS_JUNIT
     if artifacts:
         output = os.path.join(artifacts, 'junit_janitor.xml')
         if not HAS_JUNIT:
-            print('Please install junit-xml (https://pypi.org/project/junit-xml/)')
+            print 'Please install junit-xml (https://pypi.org/project/junit-xml/)'
         else:
-            print('Generating junit output:')
+            print 'Generating junit output:'
             tcs = []
             for project in CHECKED:
                 tc = TestCase(project, 'kubernetes_janitor')
@@ -162,7 +162,7 @@ def main(mode, ratelimit, projects, age, artifacts, filt):
             with open(output, 'w') as f:
                 TestSuite.to_file(f, [ts])
     if FAILED:
-        print('Failed projects: %r' % FAILED, file=sys.stderr)
+        print >>sys.stderr, 'Failed projects: %r' % FAILED
         exit(1)
 
 

--- a/scenarios/maintenance.py
+++ b/scenarios/maintenance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -25,7 +25,7 @@ import sys
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print('Run:', cmd, file=sys.stderr)
+    print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
 


### PR DESCRIPTION
Reverts #28494

This reverts commit cbf27089bd96272189173322dd8e1a215080e243.

Ref: [slack thread](https://kubernetes.slack.com/archives/C09QZ4DQB/p1674639246484719)

`pull-kubernetes-e2e-gce` has been failiing with errors like ([example](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/112629/pull-kubernetes-e2e-gce/1618275793375334400/))

```
TypeError: a bytes-like object is required, not 'str'
I0125 09:28:47.635] Call:  gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
Traceback (most recent call last):
  File "./test-infra/jenkins/bootstrap.py", line 1202, in <module>
    bootstrap(ARGS)
  File "./test-infra/jenkins/bootstrap.py", line 1117, in bootstrap
    setup_credentials(call, args.service_account, upload)
  File "./test-infra/jenkins/bootstrap.py", line 772, in setup_credentials
    '--key-file=%s' % os.environ[SERVICE_ACCOUNT_ENV],
  File "./test-infra/jenkins/bootstrap.py", line 1054, in <lambda>
    call = lambda *a, **kw: _call(end, *a, **kw)
  File "./test-infra/jenkins/bootstrap.py", line 132, in _call
    if read_all(end, *reads[fdesc]):
  File "./test-infra/jenkins/bootstrap.py", line 68, in read_all
    append(line.rstrip('\n'))
TypeError: a bytes-like object is required, not 'str'
```

/assign @aojea 
/cc @BenTheElder @dims 