### PR TITLE
add Prow API server (gangway)

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -9,6 +9,7 @@ baseImageOverrides:
   k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git-gke-gcloud-auth:v20221221-af5c6c8c0d
   k8s.io/test-infra/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20220215-ddc3ad9
+  k8s.io/test-infra/prow/cmd/gangway: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/grandmatriarch: gcr.io/cloud-builders/gcloud@sha256:5b49dfb5e366dd75a5fc6d5d447be584f8f229c5a790ee0c3b0bd0cf70ec41dd
@@ -160,6 +161,13 @@ builds:
   - -s -w
   - -X k8s.io/test-infra/prow/version.Version={{.Env.VERSION}}
   - -X k8s.io/test-infra/prow/version.Name=entrypoint
+- id: gangway
+  dir: .
+  main: prow/cmd/gangway
+  ldflags:
+  - -s -w
+  - -X k8s.io/test-infra/prow/version.Version={{.Env.VERSION}}
+  - -X k8s.io/test-infra/prow/version.Name=gangway
 - id: generic-autobumper
   dir: .
   main: prow/cmd/generic-autobumper

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,7 @@ github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/prow/cmd/gangway/main.go
+++ b/prow/cmd/gangway/main.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/test-infra/pkg/flagutil"
+	prowcr "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	configflagutil "k8s.io/test-infra/prow/flagutil/config"
+	"k8s.io/test-infra/prow/gangway"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/metrics"
+
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/pjutil"
+)
+
+type options struct {
+	client         prowflagutil.KubernetesOptions
+	github         prowflagutil.GitHubOptions
+	port           int
+	cookiefilePath string
+
+	config configflagutil.ConfigOptions
+
+	dryRun                 bool
+	gracePeriod            time.Duration
+	instrumentationOptions prowflagutil.InstrumentationOptions
+}
+
+func gatherOptions(fs *flag.FlagSet, args ...string) options {
+	var o options
+	fs.IntVar(&o.port, "port", 32000, "TCP port for gRPC.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	fs.DurationVar(&o.gracePeriod, "grace-period", 180*time.Second, "On shutdown, try to handle remaining events for the specified duration. ")
+	fs.StringVar(&o.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile, leave empty for github or anonymous")
+	for _, group := range []flagutil.OptionGroup{&o.client, &o.github, &o.instrumentationOptions, &o.config} {
+		group.AddFlags(fs)
+	}
+
+	fs.Parse(args)
+
+	return o
+}
+
+func (o *options) validate() error {
+	var errs []error
+	for _, group := range []flagutil.OptionGroup{&o.client, &o.github, &o.instrumentationOptions, &o.config} {
+		if err := group.Validate(o.dryRun); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if o.port == o.instrumentationOptions.HealthPort {
+		errs = append(errs, fmt.Errorf("both the gRPC port and health port are using the same port number %d", o.port))
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+type kubeClient struct {
+	client prowv1.ProwJobInterface
+	dryRun bool
+}
+
+// Create creates a Prow Job CR in the Kubernetes cluster (Prow service cluster).
+func (c *kubeClient) Create(ctx context.Context, job *prowcr.ProwJob, o metav1.CreateOptions) (*prowcr.ProwJob, error) {
+	if c.dryRun {
+		return job, nil
+	}
+	return c.client.Create(ctx, job, o)
+}
+
+// interruptableServer is a wrapper type around the gRPC server, so that we can
+// pass it along to our own interrupts package.
+type interruptableServer struct {
+	grpcServer *grpc.Server
+	listener   net.Listener
+	port       int
+}
+
+// Shutdown shuts down the inner gRPC server as gracefully as possible, by first
+// invoking GracefulStop() on it. This gives the server time to try to handle
+// things gracefully internally. However if it takes too long (if the parent
+// context cancels us), we forcefully kill the server by calling Stop(). Stop()
+// interrupts GracefulStop() (see
+// https://pkg.go.dev/google.golang.org/grpc#Server.Stop).
+func (s *interruptableServer) Shutdown(ctx context.Context) error {
+
+	gracefulStopFinished := make(chan struct{})
+
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(gracefulStopFinished)
+	}()
+
+	select {
+	case <-gracefulStopFinished:
+		return nil
+	case <-ctx.Done():
+		s.grpcServer.Stop()
+		return ctx.Err()
+	}
+}
+
+func (s *interruptableServer) ListenAndServe() error {
+	logrus.Infof("serving gRPC on port %d", s.port)
+	return s.grpcServer.Serve(s.listener)
+}
+
+func main() {
+	logrusutil.ComponentInit()
+
+	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	configAgent, err := o.config.ConfigAgent()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+
+	prowjobClient, err := o.client.ProwJobClient(configAgent.Config().ProwJobNamespace, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create prow job client")
+	}
+	kubeClient := &kubeClient{
+		client: prowjobClient,
+		dryRun: o.dryRun,
+	}
+
+	// If we are provided credentials for Git hosts, use them. These credentials
+	// hold per-host information in them so it's safe to set them globally.
+	if o.cookiefilePath != "" {
+		cmd := exec.Command("git", "config", "--global", "http.cookiefile", o.cookiefilePath)
+		if err := cmd.Run(); err != nil {
+			logrus.WithError(err).Fatal("unable to set cookiefile")
+		}
+	}
+
+	gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Git client.")
+	}
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
+	}
+	metrics.ExposeMetrics("gangway", configAgent.Config().PushGateway, o.instrumentationOptions.MetricsPort)
+
+	// Start serving liveness endpoint /healthz.
+	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
+
+	gw := gangway.Gangway{
+		ConfigAgent:              configAgent,
+		ProwJobClient:            kubeClient,
+		InRepoConfigCacheHandler: cacheGetter,
+	}
+
+	lis, err := net.Listen("tcp", ":"+strconv.Itoa(o.port))
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to set up tcp connection")
+	}
+
+	// Create a new gRPC (empty) server, and wire it up to act as a "ProwServer"
+	// as defined in the auto-generated gangway_grpc.pb.go file. Also inject an
+	// interceptor for collecting Prometheus metrics for all unary gRPC
+	// requests.
+	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+	)
+	gangway.RegisterProwServer(grpcServer, &gw)
+	grpc_prometheus.Register(grpcServer)
+
+	// Register reflection service on gRPC server. This enables testing through
+	// clients that don't have the generated stubs baked in, such as grpcurl.
+	reflection.Register(grpcServer)
+
+	s := &interruptableServer{
+		grpcServer: grpcServer,
+		listener:   lis,
+		port:       o.port,
+	}
+
+	// Start serving readiness endpoint /healthz/ready.
+	health.ServeReady()
+
+	// Start serving requests! Note that ListenAndServe() does not block, while
+	// WaitForGracefulShutdown() does block.
+	interrupts.ListenAndServe(s, o.gracePeriod)
+	interrupts.WaitForGracefulShutdown()
+	logrus.Info("Ended gracefully")
+}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -140,6 +140,11 @@ type ProwConfig struct {
 	SlackReporterConfigs SlackReporterConfigs `json:"slack_reporter_configs,omitempty"`
 	InRepoConfig         InRepoConfig         `json:"in_repo_config"`
 
+	// Gangway contains configurations needed by the the Prow API server of the
+	// same name. It encodes an allowlist of API clients and what kinds of Prow
+	// Jobs they are authorized to trigger.
+	Gangway Gangway `json:"gangway,omitempty"`
+
 	// TODO: Move this out of the main config.
 	JenkinsOperators []JenkinsOperator `json:"jenkins_operators,omitempty"`
 
@@ -2127,6 +2132,10 @@ func (c *Config) validateComponentConfig() error {
 	}
 
 	if err := c.Deck.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.Gangway.Validate(); err != nil {
 		return err
 	}
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -8133,6 +8133,7 @@ deck:
     size_limit: 100000000
   tide_update_period: 10s
 default_job_timeout: 24h0m0s
+gangway: {}
 gerrit:
   ratelimit: 5
   tick_interval: 1m0s
@@ -8213,6 +8214,7 @@ deck:
     size_limit: 100000000
   tide_update_period: 10s
 default_job_timeout: 24h0m0s
+gangway: {}
 gerrit:
   ratelimit: 5
   tick_interval: 1m0s
@@ -8286,6 +8288,7 @@ deck:
     size_limit: 100000000
   tide_update_period: 10s
 default_job_timeout: 24h0m0s
+gangway: {}
 gerrit:
   ratelimit: 5
   tick_interval: 1m0s
@@ -8364,6 +8367,7 @@ deck:
     size_limit: 100000000
   tide_update_period: 10s
 default_job_timeout: 24h0m0s
+gangway: {}
 gerrit:
   ratelimit: 5
   tick_interval: 1m0s

--- a/prow/config/gangway.go
+++ b/prow/config/gangway.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config knows how to read and parse config.yaml.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"google.golang.org/grpc/metadata"
+)
+
+type Gangway struct {
+	// AllowedApiClients encodes identifying information about API clients
+	// (AllowedApiClient). An AllowedApiClient has authority to trigger a subset
+	// of Prow Jobs.
+	AllowedApiClients []AllowedApiClient `json:"allowed_api_clients,omitempty"`
+}
+
+type AllowedApiClient struct {
+	// ApiClientGcp contains GoogleCloudPlatform details about a web API client.
+	// We currently only support GoogleCloudPlatform but other cloud vendors are
+	// possible as additional fields in this struct.
+	GCP *ApiClientGcp `json:"gcp,omitempty"`
+
+	// AllowedJobsFilters contains information about what kinds of Prow jobs this
+	// API client is authorized to trigger.
+	AllowedJobsFilters []AllowedJobsFilter `json:"allowed_jobs_filters,omitempty"`
+}
+
+// ApiClientGcp encodes GCP Cloud Endpoints-specific HTTP metadata header
+// information, which are expected to be populated by the ESPv2 sidecar
+// container for GKE applications (in our case, the gangway pod).
+type ApiClientGcp struct {
+	// EndpointApiConsumerType is the expected value of the
+	// x-endpoint-api-consumer-type HTTP metadata header. Typically this will be
+	// "PROJECT".
+	EndpointApiConsumerType string `json:"endpoint_api_consumer_type,omitempty"`
+	// EndpointApiConsumerNumber is the expected value of the
+	// x-endpoint-api-consumer-number HTTP metadata header. Typically this
+	// encodes the GCP Project number value, which uniquely identifies a GCP
+	// Project.
+	EndpointApiConsumerNumber string `json:"endpoint_api_consumer_number,omitempty"`
+}
+
+type ApiClientCloudVendor interface {
+	GetVendorName() string
+	GetRequiredMdHeaders() []string
+	GetUUID() string
+	Validate() error
+}
+
+func (gcp *ApiClientGcp) GetVendorName() string {
+	return "gcp"
+}
+
+func (gcp *ApiClientGcp) GetRequiredMdHeaders() []string {
+	// These headers were drawn from this example:
+	// https://github.com/envoyproxy/envoy/issues/13207 (source code appears
+	// to be
+	// https://github.com/GoogleCloudPlatform/esp-v2/blob/3828042e5b3f840e17837c1a019f4014276014d8/tests/endpoints/bookstore_grpc/server/server.go).
+	// Here's an example of what these headers can look like in practice
+	// (whitespace edited for readability):
+	//
+	//     map[
+	//       :authority:[localhost:20785]
+	//       accept-encoding:[gzip]
+	//       content-type:[application/grpc]
+	//       user-agent:[Go-http-client/1.1]
+	//       x-endpoint-api-consumer-number:[123456]
+	//       x-endpoint-api-consumer-type:[PROJECT]
+	//       x-envoy-original-method:[GET]
+	//       x-envoy-original-path:[/v1/shelves/200?key=api-key]
+	//       x-forwarded-proto:[http]
+	//       x-request-id:[44770c9a-ee5f-4e36-944e-198b8d9c5196]
+	//       ]
+	//
+	//  We only use 2 of the above because the others are not that useful at this level.
+	return []string{"x-endpoint-api-consumer-type", "x-endpoint-api-consumer-number"}
+}
+
+func (gcp *ApiClientGcp) Validate() error {
+	if gcp == nil {
+		return nil
+	}
+
+	if gcp.EndpointApiConsumerType != "PROJECT" {
+		return fmt.Errorf("unsupported GCP API consumer type: %q", gcp.EndpointApiConsumerType)
+	}
+
+	var validProjectNumber = regexp.MustCompile(`^[0-9]+$`)
+	if !validProjectNumber.MatchString(gcp.EndpointApiConsumerNumber) {
+		return fmt.Errorf("invalid EndpointApiConsumerNumber: %q", gcp.EndpointApiConsumerNumber)
+	}
+
+	return nil
+}
+
+func (gcp *ApiClientGcp) GetUUID() string {
+	return fmt.Sprintf("gcp-%s-%s", gcp.EndpointApiConsumerType, gcp.EndpointApiConsumerNumber)
+}
+
+func (allowedApiClient *AllowedApiClient) GetApiClientCloudVendor() (ApiClientCloudVendor, error) {
+	if allowedApiClient.GCP != nil {
+		return allowedApiClient.GCP, nil
+	}
+
+	return nil, errors.New("allowedApiClient did not have a cloud vendor set")
+}
+
+// IdentifyAllowedClient looks at the HTTP request headers (metadata) and tries
+// to match it up with an allowlisted Client already defined in the main Config.
+//
+// Each supported client type (e.g., GCP) has custom logic around the HTTP
+// metadata headers to know what kind of headers to look for. Different cloud
+// vendors will have different HTTP metdata headers, although technically
+// nothing stops users from injecting these headers manually on their own.
+func (c *Config) IdentifyAllowedClient(md *metadata.MD) (*AllowedApiClient, error) {
+	if md == nil {
+		return nil, errors.New("metadata cannot be nil")
+	}
+
+	if c == nil {
+		return nil, errors.New("config cannot be nil")
+	}
+
+	for _, client := range c.Gangway.AllowedApiClients {
+		cv, err := client.GetApiClientCloudVendor()
+		if err != nil {
+			return nil, err
+		}
+
+		switch cv.GetVendorName() {
+		// For GCP (GKE) Prow installations Gangway must receive the special headers
+		// "x-endpoint-api-consumer-type" and "x-endpoint-api-consumer-number". This is
+		// because in GKE, Gangway must run behind a Cloud Endpoints sidecar container
+		// (which acts as a proxy and injects these special headers). These headers
+		// allow us to identify the caller's associated GCP Project, which we need in
+		// order to filter out only those Prow Jobs that this project is allowed to
+		// create. Otherwise, any caller could trigger any Prow Job, which is far from
+		// ideal from a security standpoint.
+		case "gcp":
+			v := md.Get("x-endpoint-api-consumer-type")[0]
+			if client.GCP.EndpointApiConsumerType != "PROJECT" {
+				return nil, fmt.Errorf("unsupported GCP API consumer type: %q", v)
+			}
+			v = md.Get("x-endpoint-api-consumer-number")[0]
+
+			// Now check whether we can find the same information in the Config's allowlist.
+			//
+			// Note that we do not check whether multiple AllowedApiClient
+			// elements match here. That case (where there are duplicate clients
+			// with the same EndpointApiConsumerNumber) is taken care of during
+			// validation.
+			if client.GCP.EndpointApiConsumerNumber == v {
+				return &client, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not find allowed client from %v", md)
+}
+
+// AllowedJobsFilter defines filters for jobs that are allowed by an
+// authenticated API client.
+type AllowedJobsFilter struct {
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
+func (ajf AllowedJobsFilter) Validate() error {
+	// TODO (listx): If there are other filter fields, we have to make sure that
+	// all filters with a non-empty value are valid. Currently we only have a
+	// TenantID filter so this one must be set and not empty.
+	if len(ajf.TenantID) == 0 {
+		return errors.New("AllowedJobsFilters entry has an empty tenant_id")
+	}
+	return nil
+}
+
+func (g *Gangway) Validate() error {
+	declaredClients := make(map[string]bool)
+	for _, allowedApiClient := range g.AllowedApiClients {
+		cv, err := allowedApiClient.GetApiClientCloudVendor()
+		if err != nil {
+			return err
+		}
+		if err := cv.Validate(); err != nil {
+			return err
+		}
+
+		switch cv.GetVendorName() {
+		case "gcp":
+			if _, declaredAlready := declaredClients[cv.GetUUID()]; declaredAlready {
+				return fmt.Errorf("AllowedApiClient %q declared multiple times", cv.GetUUID())
+			}
+			declaredClients[cv.GetUUID()] = true
+		}
+
+		if len(allowedApiClient.AllowedJobsFilters) == 0 {
+			return errors.New("allowed_jobs_filters field cannot be empty")
+		}
+
+		for _, allowedJobsFilter := range allowedApiClient.AllowedJobsFilters {
+			if err := allowedJobsFilter.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -519,6 +519,35 @@ deck:
 # DefaultJobTimeout this is default deadline for prow jobs. This value is used when
 # no timeout is configured at the job level. This value is set to 24 hours.
 default_job_timeout: 0s
+
+
+# Gangway contains configurations needed by the the Prow API server of the
+# same name. It encodes an allowlist of API clients and what kinds of Prow
+# Jobs they are authorized to trigger.
+gangway:
+    # AllowedApiClients encodes identifying information about API clients
+    # (AllowedApiClient). An AllowedApiClient has authority to trigger a subset
+    # of Prow Jobs.
+    allowed_api_clients:
+      - # AllowedJobsFilters contains information about what kinds of Prow jobs this
+        # API client is authorized to trigger.
+        allowed_jobs_filters:
+          - tenant_id: ' '
+
+        # ApiClientGcp contains GoogleCloudPlatform details about a web API client.
+        # We currently only support GoogleCloudPlatform but other cloud vendors are
+        # possible as additional fields in this struct.
+        gcp:
+            # EndpointApiConsumerNumber is the expected value of the
+            # x-endpoint-api-consumer-number HTTP metadata header. Typically this
+            # encodes the GCP Project number value, which uniquely identifies a GCP
+            # Project.
+            endpoint_api_consumer_number: ' '
+
+            # EndpointApiConsumerType is the expected value of the
+            # x-endpoint-api-consumer-type HTTP metadata header. Typically this will be
+            # "PROJECT".
+            endpoint_api_consumer_type: ' '
 gerrit:
     # DeckURL is the root URL of Deck. This is used to construct links to
     # job runs for a given CL.

--- a/prow/gangway/gangway.go
+++ b/prow/gangway/gangway.go
@@ -1,0 +1,760 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gangway
+
+import (
+	context "context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	codes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	status "google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	prowcrd "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/version"
+)
+
+const (
+	HEADER_API_CONSUMER_TYPE = "x-endpoint-api-consumer-type"
+	HEADER_API_CONSUMER_ID   = "x-endpoint-api-consumer-number"
+)
+
+type Gangway struct {
+	UnimplementedProwServer
+	ConfigAgent              *config.Agent
+	ProwJobClient            ProwJobClient
+	InRepoConfigCacheHandler *config.InRepoConfigCacheHandler
+}
+
+// ProwJobClient is mostly for testing (for calling into the low-level
+// Kubernetes API to check whether gangway behaved correctly).
+type ProwJobClient interface {
+	Create(context.Context, *prowcrd.ProwJob, metav1.CreateOptions) (*prowcrd.ProwJob, error)
+}
+
+func (gw *Gangway) CreateJobExecution(ctx context.Context, cjer *CreateJobExecutionRequest) (*JobExecution, error) {
+	err, md := getHttpRequestHeaders(ctx)
+
+	if err != nil {
+		logrus.WithError(err).Debug("could not find request HTTP headers")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Validate request fields.
+	if err := cjer.Validate(); err != nil {
+		logrus.WithError(err).Debug("could not validate request fields")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// FIXME (listx) Add execution token generation database call, so that we can
+	// reduce the delay between the initial call and the creation of the ProwJob
+	// CR. We should probably use UUIDv7 (see
+	// https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html).
+	// Also see FireBase's PushID for comparison:
+	// https://firebase.blog/posts/2015/02/the-2120-ways-to-ensure-unique_68.
+
+	// Identify the client from the request metadata.
+	mainConfig := gw.ConfigAgent.Config()
+	allowedApiClient, err := mainConfig.IdentifyAllowedClient(md)
+	if err != nil {
+		logrus.WithError(err).Debug("could not find client in allowlist")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	l, err := getDecoratedLoggerEntry(allowedApiClient, md)
+	if err != nil {
+		l = logrus.NewEntry(logrus.New())
+	}
+
+	allowedClusters := []string{"*"}
+	var reporterFunc ReporterFunc = nil
+	requireTenantID := true
+
+	jobExec, err := HandleProwJob(l, reporterFunc, cjer, gw.ProwJobClient, mainConfig, gw.InRepoConfigCacheHandler, allowedApiClient, requireTenantID, allowedClusters)
+	if err != nil {
+		logrus.WithError(err).Debugf("failed to create job %q", cjer.GetJobName())
+		return nil, err
+	}
+
+	return jobExec, nil
+}
+
+// ClientAuthorized checks whether or not a client can run a Prow job based on
+// the job's identifier (is this client allowed to run jobs meant for the given
+// identifier?). This needs to traverse the config to determine whether the
+// allowlist (allowed_api_clients) allows it.
+func ClientAuthorized(allowedApiClient *config.AllowedApiClient, prowJobCR prowcrd.ProwJob) bool {
+	pjd := prowJobCR.Spec.ProwJobDefault
+	for _, allowedJobsFilter := range allowedApiClient.AllowedJobsFilters {
+		if allowedJobsFilter.TenantID == pjd.TenantID {
+			return true
+		}
+	}
+	return false
+}
+
+// FIXME: Add roundtrip tests to ensure that the conversion between gitRefs and
+// refs is lossless.
+func ToCrdRefs(gitRefs *Refs) (*prowcrd.Refs, error) {
+	if gitRefs == nil {
+		return nil, errors.New("gitRefs is nil")
+	}
+
+	refs := prowcrd.Refs{
+		Org:            gitRefs.Org,
+		Repo:           gitRefs.Repo,
+		RepoLink:       gitRefs.RepoLink,
+		BaseRef:        gitRefs.BaseRef,
+		BaseSHA:        gitRefs.BaseSha,
+		BaseLink:       gitRefs.BaseLink,
+		PathAlias:      gitRefs.PathAlias,
+		WorkDir:        gitRefs.WorkDir,
+		CloneURI:       gitRefs.CloneUri,
+		SkipSubmodules: gitRefs.SkipSubmodules,
+		CloneDepth:     int(gitRefs.CloneDepth),
+		SkipFetchHead:  gitRefs.SkipFetchHead,
+	}
+
+	var pulls []prowcrd.Pull
+	for _, pull := range gitRefs.GetPulls() {
+		if pull == nil {
+			continue
+		}
+		p := prowcrd.Pull{
+			Number:     int(pull.Number),
+			Author:     pull.Author,
+			SHA:        pull.Sha,
+			Title:      pull.Title,
+			Ref:        pull.Ref,
+			Link:       pull.Link,
+			CommitLink: pull.CommitLink,
+			AuthorLink: pull.AuthorLink,
+		}
+		pulls = append(pulls, p)
+	}
+
+	refs.Pulls = pulls
+
+	return &refs, nil
+}
+
+func FromCrdRefs(refs *prowcrd.Refs) (*Refs, error) {
+	if refs == nil {
+		return nil, errors.New("refs is nil")
+	}
+
+	gitRefs := Refs{
+		Org:            refs.Org,
+		Repo:           refs.Repo,
+		RepoLink:       refs.RepoLink,
+		BaseRef:        refs.BaseRef,
+		BaseSha:        refs.BaseSHA,
+		BaseLink:       refs.BaseLink,
+		PathAlias:      refs.PathAlias,
+		WorkDir:        refs.WorkDir,
+		CloneUri:       refs.CloneURI,
+		SkipSubmodules: refs.SkipSubmodules,
+		CloneDepth:     int32(refs.CloneDepth),
+		SkipFetchHead:  refs.SkipFetchHead,
+	}
+
+	var pulls []*Pull
+	for _, pull := range refs.Pulls {
+		p := Pull{
+			Number:     int32(pull.Number),
+			Author:     pull.Author,
+			Sha:        pull.SHA,
+			Title:      pull.Title,
+			Ref:        pull.Ref,
+			Link:       pull.Link,
+			CommitLink: pull.CommitLink,
+			AuthorLink: pull.AuthorLink,
+		}
+		pulls = append(pulls, &p)
+	}
+
+	gitRefs.Pulls = pulls
+
+	return &gitRefs, nil
+}
+
+func getHttpRequestHeaders(ctx context.Context) (error, *metadata.MD) {
+	// Retrieve HTTP headers from call. All headers are lower-cased.
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return fmt.Errorf("error retrieving metadata from context"), nil
+	}
+	return nil, &md
+}
+
+// getDecoratedLoggerEntry turns on a new logger that captures all known
+// (interesting) HTTP headers of a gRPC request. We convert these headers into
+// log fields so that the logger can be very precise.
+func getDecoratedLoggerEntry(allowedApiClient *config.AllowedApiClient, md *metadata.MD) (*logrus.Entry, error) {
+	cv, err := allowedApiClient.GetApiClientCloudVendor()
+	if err != nil {
+		return nil, err
+	}
+
+	knownHeaders := cv.GetRequiredMdHeaders()
+	fields := make(map[string]interface{})
+	for _, header := range knownHeaders {
+		values := md.Get(header)
+		// Only use the first value. MD stores multiple values in case other
+		// entities attempt to overwrite an existing key (it prevents this by
+		// storing values as a list of strings).
+		//
+		// Prefix the field with "http-header/" so that all of the headers here
+		// get displayed neatly together (when the fields are sorted by logrus's
+		// own output to the console).
+		if len(values) > 0 {
+			fields[fmt.Sprintf("http-header/%s", header)] = values[0]
+		}
+	}
+	fields["component"] = version.Name
+
+	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
+		PrintLineNumber: true,
+		DefaultFields:   fields,
+	})
+
+	return logrus.NewEntry(logrus.New()), nil
+}
+
+func (cjer *CreateJobExecutionRequest) Validate() error {
+	jobName := cjer.GetJobName()
+	jobExecutionType := cjer.GetJobExecutionType()
+	gitRefs := cjer.GetRefs()
+
+	if len(jobName) == 0 {
+		return errors.New("job_name field cannot be empty")
+	}
+
+	if jobExecutionType == JobExecutionType_JOB_EXECUTION_TYPE_UNSPECIFIED {
+		return fmt.Errorf("unsupported JobExecutionType: %s", jobExecutionType)
+	}
+
+	// Periodic jobs are not allowed to be defined with gitRefs. This is because
+	// gitRefs can denote inrepoconfig repo information (and periodic jobs are
+	// not allowed to be defined via inrepoconfig). See
+	// https://github.com/kubernetes/test-infra/issues/21729.
+	if jobExecutionType == JobExecutionType_PERIODIC && gitRefs != nil {
+		logrus.Debug("periodic jobs cannot also have gitRefs")
+		return errors.New("periodic jobs cannot also have gitRefs")
+	}
+
+	if jobExecutionType != JobExecutionType_PERIODIC {
+		// Non-periodic jobs must have a BaseRepo (default repo to clone)
+		// defined.
+		if gitRefs == nil {
+			return fmt.Errorf("gitRefs must be defined for %q", jobExecutionType)
+		}
+		if err := gitRefs.Validate(); err != nil {
+			return fmt.Errorf("gitRefs: failed to validate: %s", err)
+		}
+	}
+
+	// Finally perform some additional checks on the requested PodSpecOptions.
+	podSpecOptions := cjer.GetPodSpecOptions()
+	if podSpecOptions != nil {
+		envs := podSpecOptions.GetEnvs()
+		for k, v := range envs {
+			if len(k) == 0 || len(v) == 0 {
+				return fmt.Errorf("invalid environment variable key/value pair: %q, %q", k, v)
+			}
+		}
+
+		labels := podSpecOptions.GetLabels()
+		for k, v := range labels {
+			if len(k) == 0 || len(v) == 0 {
+				return fmt.Errorf("invalid label key/value pair: %q, %q", k, v)
+			}
+
+			errs := validation.IsValidLabelValue(v)
+			if len(errs) > 0 {
+				return fmt.Errorf("invalid label: the following errors found: %q", errs)
+			}
+		}
+
+		annotations := podSpecOptions.GetAnnotations()
+		for k, v := range annotations {
+			if len(k) == 0 || len(v) == 0 {
+				return fmt.Errorf("invalid annotation key/value pair: %q, %q", k, v)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (gitRefs *Refs) Validate() error {
+	if len(gitRefs.Org) == 0 {
+		return fmt.Errorf("gitRefs: Org cannot be empty")
+	}
+
+	if len(gitRefs.Repo) == 0 {
+		return fmt.Errorf("gitRefs: Repo cannot be empty")
+	}
+
+	if len(gitRefs.BaseRef) == 0 {
+		return fmt.Errorf("gitRefs: BaseRef cannot be empty")
+	}
+
+	if len(gitRefs.BaseSha) == 0 {
+		return fmt.Errorf("gitRefs: BaseSha cannot be empty")
+	}
+
+	for _, pull := range gitRefs.Pulls {
+		if err := pull.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (pull *Pull) Validate() error {
+	// Commit SHA must be a 40-character hex string.
+	var validSha = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	if !validSha.MatchString(pull.Sha) {
+		return fmt.Errorf("pull: invalid SHA: %q", pull.Sha)
+	}
+	return nil
+}
+
+// Ensure interface is intact. I.e., this declaration ensures that the type
+// "*config.Config" implements the "prowCfgClient" interface. See
+// https://golang.org/doc/faq#guarantee_satisfies_interface.
+var _ prowCfgClient = (*config.Config)(nil)
+
+// prowCfgClient is a subset of all the various behaviors that the
+// "*config.Config" type implements, which we will test here.
+type prowCfgClient interface {
+	AllPeriodics() []config.Periodic
+	GetPresubmitsStatic(identifier string) []config.Presubmit
+	GetPostsubmitsStatic(identifier string) []config.Postsubmit
+	GetProwJobDefault(repo, cluster string) *prowcrd.ProwJobDefault
+}
+
+type ReporterFunc func(pj *prowcrd.ProwJob, state prowcrd.ProwJobState, err error)
+
+func (cjer *CreateJobExecutionRequest) getJobHandler() (jobHandler, error) {
+	var jh jobHandler
+	switch cjer.JobExecutionType {
+	case JobExecutionType_PERIODIC:
+		jh = &periodicJobHandler{}
+	case JobExecutionType_PRESUBMIT:
+		jh = &presubmitJobHandler{}
+	case JobExecutionType_POSTSUBMIT:
+		jh = &postsubmitJobHandler{}
+	default:
+		return nil, fmt.Errorf("unsupported JobExecutionType type: %s", cjer.JobExecutionType)
+	}
+
+	return jh, nil
+}
+
+// Deep-copy all map fields from a gangway.CreateJobExecutionRequest and also
+// the statically defined (configured in YAML) Prow Job labels and annotations.
+func mergeMapFields(cjer *CreateJobExecutionRequest, staticLabels, staticAnnotations map[string]string) (map[string]string, map[string]string) {
+
+	pso := cjer.GetPodSpecOptions()
+
+	combinedLabels := make(map[string]string)
+	combinedAnnotations := make(map[string]string)
+
+	// Overwrite the static definitions with what we received in the
+	// CreateJobExecutionRequest. This order is important.
+	for k, v := range staticLabels {
+		combinedLabels[k] = v
+	}
+	for k, v := range pso.GetLabels() {
+		combinedLabels[k] = v
+	}
+
+	// Do the same for the annotations.
+	for k, v := range staticAnnotations {
+		combinedAnnotations[k] = v
+	}
+	for k, v := range pso.GetAnnotations() {
+		combinedAnnotations[k] = v
+	}
+
+	return combinedLabels, combinedAnnotations
+}
+
+func HandleProwJob(l *logrus.Entry,
+	reporterFunc ReporterFunc,
+	cjer *CreateJobExecutionRequest,
+	pjc ProwJobClient,
+	mainConfig prowCfgClient,
+	pc *config.InRepoConfigCacheHandler,
+	allowedApiClient *config.AllowedApiClient,
+	requireTenantID bool,
+	allowedClusters []string) (*JobExecution, error) {
+
+	var prowJobCR prowcrd.ProwJob
+
+	var prowJobSpec *prowcrd.ProwJobSpec
+	var jh jobHandler
+	jh, err := cjer.getJobHandler()
+	if err != nil {
+		return nil, err
+	}
+	prowJobSpec, labels, annotations, err := jh.getProwJobSpec(mainConfig, pc, cjer)
+	if err != nil {
+		// These are user errors, i.e. missing fields, requested prowjob doesn't exist etc.
+		// These errors are already surfaced to user via pubsub two lines below.
+		l.WithError(err).WithField("name", cjer.JobName).Info("Failed getting prowjob spec")
+		prowJobCR = pjutil.NewProwJob(prowcrd.ProwJobSpec{}, nil, cjer.PodSpecOptions.Annotations)
+		if reporterFunc != nil {
+			reporterFunc(&prowJobCR, prowcrd.ErrorState, err)
+		}
+		return nil, err
+	}
+	if prowJobSpec == nil {
+		return nil, fmt.Errorf("failed getting prowjob spec") // This should not happen
+	}
+
+	combinedLabels, combinedAnnotations := mergeMapFields(cjer, labels, annotations)
+
+	prowJobCR = pjutil.NewProwJob(*prowJobSpec, combinedLabels, combinedAnnotations)
+	// Adds / Updates Environments to containers
+	if prowJobCR.Spec.PodSpec != nil {
+		for i, c := range prowJobCR.Spec.PodSpec.Containers {
+			for k, v := range cjer.GetPodSpecOptions().GetEnvs() {
+				c.Env = append(c.Env, v1.EnvVar{Name: k, Value: v})
+			}
+			prowJobCR.Spec.PodSpec.Containers[i].Env = c.Env
+		}
+	}
+
+	// deny job that runs on not allowed cluster
+	var clusterIsAllowed bool
+	for _, allowedCluster := range allowedClusters {
+		if allowedCluster == "*" || allowedCluster == prowJobSpec.Cluster {
+			clusterIsAllowed = true
+			break
+		}
+	}
+	// This is a user error, not sure whether we want to return error here.
+	if !clusterIsAllowed {
+		err := fmt.Errorf("cluster %s is not allowed. Can be fixed by defining this cluster under pubsub_triggers -> allowed_clusters", prowJobSpec.Cluster)
+		l.WithField("cluster", prowJobSpec.Cluster).Warn("cluster not allowed")
+		if reporterFunc != nil {
+			reporterFunc(&prowJobCR, prowcrd.ErrorState, err)
+		}
+		return nil, err
+	}
+
+	// Figure out the tenantID defined for this job by looking it up in its
+	// config, or if that's missing, finding the default one specified in the
+	// main Config.
+	if requireTenantID {
+		var jobTenantID string
+		if prowJobCR.Spec.ProwJobDefault != nil && prowJobCR.Spec.ProwJobDefault.TenantID != "" {
+			jobTenantID = prowJobCR.Spec.ProwJobDefault.TenantID
+		} else {
+			// Derive the orgRepo from the request. Postsubmits and Presubmits both
+			// require Git refs information, so we can use that to get the job's
+			// associated orgRepo. Then we can feed this orgRepo into
+			// mainConfig.GetProwJobDefault(orgRepo, '*') to get the tenantID from
+			// the main Config's "prowjob_default_entries" field.
+			switch cjer.JobExecutionType {
+			case JobExecutionType_POSTSUBMIT:
+				fallthrough
+			case JobExecutionType_PRESUBMIT:
+				orgRepo := fmt.Sprintf("%s/%s", cjer.Refs.Org, cjer.Refs.Repo)
+				jobTenantID = mainConfig.GetProwJobDefault(orgRepo, "*").TenantID
+			}
+		}
+
+		if len(jobTenantID) == 0 {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("could not determine tenant_id for job %s", prowJobCR.Name))
+		}
+		if prowJobCR.Spec.ProwJobDefault != nil {
+			prowJobCR.Spec.ProwJobDefault.TenantID = jobTenantID
+		}
+	}
+
+	// Check whether this authenticated API client has authorization to trigger
+	// the requested Prow Job.
+	if allowedApiClient != nil {
+		authorized := ClientAuthorized(allowedApiClient, prowJobCR)
+
+		if !authorized {
+			logrus.Error("client is not authorized to execute the given job")
+			return nil, status.Error(codes.PermissionDenied, "client is not authorized to execute the given job")
+		}
+	}
+
+	if _, err := pjc.Create(context.TODO(), &prowJobCR, metav1.CreateOptions{}); err != nil {
+		l.WithError(err).Errorf("failed to create job %q as %q", cjer.GetJobName(), prowJobCR.Name)
+		if reporterFunc != nil {
+			reporterFunc(&prowJobCR, prowcrd.ErrorState, err)
+		}
+		return nil, err
+	}
+	l.WithFields(logrus.Fields{
+		"job":                 cjer.GetJobName(),
+		"name":                prowJobCR.Name,
+		"prowjob-annotations": prowJobCR.Annotations,
+	}).Info("Job created.")
+	if reporterFunc != nil {
+		reporterFunc(&prowJobCR, prowcrd.TriggeredState, nil)
+	}
+
+	// Now populate a JobExecution. We have to convert data from the ProwJob
+	// custom resource to a JobExecution. For now we just reuse the "Name" field
+	// of a ProwJob CR as a globally-unique execution ID, because this existing
+	// string is already used to do lookups on Deck
+	// (https://prow.k8s.io/prowjob?prowjob=c2891365-621c-11ed-88b0-da2d50b4915c)
+	// but also for naming the test pod itself (prowcrd.ProwJob.Status.pod_name
+	// field).
+	jobExec := &JobExecution{
+		Id:             prowJobCR.Name,
+		JobName:        cjer.JobName,
+		JobType:        cjer.JobExecutionType,
+		JobStatus:      JobExecutionStatus_TRIGGERED,
+		Refs:           cjer.Refs,
+		PodSpecOptions: cjer.PodSpecOptions,
+	}
+
+	return jobExec, nil
+}
+
+// jobHandler handles job type specific logic
+type jobHandler interface {
+	getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCacheHandler, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error)
+}
+
+// periodicJobHandler implements jobHandler
+type periodicJobHandler struct{}
+
+func (peh *periodicJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCacheHandler, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
+	var periodicJob *config.Periodic
+	// TODO(chaodaiG): do we want to support inrepoconfig when
+	// https://github.com/kubernetes/test-infra/issues/21729 is done?
+	for _, job := range mainConfig.AllPeriodics() {
+		if job.Name == cjer.JobName {
+			// Directly followed by break, so this is ok
+			// nolint: exportloopref
+			periodicJob = &job
+			break
+		}
+	}
+	if periodicJob == nil {
+		err = fmt.Errorf("failed to find associated periodic job %q", cjer.JobName)
+		return
+	}
+
+	spec := pjutil.PeriodicSpec(*periodicJob)
+	prowJobSpec = &spec
+	labels, annotations = periodicJob.Labels, periodicJob.Annotations
+	return
+}
+
+// presubmitJobHandler implements jobHandler
+type presubmitJobHandler struct {
+}
+
+func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCacheHandler, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
+	// presubmit jobs require Refs and Refs.Pulls to be set
+	refs, err := ToCrdRefs(cjer.Refs)
+	if err != nil {
+		return
+	}
+	if refs == nil {
+		err = errors.New("Refs must be supplied")
+		return
+	}
+	if len(refs.Org) == 0 {
+		err = errors.New("org must be supplied")
+		return
+	}
+	if len(refs.Repo) == 0 {
+		err = errors.New("repo must be supplied")
+		return
+	}
+	if len(refs.Pulls) == 0 {
+		err = errors.New("at least 1 Pulls is required")
+		return
+	}
+	if len(refs.BaseSHA) == 0 {
+		err = errors.New("baseSHA must be supplied")
+		return
+	}
+	if len(refs.BaseRef) == 0 {
+		err = errors.New("baseRef must be supplied")
+		return
+	}
+
+	var presubmitJob *config.Presubmit
+	org, repo, branch := refs.Org, refs.Repo, refs.BaseRef
+	orgRepo := org + "/" + repo
+	// Add "https://" prefix to orgRepo if this is a gerrit job.
+	// (Unfortunately gerrit jobs use the full repo URL as the identifier.)
+	prefix := "https://"
+	if cjer.PodSpecOptions != nil && cjer.PodSpecOptions.Labels[kube.GerritRevision] != "" && !strings.HasPrefix(orgRepo, prefix) {
+		orgRepo = prefix + orgRepo
+	}
+	baseSHAGetter := func() (string, error) {
+		return refs.BaseSHA, nil
+	}
+	var headSHAGetters []func() (string, error)
+	for _, pull := range refs.Pulls {
+		pull := pull
+		headSHAGetters = append(headSHAGetters, func() (string, error) {
+			return pull.SHA, nil
+		})
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch, "orgRepo": orgRepo})
+	// Get presubmits from Config alone.
+	presubmits := mainConfig.GetPresubmitsStatic(orgRepo)
+	// If InRepoConfigCache is provided, then it means that we also want to fetch
+	// from an inrepoconfig.
+	if pc != nil {
+		logger.Debug("Getting prow jobs.")
+		var presubmitsWithInrepoconfig []config.Presubmit
+		var err error
+		presubmitsWithInrepoconfig, err = pc.GetPresubmits(orgRepo, baseSHAGetter, headSHAGetters...)
+		if err != nil {
+			logger.WithError(err).Info("Failed to get presubmits")
+		} else {
+			logger.WithField("static-jobs", len(presubmits)).WithField("jobs-with-inrepoconfig", len(presubmitsWithInrepoconfig)).Debug("Jobs found.")
+			// Overwrite presubmits. This is safe because pc.GetPresubmits()
+			// itself calls mainConfig.GetPresubmitsStatic() and adds to it all the
+			// presubmits found in the inrepoconfig.
+			presubmits = presubmitsWithInrepoconfig
+		}
+	}
+
+	for _, job := range presubmits {
+		job := job
+		if !job.CouldRun(branch) { // filter out jobs that are not branch matching
+			continue
+		}
+		if job.Name == cjer.JobName {
+			if presubmitJob != nil {
+				err = fmt.Errorf("%s matches multiple prow jobs from orgRepo %q", cjer.JobName, orgRepo)
+				return
+			}
+			presubmitJob = &job
+		}
+	}
+	// This also captures the case where fetching jobs from inrepoconfig failed.
+	// However doesn't not distinguish between this case and a wrong prow job name.
+	if presubmitJob == nil {
+		err = fmt.Errorf("failed to find associated presubmit job %q from orgRepo %q", cjer.JobName, orgRepo)
+		return
+	}
+
+	spec := pjutil.PresubmitSpec(*presubmitJob, *refs)
+	prowJobSpec, labels, annotations = &spec, presubmitJob.Labels, presubmitJob.Annotations
+	return
+}
+
+// postsubmitJobHandler implements jobHandler
+type postsubmitJobHandler struct {
+}
+
+func (poh *postsubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCacheHandler, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
+	// postsubmit jobs require Refs to be set
+	refs, err := ToCrdRefs(cjer.Refs)
+	if refs == nil {
+		err = errors.New("refs must be supplied")
+		return
+	}
+	if len(refs.Org) == 0 {
+		err = errors.New("org must be supplied")
+		return
+	}
+	if len(refs.Repo) == 0 {
+		err = errors.New("repo must be supplied")
+		return
+	}
+	if len(refs.BaseSHA) == 0 {
+		err = errors.New("baseSHA must be supplied")
+		return
+	}
+	if len(refs.BaseRef) == 0 {
+		err = errors.New("baseRef must be supplied")
+		return
+	}
+
+	var postsubmitJob *config.Postsubmit
+	org, repo, branch := refs.Org, refs.Repo, refs.BaseRef
+	orgRepo := org + "/" + repo
+	// Add "https://" prefix to orgRepo if this is a gerrit job.
+	// (Unfortunately gerrit jobs use the full repo URL as the identifier.)
+	prefix := "https://"
+	if cjer.PodSpecOptions != nil && cjer.PodSpecOptions.Labels[kube.GerritRevision] != "" && !strings.HasPrefix(orgRepo, prefix) {
+		orgRepo = prefix + orgRepo
+	}
+	baseSHAGetter := func() (string, error) {
+		return refs.BaseSHA, nil
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch, "orgRepo": orgRepo})
+	postsubmits := mainConfig.GetPostsubmitsStatic(orgRepo)
+	if pc != nil {
+		logger.Debug("Getting prow jobs.")
+		var postsubmitsWithInrepoconfig []config.Postsubmit
+		var err error
+		postsubmitsWithInrepoconfig, err = pc.GetPostsubmits(orgRepo, baseSHAGetter)
+		if err != nil {
+			logger.WithError(err).Info("Failed to get postsubmits from inrepoconfig")
+		} else {
+			logger.WithField("static-jobs", len(postsubmits)).WithField("jobs-with-inrepoconfig", len(postsubmitsWithInrepoconfig)).Debug("Jobs found.")
+			postsubmits = postsubmitsWithInrepoconfig
+		}
+	}
+
+	for _, job := range postsubmits {
+		job := job
+		if !job.CouldRun(branch) { // filter out jobs that are not branch matching
+			continue
+		}
+		if job.Name == cjer.JobName {
+			if postsubmitJob != nil {
+				return nil, nil, nil, fmt.Errorf("%s matches multiple prow jobs from orgRepo %q", cjer.JobName, orgRepo)
+			}
+			postsubmitJob = &job
+		}
+	}
+	// This also captures the case where fetching jobs from inrepoconfig failed.
+	// However doesn't not distinguish between this case and a wrong prow job name.
+	if postsubmitJob == nil {
+		err = fmt.Errorf("failed to find associated postsubmit job %q from orgRepo %q", cjer.JobName, orgRepo)
+		return
+	}
+
+	spec := pjutil.PostsubmitSpec(*postsubmitJob, *refs)
+	prowJobSpec, labels, annotations = &spec, postsubmitJob.Labels, postsubmitJob.Annotations
+	return
+}

--- a/prow/test/integration/config/prow/cluster/gangway_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/gangway_deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gangway
+  namespace: default
+  labels:
+    app: gangway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gangway
+  template:
+    metadata:
+      labels:
+        app: gangway
+    spec:
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: gangway
+      containers:
+      - name: gangway
+        image: localhost:5001/gangway
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --job-config-path=/etc/job-config
+        - --grace-period=110s
+        # This cookie file is only here to trigger the creation of a
+        # Gerrit-flavored Git client factory. So this makes this gangway deployment
+        # "tied" to Gerrit.
+        #
+        # TODO (listx): Allow gangway to be deployed with access to multiple
+        # GitHub/Gerrit credentials (and make it know which one to use based on
+        # the org/repo name). We can't simply deploy a 2nd gangway deployment
+        # configured with GitHub creds to test that codepath because currently
+        # gangway will always choose one or the other.
+        - --cookiefile=/etc/cookies/cookies
+        - --dry-run=false
+        ports:
+        - name: grpc
+          containerPort: 32000
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - name: cookies
+          mountPath: /etc/cookies
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
+        env:
+        # When cloning from an inrepoconfig repo, don't bother verifying certs.
+        # This allows us to use "https://..." addresses to fakegitserver.
+        - name: GIT_SSL_NO_VERIFY
+          value: "1"
+      volumes:
+      - name: cookies
+        secret:
+          defaultMode: 420
+          secretName: http-cookiefile
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config
+      tolerations:
+      - key: "prowcomponent"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"

--- a/prow/test/integration/config/prow/cluster/gangway_rbac.yaml
+++ b/prow/test/integration/config/prow/cluster/gangway_rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gangway
+  namespace: default
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gangway
+  namespace: default
+rules:
+  - apiGroups:
+      - prow.k8s.io
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - get
+      - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gangway
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gangway
+subjects:
+- kind: ServiceAccount
+  name: gangway

--- a/prow/test/integration/config/prow/cluster/gangway_service.yaml
+++ b/prow/test/integration/config/prow/cluster/gangway_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gangway
+  namespace: default
+spec:
+  selector:
+    app: gangway
+  ports:
+  - name: grpc
+    port: 32000
+    targetPort: 32000
+    nodePort: 32000
+    protocol: TCP
+  - name: metrics
+    port: 9090
+    protocol: TCP
+  type: NodePort

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -21,6 +21,10 @@ prowjob_default_entries:
     repo: 'testRepo'
     config:
       tenant_id: 'tester'
+  - cluster: '*'
+    repo: "https://fakegitserver.default/repo/some/org/gangway-test-repo-1"
+    config:
+      tenant_id: 'well-behaved-tenant-for-gangway'
 
 gerrit:
   tick_interval: 1s
@@ -61,3 +65,20 @@ in_repo_config:
    "fakegitserver.default/repo/repo3": true
    "fakegitserver.default/repo/org1/repo4": true
    "fakegitserver.default/repo/org1/repo5": true
+   "fakegitserver.default/repo/some/org/gangway-test-repo-1": true
+
+# Allowlist of Prow API clients.
+gangway:
+  allowed_api_clients:
+  - gcp:
+      # This translates to the expected `x-endpoint-api-consumer-type` HTTP
+      # metadata header.
+      endpoint_api_consumer_type: "PROJECT"
+      # This translates to the expected `x-endpoint-api-consumer-number` HTTP
+      # metadata header.
+      endpoint_api_consumer_number: "123"
+
+    # We don't want this client to be able to trigger *all* jobs. So instead we
+    # limit its scope to only certain jobs defined for specific subsets of jobs.
+    allowed_jobs_filters:
+    - tenant_id: "well-behaved-tenant-for-gangway"

--- a/prow/test/integration/config/prow/jobs/periodics.yaml
+++ b/prow/test/integration/config/prow/jobs/periodics.yaml
@@ -1,0 +1,16 @@
+periodics:
+- name: trigger-mainconfig-periodic-via-gangway1
+  cron: "00 00 31 2 1" # cron is Feb 31 (never)
+  decorate: true
+  prowjob_defaults:
+    tenant_id: "well-behaved-tenant-for-gangway"
+  spec:
+    containers:
+    - image: localhost:5001/alpine
+      command:
+      - sh
+      args:
+      - -c
+      - |
+        set -eu
+        echo "hello from main config periodic"

--- a/prow/test/integration/lib.sh
+++ b/prow/test/integration/lib.sh
@@ -59,6 +59,7 @@ declare -rA PROW_IMAGES=(
   # Actual Prow components.
   [crier]=prow/cmd/crier
   [deck]=prow/cmd/deck
+  [gangway]=prow/cmd/gangway
   [gerrit]=prow/cmd/gerrit
   [hook]=prow/cmd/hook
   [horologium]=prow/cmd/horologium
@@ -87,6 +88,7 @@ declare -rA PROW_IMAGES=(
 declare -rA PROW_IMAGES_TO_COMPONENTS=(
   [crier]=crier
   [deck]="deck,deck-tenanted"
+  [gangway]=gangway
   [gerrit]=gerrit
   [hook]=hook
   [horologium]=horologium
@@ -233,6 +235,14 @@ declare -ra PROW_DEPLOYMENT_ORDER=(
   WAIT_FOR_RESOURCE_clusterrolebindings,webhook-server,default
   WAIT_FOR_RESOURCE_serviceaccounts,webhook-server,default
   WAIT_webhook-server
+
+  gangway_rbac.yaml
+  gangway_service.yaml
+  gangway_deployment.yaml
+  WAIT_FOR_RESOURCE_roles,gangway,default
+  WAIT_FOR_RESOURCE_rolebindings,gangway,default
+  WAIT_FOR_RESOURCE_serviceaccounts,gangway,default
+  WAIT_gangway
 
   sub.yaml
   WAIT_FOR_RESOURCE_roles,sub,default

--- a/prow/test/integration/setup-kind-cluster.sh
+++ b/prow/test/integration/setup-kind-cluster.sh
@@ -138,6 +138,9 @@ nodes:
   - containerPort: 443
     hostPort: 443
     protocol: TCP
+  - containerPort: 32000
+    hostPort: 32000
+    protocol: TCP
   - containerPort: ${fakepubsub_node_port}
     hostPort: ${fakepubsub_node_port}
     protocol: TCP

--- a/prow/test/integration/test/gangway_test.go
+++ b/prow/test/integration/test/gangway_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/gangway"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/test/integration/internal/fakegitserver"
+)
+
+// TestGangway makes gRPC calls to gangway.
+func TestGangway(t *testing.T) {
+	t.Parallel()
+
+	const (
+		UidLabel         = "integration-test/uid"
+		ProwJobDecorated = `
+presubmits:
+  - name: trigger-inrepoconfig-presubmit-via-gangway%s
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - image: localhost:5001/alpine
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -eu
+          echo "hello from trigger-inrepoconfig-presubmit-via-gangway-repo%s"
+          cat README.txt
+`
+	)
+
+	// createGerritRepo creates Gerrit-style Git refs for changes (PRs). The
+	// revision is always named "refs/changes/00/123/1" where 123 is the change
+	// number (PR number) and 1 is the first revision (version) of the same
+	// change.
+	CreateRepo1 := createGerritRepo("TestGangway1", fmt.Sprintf(ProwJobDecorated, "1", "1"))
+
+	tests := []struct {
+		name       string
+		repoSetups []fakegitserver.RepoSetup
+		metadata   []string
+		msg        *gangway.CreateJobExecutionRequest
+		want       string
+	}{
+		{
+			name: "inrepoconfig-presubmit",
+			repoSetups: []fakegitserver.RepoSetup{
+				{
+					Name:      "some/org/gangway-test-repo-1",
+					Script:    CreateRepo1,
+					Overwrite: true,
+				},
+			},
+			metadata: []string{
+				"x-endpoint-api-consumer-type", "PROJECT",
+				"x-endpoint-api-consumer-number", "123"},
+			msg: &gangway.CreateJobExecutionRequest{
+				JobName:          "trigger-inrepoconfig-presubmit-via-gangway1",
+				JobExecutionType: gangway.JobExecutionType_PRESUBMIT,
+				// Define where the job definition lives from inrepoconfig.
+				Refs: &gangway.Refs{
+					Org:      "https://fakegitserver.default/repo/some/org",
+					Repo:     "gangway-test-repo-1",
+					CloneUri: "https://fakegitserver.default/repo/some/org/gangway-test-repo-1",
+					BaseRef:  "master",
+					BaseSha:  "f1267354a7bbc5ce7d0458cdf4d0d36e8d35d8b3",
+					Pulls: []*gangway.Pull{
+						{
+							Number: 1,
+							Sha:    "458b96a96a74689447530035f5a71c426bacb505",
+						},
+					},
+				},
+				PodSpecOptions: &gangway.PodSpecOptions{
+					Envs: map[string]string{
+						"FOO_VAR": "value-of-foo-var",
+					},
+					Labels: map[string]string{
+						kube.GerritRevision: "123",
+					},
+					Annotations: map[string]string{
+						"foo_annotation": "value-of-foo-annotation",
+					},
+				},
+			},
+			want: `hello from trigger-inrepoconfig-presubmit-via-gangway-repo1
+this-is-from-repoTestGangway1
+`,
+		},
+		{
+			name: "mainconfig-periodic",
+			metadata: []string{
+				"x-endpoint-api-consumer-type", "PROJECT",
+				"x-endpoint-api-consumer-number", "123"},
+			msg: &gangway.CreateJobExecutionRequest{
+				JobName:          "trigger-mainconfig-periodic-via-gangway1",
+				JobExecutionType: gangway.JobExecutionType_PERIODIC,
+				PodSpecOptions: &gangway.PodSpecOptions{
+					Envs: map[string]string{
+						"FOO_VAR": "value-of-foo-var",
+					},
+					Labels: map[string]string{
+						kube.GerritRevision: "123",
+					},
+					Annotations: map[string]string{
+						"foo_annotation": "value-of-foo-annotation",
+					},
+				},
+			},
+			want: `hello from main config periodic
+`,
+		},
+	}
+
+	// Ensure that all repos are named uniquely, because otherwise they clobber
+	// each other when we create them against fakegitserver. This prevents
+	// programmer error when writing new tests.
+	allRepoDirs := []string{}
+	for _, tt := range tests {
+		for _, repoSetup := range tt.repoSetups {
+
+			allRepoDirs = append(allRepoDirs, repoSetup.Name)
+		}
+	}
+	if err := enforceUniqueRepoDirs(allRepoDirs); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Set up a connection to gangway.
+			conn, err := grpc.Dial(":32000", grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				log.Fatalf("did not connect: %v", err)
+			}
+			defer conn.Close()
+
+			prowClient := gangway.NewProwClient(conn)
+
+			ctx := context.Background()
+			ctx = metadata.NewOutgoingContext(
+				ctx,
+				metadata.Pairs(tt.metadata...),
+			)
+
+			var prowjob prowjobv1.ProwJob
+			var prowjobList prowjobv1.ProwJobList
+			var podName *string
+
+			clusterContext := getClusterContext()
+			t.Logf("Creating client for cluster: %s", clusterContext)
+
+			restConfig, err := NewRestConfig("", clusterContext)
+			if err != nil {
+				t.Fatalf("could not create restConfig: %v", err)
+			}
+
+			clientset, err := kubernetes.NewForConfig(restConfig)
+			if err != nil {
+				t.Fatalf("could not create Clientset: %v", err)
+			}
+
+			kubeClient, err := ctrlruntimeclient.New(restConfig, ctrlruntimeclient.Options{})
+			if err != nil {
+				t.Fatalf("Failed creating clients for cluster %q: %v", clusterContext, err)
+			}
+
+			// Set up repos on FGS for just this test case.
+			fgsClient := fakegitserver.NewClient("http://localhost/fakegitserver", 5*time.Second)
+			for _, repoSetup := range tt.repoSetups {
+				err := fgsClient.SetupRepo(repoSetup)
+				if err != nil {
+					t.Fatalf("FGS repo setup failed: %v", err)
+				}
+			}
+
+			// Create a unique test case ID (UID) for this particular test
+			// invocation. This makes it easier to check from this code whether
+			// sub actually received the exact same message we just published.
+			uid := RandomString(t)
+			tt.msg.PodSpecOptions.Labels = make(map[string]string)
+			tt.msg.PodSpecOptions.Labels[UidLabel] = uid
+
+			// Use Prow API to create the job through gangway. This is a gRPC
+			// call.
+			jobExecution, err := prowClient.CreateJobExecution(ctx, tt.msg)
+			if err != nil {
+				t.Fatalf("Failed to create job execution: %v", err)
+			}
+			fmt.Println(jobExecution)
+
+			// We expect the job to have succeeded. This is mostly copy/pasted
+			// from the pod-utils_test.go file next to this file.
+			//
+			// Testing that the job has succeeded is useful because if there are
+			// any refs defined, those refs need to be cloned as well. So it
+			// tests more components (clonerefs, initupload, etc). In this
+			// sense, the tests here can be thought of as a superset of the
+			// TestClonerefs test in pod-utils_test.go.
+			expectJobSuccess := func() (bool, error) {
+				err = kubeClient.List(ctx, &prowjobList, ctrlruntimeclient.MatchingLabels{"integration-test/uid": uid})
+				if err != nil {
+					t.Logf("failed getting prow job with label: %s", uid)
+					return false, nil
+				}
+				if len(prowjobList.Items) != 1 {
+					t.Logf("unexpected number of matching prow jobs: %d", len(prowjobList.Items))
+					return false, nil
+				}
+				prowjob = prowjobList.Items[0]
+				// The pod name should match the job name (this is another UID,
+				// distinct from the uid we generated above).
+				podName = &prowjob.Name
+				switch prowjob.Status.State {
+				case prowjobv1.SuccessState:
+					got, err := getPodLogs(clientset, "test-pods", *podName, &coreapi.PodLogOptions{Container: "test"})
+					if err != nil {
+						t.Errorf("failed getting logs for clonerefs")
+						return false, nil
+					}
+					if diff := cmp.Diff(got, tt.want); diff != "" {
+						return false, fmt.Errorf("actual logs differ from expected: %s", diff)
+					}
+					return true, nil
+				case prowjobv1.FailureState:
+					return false, fmt.Errorf("possible programmer error: prow job %s failed", *podName)
+				default:
+					return false, nil
+				}
+			}
+
+			// This is also mostly copy/pasted from pod-utils_test.go. The logic
+			// here deals with the case where the test fails (where we want to
+			// log as much as possible to make it easier to see why a test
+			// failed), or when the test succeeds (where we clean up the ProwJob
+			// that was created by sub).
+			timeout := 120 * time.Second
+			pollInterval := 500 * time.Millisecond
+			if waitErr := wait.Poll(pollInterval, timeout, expectJobSuccess); waitErr != nil {
+				if podName == nil {
+					t.Fatal("could not find test pod")
+				}
+				// Retrieve logs from clonerefs.
+				podLogs, err := getPodLogs(clientset, "test-pods", *podName, &coreapi.PodLogOptions{Container: "clonerefs"})
+				if err != nil {
+					t.Errorf("failed getting logs for clonerefs")
+				}
+				t.Logf("logs for clonerefs:\n\n%s\n\n", podLogs)
+
+				// If we got an error, show the failing prow job's test
+				// container (our test case's "got" and "expected" shell code).
+				pjPod := &coreapi.Pod{}
+				err = kubeClient.Get(ctx, ctrlruntimeclient.ObjectKey{
+					Namespace: "test-pods",
+					Name:      *podName,
+				}, pjPod)
+				if err != nil {
+					t.Errorf("failed getting prow job's pod %v; unable to determine why the test failed", *podName)
+					t.Error(err)
+					t.Fatal(waitErr)
+				}
+				// Error messages from clonerefs, initupload, entrypoint, or sidecar.
+				for _, containerStatus := range pjPod.Status.InitContainerStatuses {
+					terminated := containerStatus.State.Terminated
+					if terminated != nil && len(terminated.Message) > 0 {
+						t.Errorf("InitContainer %q: %s", containerStatus.Name, terminated.Message)
+					}
+				}
+				// Error messages from the test case's shell script (showing the
+				// git SHAs that we expected vs what we got).
+				for _, containerStatus := range pjPod.Status.ContainerStatuses {
+					terminated := containerStatus.State.Terminated
+					if terminated != nil && len(terminated.Message) > 0 {
+						t.Errorf("Container %s: %s", containerStatus.Name, terminated.Message)
+					}
+				}
+
+				t.Fatal(waitErr)
+			} else {
+				// Only clean up the ProwJob if it succeeded (save the ProwJob for debugging if it failed).
+				t.Cleanup(func() {
+					if err := kubeClient.Delete(ctx, &prowjob); err != nil {
+						t.Logf("Failed cleanup resource %q: %v", prowjob.Name, err)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
This includes integration tests to check that the business logic works. As it stands, this server is not intended to be exposed directly to the world, but rather behind a proxy that can handle TLS termination.

This implementation handles graceful shutdown and also serves basic (default) metrics regarding gRPC requests using the github.com/grpc-ecosystem/go-grpc-prometheus library.