### PR TITLE
Update prow with k/website milestone applier and add branch protection for k/website release-1.25

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -511,6 +511,8 @@ branch-protection:
               protect: true
             release-1.24:
               protect: true
+            release-1.25:
+              protect: true
     kubernetes-client:
       protect: true
       required_status_checks:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -501,7 +501,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.26: 1.26
+    dev-1.27: 1.27
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
This PR adds the 1.27 milestone applier to the `dev-1.27` branch in k/website and adds branch protection for the `release-1.25` branch in k/website 
