### PR TITLE
kubekins-e2e: test-infra variant: update KIND version

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -18,7 +18,7 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
-    KIND_VERSION: 0.10.0
+    KIND_VERSION: 0.17.0
   master:
     CONFIG: master
     GO_VERSION: '1.20'


### PR DESCRIPTION
Once this results in new kubekins-e2e image, we can update the image reference for pull-test-infra-integration at
https://github.com/kubernetes/test-infra/blob/a7c051d842bfcaea6b60315c78f240bbd627a589/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml#L113.

/cc @cjwagner 