### PR TITLE
Add optional go compatibility unit and integration presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -1600,7 +1600,8 @@ presubmits:
             memory: 15Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.23
     cluster: k8s-infra-prow-build
@@ -1609,6 +1610,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-integration-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1617,6 +1620,9 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
+        env:
+        - name: GO_VERSION
+          value: "1.17.3"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.23
         name: ""
         resources:
@@ -1776,7 +1782,8 @@ presubmits:
             memory: 36Gi
       securityContext:
         runAsUser: 2000
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.23
     cluster: k8s-infra-prow-build
@@ -1784,6 +1791,8 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1791,6 +1800,9 @@ presubmits:
       - command:
         - make
         - test
+        env:
+        - name: GO_VERSION
+          value: "1.17.3"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.23
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -1604,6 +1604,34 @@ presubmits:
     branches:
     - release-1.23
     cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.23
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.23
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-kind
     decorate: true
     decoration_config:
@@ -1731,6 +1759,32 @@ presubmits:
     labels:
       preset-service-account: "true"
     name: pull-kubernetes-unit
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.23
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+      securityContext:
+        runAsUser: 2000
+  - always_run: true
+    branches:
+    - release-1.23
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -1420,7 +1420,8 @@ presubmits:
             memory: 15Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.24
     cluster: k8s-infra-prow-build
@@ -1429,6 +1430,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-integration-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1437,6 +1440,9 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
+        env:
+        - name: GO_VERSION
+          value: "1.18.1"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.24
         name: ""
         resources:
@@ -1596,7 +1602,8 @@ presubmits:
             memory: 36Gi
       securityContext:
         runAsUser: 2000
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.24
     cluster: k8s-infra-prow-build
@@ -1604,6 +1611,8 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1611,6 +1620,9 @@ presubmits:
       - command:
         - make
         - test
+        env:
+        - name: GO_VERSION
+          value: "1.18.1"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.24
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -1424,6 +1424,34 @@ presubmits:
     branches:
     - release-1.24
     cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.24
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.24
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-kind
     decorate: true
     decoration_config:
@@ -1551,6 +1579,32 @@ presubmits:
     labels:
       preset-service-account: "true"
     name: pull-kubernetes-unit
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.24
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+      securityContext:
+        runAsUser: 2000
+  - always_run: true
+    branches:
+    - release-1.24
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -1434,6 +1434,34 @@ presubmits:
     branches:
     - release-1.25
     cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.25
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-kind
     decorate: true
     decoration_config:
@@ -1561,6 +1589,32 @@ presubmits:
     labels:
       preset-service-account: "true"
     name: pull-kubernetes-unit
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+      securityContext:
+        runAsUser: 2000
+  - always_run: true
+    branches:
+    - release-1.25
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -1430,7 +1430,8 @@ presubmits:
             memory: 15Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.25
     cluster: k8s-infra-prow-build
@@ -1439,6 +1440,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-integration-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1447,6 +1450,9 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
+        env:
+        - name: GO_VERSION
+          value: "1.19.1"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
         name: ""
         resources:
@@ -1606,7 +1612,8 @@ presubmits:
             memory: 36Gi
       securityContext:
         runAsUser: 2000
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.25
     cluster: k8s-infra-prow-build
@@ -1614,6 +1621,8 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1621,6 +1630,9 @@ presubmits:
       - command:
         - make
         - test
+        env:
+        - name: GO_VERSION
+          value: "1.19.1"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1462,6 +1462,34 @@ presubmits:
     branches:
     - release-1.26
     cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.26
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.26
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-kind
     decorate: true
     decoration_config:
@@ -1589,6 +1617,30 @@ presubmits:
     labels:
       preset-service-account: "true"
     name: pull-kubernetes-unit
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.26
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+  - always_run: true
+    branches:
+    - release-1.26
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1458,7 +1458,8 @@ presubmits:
             memory: 15Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.26
     cluster: k8s-infra-prow-build
