### PR TITLE
Generate CRI-O jobs for serial and prow build

### DIFF
--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -10,16 +10,18 @@
   "storage": {
     "files": [
       {
-        "path": "/etc/ssh-key-secret/ssh-public",
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
-          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "compression": "",
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
       },
       {
-        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+          "compression": "",
+          "source": "data:,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         },
         "mode": 420
       }
@@ -28,17 +30,17 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/core/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh && chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '\\\n  /usr/bin/mkdir -m 0700 -p /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/cat /etc/ssh-key-secret/ssh-public \\\n    \u003e\u003e /home/core/.ssh/authorized_keys \u0026\u0026 \\\n  /usr/bin/chown -R core:core /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -7,19 +7,32 @@
       "systemd.unified_cgroup_hierarchy=0"
     ]
   },
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "sudo"
+        ],
+        "name": "prow",
+        "system": true
+      }
+    ]
+  },
   "storage": {
     "files": [
       {
-        "path": "/etc/ssh-key-secret/ssh-public",
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
-          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "compression": "",
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
       },
       {
-        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+          "compression": "",
+          "source": "data:,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         },
         "mode": 420
       }
@@ -28,28 +41,19 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys && chown -R prow:prow /home/prow/.ssh && chmod 0600 /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '\\\n  /usr/bin/mkdir -m 0700 -p /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/cat /etc/ssh-key-secret/ssh-public \\\n    \u003e\u003e /home/core/.ssh/authorized_keys \u0026\u0026 \\\n  /usr/bin/chown -R core:core /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
-      }
-    ]
-  },
-  "passwd": {
-    "users": [
-      {
-        "name": "prow",
-        "system": true,
-        "groups": ["sudo"]
       }
     ]
   }

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -27,10 +27,10 @@ fi
 declare -A CONFIGURATIONS=(
     ["crio"]="root cgroups-v1 dbus-tools-install crio-install"
     ["crio_evented_pleg"]="root cgroups-v1 authorized-key dbus-tools-install crio-enable-pod-events crio-install"
+    ["crio_serial"]="root cgroups-v1 authorized-key dbus-tools-install crio-install passwd"
+    ["crio_k8s_infra_prow_build"]="root cgroups-v1 authorized-key dbus-tools-install crio-install"
 
     # TODO: enable them one after another for a directed rollout
-    #["crio_serial"]="root cgroups-v1 authorized-key dbus-tools-install crio-install passwd"
-    #["crio_k8s_infra_prow_build"]="root cgroups-v1 authorized-key dbus-tools-install crio-install"
     #["crio-with-1G-hugepages"]="root cgroups-v1 crio-install allocate-1G-hugepages"
     #["crio_cgrpv2"]="root dbus-tools-install crio-install"
     #["crio_cgrpv2_serial"]="root authorized-key dbus-tools-install crio-install passwd"
@@ -49,6 +49,11 @@ fi
 YQ_IMAGE=mikefarah/yq:4
 BUTANE_IMAGE=quay.io/coreos/butane:release
 BASE_PATH=base
+
+# Pull the latest image version
+for IMAGE in $YQ_IMAGE $BUTANE_IMAGE; do
+    $CONTAINER_RUNTIME pull "$IMAGE"
+done
 
 merge() {
     ARGS=()


### PR DESCRIPTION
We now ensure that the latest image version is available locally and enable the job generation for `crio_k8s_infra_prow_build.ign` and `crio_serial.ign`.

Follow-up on https://github.com/kubernetes/test-infra/pull/28650

PTAL @harche @haircommander 