### PR TITLE
Add executor duration log for metrics

### DIFF
--- a/prow/git/v2/executor.go
+++ b/prow/git/v2/executor.go
@@ -19,6 +19,7 @@ package git
 import (
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -64,6 +65,7 @@ type censoringExecutor struct {
 
 func (e *censoringExecutor) Run(args ...string) ([]byte, error) {
 	logger := e.logger.WithField("args", strings.Join(args, " "))
+	now := time.Now()
 	b, err := e.execute(e.dir, e.git, args...)
 	b = e.censor(b)
 	if err != nil {
@@ -71,5 +73,6 @@ func (e *censoringExecutor) Run(args ...string) ([]byte, error) {
 	} else {
 		logger.Debug("Running command succeeded.")
 	}
+	logger.WithFields(logrus.Fields{"duration": time.Since(now), "dir": e.dir}).Info("Time taken to execute command.")
 	return b, err
 }


### PR DESCRIPTION
Looking into trigger latency and I'm curious about how long each fetch/clone is taking especially for larger repos. Adding this log to hopefully explore using log based metrics.

/assign @cjwagner