### PR TITLE
porche postsubmit: include the git dir

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -39,6 +39,7 @@ postsubmits:
           # images are pushed to.
           - --project=k8s-staging-infra-tools
           - --scratch-bucket=gs://k8s-staging-infra-tools-gcb
+          - --with-git-dir
           - .
   kubernetes/k8s.io:
     - name: post-k8sio-push-image-octodns-docker


### PR DESCRIPTION
This lets our scripts be more consistent in terms of finding e.g. the
git root etc.
