### PR TITLE
Add jobs for new AR registry and private GCR registry

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
@@ -1,31 +1,33 @@
 # If you are adding new AR regions, you need to run this job for a while and then add the manifests in k/k8s.io
-# periodics:
-#   - name: gcr-to-ar-sync-europe
-#     interval: 2h
-#     cluster: k8s-infra-prow-build-trusted
-#     decorate: true
-#     max_concurrency: 1
-#     annotations:
-#       testgrid-dashboards: sig-k8s-infra-k8sio
-#       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-#       testgrid-num-failures-to-alert: '1'
-#     rerun_auth_config:
-#       github_team_slugs:
-#         - org: kubernetes
-#           slug: sig-k8s-infra-leads
-#         - org: kubernetes
-#           slug: release-managers
-#     spec:
-#       serviceAccountName: k8s-infra-gcr-promoter
-#       containers:
-#         - image: golang:1.18
-#           imagePullPolicy: Always
-#           command:
-#             - /bin/bash
-#           args:
-#             - -c
-#             - |
-#               export PATH=$PATH:$GOPATH/bin
-#               apt update && apt install parallel -qqy
-#               go install github.com/google/go-containerregistry/cmd/gcrane@latest
-#               parallel "gcrane cp --recursive --allow-nondistributable-artifacts eu.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west4 europe-west8 europe-west9
+periodics:
+  - name: gcr-to-ar-sync-us
+    cron: "0 */2 * * *" # 2h
+    # cron: "0 0 31 4 *" # 31st of April
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    max_concurrency: 1
+    annotations:
+      testgrid-dashboards: sig-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes
+          slug: sig-k8s-infra-leads
+        - org: kubernetes
+          slug: release-managers
+    spec:
+      serviceAccountName: k8s-infra-gcr-promoter
+      containers:
+        - image: golang:1.19
+          imagePullPolicy: Always
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - |
+              export PATH=$PATH:$GOPATH/bin
+              apt update && apt install parallel -qqy
+              go install github.com/google/go-containerregistry/cmd/gcrane@latest
+              parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: us-west3 us-west4
+              parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod gcr.io/k8s-artifacts-prod"


### PR DESCRIPTION
/cc @ameukam @BenTheElder 

The US AR Regions were created in https://github.com/kubernetes/k8s.io/pull/4419

@ameukam Can you push a dummy image to gcr.io/k8s-artifacts-prod registry? It should create the underlying bucket.

gcr.io/k8s-artifacts-prod will be registry that we can use for blob syncing till we fix it properly in the image promoter. This bucket should have public access disabled.