### PR TITLE
[KMSv2] set `run_if_changed` for presubmit job

### DIFF
--- a/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
+++ b/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
@@ -5,7 +5,13 @@ presubmits:
     decoration_config:
       timeout: 150m
     always_run: false
-    optional: true # TODO (aramase): make this required and add run_if_changed once the job is passing
+    optional: true
+    # run only if the following files are modified:
+    # - staging/src/k8s.io/apiserver/pkg/storage/value/
+    # - staging/src/k8s.io/kms/
+    # - staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/
+    # - test/e2e/testing-manifests/auth/encrypt/
+    run_if_changed: 'staging/src/k8s.io/apiserver/pkg/storage/value/|staging/src/k8s.io/kms/|staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/|test/e2e/testing-manifests/auth/encrypt/'
     path_alias: k8s.io/kubernetes
     branches:
     - ^master$ # TODO(aramase): enable for release branches


### PR DESCRIPTION
run the KMSv2 presubmit job if the following files are modified:
- staging/src/k8s.io/apiserver/pkg/storage/value/
- staging/src/k8s.io/kms/
- staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/
- test/e2e/testing-manifests/auth/encrypt/

The job is still `optional: true` and will not block PR merge in case of failures.