### PR TITLE
spyglass: add warning for negative time durations

### DIFF
--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -16,6 +16,9 @@
 {{- else -}}
   is still running
 {{- end}} after {{.Elapsed}}. (<a href="#" id="show-table-link">more info</a>)</p>
+{{if lt .Elapsed 0}}
+<p class="test-summary">WARNING: The elapsed duration ({{.Elapsed}}) is negative. This can be caused by another process outside of Prow writing into the finished.json file. The file currently has a completion time of {{.FinishedTime}}.</p>
+{{end}}
 {{if .Hint -}}
 <p class="test-summary failure-hint">{{.Hint}}</p>
 {{end -}}


### PR DESCRIPTION
    spyglass: add warning for negative time durations

    Sometimes, naughty (out of band) processes can tamper with the timestamp
    fields in finished.json. This can result in spyglass showing negative
    time durations.

    The change here notices such anomalies and surfaces it to the user,
    informing them of the naughtiness.

    Because the CI tests run with UTC as the timezone, we refrain from
    checking the entire rendered string (because locally, we could end up
    with a different timezone).
