### PR TITLE
Disable failing sig-node-cos jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -401,36 +401,40 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-features-1.6
-- interval: 12h
-  name: ci-containerd-soak-cos-gce
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=1220
-      - --scenario=kubernetes_e2e
-      - --
-      - --down=false
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-project=k8s-jkns-e2e-gci-gce-soak-1-4
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --save=gs://kubernetes-e2e-soak-configs/ci-containerd-soak-gci-gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
-      - --timeout=1200m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: soak-cos-gce
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#soak-cos-gce&width=5&sort-by-failures=
+#- interval: 12h
+#  name: ci-containerd-soak-cos-gce
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=1220
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --down=false
+#      - --extract=ci/latest
+#      - --gcp-master-image=gci
+#      - --gcp-node-image=gci
+#      - --gcp-project=k8s-jkns-e2e-gci-gce-soak-1-4
+#      - --gcp-zone=us-west1-b
+#      - --provider=gce
+#      - --save=gs://kubernetes-e2e-soak-configs/ci-containerd-soak-gci-gce
+#      - --soak
+#      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
+#      - --timeout=1200m
+#      - --up=false
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: soak-cos-gce
+
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   cron: "30 1-23/3 * * *"
   labels:
@@ -465,35 +469,38 @@ periodics:
     testgrid-tab-name: e2e-cos-device-plugin-gpu
     testgrid-num-failures-to-alert: '8'
     testgrid-alert-stale-results-hours: '24'
-- interval: 2h
-  name: ci-cri-containerd-e2e-cos-gce-alpha-features
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=200
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
-      - --env=KUBE_PROXY_DAEMONSET=true
-      - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|StorageVersionAPI|PodPreset|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|RetroactiveDefaultStorageClass|ReadWriteOncePod)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-alpha-features
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-alpha-features&width=5&sort-by-failures=
+#- interval: 2h
+#  name: ci-cri-containerd-e2e-cos-gce-alpha-features
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=200
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
+#      - --env=KUBE_PROXY_DAEMONSET=true
+#      - --env=ENABLE_POD_PRIORITY=true
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --provider=gce
+#      - --runtime-config=api/all=true
+#      - --test_args=--ginkgo.focus=\[Feature:(GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|StorageVersionAPI|PodPreset|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|RetroactiveDefaultStorageClass|ReadWriteOncePod)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
+#      - --timeout=180m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-alpha-features
 
 - name: ci-kubernetes-node-kubelet-containerd-eviction
   cluster: k8s-infra-prow-build
@@ -534,164 +541,181 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Uses kubetest to run node-e2e Eviction tests"
 
-- interval: 2h
-  name: ci-cri-containerd-e2e-cos-gce-flaky
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=200
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-flaky
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-flaky&width=5&sort-by-failures=
+#- interval: 2h
+#  name: ci-cri-containerd-e2e-cos-gce-flaky
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=200
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --provider=gce
+#      - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
+#      - --timeout=180m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-flaky
 
-- interval: 2h
-  name: ci-cri-containerd-e2e-cos-gce-ip-alias
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --cluster=
-      - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-ip-alias
-- interval: 2h
-  name: ci-cri-containerd-e2e-cos-gce-proto
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-proto
-- interval: 1h
-  name: ci-cri-containerd-e2e-cos-gce-reboot
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=200
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-reboot
-- interval: 1h
-  name: ci-cri-containerd-e2e-cos-gce-serial
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=520
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=500m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-serial
-- interval: 1h
-  name: ci-cri-containerd-e2e-cos-gce-slow
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=170
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=150m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-slow
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-ip-alias&width=5&sort-by-failures=
+#- interval: 2h
+#  name: ci-cri-containerd-e2e-cos-gce-ip-alias
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=70
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --cluster=
+#      - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-nodes=4
+#      - --gcp-zone=us-west1-b
+#      - --ginkgo-parallel=30
+#      - --provider=gce
+#      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+#      - --timeout=50m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-ip-alias
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-proto&width=5&sort-by-failures=
+#- interval: 2h
+#  name: ci-cri-containerd-e2e-cos-gce-proto
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=70
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --ginkgo-parallel=25
+#      - --provider=gce
+#      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+#      - --timeout=50m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-proto
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-reboot&width=5&sort-by-failures=
+#- interval: 1h
+#  name: ci-cri-containerd-e2e-cos-gce-reboot
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=200
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --provider=gce
+#      - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
+#      - --timeout=180m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-reboot
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-slow&width=5&sort-by-failures=
+#- interval: 1h
+#  name: ci-cri-containerd-e2e-cos-gce-serial
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=520
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --provider=gce
+#      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+#      - --timeout=500m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-serial
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+# https://testgrid.k8s.io/sig-node-cos#e2e-cos-slow&width=5&sort-by-failures=
+#- interval: 1h
+#  name: ci-cri-containerd-e2e-cos-gce-slow
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#    preset-e2e-containerd: "true"
+#    preset-e2e-containerd-image-load: "true"
+#  spec:
+#    containers:
+#    - args:
+#      - --repo=github.com/containerd/containerd=main
+#      - --timeout=170
+#      - --scenario=kubernetes_e2e
+#      - --
+#      - --check-leaked-resources
+#      - --extract=ci/latest
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --ginkgo-parallel=25
+#      - --provider=gce
+#      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+#      - --timeout=150m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#  annotations:
+#    testgrid-dashboards: sig-node-cos
+#    testgrid-tab-name: e2e-cos-slow
+
 - name: ci-cri-containerd-node-e2e-features
   cluster: k8s-infra-prow-build
   interval: 1h

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -5,7 +5,6 @@ dashboard_groups:
     - sig-node-kubelet
     - sig-node-containerd
     - sig-node-cri-o
-    - sig-node-cos
     - sig-node-dynamic-resource-allocation
     - sig-node-presubmits
     # These dashboards are for out-of-tree SIG Node projects
@@ -62,7 +61,6 @@ dashboards:
     test_group_name: post-security-profiles-operator-push-image
     base_options: width=10
 
-- name: sig-node-cos
 - name: sig-node-dynamic-resource-allocation
   dashboard_tab:
   - name: pull-kind-dra


### PR DESCRIPTION
These jobs are failing thousands of tests continuously.

![image](https://user-images.githubusercontent.com/980082/221958903-d00e8cb0-f0b0-4132-bf52-3ba3ea779346.png)

![image](https://user-images.githubusercontent.com/980082/221958979-27fe6682-c250-4214-bf32-373dbd4af167.png)

They account for the top several hundred failures listed in https://storage.googleapis.com/k8s-triage/index.html, and the amount of data that triage board has to process shows up as a significant cost for the project.

This comments out the failing jobs.

/sig node
