### PR TITLE
Add autoscaling hpa e2e tests to presubmit checks

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -47,3 +47,66 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
         securityContext:
           privileged: true
+
+  - name: pull-kubernetes-e2e-autoscaling-hpa-cpu
+    annotations:
+      testgrid-dashboards: sig-autoscaling-hpa
+      testgrid-tab-name: gci-gce-autoscaling-hpa-cpu-pull
+    # TODO: set `always_run: true` once config confirmed to be correct
+    always_run: false
+    # TODO: set `optional: false` once tests not flaky
+    optional: true
+    run_if_changed: '^(pkg\/controller\/podautoscaler\/|test\/e2e\/autoscaling\/horizontal_pod_autoscaling|test\/e2e\/framework\/autoscaling\/)'
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - args:
+        - --bare
+        - --timeout=260
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-leaked-resources
+        - --provider=gce
+        - --gcp-zone=us-west1-b
+        - --gcp-node-image=gci
+        # Enable HPAContainerMetrics. Required for container metrics tests.
+        - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
+        - --extract=ci/latest
+        - --timeout=240m
+        - --test_args=--ginkgo.focus=\[Feature:HPA\]
+          --minStartupPods=8
+        - --ginkgo-parallel=1
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master
+
+  - name: pull-kubernetes-e2e-autoscaling-hpa-cm
+    annotations:
+      testgrid-dashboards: sig-autoscaling-hpa
+      testgrid-tab-name: gci-gce-autoscaling-hpa-cm-pull
+    # TODO: set `always_run: true` once config confirmed to be correct
+    always_run: false
+    # TODO: set `optional: false` once tests not flaky
+    optional: true
+    run_if_changed: '^(pkg\/controller\/podautoscaler\/|test\/e2e\/autoscaling\/custom_metrics_stackdriver_autoscaling.go$)'
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - args:
+        - --timeout=350
+        - --bare
+        - --scenario=kubernetes_e2e
+        - --
+        - --cluster=hpa
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-project=k8s-jkns-gci-autoscaling
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        # Enable HPAContainerMetrics and HPAScaleToZero. Required for container metrics and scale to zero tests.
+        - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true,HPAScaleToZero=true
+        - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
+        - --timeout=300m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230127-9396ca613c-master


### PR DESCRIPTION
Will run if podautoscaler code or e2e test code changes. Setup currently in dry-run (optional and requires /test command).

Rationale: in the last 6 months we've had 2 cases when a bad e2e test was merged and later discovered (and fixed) by a different person, weeks/months after merge. Even worse, the same could happen to controller code. Quick feedback is better.