### PR TITLE
[KMSv2] build e2e.test, ginkgo binaries and move to _output/dockerized

### DIFF
--- a/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
+++ b/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
@@ -26,6 +26,8 @@ presubmits:
           privileged: true
         command:
         - runner.sh
+        # The build e2e.test, ginkgo and kubectl binaries + copy to dockerized dir is
+        # because of https://github.com/kubernetes-sigs/kubetest2/issues/184
         args:
         - "/bin/bash"
         - "-c"
@@ -38,6 +40,11 @@ presubmits:
           go install sigs.k8s.io/kubetest2@latest;
           go install sigs.k8s.io/kubetest2/kubetest2-kind@latest;
           go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+          make all WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo cmd/kubectl";
+          mkdir -p _output/dockerized/bin/linux/amd64;
+          for binary in kubectl e2e.test ginkgo; do
+            cp -f _output/local/go/bin/${binary} _output/dockerized/bin/linux/amd64/${binary};
+          done;
           kubetest2 kind -v 5 \;
             --build \;
             --up \;


### PR DESCRIPTION
`kubetest2 kind` when used with `--use-built-binaries` doesn't built the e2e.test, gingko binaries. This change builds the required binaries and moves them to _output/dockerized dir used by the builder to copy during build (xref: https://github.com/kubernetes-sigs/kubetest2/blob/master/pkg/build/build.go#L84-L101)

Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

/sig auth
/triage accepted
/assign @enj 