### PR TITLE
Bump crio for fixed handling of oom with cgroupv2

### DIFF
--- a/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
+++ b/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
@@ -22,7 +22,7 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -27,7 +27,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -22,7 +22,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
@@ -34,7 +34,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -45,7 +45,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -47,7 +47,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -39,7 +39,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -50,7 +50,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/templates/base/crio-install.yaml
+++ b/jobs/e2e_node/crio/templates/base/crio-install.yaml
@@ -14,7 +14,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
@@ -25,7 +25,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -42,7 +42,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
@@ -39,7 +39,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
@@ -63,7 +63,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
@@ -63,7 +63,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
@@ -70,7 +70,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
@@ -66,7 +66,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/crio/templates/crio_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_serial.yaml
@@ -66,7 +66,7 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/a8c9ddc773007c61074e224bd740ca3aecd7fecb/scripts/node_e2e_installer ;\
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
           ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 

--- a/jobs/e2e_node/swap/crio_swap1g.ign
+++ b/jobs/e2e_node/swap/crio_swap1g.ign
@@ -43,7 +43,7 @@
         "name": "swap-enable.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/74583d26406963ba150004f343bc36c16a861164/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }


### PR DESCRIPTION
It bumps the CRIO used by test-infra to its latest version after the fixes for OOM killer handling, pointing to the new version after https://github.com/cri-o/cri-o/pull/6629.

For more reference check [Add e2e_node test for oom killed container reason](https://github.com/kubernetes/kubernetes/pull/113205) and in particular this recent [comment](https://github.com/kubernetes/kubernetes/pull/113205#issuecomment-1424517837). 

I've tested locally that the OOMKiller test passes.

This is the last analogous commit which bumped CRIO: https://github.com/kubernetes/test-infra/commit/2b30f2e31d90eabcc47f7616e19e3485b09a9f59.