### PR TITLE
Adding a Windows period job that runs e2e tests using windows-service-proxy instead of in-tree kube-proxy

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -456,3 +456,48 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master
+- name: ci-kubernetes-e2e-capz-master-windows-service-proxy
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  # Use Mark's fork/branch until image building issues are resolved
+  - org: marosset
+    repo: cluster-api-provider-azure
+    base_ref: windows-service-proxy
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230126-4c28746697-master
+        command:
+          - "runner.sh"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: WINDOWS_SERVER_VERSION
+            value: "windows-2022"
+          - name: CLUSTER_TEMPLATE
+            value: "test/ci/cluster-template-prow-windows-kpng.yaml"
+          - name: WINDOWS_CONTAINERD_URL
+            value: "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz"
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: capz-master-windows-service-proxy


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

/assign @jsturtevant @knabben 

The branch I'm using for the periodic job is the PR branch for https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3098

I'm trying to resolve issues with pushing images to the K8s staging repo which is required before that PR can merge.