### PR TITLE
artifacts.k8s.io: Create periodic jobs to copy to mirrors

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -115,8 +115,7 @@ presubmits:
       - name: promote-to-primary
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        #image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b@sha256:c075e38f1aba081824a3afc1cce63f1b0571f201de9b72397ab1000bb627420b
         command:
         - /kpromo
         args:
@@ -126,8 +125,7 @@ presubmits:
       - name: promote-to-mirrors
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        #image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b@sha256:c075e38f1aba081824a3afc1cce63f1b0571f201de9b72397ab1000bb627420b
         command:
         - /kpromo
         args:
@@ -137,8 +135,7 @@ presubmits:
       - name: promote-to-mirrors-staging
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        #image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b@sha256:c075e38f1aba081824a3afc1cce63f1b0571f201de9b72397ab1000bb627420b
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -127,6 +127,85 @@ periodics:
       - org: kubernetes
         slug: release-managers
 
+# Copy artifacts to mirrors (periodic drift correction)
+- interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  max_concurrency: 1
+  name: ci-k8sio-file-promo-mirrors
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: main
+  spec:
+    serviceAccountName: k8s-infra-promoter
+    containers:
+    - name: promote-to-mirrors
+      # TODO(justinsb): replace with released image once this is working
+      # Curently lacking S3 support - at least
+      #image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
+      image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b
+      command:
+      - /kpromo
+      args:
+      - run
+      - files
+      - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/mirroring
+      - --confirm
+      - --use-service-account
+      env:
+        - name: AWS_ROLE_ARN
+          value: arn:aws:iam::354561287328:role/artifacts.k8s.io_s3writer
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/aws-iam-token/serviceaccount/token
+        - name: AWS_REGION
+          value: us-east-1
+      volumeMounts:
+        - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
+          name: aws-iam-token
+          readOnly: true
+    - name: promote-to-mirrors-staging
+      # TODO(justinsb): replace with released image once this is working
+      # Curently lacking S3 support - at least
+      #image: registry.k8s.io/artifact-promoter/kpromo:v3.4.11-1
+      image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b
+      command:
+      - /kpromo
+      args:
+      - run
+      - files
+      - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/mirroring-staging
+      - --confirm
+      - --use-service-account
+      env:
+        - name: AWS_ROLE_ARN
+          value: arn:aws:iam::354561287328:role/artifacts.k8s.io_s3writer
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/aws-iam-token/serviceaccount/token
+        - name: AWS_REGION
+          value: us-east-1
+      volumeMounts:
+        - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
+          name: aws-iam-token
+          readOnly: true
+    volumes:
+    - name: aws-iam-token
+      projected:
+        defaultMode: 420
+        sources:
+        - serviceAccountToken:
+            audience: sts.amazonaws.com
+            expirationSeconds: 86400
+            path: token
+  annotations:
+    testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
+    #testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
+    #testgrid-num-failures-to-alert: '2'
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes
+        slug: release-managers
+
 # ci-k8sio-image-promo runs every 1 hour, to make sure that the destination
 # GCRs do not deviate away from the intent of the manifest.
 - interval: 1h


### PR DESCRIPTION
We create a periodic job that should copy files to the mirrors.  We're
still setting up e.g. the IAM for this job, so starting with a
periodic job (with alerts turned off!) feels reasonable.
