### PR TITLE
change interval of ci-kubernetes-fsquota-ubuntu from 4h to 24h

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -248,7 +248,7 @@ periodics:
           value: "1"
 
 - name: ci-kubernetes-fsquota-ubuntu
-  interval: 4h
+  interval: 24h
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-dashboards: sig-node-kubelet


### PR DESCRIPTION
This is just a feature-related CI and I think the interval should be larger. 4h interval is too short for this feature in my mind.