### PR TITLE
capz: clarify ci-entrypoint.sh env vars

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -348,9 +348,9 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.24"
     annotations:
       testgrid-dashboards: sig-storage-csi-other
@@ -390,17 +390,17 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: sig-storage-csi-other

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -621,19 +621,19 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
-            - name: EXTERNAL_E2E_TEST
+            - name: EXTERNAL_E2E_TEST # azuredisk-csi-driver config
               value: "true"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
@@ -725,17 +725,17 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
             - name: WORKER_MACHINE_COUNT
               value: "0" # Don't create any linux worker nodes
@@ -776,21 +776,21 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_SERVER_VERSION
+            - name: WINDOWS_SERVER_VERSION # CAPZ config
               value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
@@ -829,9 +829,9 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
@@ -875,33 +875,33 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: TEST_CCM
+            - name: TEST_CCM # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_VMSS_FLEX
+            - name: TEST_VMSS_FLEX # azuredisk-csi-driver config
               value: "true"
-            - name: CONTROL_PLANE_MACHINE_COUNT
+            - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
-            - name: AZURE_LOADBALANCER_SKU
+            - name: AZURE_LOADBALANCER_SKU # azuredisk-csi-driver config
               value: "Standard"
-            - name: CLUSTER_PROVISIONING_TOOL
+            - name: CLUSTER_PROVISIONING_TOOL # azuredisk-csi-driver config
               value: "capz"
-            - name: CLUSTER_TEMPLATE
+            - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/jackfrancis/cluster-api-provider-azure/vmss-flex-cloudprovider/templates/cluster-template-external-cloud-provider-machinepool.yaml
-            - name: CUSTOM_CLOUD_PROVIDER_CONFIG
+            - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
               value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-            - name: ENABLE_VMSS_FLEX
+            - name: ENABLE_VMSS_FLEX # azuredisk-csi-driver config
               value: "true"
-            - name: ENABLE_MULTI_SLB
+            - name: ENABLE_MULTI_SLB # azuredisk-csi-driver config
               value: "false"
-            - name: PUT_VMSS_VM_BATCH_SIZE
+            - name: PUT_VMSS_VM_BATCH_SIZE # azuredisk-csi-driver config
               value: "0"
-            - name: LB_BACKEND_POOL_CONFIG_TYPE
+            - name: LB_BACKEND_POOL_CONFIG_TYPE # azuredisk-csi-driver config
               value: ""
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -504,21 +504,21 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: BUILD_V2
+            - name: BUILD_V2 # azuredisk-csi-driver config
               value: "true"
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
-            - name: EXTERNAL_E2E_TEST
+            - name: EXTERNAL_E2E_TEST # azuredisk-csi-driver config
               value: "true"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
@@ -619,23 +619,23 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: BUILD_V2
+            - name: BUILD_V2 # azuredisk-csi-driver config
               value: "true"
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WINDOWS_WORKER_MACHINE_COUNT
+            - name: WINDOWS_WORKER_MACHINE_COUNT # CAPZ config
               value: "3" # Need at least three workers for replica testing.
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
@@ -676,25 +676,25 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: BUILD_V2
+            - name: BUILD_V2 # azuredisk-csi-driver config
               value: "true"
-            - name: WINDOWS
+            - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_SERVER_VERSION
+            - name: WINDOWS_SERVER_VERSION # CAPZ config
               value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WINDOWS_WORKER_MACHINE_COUNT
+            - name: WINDOWS_WORKER_MACHINE_COUNT # CAPZ config
               value: "3" # Need at least three workers for replica testing.
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
@@ -736,13 +736,13 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: BUILD_V2
+            - name: BUILD_V2 # azuredisk-csi-driver config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "3" # Need at least three workers for replica testing.
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -505,19 +505,19 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azurefile-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
-            - name: EXTERNAL_E2E_TEST_SMB
+            - name: EXTERNAL_E2E_TEST_SMB # azurefile-csi-driver config
               value: "true"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
