### PR TITLE
`Prow Config`: Do not deduplicate tide queries for different tenants

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -3407,7 +3407,7 @@ func sortStringSlice(s []string) []string {
 	return s
 }
 
-func (c Config) deduplicateTideQueries(queries TideQueries) (TideQueries, error) {
+func (c *Config) deduplicateTideQueries(queries TideQueries) (TideQueries, error) {
 	m := tideQueryMap{}
 	for _, query := range queries {
 		key := tideQueryConfig{
@@ -3418,7 +3418,7 @@ func (c Config) deduplicateTideQueries(queries TideQueries) (TideQueries, error)
 			MissingLabels:          sortStringSlice(query.MissingLabels),
 			Milestone:              query.Milestone,
 			ReviewApprovedRequired: query.ReviewApprovedRequired,
-			TenantIDs:              query.TenantIDs(c),
+			TenantIDs:              query.TenantIDs(*c),
 		}
 		keyRaw, err := json.Marshal(key)
 		if err != nil {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1779,7 +1779,7 @@ func loadConfig(prowConfig, jobConfig string, additionalProwConfigDirs []string,
 	nc.ProwYAMLGetter = prowYAMLGetter
 	nc.ProwYAMLGetterWithDefaults = prowYAMLGetterWithDefaults
 
-	if deduplicatedTideQueries, err := deduplicateTideQueries(nc.Tide.Queries); err != nil {
+	if deduplicatedTideQueries, err := nc.deduplicateTideQueries(nc.Tide.Queries); err != nil {
 		logrus.WithError(err).Error("failed to deduplicate tide queriees")
 	} else {
 		nc.Tide.Queries = deduplicatedTideQueries
@@ -3407,7 +3407,7 @@ func sortStringSlice(s []string) []string {
 	return s
 }
 
-func deduplicateTideQueries(queries TideQueries) (TideQueries, error) {
+func (c Config) deduplicateTideQueries(queries TideQueries) (TideQueries, error) {
 	m := tideQueryMap{}
 	for _, query := range queries {
 		key := tideQueryConfig{
@@ -3418,6 +3418,7 @@ func deduplicateTideQueries(queries TideQueries) (TideQueries, error) {
 			MissingLabels:          sortStringSlice(query.MissingLabels),
 			Milestone:              query.Milestone,
 			ReviewApprovedRequired: query.ReviewApprovedRequired,
+			TenantIDs:              query.TenantIDs(c),
 		}
 		keyRaw, err := json.Marshal(key)
 		if err != nil {

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -332,6 +332,7 @@ type tideQueryConfig struct {
 	MissingLabels          []string
 	Milestone              string
 	ReviewApprovedRequired bool
+	TenantIDs              []string
 }
 
 type tideQueryTarget struct {


### PR DESCRIPTION
This is the second half of the solution to https://github.com/kubernetes/test-infra/issues/28459. The first half involved not filtering out exposed repos that shared tide queries with hidden repos in https://github.com/kubernetes/test-infra/pull/28460.

This fixes the same issue when the repos that share the same query have a different default tenant configured. I opted to approach this one by simply not deduplicating those queries so that the `tide` queries would be separated by tenant. This solves the problem without having to tinker with the filtering logic. 

An argument could be made that this bug would be better fixed by changing the filtering logic in `deck` (similarly to how it was done in https://github.com/kubernetes/test-infra/pull/28460), but with the way the default tenant ids are configured that would be a very clunky and involved change. I also think that the approach I have made will be more performant as it is only run each time the config is loaded rather than every time someone hits the 'PR Status' page. The downside of this approach is that there will be additional `tide` queries for the different tenant ids, if configured. This won't result in any issues, but is technically unnecessary outside of fixing this issue.