### PR TITLE
sub: refactor to use gangway

### DIFF
--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -19,7 +19,6 @@ package subscriber
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -27,15 +26,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowcrd "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/kube"
-	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/gangway"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -45,24 +40,11 @@ const (
 	PostsubmitProwJobEvent = "prow.k8s.io/pubsub.PostsubmitProwJobEvent"
 )
 
-// Ensure interface is intact. I.e., this declaration ensures that the type
-// "*config.Config" implements the "prowCfgClient" interface. See
-// https://golang.org/doc/faq#guarantee_satisfies_interface.
-var _ prowCfgClient = (*config.Config)(nil)
-
-// prowCfgClient is a subset of all the various behaviors that the
-// "*config.Config" type implements, which we will test here.
-type prowCfgClient interface {
-	AllPeriodics() []config.Periodic
-	GetPresubmitsStatic(identifier string) []config.Presubmit
-	GetPostsubmitsStatic(identifier string) []config.Postsubmit
-}
-
 // ProwJobEvent contains the minimum information required to start a ProwJob.
 type ProwJobEvent struct {
 	Name string `json:"name"`
 	// Refs are used by presubmit and postsubmit jobs supplying baseSHA and SHA
-	Refs        *v1.Refs          `json:"refs,omitempty"`
+	Refs        *prowcrd.Refs     `json:"refs,omitempty"`
 	Envs        map[string]string `json:"envs,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
@@ -98,7 +80,7 @@ func (pe *ProwJobEvent) ToMessageOfType(t string) (*pubsub.Message, error) {
 
 // ProwJobClient mostly for testing.
 type ProwJobClient interface {
-	Create(context.Context, *prowapi.ProwJob, metav1.CreateOptions) (*prowapi.ProwJob, error)
+	Create(context.Context, *prowcrd.ProwJob, metav1.CreateOptions) (*prowcrd.ProwJob, error)
 }
 
 // Subscriber handles Pub/Sub subscriptions, update metrics,
@@ -121,8 +103,8 @@ type messageInterface interface {
 }
 
 type reportClient interface {
-	Report(ctx context.Context, log *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, *reconcile.Result, error)
-	ShouldReport(ctx context.Context, log *logrus.Entry, pj *prowapi.ProwJob) bool
+	Report(ctx context.Context, log *logrus.Entry, pj *prowcrd.ProwJob) ([]*prowcrd.ProwJob, *reconcile.Result, error)
+	ShouldReport(ctx context.Context, log *logrus.Entry, pj *prowcrd.ProwJob) bool
 }
 
 type pubSubMessage struct {
@@ -148,215 +130,6 @@ func (m *pubSubMessage) nack() {
 	m.Message.Nack()
 }
 
-// jobHandler handles job type specific logic
-type jobHandler interface {
-	getProwJobSpec(cfg prowCfgClient, pc *config.InRepoConfigCacheHandler, pe ProwJobEvent) (jobSpec *v1.ProwJobSpec, labels map[string]string, annotations map[string]string, err error)
-}
-
-// periodicJobHandler implements jobHandler
-type periodicJobHandler struct{}
-
-func (peh *periodicJobHandler) getProwJobSpec(cfg prowCfgClient, pc *config.InRepoConfigCacheHandler, pe ProwJobEvent) (jobSpec *v1.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
-	var periodicJob *config.Periodic
-	// TODO(chaodaiG): do we want to support inrepoconfig when
-	// https://github.com/kubernetes/test-infra/issues/21729 is done?
-	for _, job := range cfg.AllPeriodics() {
-		if job.Name == pe.Name {
-			// Directly followed by break, so this is ok
-			// nolint: exportloopref
-			periodicJob = &job
-			break
-		}
-	}
-	if periodicJob == nil {
-		err = fmt.Errorf("failed to find associated periodic job %q", pe.Name)
-		return
-	}
-
-	spec := pjutil.PeriodicSpec(*periodicJob)
-	jobSpec = &spec
-	labels, annotations = periodicJob.Labels, periodicJob.Annotations
-	return
-}
-
-// presubmitJobHandler implements jobHandler
-type presubmitJobHandler struct {
-}
-
-func (prh *presubmitJobHandler) getProwJobSpec(cfg prowCfgClient, pc *config.InRepoConfigCacheHandler, pe ProwJobEvent) (jobSpec *v1.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
-	// presubmit jobs require Refs and Refs.Pulls to be set
-	refs := pe.Refs
-	if refs == nil {
-		err = errors.New("Refs must be supplied")
-		return
-	}
-	if len(refs.Org) == 0 {
-		err = errors.New("org must be supplied")
-		return
-	}
-	if len(refs.Repo) == 0 {
-		err = errors.New("repo must be supplied")
-		return
-	}
-	if len(refs.Pulls) == 0 {
-		err = errors.New("at least 1 Pulls is required")
-		return
-	}
-	if len(refs.BaseSHA) == 0 {
-		err = errors.New("baseSHA must be supplied")
-		return
-	}
-	if len(refs.BaseRef) == 0 {
-		err = errors.New("baseRef must be supplied")
-		return
-	}
-
-	var presubmitJob *config.Presubmit
-	org, repo, branch := refs.Org, refs.Repo, refs.BaseRef
-	orgRepo := org + "/" + repo
-	// Add "https://" prefix to orgRepo if this is a gerrit job.
-	// (Unfortunately gerrit jobs use the full repo URL as the identifier.)
-	prefix := "https://"
-	if pe.Labels[kube.GerritRevision] != "" && !strings.HasPrefix(orgRepo, prefix) {
-		orgRepo = prefix + orgRepo
-	}
-	baseSHAGetter := func() (string, error) {
-		return refs.BaseSHA, nil
-	}
-	var headSHAGetters []func() (string, error)
-	for _, pull := range refs.Pulls {
-		pull := pull
-		headSHAGetters = append(headSHAGetters, func() (string, error) {
-			return pull.SHA, nil
-		})
-	}
-
-	logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch, "orgRepo": orgRepo})
-	// Get presubmits from Config alone.
-	presubmits := cfg.GetPresubmitsStatic(orgRepo)
-	// If InRepoConfigCache is provided, then it means that we also want to fetch
-	// from an inrepoconfig.
-	if pc != nil {
-		logger.Debug("Getting prow jobs.")
-		var presubmitsWithInrepoconfig []config.Presubmit
-		var err error
-		presubmitsWithInrepoconfig, err = pc.GetPresubmits(orgRepo, baseSHAGetter, headSHAGetters...)
-		if err != nil {
-			logger.WithError(err).Info("Failed to get presubmits")
-		} else {
-			logger.WithField("static-jobs", len(presubmits)).WithField("jobs-with-inrepoconfig", len(presubmitsWithInrepoconfig)).Debug("Jobs found.")
-			// Overwrite presubmits. This is safe because pc.GetPresubmits()
-			// itself calls cfg.GetPresubmitsStatic() and adds to it all the
-			// presubmits found in the inrepoconfig.
-			presubmits = presubmitsWithInrepoconfig
-		}
-	}
-
-	for _, job := range presubmits {
-		job := job
-		if !job.CouldRun(branch) { // filter out jobs that are not branch matching
-			continue
-		}
-		if job.Name == pe.Name {
-			if presubmitJob != nil {
-				err = fmt.Errorf("%s matches multiple prow jobs from orgRepo %q", pe.Name, orgRepo)
-				return
-			}
-			presubmitJob = &job
-		}
-	}
-	// This also captures the case where fetching jobs from inrepoconfig failed.
-	// However doesn't not distinguish between this case and a wrong prow job name.
-	if presubmitJob == nil {
-		err = fmt.Errorf("failed to find associated presubmit job %q from orgRepo %q", pe.Name, orgRepo)
-		return
-	}
-
-	spec := pjutil.PresubmitSpec(*presubmitJob, *refs)
-	jobSpec, labels, annotations = &spec, presubmitJob.Labels, presubmitJob.Annotations
-	return
-}
-
-// postsubmitJobHandler implements jobHandler
-type postsubmitJobHandler struct {
-}
-
-func (poh *postsubmitJobHandler) getProwJobSpec(cfg prowCfgClient, pc *config.InRepoConfigCacheHandler, pe ProwJobEvent) (jobSpec *v1.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
-	// postsubmit jobs require Refs to be set
-	refs := pe.Refs
-	if refs == nil {
-		err = errors.New("refs must be supplied")
-		return
-	}
-	if len(refs.Org) == 0 {
-		err = errors.New("org must be supplied")
-		return
-	}
-	if len(refs.Repo) == 0 {
-		err = errors.New("repo must be supplied")
-		return
-	}
-	if len(refs.BaseSHA) == 0 {
-		err = errors.New("baseSHA must be supplied")
-		return
-	}
-	if len(refs.BaseRef) == 0 {
-		err = errors.New("baseRef must be supplied")
-		return
-	}
-
-	var postsubmitJob *config.Postsubmit
-	org, repo, branch := refs.Org, refs.Repo, refs.BaseRef
-	orgRepo := org + "/" + repo
-	// Add "https://" prefix to orgRepo if this is a gerrit job.
-	// (Unfortunately gerrit jobs use the full repo URL as the identifier.)
-	prefix := "https://"
-	if pe.Labels[kube.GerritRevision] != "" && !strings.HasPrefix(orgRepo, prefix) {
-		orgRepo = prefix + orgRepo
-	}
-	baseSHAGetter := func() (string, error) {
-		return refs.BaseSHA, nil
-	}
-
-	logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch, "orgRepo": orgRepo})
-	postsubmits := cfg.GetPostsubmitsStatic(orgRepo)
-	if pc != nil {
-		logger.Debug("Getting prow jobs.")
-		var postsubmitsWithInrepoconfig []config.Postsubmit
-		var err error
-		postsubmitsWithInrepoconfig, err = pc.GetPostsubmits(orgRepo, baseSHAGetter)
-		if err != nil {
-			logger.WithError(err).Info("Failed to get postsubmits from inrepoconfig")
-		} else {
-			logger.WithField("static-jobs", len(postsubmits)).WithField("jobs-with-inrepoconfig", len(postsubmitsWithInrepoconfig)).Debug("Jobs found.")
-			postsubmits = postsubmitsWithInrepoconfig
-		}
-	}
-
-	for _, job := range postsubmits {
-		job := job
-		if !job.CouldRun(branch) { // filter out jobs that are not branch matching
-			continue
-		}
-		if job.Name == pe.Name {
-			if postsubmitJob != nil {
-				return nil, nil, nil, fmt.Errorf("%s matches multiple prow jobs from orgRepo %q", pe.Name, orgRepo)
-			}
-			postsubmitJob = &job
-		}
-	}
-	// This also captures the case where fetching jobs from inrepoconfig failed.
-	// However doesn't not distinguish between this case and a wrong prow job name.
-	if postsubmitJob == nil {
-		err = fmt.Errorf("failed to find associated postsubmit job %q from orgRepo %q", pe.Name, orgRepo)
-		return
-	}
-
-	spec := pjutil.PostsubmitSpec(*postsubmitJob, *refs)
-	jobSpec, labels, annotations = &spec, postsubmitJob.Labels, postsubmitJob.Annotations
-	return
-}
-
 func extractFromAttribute(attrs map[string]string, key string) (string, error) {
 	value, ok := attrs[key]
 	if !ok {
@@ -365,48 +138,40 @@ func extractFromAttribute(attrs map[string]string, key string) (string, error) {
 	return value, nil
 }
 
-func (s *Subscriber) handleMessage(msg messageInterface, subscription string, allowedClusters []string) error {
-	// Observed message payload drifts to the payload from another pubsub
-	// message and couldn't figure out why. Extracts the values ahead of time
-	// and hopefully could mitigate this issue for now.
-	// TODO(chaodaiG): remove these once figured out the root cause of data race.
-	msgID := msg.getID()
-	msgPayload := msg.getPayload()
-	msgAttributes := msg.getAttributes()
+func (s *Subscriber) getReporterFunc(l *logrus.Entry) gangway.ReporterFunc {
+	return func(pj *prowcrd.ProwJob, state prowcrd.ProwJobState, err error) {
+		pj.Status.State = state
+		pj.Status.Description = "Successfully triggered prowjob."
+		if err != nil {
+			pj.Status.Description = fmt.Sprintf("Failed creating prowjob: %v", err)
+		}
+		if s.Reporter.ShouldReport(context.TODO(), l, pj) {
+			if _, _, err := s.Reporter.Report(context.TODO(), l, pj); err != nil {
+				l.WithError(err).Warning("Failed to report status.")
+			}
+		}
+	}
+}
 
+func (s *Subscriber) handleMessage(msg messageInterface, subscription string, allowedClusters []string) error {
+
+	msgID := msg.getID()
 	l := logrus.WithFields(logrus.Fields{
 		"pubsub-subscription": subscription,
 		"pubsub-id":           msgID})
-	s.Metrics.MessageCounter.With(prometheus.Labels{subscriptionLabel: subscription}).Inc()
 
-	l.WithField("payload", string(msgPayload)).Debug("Received message")
-	eType, err := extractFromAttribute(msgAttributes, ProwEventType)
+	// First, convert the incoming message into a CreateJobExecutionRequest type.
+	cjer, err := s.msgToCjer(l, msg, subscription)
 	if err != nil {
-		l.WithError(err).Error("failed to read message")
-		s.Metrics.ErrorCounter.With(prometheus.Labels{
-			subscriptionLabel: subscription,
-			errorTypeLabel:    "malformed-message",
-		}).Inc()
 		return err
 	}
 
-	var jh jobHandler
-	switch eType {
-	case PeriodicProwJobEvent:
-		jh = &periodicJobHandler{}
-	case PresubmitProwJobEvent:
-		jh = &presubmitJobHandler{}
-	case PostsubmitProwJobEvent:
-		jh = &postsubmitJobHandler{}
-	default:
-		l.WithField("type", eType).Info("Unsupported event type")
-		s.Metrics.ErrorCounter.With(prometheus.Labels{
-			subscriptionLabel: subscription,
-			errorTypeLabel:    "unsupported-event-type",
-		}).Inc()
-		return fmt.Errorf("unsupported event type: %s", eType)
-	}
-	if err = s.handleProwJob(l, jh, msgPayload, subscription, eType, allowedClusters); err != nil {
+	// Do not check for HTTP client authorization, because we're handling a
+	// PubSub message.
+	var allowedApiClient *config.AllowedApiClient = nil
+	var requireTenantID bool = false
+
+	if _, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigCacheHandler, allowedApiClient, requireTenantID, allowedClusters); err != nil {
 		l.WithError(err).Info("failed to create Prow Job")
 		s.Metrics.ErrorCounter.With(prometheus.Labels{
 			subscriptionLabel: subscription,
@@ -422,116 +187,92 @@ func (s *Subscriber) handleMessage(msg messageInterface, subscription string, al
 	return err
 }
 
-func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msgPayload []byte, subscription, eType string, allowedClusters []string) error {
+// msgToCjer converts an incoming message (PubSub message) into a CJER. It
+// actually does 2 conversions --- from the message to ProwJobEvent (in order to
+// unmarshal the raw bytes) then again from ProwJobEvent to a CJER.
+func (s *Subscriber) msgToCjer(l *logrus.Entry, msg messageInterface, subscription string) (*gangway.CreateJobExecutionRequest, error) {
+	msgAttributes := msg.getAttributes()
+	msgPayload := msg.getPayload()
 
+	l.WithField("payload", string(msgPayload)).Debug("Received message")
+	s.Metrics.MessageCounter.With(prometheus.Labels{subscriptionLabel: subscription}).Inc()
+
+	// Note that a CreateJobExecutionRequest is a superset of ProwJobEvent.
+	// However we still use ProwJobEvent here because we want to use the
+	// existing jobHandlers to fetch the prowJobSpec (and the jobHandlers expect
+	// a ProwJobEvent as an argument).
 	var pe ProwJobEvent
-	var prowJob prowapi.ProwJob
 
+	// We use ProwJobEvent here mainly to ensrue that the incoming payload
+	// (JSON) is well-formed. We convert it into a CreateJobExecutionRequest
+	// type here and never use it anywhere else.
 	l.WithField("raw-payload", string(msgPayload)).Debug("Raw payload passed in handleProwJob.")
 	if err := pe.FromPayload(msgPayload); err != nil {
-		return err
+		return nil, err
 	}
 
-	l.WithField("prowjob-event", pe).Debug("ProwjobEvent unmarshalled.")
-	reportProwJob := func(pj *prowapi.ProwJob, state v1.ProwJobState, err error) {
-		pj.Status.State = state
-		pj.Status.Description = "Successfully triggered prowjob."
-		if err != nil {
-			pj.Status.Description = fmt.Sprintf("Failed creating prowjob: %v", err)
-		}
-		if s.Reporter.ShouldReport(context.TODO(), l, pj) {
-			if _, _, err := s.Reporter.Report(context.TODO(), l, pj); err != nil {
-				l.WithError(err).Warning("Failed to report status.")
-			}
-		}
-	}
-
-	reportProwJobFailure := func(pj *prowapi.ProwJob, err error) {
-		reportProwJob(pj, prowapi.ErrorState, err)
-	}
-
-	reportProwJobTriggered := func(pj *prowapi.ProwJob) {
-		reportProwJob(pj, prowapi.TriggeredState, nil)
-	}
-
-	// Normalize job name
-	pe.Name = strings.TrimSpace(pe.Name)
-
-	prowJobSpec, labels, annotations, err := jh.getProwJobSpec(s.ConfigAgent.Config(), s.InRepoConfigCacheHandler, pe)
+	eType, err := extractFromAttribute(msgAttributes, ProwEventType)
 	if err != nil {
-		// These are user errors, i.e. missing fields, requested prowjob doesn't exist etc.
-		// These errors are already surfaced to user via pubsub two lines below.
-		l.WithError(err).WithField("name", pe.Name).Info("Failed getting prowjob spec")
-		prowJob = pjutil.NewProwJob(prowapi.ProwJobSpec{}, nil, pe.Annotations)
-		reportProwJobFailure(&prowJob, err)
-		return err
-	}
-	if prowJobSpec == nil {
-		return fmt.Errorf("failed getting prowjob spec") // This should not happen
+		l.WithError(err).Error("failed to read message")
+		s.Metrics.ErrorCounter.With(prometheus.Labels{
+			subscriptionLabel: subscription,
+			errorTypeLabel:    "malformed-message",
+		}).Inc()
+		return nil, err
 	}
 
-	// Copy labels and annotations instead of modifying them, they are pointers
-	// to the static prowjobs labels and annotations.
-	combinedLabels := make(map[string]string)
-	combinedAnnotations := make(map[string]string)
-	for k, v := range labels {
-		combinedLabels[k] = v
-	}
-	for k, v := range annotations {
-		combinedAnnotations[k] = v
+	return s.peToCjer(l, &pe, eType, subscription)
+}
+
+func (s *Subscriber) peToCjer(l *logrus.Entry, pe *ProwJobEvent, eType, subscription string) (*gangway.CreateJobExecutionRequest, error) {
+
+	cjer := gangway.CreateJobExecutionRequest{
+		JobName: strings.TrimSpace(pe.Name),
 	}
 
-	l.WithField("prowjob-event", pe).WithField("annotations", combinedAnnotations).Debug("ProwjobEvent and annotations after getProwJobSpec.")
+	// First encode the job type.
+	switch eType {
+	case PeriodicProwJobEvent:
+		cjer.JobExecutionType = gangway.JobExecutionType_PERIODIC
+	case PresubmitProwJobEvent:
+		cjer.JobExecutionType = gangway.JobExecutionType_PRESUBMIT
+	case PostsubmitProwJobEvent:
+		cjer.JobExecutionType = gangway.JobExecutionType_POSTSUBMIT
+	default:
+		l.WithField("type", eType).Info("Unsupported event type")
+		s.Metrics.ErrorCounter.With(prometheus.Labels{
+			subscriptionLabel: subscription,
+			errorTypeLabel:    "unsupported-event-type",
+		}).Inc()
+		return nil, fmt.Errorf("unsupported event type: %s", eType)
+	}
 
-	// Adds / Updates Labels from prow job event
+	pso := gangway.PodSpecOptions{}
+	pso.Labels = make(map[string]string)
 	for k, v := range pe.Labels {
-		combinedLabels[k] = v
+		pso.Labels[k] = v
 	}
+
+	pso.Annotations = make(map[string]string)
 	for k, v := range pe.Annotations {
-		combinedAnnotations[k] = v
+		pso.Annotations[k] = v
 	}
 
-	// deny job that runs on not allowed cluster
-	var clusterIsAllowed bool
-	for _, allowedCluster := range allowedClusters {
-		if allowedCluster == "*" || allowedCluster == prowJobSpec.Cluster {
-			clusterIsAllowed = true
-			break
-		}
-	}
-	// This is a user error, not sure whether we want to return error here.
-	if !clusterIsAllowed {
-		err := fmt.Errorf("cluster %s is not allowed. Can be fixed by defining this cluster under pubsub_triggers -> allowed_clusters", prowJobSpec.Cluster)
-		l.WithField("cluster", prowJobSpec.Cluster).Warn("cluster not allowed")
-		prowJob = pjutil.NewProwJob(*prowJobSpec, nil, pe.Annotations)
-		reportProwJobFailure(&prowJob, err)
-		return err
+	pso.Envs = make(map[string]string)
+	for k, v := range pe.Envs {
+		pso.Envs[k] = v
 	}
 
-	l.WithField("prowjob-event", pe).WithField("annotations", combinedAnnotations).WithField("prowjob-annotations", prowJob.Annotations).Debug("ProwjobEvent and annotations before pjutil.NewProwJob.")
-	// Adds annotations
-	prowJob = pjutil.NewProwJob(*prowJobSpec, combinedLabels, combinedAnnotations)
-	// Adds / Updates Environments to containers
-	if prowJob.Spec.PodSpec != nil {
-		for i, c := range prowJob.Spec.PodSpec.Containers {
-			for k, v := range pe.Envs {
-				c.Env = append(c.Env, coreapi.EnvVar{Name: k, Value: v})
-			}
-			prowJob.Spec.PodSpec.Containers[i].Env = c.Env
+	cjer.PodSpecOptions = &pso
+
+	var err error
+
+	if pe.Refs != nil {
+		cjer.Refs, err = gangway.FromCrdRefs(pe.Refs)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	l.WithField("prowjob-event", pe).WithField("annotations", combinedAnnotations).WithField("prowjob-annotations", prowJob.Annotations).Debug("ProwjobEvent and annotations before creating prowjob.")
-	if _, err := s.ProwJobClient.Create(context.TODO(), &prowJob, metav1.CreateOptions{}); err != nil {
-		l.WithError(err).Errorf("failed to create job %q as %q", pe.Name, prowJob.Name)
-		reportProwJobFailure(&prowJob, err)
-		return err
-	}
-	l.WithFields(logrus.Fields{
-		"job":                 pe.Name,
-		"name":                prowJob.Name,
-		"prowjob-annotations": prowJob.Annotations,
-	}).Info("Job created.")
-	reportProwJobTriggered(&prowJob)
-	return nil
+	return &cjer, nil
 }


### PR DESCRIPTION
This de-duplicates logic in Sub to use Gangway's idea of a `CreateJobExecutionRequest`. It does this by converting the incoming PubSub payload into a CreateJobExecutionRequest in msgToCjer().

/cc @chaodaiG @mpherman2 