@@ -605,17 +605,17 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azurefile-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
-            - name: WORKER_MACHINE_COUNT
+            - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
@@ -654,19 +654,19 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: WINDOWS
+            - name: WINDOWS # azurefile-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS
+            - name: TEST_WINDOWS # CAPZ config
               value: "true"
-            - name: WINDOWS_SERVER_VERSION
+            - name: WINDOWS_SERVER_VERSION # CAPZ config
               value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
               value: "true"
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE
+            - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest-1.23"
             - name: WORKER_MACHINE_COUNT
               value: "0" # Don't create any linux worker nodes
@@ -707,7 +707,7 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -427,7 +427,7 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: NODE_MACHINE_TYPE
+            - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
     annotations:
       testgrid-dashboards: provider-azure-blobfuse-csi-driver

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -63,17 +63,17 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: TEST_CCM
+            - name: TEST_CCM # CAPZ config
               value: "true"
-            - name: CONTROL_PLANE_MACHINE_COUNT
+            - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
-            - name: CLUSTER_TEMPLATE
+            - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-            - name: AZURE_LOADBALANCER_SKU
+            - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
-            - name: CLUSTER_PROVISIONING_TOOL
+            - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -115,29 +115,29 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: TEST_CCM
+            - name: TEST_CCM # CAPZ config
               value: "true"
-            - name: TEST_VMSS_FLEX
+            - name: TEST_VMSS_FLEX # cloud-provider-azure config
               value: "true"
-            - name: CONTROL_PLANE_MACHINE_COUNT
+            - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
-            - name: CLUSTER_TEMPLATE
+            - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/jackfrancis/cluster-api-provider-azure/vmss-flex-cloudprovider/templates/cluster-template-external-cloud-provider-machinepool.yaml
-            - name: AZURE_LOADBALANCER_SKU
+            - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
-            - name: CLUSTER_PROVISIONING_TOOL
+            - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
-            - name: CUSTOM_CLOUD_PROVIDER_CONFIG
+            - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
               value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-            - name: ENABLE_VMSS_FLEX
+            - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
               value: "true"
-            - name: ENABLE_MULTI_SLB
+            - name: ENABLE_MULTI_SLB # cloud-provider-azure config
               value: "false"
-            - name: PUT_VMSS_VM_BATCH_SIZE
+            - name: PUT_VMSS_VM_BATCH_SIZE # cloud-provider-azure config
               value: "0"
-            - name: LB_BACKEND_POOL_CONFIG_TYPE
+            - name: LB_BACKEND_POOL_CONFIG_TYPE # cloud-provider-azure config
               value: ""
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -185,19 +185,19 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: TEST_CCM
+            - name: TEST_CCM # CAPZ config
               value: "true"
-            - name: AZURE_LOADBALANCER_SKU
+            - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "standard"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
-            - name: GINKGO_ARGS
+            - name: GINKGO_ARGS # cloud-provider-azure config
               value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-            - name: CONTROL_PLANE_MACHINE_COUNT
+            - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
-            - name: CLUSTER_PROVISIONING_TOOL
+            - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
-            - name: GINKGO_PARALLEL_NODES
+            - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
               value: "30"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -239,15 +239,15 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: TEST_CCM
+            - name: TEST_CCM # CAPZ config
               value: "true"
-            - name: AZURE_LOADBALANCER_SKU
+            - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "standard"
-            - name: CONTROL_PLANE_MACHINE_COUNT
+            - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
-            - name: CLUSTER_PROVISIONING_TOOL
+            - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -291,31 +291,31 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: TEST_CCM
+            - name: TEST_CCM # CAPZ config
               value: "true"
-            - name: CONTROL_PLANE_MACHINE_COUNT
+            - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
-            - name: KUBERNETES_VERSION
+            - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
-            - name: CLUSTER_TEMPLATE
+            - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-            - name: AZURE_LOADBALANCER_SKU
+            - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
-            - name: ENABLE_MULTI_SLB
+            - name: ENABLE_MULTI_SLB # cloud-provider-azure config
               value: "false"
