### PR TITLE
Ensure buildx plugin is availble in gcb-docker-gcloud image when HOME=/buidler/home

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -47,6 +47,10 @@ ENV HOME=/root
 RUN mkdir -p  $HOME/.docker/cli-plugins \
     && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.9.1/buildx-v0.9.1.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
     && chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+# Link link /root/.docker to /builder/home/.docker because the default home for cloudbuild jobs is /builder/home
+# and this will make in uncessarry for each cloudbuild.yaml file in K8s project to specify HOME=/root
+RUN mkdir -p /builder/home \
+    && ln -s /root/.docker /builder/home/.docker
 
 # Copy qemu static binaries.
 COPY --from=qemu-image /usr/bin /qemu-bin


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Cloudbuild uses `/builder/home` as the default HOME dir but the gcb-docker-gcloud image sets `HOME=/root` and installs the buildx cli plugins under `/root/docker`
This requires each contianer build+push job that wants to use buildx to override `HOME=/root` in the cloudbuild.yaml file for the job 
Ex:
https://github.com/kubernetes/ingress-nginx/blob/5628f765fe883dd8c13ccd3084e9003ffd3e28d5/images/go-grpc-greeter-server/cloudbuild.yaml#L14-L15

If we link `/root/.docker` to `/builder/home/.docker` then new jobs will no longer need to set `HOME=/root`

ex:
>docker run -it --rm gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230111-cd1b3caf9c
ee41f90653ad:/workspace# export HOME=/builder/home
ee41f90653ad:/workspace# ls
gcloud-info.txt
ee41f90653ad:/workspace# docker buildx
docker: 'buildx' is not a docker command.
See 'docker --help'

(buildx not available with HOME=/builder/home)

> ee41f90653ad:/workspace# mkdir -p /builder/home
ee41f90653ad:/workspace# ln -s /root/.docker /builder/home/.docker
ee41f90653ad:/workspace# docker buildx Usage:  docker buildx [OPTIONS] COMMAND Extended build capabilities with BuildKit Options:
      --builder string   Override the configured builder instance
Management Commands:
  imagetools  Commands to work on images in registry Commands:
  bake        Build from a file
  build       Start a build
  create      Create a new builder instance
  du          Disk usage
 
(buildx is now available)

Discussion on slack - https://kubernetes.slack.com/archives/CCK68P2Q2/p1674851724958489

/assign @dims @ameukam 