### PR TITLE
Feat: do not create Prow jobs for Gerrit patch set with no code change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.20
 	github.com/GoogleCloudPlatform/testgrid v0.0.123
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268
+	github.com/andygrunwald/go-gerrit v0.0.0-20230208122044-15d9b4422724
 	github.com/andygrunwald/go-jira v1.14.0
 	github.com/aws/aws-sdk-go v1.38.49
 	github.com/bazelbuild/buildtools v0.0.0-20200922170545-10384511ce98

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alvaroaleman/httpcache v0.0.0-20210618195546-ab9a1a3f8a38 h1:ML+zGuJv9er8cg0N8D8edCNOwqI/Kb3WoV6VsIV93SU=
 github.com/alvaroaleman/httpcache v0.0.0-20210618195546-ab9a1a3f8a38/go.mod h1:R4sf/p+3TZ6dvs7BxjxjozS7lIpzKtuS4jmQt4egJfU=
-github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268 h1:7gokoTWteZhP1t2f0OzrFFXlyL8o0+b0r4ZaRV9PXOs=
-github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268/go.mod h1:aqcjwEnmLLSalFNYR0p2ttnEXOVVRctIzsUMHbEcruU=
+github.com/andygrunwald/go-gerrit v0.0.0-20230208122044-15d9b4422724 h1:0TvOoEps4QAHGCJ3+x2y46RaK6+hvLAO18RyvvSwECs=
+github.com/andygrunwald/go-gerrit v0.0.0-20230208122044-15d9b4422724/go.mod h1:SeP12EkHZxEVjuJ2HZET304NBtHGG2X6w2Gzd0QXAZw=
 github.com/andygrunwald/go-jira v1.14.0 h1:7GT/3qhar2dGJ0kq8w0d63liNyHOnxZsUZ9Pe4+AKBI=
 github.com/andygrunwald/go-jira v1.14.0/go.mod h1:KMo2f4DgMZA1C9FdImuLc04x4WQhn5derQpnsuBFgqE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -534,6 +534,19 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		}
 	case client.New:
 		logger := logger.WithField("status", client.New)
+		lastUpdate, ok := c.tracker.Current()[instance][change.Project]
+		if !ok {
+			lastUpdate = time.Now()
+			logger.WithField("lastUpdate", lastUpdate).Warnf("lastUpdate not found, falling back to now")
+		}
+		if shouldSkipChangeProcessing(change, lastUpdate) {
+			logger.WithFields(logrus.Fields{
+				"project":  change.Project,
+				"changeID": change.ChangeID,
+			}).Debug("No code change since last update.")
+			return nil
+		}
+
 		var presubmits []config.Presubmit
 		// Gerrit server might be unavailable intermittently, retry inrepoconfig
 		// processing for increased reliability.
@@ -577,12 +590,6 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		if err != nil {
 			// This would happen if authenticateOnce hasn't done register this instance yet
 			return fmt.Errorf("account not found for %q: %w", instance, err)
-		}
-
-		lastUpdate, ok := c.tracker.Current()[instance][change.Project]
-		if !ok {
-			lastUpdate = time.Now()
-			logger.WithField("lastUpdate", lastUpdate).Warnf("lastUpdate not found, falling back to now")
 		}
 
 		revision := change.Revisions[change.CurrentRevision]
@@ -690,6 +697,29 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 	}
 
 	return nil
+}
+
+// shouldSkipChangeProcessing returns true if the revisions in the change after
+// last repo update does not contain code change or valid test related comments.
+func shouldSkipChangeProcessing(change client.ChangeInfo, lastUpdate time.Time) bool {
+	// this should not happen
+	if change.Revisions == nil {
+		return false
+	}
+
+	for _, message := range currentMessages(change, lastUpdate) {
+		if pjutil.RetestRe.MatchString(message.Message) || pjutil.TestRe.MatchString(message.Message) {
+			return false
+		}
+	}
+
+	for _, rev := range change.Revisions {
+		if rev.Created.Time.After(lastUpdate) && rev.Kind != gerrit.NoCodeChange {
+			return false
+		}
+	}
+
+	return true
 }
 
 // isProjectOptOutHelp returns if the project is opt-out from getting help

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -303,6 +303,87 @@ func TestCreateRefs(t *testing.T) {
 	}
 }
 
