### PR TITLE
Fixup example metadata lens configs

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -70,7 +70,9 @@ data:
        - lens:
            name: metadata
          required_files:
-         - started.json|finished.json
+           - ^(?:started|finished)\.json$
+         optional_files:
+           - ^(?:podinfo|prowjob)\.json$
        - lens:
            config:
            name: buildlog

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -70,7 +70,9 @@ data:
        - lens:
            name: metadata
          required_files:
-         - started.json|finished.json
+           - ^(?:started|finished)\.json$
+         optional_files:
+           - ^(?:podinfo|prowjob)\.json$
        - lens:
            config:
            name: buildlog

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -70,7 +70,9 @@ data:
        - lens:
            name: metadata
          required_files:
-         - started.json|finished.json
+           - ^(?:started|finished)\.json$
+         optional_files:
+           - ^(?:podinfo|prowjob)\.json$
        - lens:
            config:
            name: buildlog


### PR DESCRIPTION
The examples for the spyglass metadata lens did not include the job and pod info, so if you followed those examples some information would be missing in the metadata lens.