### PR TITLE
Fix: parse prow credentials for win-soak-test jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -104,6 +104,7 @@ periodics:
             - bash
             - -c
             - >-
+              ./hack/parse-prow-creds.sh &&
               ./hack/ensure-azcli.sh &&
               az keyvault secret show
               --vault-name win-soak-test
@@ -157,7 +158,10 @@ periodics:
           command:
             - runner.sh
           args:
+            - bash
+            - -c
             - >-
+              ./hack/parse-prow-creds.sh &&
               ./hack/ensure-azcli.sh &&
               az
               group


### PR DESCRIPTION
* parse prow credentials, required for `az` cli