### PR TITLE
[sig-windows-networking] Remove Docker prowjobs

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -31,18 +31,6 @@ dashboards:
       test_group_name: sig-windows-soak-tests
 - name: sig-windows-networking
   dashboard_tab:
-  - name: ltsc2019-docker-flannel-winbridge-stable-dsr-disabled
-    description: Runs Windows (LTSC 2019 with Docker) E2E tests on stable branch K8s clusters (with WinDSR disabled) and latest Flannel CNI release in l2bridge network mode.
-    test_group_name: k8s-e2e-ltsc2019-docker-flannel-winbridge-stable-dsr-disabled
-  - name: ltsc2019-docker-flannel-winoverlay-stable-dsr-disabled
-    description: Runs Windows (LTSC 2019 with Docker) E2E tests on stable branch K8s clusters (with WinDSR disabled) and latest Flannel CNI release in overlay network mode.
-    test_group_name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-stable-dsr-disabled
-  - name: ltsc2019-docker-flannel-winbridge-stable
-    description: Runs Windows (LTSC 2019 with Docker) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
-    test_group_name: k8s-e2e-ltsc2019-docker-flannel-winbridge-stable
-  - name: ltsc2019-docker-flannel-winoverlay-stable
-    description: Runs Windows (LTSC 2019 with Docker) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
-    test_group_name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-stable
   - name: ltsc2019-containerd-flannel-sdnbridge-master
     description: Runs Windows (LTSC 2019 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
@@ -85,14 +73,6 @@ dashboards:
 
 test_groups:
 # Flannel CNI on Windows test groups
-- name: k8s-e2e-ltsc2019-docker-flannel-winbridge-stable-dsr-disabled
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-docker-flannel-winbridge-stable-dsr-disabled
-- name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-stable-dsr-disabled
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-docker-flannel-winoverlay-stable-dsr-disabled
-- name: k8s-e2e-ltsc2019-docker-flannel-winbridge-stable
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-docker-flannel-winbridge-stable
-- name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-stable
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-docker-flannel-winoverlay-stable
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master


### PR DESCRIPTION
The last Kubernetes release with Docker (`v1.23.16`) goes out of support on 28-Feb-2023.

There is no need to run Docker tests anymore.