### PR TITLE
Fix CRI-O SSH key injection

### DIFF
--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -20,8 +20,7 @@
       {
         "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "compression": "",
-          "source": "data:,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -20,8 +20,7 @@
       {
         "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "compression": "",
-          "source": "data:,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -31,8 +31,7 @@
       {
         "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "compression": "",
-          "source": "data:,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/templates/base/authorized-key.yaml
+++ b/jobs/e2e_node/crio/templates/base/authorized-key.yaml
@@ -3,7 +3,8 @@ storage:
   files:
     - path: /etc/ssh-key-secret/ssh-public
       contents:
-        inline: GCE_SSH_PUBLIC_KEY_FILE_CONTENT
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 systemd:
   units:

--- a/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
@@ -9,7 +9,7 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
-        inline: GCE_SSH_PUBLIC_KEY_FILE_CONTENT
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
       contents:

--- a/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
@@ -9,7 +9,7 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
-        inline: GCE_SSH_PUBLIC_KEY_FILE_CONTENT
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 kernel_arguments:
   should_exist:

--- a/jobs/e2e_node/crio/templates/crio_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_serial.yaml
@@ -9,7 +9,7 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
-        inline: GCE_SSH_PUBLIC_KEY_FILE_CONTENT
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 kernel_arguments:
   should_exist:


### PR DESCRIPTION
We have to pass valid base64 to make the data URL valid, means we have to pre-encode it to produce a valid ignition file.

This change has to be merged with https://github.com/kubernetes/kubernetes/pull/115657 to be able to inject the SSH key.

cc @harche @haircommander 