### PR TITLE
Don't use parallel for the global gcr registry

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
@@ -30,4 +30,4 @@ periodics:
               apt update && apt install parallel -qqy
               go install github.com/google/go-containerregistry/cmd/gcrane@latest
               parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: us-west3 us-west4
-              parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod gcr.io/k8s-artifacts-prod"
+              gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod gcr.io/k8s-artifacts-prod


### PR DESCRIPTION
Parallel command doesn't do anything if it not substituting something.

```
cy@cloudshell:~ (k8s-artifacts-prod)$ parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod gcr.io/k8s-artifacts-prod"
cy@cloudshell:~ (k8s-artifacts-prod)$ gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod gcr.io/k8s-artifacts-prod
2023/02/16 22:25:09 Copying from us.gcr.io/k8s-artifacts-prod/addon-builder@sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53 to gcr.io/k8s-artifacts-prod/addon-builder@sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53
2023/02/16 22:25:09 Copying from us.gcr.io/k8s-artifacts-prod/addon-builder@sha256:a8808510bb242ff0f7fb4b45df29d77b28fefc9337c96a1c3f72c04e4e3b32dc to gcr.io/k8s-artifacts-prod/addon-builder@sha256:a8808510bb242ff0f7fb4b45df29d77b28fefc9337c96a1c3f72c04e4e3b32dc
2023/02/16 22:25:09 Copying from us.gcr.io/k8s-artifacts-prod/addon-builder@sha256:f133c116ab433e2afbc28eddcd1ce4e8dcf02f256684d5e3a362ffaa583ff586 to gcr.io/k8s-artifacts-prod/addon-builder@sha256:f133c116ab433e2afbc28eddcd1ce4e8dcf02f256684d5e3a362ffaa583ff586
2023/02/16 22:25:09 Copying from us.gcr.io/k8s-artifacts-prod/addon-builder@sha256:882a20ee0df7399a445285361d38b711c299ca093af978217112c73803546d5e to gcr.io/k8s-artifacts-prod/addon-builder@sha256:882a20ee0df7399a445285361d38b711c299ca093af978217112c73803546d5e
Error: failed to copy "sha256:f133c116ab433e2afbc28eddcd1ce4e8dcf02f256684d5e3a362ffaa583ff586": failed to copy image: PATCH https://gcr.io/v2/k8s-artifacts-prod/addon-builder/blobs/uploads/AH2q6buFxZR2RKFBcDFQX4qlLCjYx0SmCE0ZiRgNlUJvATZWLoPoL23O4WoXba8P342TpCTKA2qXoAlWMWDzNPw: DENIED: Access denied.
```

The AR registries are synced now.

https://prow.k8s.io/?job=gcr-to-ar-sync-us

/cc @ameukam @BenTheElder 