### PR TITLE
capz: test Windows 2022 in ci-entrypoint presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -484,6 +484,8 @@ presubmits:
         env:
           - name: TEST_WINDOWS
             value: "true"
+          - name: WINDOWS_SERVER_VERSION
+            value: "windows-2022"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-ci-entrypoint-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -336,6 +336,8 @@ presubmits:
         env:
           - name: TEST_WINDOWS
             value: "true"
+          - name: WINDOWS_SERVER_VERSION
+            value: "windows-2022"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-ci-entrypoint-v1beta1


### PR DESCRIPTION
This PR updates the CAPZ ci-entrypoint presubmit jobs so that we build Windows 2022 nodes (instead of 2019 which is the default if you don't specify a configuration opinion to ci-entrypoing).