### PR TITLE
big query / gcloud do not need python2 and python3 is not available i…

### DIFF
--- a/images/bigquery/Dockerfile
+++ b/images/bigquery/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y \
     git \
     jq \
     wget \
-    python \
     python3 \
     python3-pip && \
     rm -rf /var/lib/apt/lists/*

--- a/images/bigquery/README.md
+++ b/images/bigquery/README.md
@@ -3,8 +3,7 @@
 The `gcr.io/k8s-staging-test-infra/bigquery` image is used to run [`/metrics/bigquery.py`] and [`/kettle/monitor.py`]
 
 It is mostly present to ensure the following is available:
-- `python` - required by `gcloud` and `bq`
-- `python3` - required by `/metrics/bigquery.py`
+- `python3` - required by `/metrics/bigquery.py`, `glcoud` and `bq`
 - `jq` - invoked by the script to transform json results
 - `bq` - invoked by the script to hit bigquery (comes with `gcloud`)
 - python libraries used by the script


### PR DESCRIPTION
…n base anymore

see: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-bigquery/1618421582068191232

this is *wholly unrelated* to all the other python2/3 bits in this repo of late, I just noticed it while checking the image build postsubmits. this image uses a different base image but has the same issue that python2 isn't available anymore.

bigquery library was already only being installed with pip3
gcloud has supported python3 since well before the version used here