### PR TITLE
add job to run geranos to sync AR to S3 for registry.k8s.io

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml
@@ -1,0 +1,50 @@
+periodics:
+  - name: ar-to-s3-sync
+    interval: 2h
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    max_concurrency: 1
+    annotations:
+      testgrid-dashboards: sig-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: "1"
+    extra_refs:
+      - org: kubernetes
+        repo: registry.kk8s.io
+        base_ref: main
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes
+          slug: sig-k8s-infra-leads
+    spec:
+      serviceAccountName: s3-sync
+      containers:
+        - name: s3-sync
+          image: gcr.io/k8s-staging-infra-tools/k8s-infra@sha256:48fb967be4c36da551584c3004330c7ce37568e4226ea7233eeb08c979374bc6
+          command:
+            - /bin/bash
+            - -c
+            - |
+              aws sts get-caller-identity
+              source hack/tools/setup-go.sh
+              go run ./cmd/geranos
+          env:
+            - name: AWS_ROLE_ARN
+              value: arn:aws:iam::513428760722:role/registry.k8s.io_s3writer
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/aws-iam-token/serviceaccount/token
+            - name: AWS_REGION
+              value: us-east-1
+          volumeMounts:
+            - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
+              name: aws-iam-token
+              readOnly: true
+      volumes:
+        - name: aws-iam-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: sts.amazonaws.com
+                  expirationSeconds: 86400
+                  path: token


### PR DESCRIPTION
NOTE: this will run in dry-run mode for now

/hold
depends on https://github.com/kubernetes/registry.k8s.io/pull/155/