### PR TITLE
Remove linter jobs for CAPV releases

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
@@ -1,24 +1,5 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
-  - name: pull-cluster-api-provider-vsphere-verify-lint-release-1-5
-    branches:
-    # The script this job runs is not in all branches.
-    - ^release-1.5$
-    always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh)'
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.24
-        command:
-        - hack/check-lint.sh
-    annotations:
-      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-      testgrid-tab-name: pr-verify-lint-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Verifies the Golang sources are linted
-
   - name: pull-cluster-api-provider-vsphere-test-release-1-5
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -102,25 +102,6 @@ presubmits:
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Checks for API changes in the PR
 
-  - name: pull-cluster-api-provider-vsphere-verify-lint
-    branches:
-    # The script this job runs is not in all branches.
-    - ^main$
-    always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh|main\.go)'
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-1.25
-        command:
-        - hack/check-lint.sh
-    annotations:
-      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-      testgrid-tab-name: pr-verify-lint
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Verifies the Golang sources are linted
-
   - name: pull-cluster-api-provider-vsphere-verify-markdown
     always_run: false
     run_if_changed: '.*\.md$'


### PR DESCRIPTION
CAPV now relies on Github actions to run linters. This patch removes the duplicate jobs for CAPV presubmits.