### PR TITLE
re-enable autobumping (but not auto-merging) boostrap upgrades in kub…

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -21,7 +21,7 @@ extraFiles:
   - "config/jobs/README.md"
   - "releng/generate_tests.py"
   - "releng/test_config.yaml"
-  #- "images/kubekins-e2e/Dockerfile"
+  - "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"
 prefixes:
   - name: "k8s-testimages images"


### PR DESCRIPTION
…ekins-e2e

we'll still be merging new images bumps in CI in a controlled fashion, but autobumping this well help us avoid staying out of date in the future. I only meant to temporarily disable this while we sorted out the py3 issues, which seem to be resolved *and* bootstrap jobs are automatically pulling test-infra HEAD before running scripts anyhow