### PR TITLE
update release-sdk jobs to use go1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-sdk"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - go
@@ -50,7 +50,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-sdk"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
needed for https://github.com/kubernetes-sigs/release-sdk/pull/165

/assign @saschagrunert @puerco @xmudrii 
cc @kubernetes/release-engineering 