### PR TITLE
update bootstrap to v20230126-215ae799eb with gsutil 5.17

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -35,7 +35,7 @@ periodics:
     testgrid-tab-name: build-and-push-k8s-at-golang-tip
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/bootstrap@sha256:4bf4459fbd1349804158e7645b4f515c1e7aa4b230b929df71d0fd75d25caa98
+    - image: gcr.io/k8s-staging-test-infra/bootstrap:v20230126-215ae799eb
       command:
       - runner.sh
       args:

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-staging-test-infra/bootstrap:v20230126-f1a4452ec1
+FROM gcr.io/k8s-staging-test-infra/bootstrap:v20230126-215ae799eb
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
hoping this has the actual resolution to https://github.com/kubernetes/test-infra/issues/28544

if so, we'll still need to roll forward kubekins-e2e images in CI next