### PR TITLE
Revert "Add ACR preset for all Azure jobs that need to build and push CCM

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -41,7 +41,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.7.yaml
@@ -41,7 +41,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -258,7 +258,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
     branches:
     - ^main$
     extra_refs:
@@ -298,7 +297,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
     branches:
     - ^main$
     extra_refs:
@@ -344,7 +342,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
     branches:
     - ^main$
     extra_refs:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -355,7 +355,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
     branches:
     - ^release-1.*
     extra_refs:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -18,7 +18,6 @@ periodics:
     timeout: 4h0m0s
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
     preset-capz-containerd-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-124: "true"
@@ -62,7 +61,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
     preset-capz-windows-common-124: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-latest: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -18,7 +18,6 @@ periodics:
     timeout: 4h0m0s
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
     preset-capz-containerd-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-125: "true"
@@ -62,7 +61,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
     preset-capz-windows-common-125: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-latest: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -29,7 +29,6 @@ periodics:
   interval: 24h
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
     preset-capz-containerd-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-126: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -83,7 +83,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
     preset-capz-windows-common-main: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-latest: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -343,7 +343,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -602,7 +601,6 @@ EOF
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
@@ -274,7 +274,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.24.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.24.yaml
@@ -274,7 +274,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
@@ -274,7 +274,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
@@ -274,7 +274,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -304,7 +304,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -560,7 +559,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
This reverts commit cee478cd3074107bad76ada03f656d0142985cad.

See slack thread [here](https://kubernetes.slack.com/archives/C09QZ4DQB/p1677120925938689) for more details. This reverts a commit in order to re-apply it as there was a GitHub hiccup and the postsubmit job to update the config never ran last week.