### PR TITLE
fix conformance kubetest params for periodic cloud-provider-gcp job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -332,9 +332,4 @@ periodics:
         done;
         go work sync;
         cd -;
-        kubetest2 gce -v 2 --repo-root $REPO_ROOT \
-          --build --up --down --test=ginkgo \
-          --master-size n1-standard-2  \
-          -- \
-          --test-package-version="${TEST_PACKAGE_VERSION}" \
-          --focus-regex='\[Conformance\]'
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size n1-standard-2 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --focus-regex='\[Conformance\]' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
It seems the commands were not executed correctly as seen in the jobs

https://testgrid.k8s.io/provider-gcp-periodics#Conformance%20-%20Cloud%20Provider%20GCP%20-%20Kubernetes%20-%20master

the build phase never ran and as a consequence the `up` phase failed because didn't find any binary to install