### PR TITLE
run pull-kubernetes-cross when a PR likely impacts cross builds

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-kubernetes-cross
     optional: true
     always_run: false
+    run_if_changed: '(^.go-version)|(^build/build-image/)|(^hack/lib/golang.sh)|(^build/common.sh)'
     decorate: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Currently you have to manually `/test pull-kubernetes-cross`

Running the cross build is not cheap, and we already have a periodic, but these paths are tightly coupled to the cross build behavior. E.G. https://github.com/kubernetes/kubernetes/commit/b9ddf07a75e728cd28582089ded406e5c15c90d3 would have triggered with this `run_if_changed`.

xref: https://github.com/kubernetes/kubernetes/issues/115605