### PR TITLE
Chore: reduce logging level for deck and spyglass from warn to debug

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -950,7 +950,7 @@ func handleRequestJobViews(sg *spyglass.Spyglass, cfg config.Getter, o options, 
 		if err != nil {
 			msg := fmt.Sprintf("error rendering spyglass page: %v", err)
 			if shouldLogHTTPErrors(err) {
-				log.WithError(err).Warn(msg)
+				log.WithError(err).Debug(msg)
 			}
 			http.Error(w, msg, httpStatusForError(err))
 			return

--- a/prow/spyglass/artifacts.go
+++ b/prow/spyglass/artifacts.go
@@ -41,7 +41,7 @@ func (s *Spyglass) ListArtifacts(ctx context.Context, src string) ([]string, err
 	case prowKeyType:
 		storageProvider, key, err := s.prowToGCS(key)
 		if err != nil {
-			logrus.Warningf("Failed to get gcs source for prow job: %v", err)
+			logrus.Debugf("Failed to get gcs source for prow job: %v", err)
 		}
 		gcsKey = fmt.Sprintf("%s://%s", storageProvider, key)
 	default:


### PR DESCRIPTION
We have seen a flood of warn logs from Deck and Spyglass that are not from user errors. In this change we are downgrading some of the internal error levels to debug.