### PR TITLE
Capture CCM logs from tests.

### DIFF
--- a/kubetest/dump.go
+++ b/kubetest/dump.go
@@ -63,6 +63,7 @@ func newLogDumper(sshClientFactory sshClientFactory, artifactsDir string) (*logD
 		"kube-apiserver",
 		"kube-scheduler",
 		"rescheduler",
+		"cloud-controller-manager",
 		"kube-controller-manager",
 		"kops-controller",
 		"etcd",

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -41,7 +41,7 @@ readonly master_ssh_supported_providers="gce aws"
 readonly node_ssh_supported_providers="gce gke aws"
 readonly gcloud_supported_providers="gce gke"
 
-readonly master_logfiles="kube-apiserver.log kube-apiserver-audit.log kube-scheduler.log kube-controller-manager.log etcd.log etcd-events.log glbc.log cluster-autoscaler.log kube-addon-manager.log konnectivity-server.log fluentd.log kubelet.cov"
+readonly master_logfiles="kube-apiserver.log kube-apiserver-audit.log kube-scheduler.log cloud-controller-manager.log kube-controller-manager.log etcd.log etcd-events.log glbc.log cluster-autoscaler.log kube-addon-manager.log konnectivity-server.log fluentd.log kubelet.cov"
 readonly node_logfiles="kube-proxy.log containers/konnectivity-agent-*.log fluentd.log node-problem-detector.log kubelet.cov"
 readonly node_systemd_services="node-problem-detector"
 readonly hollow_node_logfiles="kubelet-hollow-node-*.log kubeproxy-hollow-node-*.log npd-hollow-node-*.log"


### PR DESCRIPTION
We are migrating to cloud provider code running in the CCM. It should no longer be running in the KCM, KAS or Kubelet. Several of our tests now run the CCM as a result.
We are also trying to make more of the tests run the CCM. However our current test runs do not capture the logs of the CCM.