### PR TITLE
Fix missing history in HPA e2e presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -52,21 +52,19 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
       testgrid-tab-name: gci-gce-autoscaling-hpa-cpu-pull
-    # TODO: set `always_run: true` once config confirmed to be correct
-    always_run: false
     # TODO: set `optional: false` once tests not flaky
     optional: true
+    decorate: true
     run_if_changed: '^(pkg\/controller\/podautoscaler\/|test\/e2e\/autoscaling\/horizontal_pod_autoscaling|test\/e2e\/framework\/autoscaling\/)'
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - args:
-        - --bare
-        - --timeout=260
-        - --scenario=kubernetes_e2e
-        - --
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
         - --check-leaked-resources
         - --provider=gce
         - --gcp-zone=us-west1-b
@@ -78,27 +76,26 @@ presubmits:
         - --test_args=--ginkgo.focus=\[Feature:HPA\]
           --minStartupPods=8
         - --ginkgo-parallel=1
+        - --timeout=260m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
 
   - name: pull-kubernetes-e2e-autoscaling-hpa-cm
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
       testgrid-tab-name: gci-gce-autoscaling-hpa-cm-pull
-    # TODO: set `always_run: true` once config confirmed to be correct
-    always_run: false
     # TODO: set `optional: false` once tests not flaky
     optional: true
+    decorate: true
     run_if_changed: '^(pkg\/controller\/podautoscaler\/|test\/e2e\/autoscaling\/custom_metrics_stackdriver_autoscaling.go$)'
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - args:
-        - --timeout=350
-        - --bare
-        - --scenario=kubernetes_e2e
-        - --
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
         - --cluster=hpa
         - --extract=ci/latest
         - --gcp-node-image=gci


### PR DESCRIPTION
Should fix missing history in https://k8s-testgrid.appspot.com/sig-autoscaling-hpa#gci-gce-autoscaling-hpa-cpu-pull and https://k8s-testgrid.appspot.com/sig-autoscaling-hpa#gci-gce-autoscaling-hpa-cm-pull and make job run logs available.