### PR TITLE
Make /lgtm and /approve also act the same as /ok-to-test

### DIFF
--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -38,17 +38,17 @@ var RetestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 // RetestRequiredRe provides the regex for `/retest-required`
 var RetestRequiredRe = regexp.MustCompile(`(?m)^/retest-required\s*$`)
 
-var OkToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
+var okToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 
-var LGTMRe = regexp.MustCompile(`(?m)^/lgtm\s*$`)
+var lgtmRe = regexp.MustCompile(`(?m)^/lgtm\s*$`)
 
-var ApproveRe = regexp.MustCompile(`(?m)^/approve\s*$`)
+var approveRe = regexp.MustCompile(`(?m)^/approve\s*$`)
 
 // CommentMakesPROkToTest returns true if a comment's content indicates the user is allowing the PR to be tested
 // The most obvious case of this is using /ok-to-test, but /lgtm and /approve are also taken as implying the PR is
 // trusted for running tests
 func CommentMakesPROkToTest(comment string) bool {
-	return OkToTestRe.MatchString(comment) || LGTMRe.MatchString(comment) || ApproveRe.MatchString(comment)
+	return okToTestRe.MatchString(comment) || lgtmRe.MatchString(comment) || approveRe.MatchString(comment)
 }
 
 // AvailablePresubmits returns 3 sets of presubmits:

--- a/prow/pjutil/filter_test.go
+++ b/prow/pjutil/filter_test.go
@@ -576,6 +576,110 @@ func TestPresubmitFilter(t *testing.T) {
 			expected: [][]bool{{true, false, false}, {true, false, false}, {true, false, false}, {false, false, false}},
 		},
 		{
+			name:          "/lgtm comment honored for ok to test selects all tests that don't need an explicit trigger",
+			body:          "/lgtm",
+			honorOkToTest: true,
+			org:           "org",
+			repo:          "repo",
+			ref:           "ref",
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "always-runs",
+					},
+					AlwaysRun: true,
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						RunIfChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-triggered",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
+					RerunCommand: "/test trigger",
+				},
+			},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {true, false, false}, {false, false, false}},
+		},
+		{
+			name:          "/approve comment honored for ok to test selects all tests that don't need an explicit trigger",
+			body:          "/approve",
+			honorOkToTest: true,
+			org:           "org",
+			repo:          "repo",
+			ref:           "ref",
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "always-runs",
+					},
+					AlwaysRun: true,
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						RunIfChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-triggered",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
+					RerunCommand: "/test trigger",
+				},
+			},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {true, false, false}, {false, false, false}},
+		},
+		{
 			name:          "not honored ok-to-test comment selects no tests",
 			body:          "/ok-to-test",
 			honorOkToTest: false,

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -181,6 +181,26 @@ func TestHandleGenericComment(t *testing.T) {
 			IgnoreOkToTest: true,
 		},
 		{
+			name: "Trusted member's LGTM, IgnoreOkToTest",
+
+			Author:         "trusted-member",
+			Body:           "/lgtm",
+			State:          "open",
+			IsPR:           true,
+			ShouldBuild:    false,
+			IgnoreOkToTest: true,
+		},
+		{
+			name: "Trusted member's approval, IgnoreOkToTest",
+
+			Author:         "trusted-member",
+			Body:           "/approve",
+			State:          "open",
+			IsPR:           true,
+			ShouldBuild:    false,
+			IgnoreOkToTest: true,
+		},
+		{
 			name: "Trusted member's ok to test",
 
 			Author:      "trusted-member",

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -114,6 +114,24 @@ func TestHandleGenericComment(t *testing.T) {
 			ShouldBuild: false,
 		},
 		{
+			name: "Non-trusted member's LGTM.",
+
+			Author:      "untrusted-member",
+			Body:        "/lgtm",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: false,
+		},
+		{
+			name: "Non-trusted member's approval.",
+
+			Author:      "untrusted-member",
+			Body:        "/approve",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: false,
+		},
+		{
 			name:        "accept /test from non-trusted member if PR author is trusted",
 			Author:      "untrusted-member",
 			PRAuthor:    "trusted-member",
@@ -177,6 +195,46 @@ func TestHandleGenericComment(t *testing.T) {
 
 			Author:      "trusted-member",
 			Body:        "looks great, thanks!\n/ok-to-test \r",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: true,
+			AddedLabels: issueLabels(labels.OkToTest),
+		},
+		{
+			name: "Trusted member's LGTM",
+
+			Author:      "trusted-member",
+			Body:        "looks great, thanks!\n/lgtm",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: true,
+			AddedLabels: issueLabels(labels.OkToTest),
+		},
+		{
+			name: "Trusted member's LGTM, trailing space.",
+
+			Author:      "trusted-member",
+			Body:        "looks great, thanks!\n/lgtm \r",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: true,
+			AddedLabels: issueLabels(labels.OkToTest),
+		},
+		{
+			name: "Trusted member's approval",
+
+			Author:      "trusted-member",
+			Body:        "looks great, thanks!\n/approve",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: true,
+			AddedLabels: issueLabels(labels.OkToTest),
+		},
+		{
+			name: "Trusted member's approval, trailing space.",
+
+			Author:      "trusted-member",
+			Body:        "looks great, thanks!\n/approve \r",
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: true,


### PR DESCRIPTION
If a contributor gives a /lgtm or /approve on a PR there is a strong implication they believe the PR is also ok to test

It is very easy for contributors to miss the fact that they need to also provide /ok-to-test if they want the tests to run and the PR to become mergeable, especially as they only need to do this for folks who are not part of the org

This PR makes prow treat /lgtm and /approve the same as /ok-to-test, making the PR trusted and kicking off tests