### PR TITLE
remove superfulous usage of scenarios/execute.py from scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
@@ -23,7 +23,6 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230117-50d6df3625-master
       command:
       - runner.sh
-      - /workspace/scenarios/execute.py
       args:
       - $(GOPATH)/src/k8s.io/perf-tests/clusterloader2/clean-up-old-snapshots-boskos.sh
       # Command (list|delete)
@@ -64,7 +63,6 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230117-50d6df3625-master
       command:
       - runner.sh
-      - /workspace/scenarios/execute.py
       args:
       - $(GOPATH)/src/k8s.io/perf-tests/clusterloader2/clean-up-old-snapshots.sh
       # Command (list|delete)

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -38,7 +38,6 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/bootstrap@sha256:88e45751be728958c78981f2886b5f4fbf8878f37678c447ae08f336e6c7e7e0
       command:
       - runner.sh
-      - /workspace/scenarios/execute.py
       args:
       - make
       - --

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -700,7 +700,6 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230117-50d6df3625-master
       command:
       - runner.sh
-      - /workspace/scenarios/execute.py
       args:
       - ./benchmark/runner.sh
       resources:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -791,7 +791,6 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/bootstrap:v20230124-cbf27089bd
         command:
         - runner.sh
-        - /workspace/scenarios/execute.py
         args:
         - /home/prow/go/src/k8s.io/perf-tests/util-images/presubmit.sh
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/28543#discussion_r1088097949

https://github.com/kubernetes/test-infra/issues/28544

cc @Argh4k @aojea 

the scenario scripts are only meant to be used from the kuebkins-e2e image, underneath the **deprecated** bootstrap.py system

`decorate: true` jobs should not be using any of this.

bootstrap image is also long deprecated and should not be used directly in jobs, will come back to that part later after inspecting what exactly these jobs do 

https://github.com/kubernetes/test-infra/tree/master/images/bootstrap#deprecated

https://github.com/kubernetes/test-infra/tree/master/scenarios#deprecation-notice