### PR TITLE
Move the sync script to the registry.k8s.io repo and run the job with k8s-infra-gcr-promoter service account

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcs-to-aws-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcs-to-aws-sync.yaml
@@ -10,7 +10,7 @@ periodics:
       testgrid-num-failures-to-alert: "1"
     extra_refs:
       - org: kubernetes
-        repo: k8s.io
+        repo: registry.k8s.io
         base_ref: main
     rerun_auth_config:
       github_team_slugs:
@@ -28,17 +28,15 @@ periodics:
             - -c
             - |
               aws sts get-caller-identity
-              git clone https://github.com/kubernetes/k8s.io /tmp/workspace/kubernetes/k8s.io
-              cd /tmp/workspace/kubernetes/k8s.io/registry.k8s.io
               echo "initiating a sync between GCS and S3..."
-              ./hack/initial-copy-to-s3.sh
+              ./hack/tools/sync-to-s3.sh
           env:
             - name: AWS_ROLE_ARN
               value: arn:aws:iam::513428760722:role/registry.k8s.io_s3writer
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: /var/run/secrets/aws-iam-token/serviceaccount/token
             - name: AWS_REGION
-              value: us-east-1
+              value: us-east-2
           volumeMounts:
             - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
               name: aws-iam-token

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcs-to-aws-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcs-to-aws-sync.yaml
@@ -19,7 +19,7 @@ periodics:
         - org: kubernetes
           slug: release-managers
     spec:
-      serviceAccountName: s3-sync
+      serviceAccountName: k8s-infra-gcr-promoter
       containers:
         - name: s3-sync
           image: gcr.io/k8s-staging-infra-tools/k8s-infra@sha256:48fb967be4c36da551584c3004330c7ce37568e4226ea7233eeb08c979374bc6


### PR DESCRIPTION
This change should be ready now.

/label tide/merge-method-squash

/cc @ameukam 

We need to merge https://github.com/kubernetes/k8s.io/pull/4814 first

/hold