### PR TITLE
Revert back to CAPZ release-1.7 for all Azure jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -486,7 +486,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -601,7 +601,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -658,7 +658,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -718,7 +718,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.6
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -70,7 +70,7 @@ presubmits:
             - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -298,7 +298,7 @@ presubmits:
             - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: ENABLE_MULTI_SLB # cloud-provider-azure config
@@ -392,7 +392,7 @@ periodics:
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz
@@ -796,7 +796,7 @@ periodics:
         - name: KUBERNETES_VERSION # CAPZ config
           value: "latest"
         - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
         - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -858,7 +858,7 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
       - name: CLUSTER_TEMPLATE # CAPZ config
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -923,7 +923,7 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
       - name: CLUSTER_TEMPLATE # CAPZ config
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -990,7 +990,7 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
       - name: CLUSTER_TEMPLATE # CAPZ config
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -1054,7 +1054,7 @@ periodics:
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
         value: "1"
       - name: CLUSTER_TEMPLATE # CAPZ config
-        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "Standard"
       - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: K8S_FEATURE_GATES # cloud-provider-azure config
@@ -97,7 +97,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -153,7 +153,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
       annotations:
@@ -95,7 +95,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -151,7 +151,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -97,7 +97,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -157,7 +157,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -45,7 +45,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -70,7 +70,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/ad2785190025d1109f7e6d2a586ecd1fc7931b99/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -97,7 +97,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -157,7 +157,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.6
+          base_ref: release-1.7
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:


### PR DESCRIPTION
Reverts the revert now that transient issues in release-1.7 are fixed: #28638 and https://github.com/kubernetes/test-infra/pull/28573