### PR TITLE
Re-enable Clusterfuzzlite Demo

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -52,3 +52,118 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-broken-column-threshold: '0.5'
     description: Monitors Kettle's BigQuery database freshness.
+
+- name: test-infra-fuzz
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  interval: 1h
+  spec:
+    serviceAccountName: fuzz-test
+    containers:
+      #TODO(mpherman) : Change to versioned once stable
+    - image: gcr.io/k8s-testimages/ci_fuzz:latest
+      command:
+        - runner.sh
+      args:
+        - python3
+        - "/opt/oss-fuzz/infra/cifuzz/cifuzz_combined_entrypoint.py"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      env:
+      - name: MODE
+        value: batch
+      - name: REPO_NAME
+        value: test-infra
+      - name: SANITIZER
+        value: 'address'
+      - name: CLOUD_BUCKET
+        value: gs://prow-cifuzz-test/
+      - name: CFL_PLATFORM
+        value: prow
+  annotations:
+    testgrid-dashboards: sig-testing-misc
+    testgrid-tab-name: test-infra-fuzz
+    testgrid-broken-column-threshold: '0.5'
+    description: Runs clusterfuzzlite every hour
+
+- name: test-infra-cfl-coverage-report
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  interval: 12h
+  spec:
+    serviceAccountName: fuzz-test
+    containers:
+      #TODO(mpherman) : Change to versioned once stable
+    - image: gcr.io/k8s-testimages/ci_fuzz:latest
+      command:
+        - runner.sh
+      args:
+        - python3
+        - "/opt/oss-fuzz/infra/cifuzz/cifuzz_combined_entrypoint.py"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      env:
+      - name: MODE
+        value: coverage
+      - name: REPO_NAME
+        value: test-infra
+      - name: SANITIZER
+        value: 'coverage'
+      - name: CLOUD_BUCKET
+        value: gs://prow-cifuzz-test/
+      - name: CFL_PLATFORM
+        value: prow
+  annotations:
+    testgrid-dashboards: sig-testing-misc
+    testgrid-tab-name: test-infra-cfl-coverage-report
+    testgrid-broken-column-threshold: '0.5'
+    description: Runs clusterfuzzlite coverage report every day
+
+- name: test-infra-cfl-prune
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  interval: 12h
+  spec:
+    serviceAccountName: fuzz-test
+    containers:
+      #TODO(mpherman) : Change to versioned once stable
+    - image: gcr.io/k8s-testimages/ci_fuzz:latest
+      command:
+        - runner.sh
+      args:
+        - python3
+        - "/opt/oss-fuzz/infra/cifuzz/cifuzz_combined_entrypoint.py"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      env:
+      - name: MODE
+        value: prune
+      - name: REPO_NAME
+        value: test-infra
+      - name: CLOUD_BUCKET
+        value: gs://prow-cifuzz-test/
+      - name: CFL_PLATFORM
+        value: prow
+  annotations:
+    testgrid-dashboards: sig-testing-misc
+    testgrid-tab-name: test-infra-cfl-prune
+    testgrid-broken-column-threshold: '0.5'
+    description: Runs clusterfuzzlite corpora prune every day


### PR DESCRIPTION
We turned off the ClusterFuzzLite Demo because there was too much noise from the intentionally failing job. I am turning this back on to take a look at what might be needed to revive ClusterFuzzLite, but will make sure the job does not fail for too long. 

/assign @listx 
