### PR TITLE
fix legacy SA key rotation cronjob

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -793,13 +793,18 @@ periodics:
     - name: gcloud
       image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
       command:
-      - bash
-        - -c
-        -
-            temp_file="$(mktemp)"
-            && gcloud iam service-accounts keys create "${temp_file}" --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --key-file-type=json
-            && gcloud secrets versions add default-k8s-build-cluster-service-account-key --data-file=${temp_file} --project=k8s-prow-builds
-            && for key_id in $(gcloud iam service-accounts keys list --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --managed-by=user --created-before=$(date +%Y-%m-%d -d "90 days ago") --format="value(KEY_ID)"); do gcloud iam service-accounts keys delete "$key_id" -q --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com;done
+      - /bin/bash
+      args:
+      - -c
+      - |
+        set -euo pipefail
+
+        temp_file="$(mktemp)"
+        gcloud iam service-accounts keys create "${temp_file}" --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --key-file-type=json
+        gcloud secrets versions add default-k8s-build-cluster-service-account-key --data-file="${temp_file}" --project=k8s-prow-builds
+        for key_id in $(gcloud iam service-accounts keys list --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --managed-by=user --created-before=$(date +%Y-%m-%d -d "90 days ago") --format="value(KEY_ID)"); do
+          gcloud iam service-accounts keys delete "${key_id}" -q --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+        done
   annotations:
     testgrid-num-failures-to-alert: '3'
     testgrid-dashboards: sig-testing-misc


### PR DESCRIPTION
The ci-test-infra-rotate-legacy-default-build-sa-json-key job's command invocation was syntatically correct (thanks to YAML...) but semantically wrong. The arguments were slightly over-indented, meaning that YAML was treating all of the `-` dash characters (such as the `-` in `- c`) as part of the Bash invocation. This resulted in all of the Bash arguments being treated as a single string, which lines up with the failure message most recently observed [1]:

    could not start the process: exec: "bash - -c - temp_file=\"$(mktemp)\" && gcloud iam service-accounts keys create \"${temp_file}\" --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --key-file-type=json && gcloud secrets versions add default-k8s-build-cluster-service-account-key --data-file=${temp_file} --project=k8s-prow-builds && for key_id in $(gcloud iam service-accounts keys list --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --managed-by=user --created-before=$(date +%Y-%m-%d -d \"90 days ago\") --format=\"value(KEY_ID)\"); do gcloud iam service-accounts keys delete \"$key_id\" -q --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com;done": executable file not found in $PATH

We take this opportunity to use best practices to not just fix the formatting but to also break up the long command into multiple lines (removing the need for chaining with `&&`), following a known-good example [2].

[1]: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-rotate-legacy-default-build-sa-json-key/1625668857463050240
[2]: https://github.com/kubernetes/test-infra/blob/3c77b9b170e6605d17e9ca021a4c2164f26eb10a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml#L16-L31

/cc @chaodaiG @BenTheElder @liggitt 