### PR TITLE
Rollback bootstrap image in ci-build-and-push-k8s-at-golang-tip

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -35,7 +35,7 @@ periodics:
     testgrid-tab-name: build-and-push-k8s-at-golang-tip
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/bootstrap:v20230124-cbf27089bd
+    - image: gcr.io/k8s-staging-test-infra/bootstrap@sha256:88e45751be728958c78981f2886b5f4fbf8878f37678c447ae08f336e6c7e7e0
       command:
       - runner.sh
       - /workspace/scenarios/execute.py


### PR DESCRIPTION
Rollback bootstrap image in ci-build-and-push-k8s-at-golang-tip to working version