### PR TITLE
upgrade kubekins-e2e to bootstrap with stable gcloud

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-staging-test-infra/bootstrap:v20230126-215ae799eb
+FROM gcr.io/k8s-staging-test-infra/bootstrap:v20230203-307498bcfc
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
follows https://github.com/kubernetes/test-infra/pull/28628