### PR TITLE
Protect all website branches

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -222,7 +222,6 @@ slack_reporter_configs:
     report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>'
 
 branch-protection:
-  allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website
   orgs:
     kubernetes:
       protect: true
@@ -465,54 +464,7 @@ branch-protection:
             teams:
             - stage-bots
         website:
-          protect: false # TODO(fejta): protect all branches soon
-          branches:
-            master:
-              protect: true
-            release-1.4:
-              protect: true
-            release-1.5:
-              protect: true
-            release-1.6:
-              protect: true
-            release-1.7:
-              protect: true
-            release-1.8:
-              protect: true
-            release-1.9:
-              protect: true
-            release-1.10:
-              protect: true
-            release-1.11:
-              protect: true
-            release-1.12:
-              protect: true
-            release-1.13:
-              protect: true
-            release-1.14:
-              protect: true
-            release-1.15:
-              protect: true
-            release-1.16:
-              protect: true
-            release-1.17:
-              protect: true
-            release-1.18:
-              protect: true
-            release-1.19:
-              protect: true
-            release-1.20:
-              protect: true
-            release-1.21:
-              protect: true
-            release-1.22:
-              protect: true
-            release-1.23:
-              protect: true
-            release-1.24:
-              protect: true
-            release-1.25:
-              protect: true
+          protect: true
     kubernetes-client:
       protect: true
       required_status_checks:


### PR DESCRIPTION
The protection for `main` in [k/website](https://github.com/kubernetes/website) was accidentally missing because that branch was previously renamed from `master`.

It seems OK to protect every branch, so do that.