### PR TITLE
Add postsubmit job to generate sigs.yaml

### DIFF
--- a/config/jobs/kubernetes/community/community-postsubmits.yaml
+++ b/config/jobs/kubernetes/community/community-postsubmits.yaml
@@ -1,0 +1,24 @@
+# kubernetes/community postsubmits
+postsubmits:
+  kubernetes/community:
+  - name: generate-sigs
+    branches:
+    - ^master$
+    decorate: true
+    path_alias: k8s.io/community
+    always_run: false
+    run_if_changed: '^sigs.yaml'
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: golang:1.18
+        command:
+        - make
+        args:
+        - generate-dockerized
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-contribex-org


### PR DESCRIPTION
Create postsubmit job to automate the `make generate-dockerized` after eaching update of sigs.yaml file. 

https://github.com/kubernetes/community/issues/6529 