### PR TITLE
Use Windows 2019 for conformance Windows test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -675,8 +675,6 @@ periodics:
         value: "1"
       - name: TEST_WINDOWS # CAPZ config
         value: "true"
-      - name: WINDOWS_SERVER_VERSION # CAPZ config
-        value: "windows-2022"
       - name: WORKER_MACHINE_COUNT # CAPZ config
         value: "0"
       - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config


### PR DESCRIPTION
gcr.io/authenticated-image-pulling/windows-nanoserver doesn't have Windows 2022 version but the following test needs it. [sig-node] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]