### PR TITLE
encode strings before md5 hashing

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -246,8 +246,8 @@ def cluster_name(cluster, tear_down_previous=False):
     else:
         suffix = '%s' % os.getenv('BUILD_ID', 0)
     if len(suffix) > 10:
-        suffix = hashlib.md5(suffix).hexdigest()[:10]
-    job_hash = hashlib.md5(os.getenv('JOB_NAME', '')).hexdigest()[:5]
+        suffix = hashlib.md5(suffix.encode('utf-8')).hexdigest()[:10]
+    job_hash = hashlib.md5(os.getenv('JOB_NAME', '').encode('utf-8')).hexdigest()[:5]
     return 'e2e-%s-%s' % (suffix, job_hash)
 
 


### PR DESCRIPTION
from previous test run: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/115322/pull-kubernetes-e2e-gce/1618417212882685952/