### PR TITLE
Add myself as a sig-cluster-lifecycle job approver

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/OWNERS
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - fabriziopandini
 - neolit123
 - vincepri
+- SataQiu
 emeritus_approvers:
 - luxas
 - timothysc


### PR DESCRIPTION
I'm a kubeadm approver, and folder `config/jobs/kubernetes/sig-cluster-lifecycle` holds most of the kubeadm test jobs.
I want to add myself(SataQiu) as a sig-cluster-lifecycle approver. It makes me better able to help maintain these jobs.

/cc @neolit123 @fabriziopandini 