@@ -1467,6 +1468,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-integration-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1475,6 +1478,9 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
+        env:
+        - name: GO_VERSION
+          value: "1.19.4"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.26
         name: ""
         resources:
@@ -1632,7 +1638,8 @@ presubmits:
           requests:
             cpu: "4"
             memory: 36Gi
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-1.26
     cluster: k8s-infra-prow-build
@@ -1640,6 +1647,8 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
+    annotations:
+      description: run with GO_VERSION set to the original go version used for this branch
     name: pull-kubernetes-unit-go-compatibility
     path_alias: k8s.io/kubernetes
     spec:
@@ -1647,6 +1656,9 @@ presubmits:
       - command:
         - make
         - test
+        env:
+        - name: GO_VERSION
+          value: "1.19.4"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.26
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -33,6 +33,36 @@ presubmits:
           requests:
             cpu: 6
             memory: 15Gi
+  - name: pull-kubernetes-integration-go-compatibility
+    cluster: k8s-infra-prow-build
+    always_run: true
+    decorate: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: sig-testing-canaries
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/jenkins/test-dockerized.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: 15Gi
+          requests:
+            cpu: 6
+            memory: 15Gi
   - name: pull-kubernetes-integration-go-canary
     cluster: k8s-infra-prow-build
     always_run: false

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -35,13 +35,15 @@ presubmits:
             memory: 15Gi
   - name: pull-kubernetes-integration-go-compatibility
     cluster: k8s-infra-prow-build
-    always_run: true
+    always_run: false
+    optional: true
     decorate: true
     skip_branches:
     - release-\d+.\d+ # per-release job
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: sig-testing-canaries
+      description: run with GO_VERSION set to the original go version used for this branch
     path_alias: k8s.io/kubernetes
     labels:
       preset-service-account: "true"
@@ -51,6 +53,9 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
         command:
         - runner.sh
+        env:
+        - name: GO_VERSION
+          value: ""
         args:
         - ./hack/jenkins/test-dockerized.sh
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -39,14 +39,15 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: sig-testing-canaries
+      description: run with GO_VERSION set to the original go version used for this branch
     decorate: true
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+.\d+ # per-release job
     labels:
       preset-service-account: "true"
-    optional: false
-    always_run: true
+    optional: true
+    always_run: false
     path_alias: k8s.io/kubernetes
     spec:
       # unit tests have no business requiring root or doing privileged operations
@@ -62,6 +63,9 @@ presubmits:
           command:
             - make
             - test
+          env:
+          - name: GO_VERSION
+            value: ""
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -35,6 +35,41 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
+  - name: pull-kubernetes-unit-go-compatibility
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: sig-testing-canaries
+    decorate: true
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    labels:
+      preset-service-account: "true"
+    optional: false
+    always_run: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        # NOTE: these are arbitrary non-root values. They don't exist in the
+        # image and don't need to, the unit tests should only write to TMPDIR
+        runAsUser: 2001
+        runAsGroup: 2010
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - make
+            - test
+          # TODO: direct copy from pull-kubernetes-bazel-test, tune these
+          resources:
+            limits:
+              cpu: 4
+              memory: "36Gi"
+            requests:
+              cpu: 4
+              memory: "36Gi"
   - name: pull-kubernetes-unit-experimental
     # try clonerefs with preclone
     decoration_config:


### PR DESCRIPTION
Related to https://github.com/kubernetes/test-infra/issues/28310 and https://github.com/kubernetes/enhancements/issues/3744

* Clones the unit/integration presubmits for release branches (first commit)
* Makes them optional and non-blocking, and records the GO_VERSION that release branch originally shipped with (second commit)

Eventually intended to be used in combination with something like https://github.com/kubernetes/kubernetes/pull/115377

Once this is proven out, we can figure out how to keep these created / updated as part of the fork-config script

cc @dims @BenTheElder 