-            - name: PUT_VMSS_VM_BATCH_SIZE
+            - name: PUT_VMSS_VM_BATCH_SIZE # cloud-provider-azure config
               value: "0"
-            - name: LB_BACKEND_POOL_CONFIG_TYPE
+            - name: LB_BACKEND_POOL_CONFIG_TYPE # cloud-provider-azure config
               value: "nodeIP"
-            - name: CUSTOM_CLOUD_PROVIDER_CONFIG
+            - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
               value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-            - name: CCM_E2E_ARGS
+            - name: CCM_E2E_ARGS # cloud-provider-azure config
               value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-            - name: LABEL_FILTER
+            - name: LABEL_FILTER # cloud-provider-azure config
               value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-            - name: CLUSTER_PROVISIONING_TOOL
+            - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
-            - name: ENABLE_VMSS_FLEX
+            - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
               value: "false"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -381,17 +381,17 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM
+        - name: TEST_CCM # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
           value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION
+        - name: KUBERNETES_VERSION # CAPZ config
           value: "v1.25.3"
-        - name: CLUSTER_PROVISIONING_TOOL
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
-        - name: CLUSTER_TEMPLATE
+        - name: CLUSTER_TEMPLATE # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -435,15 +435,15 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM
+        - name: TEST_CCM # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
           value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION
+        - name: KUBERNETES_VERSION # CAPZ config
           value: "latest"
-        - name: CLUSTER_PROVISIONING_TOOL
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -487,15 +487,15 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM
+        - name: TEST_CCM # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
           value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION
+        - name: KUBERNETES_VERSION # CAPZ config
           value: "latest"
-        - name: CLUSTER_PROVISIONING_TOOL
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -538,21 +538,21 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM
+        - name: TEST_CCM # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
           value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
-        - name: TEST_WINDOWS
+        - name: TEST_WINDOWS # CAPZ config
           value: "true"
-        - name: WINDOWS_FLAVOR
-          value: "containerd-2022"
-        - name: KUBERNETES_VERSION
+        - name: WINDOWS_SERVER_VERSION # CAPZ config
+          value: "windows-2022"
+        - name: KUBERNETES_VERSION # CAPZ config
           value: "latest"
-        - name: WORKER_MACHINE_COUNT
+        - name: WORKER_MACHINE_COUNT # CAPZ config
           value: "0"
-        - name: CLUSTER_PROVISIONING_TOOL
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -602,19 +602,19 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "standard"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "30"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -663,27 +663,27 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "standard"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\] --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: TEST_WINDOWS
+      - name: TEST_WINDOWS # CAPZ config
         value: "true"
-      - name: WINDOWS_FLAVOR
-        value: "containerd-2022"
-      - name: WORKER_MACHINE_COUNT
+      - name: WINDOWS_SERVER_VERSION # CAPZ config
+        value: "windows-2022"
+      - name: WORKER_MACHINE_COUNT # CAPZ config
         value: "0"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "3"
-      - name: GINKGO_TOLERATE_FLAKES
+      - name: GINKGO_TOLERATE_FLAKES # cloud-provider-azure config
         value: "y"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -733,19 +733,19 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "standard"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "4"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -789,17 +789,17 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM
+        - name: TEST_CCM # CAPZ config
           value: "true"
-        - name: CONTROL_PLANE_MACHINE_COUNT
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION
+        - name: KUBERNETES_VERSION # CAPZ config
           value: "latest"
-        - name: CLUSTER_TEMPLATE
+        - name: CLUSTER_TEMPLATE # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-        - name: AZURE_LOADBALANCER_SKU
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
           value: "Standard"
