### PR TITLE
set bigquery ruamel yaml version to valid version matching requiremen…

### DIFF
--- a/images/bigquery/Dockerfile
+++ b/images/bigquery/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 
 ARG CLOUD_SDK_VERSION=390.0.0
 ARG BIGQUERY_LIBRARY_VERSION=0.26.0
-ARG RUAMEL_VERSION=0.16
+ARG RUAMEL_VERSION=0.16.5
 
 RUN pip3 install --no-cache-dir google-cloud-bigquery==${BIGQUERY_LIBRARY_VERSION} ruamel.yaml==${RUAMEL_VERSION}}
 


### PR DESCRIPTION
…ts3.txt

see: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-bigquery/1618488530248404992

follow-up to https://github.com/kubernetes/test-infra/pull/28539, this image still isn't building