### PR TITLE
Fix misspelling in config to satisfy lint

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -960,7 +960,7 @@ presets:
   env:
     - name: REGISTRY
       value: capzci.azurecr.io
-    - name: LOCAL_ONLY # This variable is used for backwards compatability, can be removed once CAPZ v1.7.0+ is used in all jobs
+    - name: LOCAL_ONLY # This variable is used for backwards compatibility, can be removed once CAPZ v1.7.0+ is used in all jobs
       value: "false"
     - name: USE_LOCAL_KIND_REGISTRY
       value: "false"


### PR DESCRIPTION
./config/prow/config.yaml:963:61: compatability is a misspelling of compatibility

Signed-off-by: Jakub Guzik <jguzik@redhat.com>