-        - name: CLUSTER_PROVISIONING_TOOL
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -849,21 +849,21 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: CLUSTER_TEMPLATE
+      - name: CLUSTER_TEMPLATE # CAPZ config
         value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "30"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -913,24 +913,24 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular.resource.usage.tracking.resource.tracking.for|validates.MaxPods.limit.number.of.pods.that.are.allowed.to.run|In-tree.Volumes|RuntimeClass.should.run.a.Pod.requesting.a.RuntimeClass.with.scheduling.with.taints|Multi-AZ.Clusters.should.spread.the.pods.of.a.replication.controller.across.zones|Multi-AZ.Clusters.should.spread.the.pods.of.a.service.across.zones|Should.test.that.pv.used.in.a.pod.that.is.deleted.while.the.kubelet.is.down.cleans.up.when.the.kubelet.returns|Should.test.that.pv.used.in.a.pod.that.is.force.deleted.while.the.kubelet.is.down.cleans.up.when.the.kubelet.returns|Should.test.that.pv.written.before.kubelet.restart.is.readable.after.restart|subPath.should.unmount.if.pod.is.force.deleted.while.kubelet.is.down|subPath.should.unmount.if.pod.is.gracefully.deleted.while.kubelet.is.down|Should.test.that.pv.written.before.kubelet.restart.is.readable.after.restart --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: CLUSTER_TEMPLATE
+      - name: CLUSTER_TEMPLATE # CAPZ config
         value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "1"
-      - name: GINKGO_TOLERATE_FLAKES
+      - name: GINKGO_TOLERATE_FLAKES # cloud-provider-azure config
         value: "y"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -980,22 +980,22 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: CLUSTER_TEMPLATE
+      - name: CLUSTER_TEMPLATE # CAPZ config
         value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "30"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -1045,21 +1045,21 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: TEST_CCM
+      - name: TEST_CCM # CAPZ config
         value: "true"
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: GINKGO_ARGS
+      - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT
+      - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
-      - name: CLUSTER_TEMPLATE
+      - name: CLUSTER_TEMPLATE # CAPZ config
         value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-      - name: AZURE_LOADBALANCER_SKU
+      - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
-      - name: CLUSTER_PROVISIONING_TOOL
+      - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
         value: "capz"
-      - name: GINKGO_PARALLEL_NODES
+      - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
         value: "30"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -63,17 +63,17 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.23"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: CLUSTER_TEMPLATE
+              - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
-              - name: K8S_FEATURE_GATES
+              - name: K8S_FEATURE_GATES # cloud-provider-azure config
                 value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
@@ -121,15 +121,15 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.23"
-              - name: GINKGO_ARGS
+              - name: GINKGO_ARGS # cloud-provider-azure config
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
@@ -171,15 +171,15 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.23"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: K8S_FEATURE_GATES
+              - name: K8S_FEATURE_GATES # cloud-provider-azure config
                 value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -63,15 +63,15 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.24"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: CLUSTER_TEMPLATE
+              - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-24-presubmit
@@ -119,15 +119,15 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.24"
-              - name: GINKGO_ARGS
+              - name: GINKGO_ARGS # cloud-provider-azure config
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-24-presubmit
@@ -169,13 +169,13 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.24"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-24-presubmit

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -63,17 +63,17 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.25"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: CLUSTER_TEMPLATE
+              - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-25-presubmit
@@ -121,19 +121,19 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.25"
-              - name: GINKGO_ARGS
+              - name: GINKGO_ARGS # cloud-provider-azure config
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: CLUSTER_PROVISIONING_TOOL
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
-              - name: GINKGO_PARALLEL_NODES
+              - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
                 value: "30"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-25-presubmit
@@ -175,13 +175,13 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.25"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-25-presubmit

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -63,17 +63,17 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.26"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: CLUSTER_TEMPLATE
+              - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
@@ -121,19 +121,19 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.26"
-              - name: GINKGO_ARGS
+              - name: GINKGO_ARGS # cloud-provider-azure config
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
-              - name: CLUSTER_PROVISIONING_TOOL
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
-              - name: GINKGO_PARALLEL_NODES
+              - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
                 value: "30"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
