### PR TITLE
Enable release notes plugin for CAPA

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1325,6 +1325,7 @@ plugins:
     - milestonestatus
     - override
     - require-matching-label
+    - release-note
 
   kubernetes-sigs/cluster-api-provider-azure:
     plugins:


### PR DESCRIPTION
Enable the `release-note` prow plugin for CAPA.