### PR TITLE
(secrets-store-csi-driver): use kubekins-e2e 1.25 image

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -12,7 +12,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-1.25
         command:
           - runner.sh
         args:
@@ -37,7 +37,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-1.25
         command:
           - runner.sh
         args:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar [anish.ramasekar@gmail.com](mailto:anish.ramasekar@gmail.com)

The go version for -master image has been bumped to go version `go1.20 linux/amd64` which causes lint failures. Pinning the kubekins-e2e image to -1.25 as we are using go1.19.