### PR TITLE
Remove ignore_skip default.

### DIFF
--- a/config/testgrids/default.yaml
+++ b/config/testgrids/default.yaml
@@ -6,7 +6,7 @@ default_test_group:
   days_of_results: 15 # Number of days of test results to gather and serve.
   tests_name_policy: 2 # replace the name of the test
   ignore_pending: false # Show in-progress tests.
-  ignore_skip: true # Don't show skipped tests by default.
+  ignore_skip: false # Show skipped tests.
   column_header:
     - configuration_value: Commit # Shows the commit number on column header
   num_columns_recent: 10


### PR DESCRIPTION
This is currently a no-op (ignore_skip does not do anything right now), but removing the default since I am adding the actual implementation for ignore_skip shortly, and don't want to remove skipped tests from users' views who didn't mean to specify it in their config.