### PR TITLE
controller-runtime: change jobs to main

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
@@ -17,3 +17,21 @@ periodics:
   annotations:
     testgrid-dashboards: sig-api-machinery-kubebuilder
     testgrid-tab-name: controller-runtime-periodic-master
+- interval: 6h
+  name: periodic-controller-runtime-test
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: controller-runtime
+    base_ref: main
+  spec:
+    containers:
+    - image: golang:1.19
+      command:
+      - ./hack/ci-check-everything.sh
+      resources:
+        requests:
+          cpu: "7000m"
+  annotations:
+    testgrid-dashboards: sig-api-machinery-kubebuilder
+    testgrid-tab-name: controller-runtime-periodic-main

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
@@ -1,12 +1,13 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
-  - name: pull-controller-runtime-test-master
+  - name: pull-controller-runtime-test
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
     branches:
     # The script this job runs is not in all branches.
     - ^master$
+    - ^main$
     spec:
       containers:
       - image: golang:1.19
@@ -17,14 +18,15 @@ presubmits:
             cpu: "7000m"
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: controller-runtime-master
-  - name: pull-controller-runtime-apidiff-master
+      testgrid-tab-name: controller-runtime-main
+  - name: pull-controller-runtime-apidiff
     decorate: true
     always_run: true
     optional: true
     path_alias: sigs.k8s.io/controller-runtime
     branches:
     - ^master$
+    - ^main$
     spec:
       containers:
       - image: golang:1.19
@@ -32,4 +34,4 @@ presubmits:
         - ./hack/apidiff.sh
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: controller-runtime-master-apidiff
+      testgrid-tab-name: controller-runtime-main-apidiff


### PR DESCRIPTION
xref: https://github.com/kubernetes-sigs/controller-runtime/issues/1026

This PR should cover the following sub-tasks from the issue and be non-disruptive:
* If a presubmit or postsubmit prowjob triggers on the master branch (branches field of the prowjob), add the main branch to the list
* For periodic prowjobs, or any prowjob that mentions the master branch in base_ref, update them to the main branch.
  * I just added a new job for main. The old one for master will be removed after the branch rename in the CR repo
* If a prowjob mentions master in its name, rename the job to not include the branch name

After this PR we should be ready to actually rename the branch in the repo according to the [official instructions](https://github.com/github/renaming#renaming-existing-branches).