### PR TITLE
kops-artifacts-sandbox: actually run the upgrade-ab scenario

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -458,6 +458,7 @@ def generate_misc():
                    cloud="aws",
                    k8s_version='stable',
                    extra_dashboards=['kops-misc'],
+                   scenario='upgrade-ab',
                    env={
                        'KOPS_BASE_URL': "https://artifacts-sandbox.k8s.io/binaries/kops/1.26.0-beta.2/", # pylint: disable=line-too-long
                        'KOPS_VERSION_A': "1.26.0-beta.2",

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -66,13 +66,15 @@ periodics:
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-scenario-gcr-mirror
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-artifacts-sandbox
   cron: '1 0-23/1 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+    preset-dind-enabled: "true"
+  max_concurrency: 1
   decorate: true
   decoration_config:
     timeout: 90m
@@ -87,28 +89,8 @@ periodics:
     - command:
       - runner.sh
       args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230208' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
-          --test=kops \
-          -- \
-          --ginkgo-args="--debug" \
-          --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-marker=stable.txt \
-          --parallel=25
+      - ./tests/e2e/scenarios/upgrade-ab/run-test.sh
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
       - name: KOPS_BASE_URL
         value: "https://artifacts-sandbox.k8s.io/binaries/kops/1.26.0-beta.2/"
       - name: KOPS_VERSION_A
@@ -123,19 +105,30 @@ periodics:
         value: "1"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: CLOUD_PROVIDER
+        value: "aws"
+      - name: CLUSTER_NAME
+        value: "e2e-622a77307c-4bdbd.test-cncf-aws.k8s.io"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
+      - name: KUBE_SSH_USER
+        value: "ubuntu"
+      - name: KOPS_IRSA
+        value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
       imagePullPolicy: Always
       resources:
         limits:
-          memory: 3Gi
+          memory: 6Gi
         requests:
           cpu: "2"
-          memory: 3Gi
+          memory: 6Gi
+      securityContext:
+        privileged: true
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''


### PR DESCRIPTION
I forgot to specify the scenario in the previous job, env vars were
being ignored.
