### PR TITLE
Bump docker buildx to v0.10.2 for gcb-docker-gcloud

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -45,7 +45,7 @@ RUN gcloud config set core/disable_usage_reporting true && \
 # Install docker Buildx for fast docker builds
 ENV HOME=/root
 RUN mkdir -p  $HOME/.docker/cli-plugins \
-    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.9.1/buildx-v0.9.1.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.10.2/buildx-v0.10.2.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
     && chmod a+x $HOME/.docker/cli-plugins/docker-buildx
 # Link link /root/.docker to /builder/home/.docker because the default home for cloudbuild jobs is /builder/home
 # and this will make in uncessarry for each cloudbuild.yaml file in K8s project to specify HOME=/root


### PR DESCRIPTION
Support --provenance option

Because of recent kubekins-e2e image update, cloud-provider-azure adds `--provenance=false` in its Makefile. Since cloud-provider-azure also has a push image job, image-builder image should update as well.

https://storage.googleapis.com/kubernetes-jenkins/logs/post-provider-azure-push-images/1622289078533754880/build-log.txt

I think such update should apply to other image-builder usage as well.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>