### PR TITLE
fix bash error

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -323,17 +323,17 @@ periodics:
           export TEST_PACKAGE_VERSION="v1.25.0";
           echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
         fi;
-        cd $REPO_ROOT
-        sed -i 's/^\s*k8s.io.*//g' go.mod
-        go work init .
-        go work use crd
-        go work use providers
-        go work use ${KUBE_SOURCE}
+        cd $REPO_ROOT;
+        sed -i 's/^\s*k8s.io.*//g' go.mod;
+        go work init .;
+        go work use crd;
+        go work use providers;
+        go work use ${KUBE_SOURCE};
         for i in ${KUBE_SOURCE}/staging/src/k8s.io/*; do
-            go work use ./$i
-        done
-        go work sync
-        cd -
+          go work use ./$i ;
+        done;
+        go work sync;
+        cd -;
         kubetest2 gce -v 2 --repo-root $REPO_ROOT \
           --build --up --down --test=ginkgo \
           --master-size n1-standard-2  \


### PR DESCRIPTION
it seems the codeblock is passed as one line

```
bin/bash: -c: line 1: syntax error near unexpected token `do'
/bin/bash: -c: line 1: `set -o errexit; set -o nounset; set -o pipefail; set -o xtrace; KUBE_SOURCE=$GOPATH/src/k8s.io/kubernetes; REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp; cd; if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion"); echo "BAZEL_VERSION set to ${BAZEL_VERSION}"; else export BAZEL_VERSION="5.3.0"; echo "BAZEL_VERSION - Falling back to 5.3.0"; fi; /workspace/test-infra/images/kubekins-e2e/install-bazel.sh; go install sigs.k8s.io/kubetest2@latest; go install sigs.k8s.io/kubetest2/kubetest2-gce@latest; go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest; if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env"); echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"; else export TEST_PACKAGE_VERSION="v1.25.0"; echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"; fi; cd $REPO_ROOT sed -i 's/^\s*k8s.io.*//g' go.mod go work init . go work use crd go work use providers go work use ${KUBE_SOURCE} for i in ${KUBE_SOURCE}/staging/src/k8s.io/*; do go work use ./$i done go work sync cd - kubetest2 gce -v 2 --repo-root $REPO_ROOT \ --build --up --down --test=ginkgo \ --master-size n1-standard-2  \ -- \ --test-package-version="${TEST_PACKAGE_VERSION}" \ --focus-regex='\[Conformance\]''
+ EXIT_VALUE=2
+ set +o xtrace
```