### PR TITLE
`deck`: PR Status: null check the tidePools prior to filter

### DIFF
--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -553,11 +553,15 @@ function createPRCardTitle(pr: PullRequest, tidePools: TidePool[], jobStatus: Va
   prTitleText.classList.add("pr-title-text");
   prTitle.appendChild(prTitleText);
 
-  const pool = tidePools.filter((p) => {
-    const repo = `${p.Org}/${p.Repo}`;
-    return pr.Repository.NameWithOwner === repo && pr.BaseRef.Name === p.Branch;
-  });
-  let tidePoolLabel = createTidePoolLabel(pr, pool[0]);
+  let tidePoolLabel;
+  if (tidePools && tidePools.length) {
+    const pool = tidePools.filter((p) => {
+      const repo = `${p.Org}/${p.Repo}`;
+      return pr.Repository.NameWithOwner === repo && pr.BaseRef.Name === p.Branch;
+    });
+    tidePoolLabel = createTidePoolLabel(pr, pool[0]);
+  }
+
   if (!tidePoolLabel) {
     tidePoolLabel = createTitleLabel(pr.Merged, jobStatus, noQuery, labelConflict, mergeConflict, branchConflict, authorConflict, milestoneConflict);
   }


### PR DESCRIPTION
There is a bug causing the PR Status page to not display anything if the `tidePolls` are null. I can't determine how https://github.com/kubernetes/test-infra/pull/28669 could have caused it, but the timing is suspicious. A null check prior to filtering will solve this problem.

For: https://github.com/kubernetes/test-infra/issues/28751