### PR TITLE
cluster-api: use runner for periodic tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -14,7 +14,8 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230117-50d6df3625-1.26
       command:
-      - "./scripts/ci-test.sh"
+      - runner.sh
+      - ./scripts/ci-test.sh
       resources:
         requests:
           cpu: 7300m
@@ -38,7 +39,8 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230117-50d6df3625-1.26
       command:
-      - "./scripts/ci-test.sh"
+      - runner.sh
+      - ./scripts/ci-test.sh
       env:
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.


### PR DESCRIPTION
Just syncing the periodics with the presubmit jobs.

This should fix the failures we now get in CI since verifying that GOPATH/bin/ is in PATH

xref:
* https://github.com/kubernetes-sigs/cluster-api/pull/8017
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-test-main/1620622880494587904
