### PR TITLE
pull-k8sio-file-promo presubmit should guard entire artifacts tree

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
       #testgrid-num-failures-to-alert: '10'
     decorate: true
     skip_report: true # Don't report a WIP job on github
-    run_if_changed: '^artifacts\/(filestores|manifests)\/.*\/*.yaml'
+    run_if_changed: '^artifacts\/.*\/*.yaml'
     max_concurrency: 10
     branches:
     - ^main$


### PR DESCRIPTION
We're introducing some new directories here (probably) so we need to
run on more files.
