### PR TITLE
Fix SSH Keys issue in the crio evented pleg presubmit ci job

### DIFF
--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -28,6 +28,11 @@
   "systemd": {
     "units": [
       {
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/core/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh && chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "authorized-key.service"
+      },
+      {
         "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"


### PR DESCRIPTION
Continuation of the following PR.
https://github.com/kubernetes/test-infra/pull/28508

This change copies the required authorized keys before starting the crio service.
This is a reference from the ci job that is not experiencing the Permission Denied issue.
https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign#L25-L29

Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>