### PR TITLE
ci-k8sio-file-promo-mirrors: allocate more CPU

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -160,6 +160,14 @@ periodics:
           value: /var/run/secrets/aws-iam-token/serviceaccount/token
         - name: AWS_REGION
           value: us-east-1
+      resources:
+        # We hash files as we upload them, so take a whole core
+        requests:
+          cpu: 1
+          memory: "2Gi"
+        limits:
+          cpu: 1
+          memory: "2Gi"
       volumeMounts:
         - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
           name: aws-iam-token
@@ -184,6 +192,14 @@ periodics:
           value: /var/run/secrets/aws-iam-token/serviceaccount/token
         - name: AWS_REGION
           value: us-east-1
+      resources:
+        # We hash files as we upload them, so take a whole core
+        requests:
+          cpu: 1
+          memory: "2Gi"
+        limits:
+          cpu: 1
+          memory: "2Gi"
       volumeMounts:
         - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
           name: aws-iam-token


### PR DESCRIPTION
We are likely CPU bound because we have to hash any files we upload,
so allocate a bit more CPU to speed things along when we do have to
copy files.
