### PR TITLE
Fix CRI-O verification presubmit

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -217,7 +217,7 @@ presubmits:
   - name: pull-test-infra-verify-cri-o
     branches:
     - master
-    run_if_changed: '^jobs/e2e_node/crio/'
+    run_if_changed: 'jobs\/e2e_node\/crio\/'
     decorate: true
     labels:
       preset-service-account: "true"
@@ -232,6 +232,9 @@ presubmits:
         - verify
         - -C
         - jobs/e2e_node/crio
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-cri-o


### PR DESCRIPTION
- Use a privileged container to make docker in docker work
- Escape the `run_if_changed` path and remove `^`

PTAL @aojea @dims @sbueringer