### PR TITLE
Revert "Make ipv6 pre-submits optional"

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1108,7 +1108,7 @@ def generate_presubmits_network_plugins():
                                  '--zones=us-west-2a',
                                  ],
                     run_if_changed=run_if_changed,
-                    optional=True,
+                    optional=optional,
                 )
             )
     return results

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -206,7 +206,7 @@ presubmits:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.projectcalico\.org\/|pkg\/model\/(components\/containerd|firewall|pki|iam\/iam_builder)\.go|nodeup\/pkg\/model\/networking\/calico\.go)'
     always_run: false
-    optional: true
+    optional: false
     skip_report: false
     labels:
       preset-service-account: "true"
@@ -404,7 +404,7 @@ presubmits:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.cilium\.io\/|pkg\/model\/(components\/containerd|firewall|components\/cilium|iam\/iam_builder)\.go|nodeup\/pkg\/model\/(context|networking\/cilium)\.go)'
     always_run: false
-    optional: true
+    optional: false
     skip_report: false
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
This reverts commit dbb9bc959ce058b1143c6d70b945c81a6d93e8de.

IPv6 is a beta feature. We should ensure it does not get broken.