### PR TITLE
Enable further CRI-O job generation

### DIFF
--- a/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
+++ b/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
@@ -12,6 +12,7 @@
       {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
+          "compression": "",
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
@@ -21,12 +22,12 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Allocate 1G hugepages.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/bash -c 'echo 1 > /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Allocate 1G hugepages.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/echo 1 \u003e \\\n  /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "allocate-1G-hugepages.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -7,6 +7,7 @@
       {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
+          "compression": "",
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
@@ -16,12 +17,12 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
@@ -5,16 +5,17 @@
   "storage": {
     "files": [
       {
-        "path": "/etc/ssh-key-secret/ssh-public",
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
-          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "compression": "",
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
       },
       {
-        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+          "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
       }
@@ -23,17 +24,17 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/core/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh && chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '\\\n  /usr/bin/mkdir -m 0700 -p /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/cat /etc/ssh-key-secret/ssh-public \\\n    \u003e\u003e /home/core/.ssh/authorized_keys \u0026\u0026 \\\n  /usr/bin/chown -R core:core /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -2,19 +2,31 @@
   "ignition": {
     "version": "3.3.0"
   },
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "sudo"
+        ],
+        "name": "prow",
+        "system": true
+      }
+    ]
+  },
   "storage": {
     "files": [
       {
-        "path": "/etc/ssh-key-secret/ssh-public",
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
-          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+          "compression": "",
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
       },
       {
-        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "path": "/etc/ssh-key-secret/ssh-public",
         "contents": {
-          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+          "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
       }
@@ -23,28 +35,19 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys && chown -R prow:prow /home/prow/.ssh && chmod 0600 /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '\\\n  /usr/bin/mkdir -m 0700 -p /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/cat /etc/ssh-key-secret/ssh-public \\\n    \u003e\u003e /home/core/.ssh/authorized_keys \u0026\u0026 \\\n  /usr/bin/chown -R core:core /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
-      }
-    ]
-  },
-  "passwd": {
-    "users": [
-      {
-        "name": "prow",
-        "system": true,
-        "groups": ["sudo"]
       }
     ]
   }

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
@@ -9,7 +9,8 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
-        inline: GCE_SSH_PUBLIC_KEY_FILE_CONTENT
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 systemd:
   units:

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
@@ -9,7 +9,8 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
-        inline: GCE_SSH_PUBLIC_KEY_FILE_CONTENT
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 systemd:
   units:

--- a/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
@@ -9,6 +9,7 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf

--- a/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
@@ -9,6 +9,7 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 kernel_arguments:

--- a/jobs/e2e_node/crio/templates/crio_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_serial.yaml
@@ -9,6 +9,7 @@ storage:
       mode: 0644
     - path: /etc/ssh-key-secret/ssh-public
       contents:
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
 kernel_arguments:

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -29,12 +29,10 @@ declare -A CONFIGURATIONS=(
     ["crio_evented_pleg"]="root cgroups-v1 authorized-key dbus-tools-install crio-enable-pod-events crio-install"
     ["crio_serial"]="root cgroups-v1 authorized-key dbus-tools-install crio-install passwd"
     ["crio_k8s_infra_prow_build"]="root cgroups-v1 authorized-key dbus-tools-install crio-install"
-
-    # TODO: enable them one after another for a directed rollout
-    #["crio-with-1G-hugepages"]="root cgroups-v1 crio-install allocate-1G-hugepages"
-    #["crio_cgrpv2"]="root dbus-tools-install crio-install"
-    #["crio_cgrpv2_serial"]="root authorized-key dbus-tools-install crio-install passwd"
-    #["crio_cgrpv2_k8s_infra_prow_build"]="root authorized-key dbus-tools-install crio-install"
+    ["crio-with-1G-hugepages"]="root cgroups-v1 crio-install allocate-1G-hugepages"
+    ["crio_cgrpv2"]="root dbus-tools-install crio-install"
+    ["crio_cgrpv2_serial"]="root authorized-key dbus-tools-install crio-install passwd"
+    ["crio_cgrpv2_k8s_infra_prow_build"]="root authorized-key dbus-tools-install crio-install"
 )
 
 CONTAINER_RUNTIME=$(which podman 2>/dev/null) ||


### PR DESCRIPTION
We now enable all CRI-O jobs with generated configuraitons. We have to watch the following jobs after merge:

- **crio-with-1G-hugepages.ign:**
  - [ci-crio-cgroupv1-node-e2e-hugepages](https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-hugepages)
- **crio_cgrpv2.ign:**
  - [ci-crio-cgroupv2-node-e2e-conformance](https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv2-node-e2e-conformance)
  - [pull-kubernetes-node-memoryqos-cgrpv2](https://prow.k8s.io/?job=pull-kubernetes-node-memoryqos-cgrpv2)
- **crio_cgrpv2_serial.ign:**
  - [pull-kubernetes-node-kubelet-serial-crio-cgroupv2](https://prow.k8s.io/?job=pull-kubernetes-node-kubelet-serial-crio-cgroupv2)
- **crio_cgrpv2_k8s_infra_prow_build.ign:**
  - [pull-kubernetes-node-crio-cgrpv2-e2e](https://prow.k8s.io/?job=pull-kubernetes-node-crio-cgrpv2-e2e)
  - [pull-kubernetes-node-crio-cgrpv2-e2e-kubetest2](https://prow.k8s.io/?job=pull-kubernetes-node-crio-cgrpv2-e2e-kubetest2)

PTAL @harche @haircommander 