@@ -175,13 +175,13 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: TEST_CCM
+              - name: TEST_CCM # CAPZ config
                 value: "true"
-              - name: AZURE_LOADBALANCER_SKU
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "standard"
-              - name: KUBERNETES_VERSION
+              - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.26"
-              - name: CONTROL_PLANE_MACHINE_COUNT
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -104,7 +104,7 @@ presubmits:
               cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
           securityContext:
             privileged: true
@@ -149,9 +149,9 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-d
               cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -197,7 +197,7 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-d
               cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
@@ -243,9 +243,9 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-f
               cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -407,9 +407,9 @@ periodics:
         cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -459,11 +459,11 @@ periodics:
         cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIAzureFileDrivers}
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -512,9 +512,9 @@ periodics:
         cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -563,11 +563,11 @@ periodics:
         cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -659,9 +659,9 @@ EOF
         cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIAzureFileDrivers}
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -711,11 +711,11 @@ EOF
         cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIAzureFileDrivers}
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -764,9 +764,9 @@ EOF
         cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -815,11 +815,11 @@ EOF
         cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "${kubernetes_version}"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
@@ -37,7 +37,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
           securityContext:
             privileged: true
@@ -82,9 +82,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -130,7 +130,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
@@ -176,9 +176,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -340,9 +340,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.23"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -392,11 +392,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.23"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -445,9 +445,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.23"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -496,11 +496,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.23"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.24.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.24.yaml
@@ -37,7 +37,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
           securityContext:
             privileged: true
@@ -82,9 +82,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -130,7 +130,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
@@ -176,9 +176,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -340,9 +340,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.24"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -392,11 +392,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.24"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -445,9 +445,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.24"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -496,11 +496,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.24"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
@@ -37,7 +37,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
           securityContext:
             privileged: true
@@ -82,9 +82,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -130,7 +130,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
@@ -176,9 +176,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -340,9 +340,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.25"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -392,11 +392,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.25"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -445,9 +445,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.25"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -496,11 +496,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.25"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
@@ -37,7 +37,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
           securityContext:
             privileged: true
@@ -82,9 +82,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -130,7 +130,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
@@ -176,9 +176,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -340,9 +340,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.26"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -392,11 +392,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.26"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -445,9 +445,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.26"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -496,11 +496,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest-1.26"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -38,7 +38,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
           securityContext:
             privileged: true
@@ -88,9 +88,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -141,7 +141,7 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
@@ -192,9 +192,9 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER
+            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: EXP_MACHINE_POOL
+            - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
             privileged: true
@@ -370,9 +370,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -422,11 +422,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -475,9 +475,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -526,11 +526,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -619,9 +619,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -671,11 +671,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
         privileged: true
@@ -724,9 +724,9 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true
@@ -775,11 +775,11 @@ periodics:
         cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
-      - name: KUBERNETES_VERSION
+      - name: KUBERNETES_VERSION # CAPZ config
         value: "latest"
-      - name: EXP_MACHINE_POOL
+      - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
-      - name: AZURE_STORAGE_DRIVER
+      - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
         privileged: true


### PR DESCRIPTION
This PR adds comments to environment variable definitions in various jobs that use capz's ci-entrypoint.sh script, to clarify which environment variables act as input to ci-entrypoint.sh, and which act as inputs to another CI workflow.

For example, a common test job configuration pattern is to checkout out multiple repos, one of which is capz, and then to use capz solely for the purpose of scaffolding a particularly configured Kubernetes cluster running in Azure. The test job then changes working directories to the root of one of the other checked out repos, and then kicks off domain-specific tests that run on top of that particularly configured Azure-backed Kubernetes cluster. Each of those steps may require environment variables as configuration input, and these comments make it clear which test-infra-declared env vars belong to which.