### PR TITLE
Bump master k8s version to v1.26

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.25.yaml
@@ -1,12 +1,12 @@
 # sigs.k8s.io/cluster-capacity presubmits
 presubmits:
   kubernetes-sigs/cluster-capacity:
-  - name: pull-cluster-capacity-verify-gofmt
+  - name: pull-cluster-capacity-verify-gofmt-release-1-25
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.25$
     always_run: true
     spec:
       containers:
@@ -15,12 +15,12 @@ presubmits:
         - make
         args:
         - verify-gofmt
-  - name: pull-cluster-capacity-verify-build
+  - name: pull-cluster-capacity-verify-build-release-1-25
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.25$
     always_run: true
     spec:
       containers:
@@ -29,12 +29,12 @@ presubmits:
         - make
         args:
         - build
-  - name: pull-cluster-capacity-unit-test
+  - name: pull-cluster-capacity-unit-test-release-1-25
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.25$
     always_run: true
     spec:
       containers:
@@ -43,10 +43,10 @@ presubmits:
         - make
         args:
         - test-unit
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-26
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-25-1-25
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.26
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.25-1.25
     decorate: true
     decoration_config:
       timeout: 20m
@@ -56,38 +56,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.26.0"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-25
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.25
-    decorate: true
-    decoration_config:
-      timeout: 20m
-    path_alias: sigs.k8s.io/cluster-capacity
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
+    - release-1.25
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
@@ -105,10 +74,10 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-24
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-25-1-24
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.24
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.25-1.24
     decorate: true
     decoration_config:
       timeout: 20m
@@ -118,7 +87,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
+    - release-1.25
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
@@ -128,6 +97,37 @@ presubmits:
         env:
         - name: KUBERNETES_VERSION
           value: "v1.24.4"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-25-1-23
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.25-1.23
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - release-1.25
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.23.3"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
For https://github.com/kubernetes-sigs/cluster-capacity/pull/164

https://hub.docker.com/layers/kindest/node/v1.26.0/images/sha256-3264cbae4b80c241743d12644b2506fff13dce07fcadf29079c1d06a47b399dd?context=explore