### PR TITLE
CRI-O jobs: Make CRI-O systemd unit fail if install fails

### DIFF
--- a/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
+++ b/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
@@ -22,7 +22,7 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -27,7 +27,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -22,7 +22,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
@@ -34,7 +34,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -34,7 +34,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -47,7 +47,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -39,7 +39,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -39,7 +39,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -44,7 +44,7 @@
         "name": "swap-enable.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\\\n  ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/templates/base/crio-install.yaml
+++ b/jobs/e2e_node/crio/templates/base/crio-install.yaml
@@ -14,8 +14,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
@@ -25,8 +25,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -42,8 +42,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
@@ -39,8 +39,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
@@ -63,8 +63,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
@@ -63,8 +63,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
@@ -70,8 +70,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
@@ -66,8 +66,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_serial.yaml
@@ -66,8 +66,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -80,8 +80,8 @@ systemd:
           /usr/bin/curl --fail --retry 5 \
             --retry-delay 3 --silent --show-error \
             -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer ;\
-          ln -s /usr/bin/runc /usr/local/bin/runc'
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
         ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]


### PR DESCRIPTION
The `;` would make the bash script continue even if the CRI-O install fails. We now fix that by using `&&`.

Beside that we set an absolute path for the `ln` binary.

PTAL @harche @haircommander 