### PR TITLE
kubekins-e2e: Bump go canary to 1.20

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.20rc3
+    GO_VERSION: 1.20
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Bumping for early CI signal for whenever k/k has 1.20


/assign @dims @saschagrunert @liggitt @xmudrii 
cc @kubernetes/release-managers 