### PR TITLE
drop python2 pip install from bootstrap

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -51,7 +51,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
     && python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Install gcloud


### PR DESCRIPTION
this got lost in the revert churn