### PR TITLE
skip integration tests for more paths

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
   - name: pull-test-infra-integration
     branches:
     - master
-    skip_if_only_changed: '^config/jobs/'
+    skip_if_only_changed: '(^config/jobs/)|(^images/)|(^scenarios/)|(^jenkins/)|(^kubetest/)'
     decorate: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
the integration test is for prow components, these directories do not affect it and the integration test noticably slows down critical revert PRs like https://github.com/kubernetes/test-infra/pull/28654

this is not a comprehensive list but should help with shipping fixes to kubernetes CI that are e2e/tooling/image based, not CI components