### PR TITLE
Create job to update Prow's ClusterfuzzLite image twice a month

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -65,7 +65,6 @@ periodics:
   spec:
     serviceAccountName: fuzz-test
     containers:
-      #TODO(mpherman) : Change to versioned once stable
     - image: gcr.io/k8s-testimages/clusterfuzzlite:v20230201-4b504e83f1
       command:
         - runner.sh

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -53,7 +53,7 @@ postsubmits:
     annotations:
       testgrid-dashboards: "sig-testing-images"
       testgrid-tab-name: "clusterfuzzlite-push"
-      description: builds and pushes the clusterfuzzlite image
+      description: builds and pushes the clusterfuzzlite image on change
     decorate: true
     branches:
     - ^master$
@@ -806,6 +806,27 @@ periodics:
     testgrid-tab-name: rotate-legacy-default-build-sa-json-key
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     description: Rotate legacy build cluster service account json key.
+# This job keeps the Prow Clusterfuzzlite image up to date.
+- cron: "30 1 1,15 * *"  # At 01:30 on day-of-month 1 and 15.
+  name: update-clusterfuzz-lite
+  cluster: test-infra-trusted
+  decorate: true
+  spec:
+      serviceAccountName: deployer # TODO(fejta): should be pusher
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20230111-cd1b3caf9c
+        command:
+        - /run.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - --build-dir=.
+        - experiment/clusterfuzzlite/'
+  annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "clusterfuzzlite-update"
+      description: builds and pushes the clusterfuzzlite image regularly
+
 
 # This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
 # Alerts expect it to run every 5 mins and will fire after 20 mins without a successful run.

--- a/experiment/clusterfuzzlite/Dockerfile
+++ b/experiment/clusterfuzzlite/Dockerfile
@@ -14,9 +14,8 @@
 
 FROM gcr.io/k8s-staging-test-infra/bootstrap:v20210913-fc7c4e84f6
 
-#TODO(mpherman) : Change to versioned once stable
-FROM gcr.io/oss-fuzz-base/cifuzz-base@sha256:de5eb4b2937831723cffd31d684b50442bc50f55b4a4019be83231f20270b2ba
-COPY --from=gcr.io/oss-fuzz-base/cifuzz-base /opt/oss-fuzz /opt/
+FROM gcr.io/oss-fuzz-base/cifuzz-base:latest
+COPY --from=gcr.io/oss-fuzz-base/cifuzz-base:latest /opt/oss-fuzz /opt/
 
 #
 # BEGIN: DOCKER IN DOCKER SETUP


### PR DESCRIPTION
Currently the Clusterfuzzlite image that prow uses only gets updated if there is a change to the dockerfile. This will allow Prow's CFL image to stay up to date with the upstream version.

/assign @listx 
/cc @cjwagner 