### PR TITLE
Fixes Jira CreateIssue() failing with Internal Server Error

### DIFF
--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -535,6 +535,12 @@ func unsetProblematicFields(issue *jira.Issue, responseBody string) (*jira.Issue
 	for field := range processedResponse.Errors {
 		delete(fieldsMap, field)
 	}
+	// Remove null value "customfields_" because they cause the server to return: 500 Internal Server Error
+	for field, value := range fieldsMap {
+		if strings.HasPrefix(field, "customfield_") && value == nil {
+			delete(fieldsMap, field)
+		}
+	}
 	issueMap["fields"] = fieldsMap
 	// turn back into jira.Issue type
 	marshalledFixedIssue, err := json.Marshal(issueMap)


### PR DESCRIPTION
We have observed an issue where calling the `CreateIssue()` API with an issue that has been cloned, and therefore contains all the custom fields (a majority of which are `null` values), causes the backend to return a `500 Internal Server Error`.  This PR adds logic to remove any custom fields that are `null` when processing the "problematic" fields.