### PR TITLE
Add CRI-O job verification presubmit

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -214,3 +214,24 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-test
+  - name: pull-test-infra-verify-cri-o
+    branches:
+    - master
+    run_if_changed: '^jobs/e2e_node/crio/'
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify
+        - -C
+        - jobs/e2e_node/crio
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: verify-cri-o

--- a/jobs/e2e_node/crio/Makefile
+++ b/jobs/e2e_node/crio/Makefile
@@ -14,3 +14,7 @@
 
 all:
 	templates/generate
+
+.PHONY: verify
+verify: all
+	./tree_status

--- a/jobs/e2e_node/crio/tree_status
+++ b/jobs/e2e_node/crio/tree_status
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+STATUS=$(git status --porcelain)
+if [[ -z $STATUS ]]; then
+    echo "tree is clean"
+else
+    echo "tree is dirty, please commit all changes"
+    echo ""
+    echo "$STATUS"
+    git diff
+    exit 1
+fi


### PR DESCRIPTION
We now add a dedicated verification presubmit job to verify the contents of the `jobs/e2e_node/crio` directory.

PTAL @haircommander @harche