### PR TITLE
Drop always RED CI job - ci-kubernetes-generate-make-test-count10

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -186,32 +186,34 @@ periodics:
             requests:
               cpu: 4
               memory: "36Gi"
-  - interval: 6h
-    name: ci-kubernetes-generate-make-test-count10
-    annotations:
-      testgrid-dashboards: sig-testing-canaries
-    decorate: true
-    extra_refs:
-      - org: kubernetes
-        repo: kubernetes
-        base_ref: master
-        path_alias: k8s.io/kubernetes
-    labels:
-      preset-service-account: "true"
-    spec:
-      # unit tests have no business requiring root or doing privileged operations
-      securityContext:
-        # NOTE: these are arbitrary non-root values. They don't exist in the
-        # image and don't need to, the unit tests should only write to TMPDIR
-        runAsUser: 2001
-        runAsGroup: 2010
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
-          securityContext:
-            allowPrivilegeEscalation: false
-          command:
-            - runner.sh
-            - bash
-            - -c
-          args:
-            - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10'
+
+# Disabled on 2022-02-28 because the job is consistently failing or skipping all tests
+#  - interval: 6h
+#    name: ci-kubernetes-generate-make-test-count10
+#    annotations:
+#      testgrid-dashboards: sig-testing-canaries
+#    decorate: true
+#    extra_refs:
+#      - org: kubernetes
+#        repo: kubernetes
+#        base_ref: master
+#        path_alias: k8s.io/kubernetes
+#    labels:
+#      preset-service-account: "true"
+#    spec:
+#      # unit tests have no business requiring root or doing privileged operations
+#      securityContext:
+#        # NOTE: these are arbitrary non-root values. They don't exist in the
+#        # image and don't need to, the unit tests should only write to TMPDIR
+#        runAsUser: 2001
+#        runAsGroup: 2010
+#      containers:
+#        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
+#          securityContext:
+#            allowPrivilegeEscalation: false
+#          command:
+#            - runner.sh
+#            - bash
+#            - -c
+#          args:
+#            - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10'


### PR DESCRIPTION
This job also contributes massively to the size of failure text that ends up in the triage json (lost $$$'s when running big query scripts)

See https://kubernetes.slack.com/archives/C09QZ4DQB/p1677611689972059?thread_ts=1677608599.806579&cid=C09QZ4DQB

![image](https://user-images.githubusercontent.com/23304/221959743-7f91c8b3-238c-44d6-a41c-ca6f661c30f5.png)
