### PR TITLE
move to a working boostrap version

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,10 +17,11 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-# gcr.io/k8s-staging-test-infra/bootstrap:v20230124-61b36115b7
+# gcr.io/k8s-staging-test-infra/bootstrap:v20221021-5771e8efb3
+# This is the last working image set by #28485
 # except the autobumber will ignore the digest-only version
 # we will resume autobumping later when python2 vs 3 is sorted out
-FROM gcr.io/k8s-staging-test-infra/bootstrap@sha256:35443bdbc2a16b36ba52eaa43a946a1568fb3071c2f08af5586cad651f54c26d
+FROM gcr.io/k8s-staging-test-infra/bootstrap@sha256:4bf4459fbd1349804158e7645b4f515c1e7aa4b230b929df71d0fd75d25caa98
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6450081/214636290-4c0956e3-72ad-44de-8037-14bbba19ce21.png)


tested locally this one has python2

```
abb2cb9e3eda: Pull complete 
Digest: sha256:4bf4459fbd1349804158e7645b4f515c1e7aa4b230b929df71d0fd75d25caa98
Status: Downloaded newer image for gcr.io/k8s-staging-test-infra/bootstrap@sha256:4bf4459fbd1349804158e7645b4f515c1e7aa4b230b929df71d0fd75d25caa98
root@91d5535e55cc:/workspace# python2
Python 2.7.16 (default, Oct 10 2019, 22:02:15) 
```