+func TestShouldSkipChangeProcessing(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name       string
+		change     gerrit.ChangeInfo
+		lastUpdate time.Time
+		expected   bool
+	}{
+		{
+			name: "should skip change processing if no code change since last update",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Revisions: map[string]gerrit.RevisionInfo{
+					"1": {
+						Number:  1,
+						Created: makeStamp(now.Add(time.Hour)),
+						Kind:    gerrit.NoCodeChange,
+					},
+				},
+			},
+			lastUpdate: now,
+			expected:   true,
+		},
+		{
+			name: "should not skip change processing if some revisions have code change since last update",
+			change: client.ChangeInfo{
+				CurrentRevision: "3",
+				Revisions: map[string]gerrit.RevisionInfo{
+					"1": {
+						Number:  1,
+						Created: makeStamp(now.Add(time.Hour)),
+						Kind:    gerrit.NoCodeChange,
+					},
+					"2": {
+						Number:  2,
+						Created: makeStamp(now.Add(2 * time.Hour)),
+						Kind:    gerrit.MergeFirstParentUpdate,
+					},
+					"3": {
+						Number:  3,
+						Created: makeStamp(now.Add(3 * time.Hour)),
+						Kind:    gerrit.NoCodeChange,
+					},
+				},
+			},
+			lastUpdate: now,
+			expected:   false,
+		},
+		{
+			name: "should not skip change processing if change comment demands testing",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Revisions: map[string]gerrit.RevisionInfo{
+					"1": {
+						Number:  1,
+						Created: makeStamp(now.Add(-time.Hour)),
+						Kind:    gerrit.NoCodeChange,
+					},
+				},
+				Messages: []gerrit.ChangeMessageInfo{
+					{
+						Message:        "/test",
+						RevisionNumber: 1,
+						Date:           makeStamp(now.Add(time.Hour)),
+					},
+				},
+			},
+			lastUpdate: now,
+			expected:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if r := shouldSkipChangeProcessing(tc.change, tc.lastUpdate); r != tc.expected {
+				t.Errorf("expected shouldSkipChangeProcessing(%+v, %v) returns %t, expected %t", tc.change, tc.lastUpdate, r, tc.expected)
+			}
+		})
+	}
+}
+
 func TestFailedJobs(t *testing.T) {
 	const (
 		me      = 314159
@@ -512,6 +593,161 @@ func TestProcessChange(t *testing.T) {
 			instancesMap: map[string]*gerrit.AccountInfo{testInstance: {AccountID: 42}},
 			instance:     testInstance,
 			wantError:    true,
+		},
+		{
+			name: "changes with no code change in new revisions should not trigger prow jobs",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "test-infra",
+				Status:          "NEW",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Created: stampNow,
+						Kind:    gerrit.NoCodeChange,
+					},
+				},
+			},
+			instancesMap: map[string]*gerrit.AccountInfo{testInstance: {AccountID: 42}},
+			instance:     testInstance,
+			wantError:    false,
+			wantPjs:      nil,
+		},
+		{
+			name: "wrong test commands on new revisions with no code change should not trigger prow jobs",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "test-infra",
+				Branch:          "baz",
+				Status:          "NEW",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Number:  1,
+						Created: stampNow,
+						Kind:    gerrit.NoCodeChange,
+					},
+				},
+				Messages: []gerrit.ChangeMessageInfo{
+					{
+						Message:        "go /test foo",
+						RevisionNumber: 1,
+						Date:           makeStamp(timeNow.Add(time.Hour)),
+					},
+				},
+			},
+			instancesMap: map[string]*gerrit.AccountInfo{testInstance: {AccountID: 42}},
+			instance:     testInstance,
+		},
+		{
+			name: "changes with no code change in new revisions and retest command should trigger prow jobs",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "test-infra",
+				Branch:          "retest-branch",
+				Status:          "NEW",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Number:  1,
+						Created: stampNow,
+						Kind:    gerrit.NoCodeChange,
+					},
+				},
+				Messages: []gerrit.ChangeMessageInfo{
+					{
+						Message:        "/retest",
+						RevisionNumber: 1,
+						Date:           makeStamp(timeNow.Add(time.Hour)),
+					},
+				},
+			},
+			instancesMap: map[string]*gerrit.AccountInfo{testInstance: {AccountID: 42}},
+			instance:     testInstance,
+			wantPjs: []*prowapi.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"prow.k8s.io/gerrit-report-label": "Code-Review",
+							"created-by-prow":                 "true",
+							"prow.k8s.io/job":                 "always-runs-all-branches",
+							"prow.k8s.io/gerrit-revision":     "1",
+							"prow.k8s.io/type":                "presubmit",
+							"prow.k8s.io/context":             "always-runs-all-branches",
+							"prow.k8s.io/refs.org":            "gerrit",
+							"prow.k8s.io/refs.base_ref":       "retest-branch",
+							"prow.k8s.io/refs.pull":           "0",
+							"prow.k8s.io/refs.repo":           "test-infra",
+							"prow.k8s.io/gerrit-patchset":     "1",
+						},
+						Annotations: map[string]string{
+							"foo":                         "bar",
+							"prow.k8s.io/gerrit-id":       "",
+							"prow.k8s.io/job":             "always-runs-all-branches",
+							"prow.k8s.io/context":         "always-runs-all-branches",
+							"prow.k8s.io/gerrit-instance": "https://gerrit",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Refs: &prowapi.Refs{
+							Org:      "https://gerrit",
+							Repo:     "test-infra",
+							RepoLink: "https://gerrit/test-infra",
+							BaseSHA:  "abc",
+							BaseRef:  "retest-branch",
+							BaseLink: "https://gerrit/test-infra/+/abc",
+							CloneURI: "https://gerrit/test-infra",
+							Pulls: []prowapi.Pull{
+								{
+									SHA:        "1",
+									Link:       "https://gerrit/c/test-infra/+/0",
+									CommitLink: "https://gerrit/test-infra/+/1",
+									AuthorLink: "https://gerrit/q/",
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"prow.k8s.io/gerrit-revision":     "1",
+							"prow.k8s.io/gerrit-patchset":     "1",
+							"created-by-prow":                 "true",
+							"prow.k8s.io/context":             "runs-on-all-but-baz-branch",
+							"prow.k8s.io/refs.repo":           "test-infra",
+							"prow.k8s.io/refs.org":            "gerrit",
+							"prow.k8s.io/refs.base_ref":       "retest-branch",
+							"prow.k8s.io/refs.pull":           "0",
+							"prow.k8s.io/type":                "presubmit",
+							"prow.k8s.io/job":                 "runs-on-all-but-baz-branch",
+							"prow.k8s.io/gerrit-report-label": "Code-Review",
+						},
+						Annotations: map[string]string{
+							"prow.k8s.io/gerrit-id":       "",
+							"prow.k8s.io/job":             "runs-on-all-but-baz-branch",
+							"prow.k8s.io/context":         "runs-on-all-but-baz-branch",
+							"prow.k8s.io/gerrit-instance": "https://gerrit",
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Refs: &prowapi.Refs{
+							Org:      "https://gerrit",
+							Repo:     "test-infra",
+							RepoLink: "https://gerrit/test-infra",
+							BaseSHA:  "abc",
+							BaseRef:  "retest-branch",
+							BaseLink: "https://gerrit/test-infra/+/abc",
+							CloneURI: "https://gerrit/test-infra",
+							Pulls: []prowapi.Pull{
+								{
+									SHA:        "1",
+									Link:       "https://gerrit/c/test-infra/+/0",
+									CommitLink: "https://gerrit/test-infra/+/1",
+									AuthorLink: "https://gerrit/q/",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "wrong project triggers no jobs",

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -602,7 +602,7 @@ func (h *gerritInstanceHandler) QueryChangesForProject(log logrus.FieldLogger, p
 
 	var opt gerrit.QueryChangeOptions
 	opt.Query = append(opt.Query, strings.Join(append(additionalFilters, "project:"+project), "+"))
-	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
+	opt.AdditionalFields = []string{"ALL_REVISIONS", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
 
 	log = log.WithFields(logrus.Fields{"query": opt.Query, "additional_fields": opt.AdditionalFields})
 	var start int

--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -29,6 +29,9 @@ import (
 
 var TestAllRe = regexp.MustCompile(`(?m)^/test all,?($|\s.*)`)
 
+// TestRe provides the regex for `/test` command
+var TestRe = regexp.MustCompile(`(?m)^/test\s*?($|\s.*)`)
+
 // RetestRe provides the regex for `/retest`
 var RetestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 


### PR DESCRIPTION
This change attempts to address the issue `Not trigger jobs if only description changed`. For a Gerrit patch set with revision info, we can check the `Kind` field to determine if the patch set contains code change over its parent patch set. If not, we can pass processing the change.
/cc @mpherman2 @listx @cjwagner @chaodaiG 