### PR TITLE
update runner image to use go1.19 for capdo janitor job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
@@ -13,7 +13,7 @@ periodics:
         path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+        - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
           imagePullPolicy: Always
           command:
             - "./scripts/ci-janitor.sh"


### PR DESCRIPTION
Fixes: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-digitalocean#capdo-periodic-janitor


/assign @timoreimann @MorrisLaw 