### PR TITLE
add project.yaml file to .clusterfuzzlite

### DIFF
--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go


### PR DESCRIPTION
Working on debugging CFL Coverage reports and realized this is missing from our .clusterfuzzlite dir
/assign @listx 