### PR TITLE
[KMSv2] update presubmit job to only run the script

### DIFF
--- a/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
+++ b/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
@@ -32,35 +32,7 @@ presubmits:
           privileged: true
         command:
         - runner.sh
-        # The build e2e.test, ginkgo and kubectl binaries + copy to dockerized dir is
-        # because of https://github.com/kubernetes-sigs/kubetest2/issues/184
         args:
         - "/bin/bash"
         - "-c"
-        - set -o errexit;
-          set -o nounset;
-          set -o pipefail;
-          set -o xtrace;
-          export GO111MODULE=on;
-          go install sigs.k8s.io/kind@v0.17.0;
-          go install sigs.k8s.io/kubetest2@latest;
-          go install sigs.k8s.io/kubetest2/kubetest2-kind@latest;
-          go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-          make all WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo cmd/kubectl";
-          mkdir -p _output/dockerized/bin/linux/amd64;
-          for binary in kubectl e2e.test ginkgo; do
-            cp -f _output/local/go/bin/${binary} _output/dockerized/bin/linux/amd64/${binary};
-          done;
-          test/e2e/testing-manifests/auth/encrypt/setup-cluster-prereqs.sh;
-          kubetest2 kind -v 5 \;
-            --build \;
-            --up \;
-            --down \;
-            --config test/e2e/testing-manifests/auth/encrypt/kind.yaml \;
-            --cluster-name kms \;
-            --test=ginkgo \;
-            -- \;
-            --focus-regex='\[Conformance\]' \;
-            --skip-regex='\[Serial\]' \;
-            --parallel 20 \;
-            --use-built-binaries # use the kubectl, e2e.test, and ginkgo binaries built during --build as opposed to from a GCS release tarball
+        - ./test/e2e/testing-manifests/auth/encrypt/run-e2e.sh


### PR DESCRIPTION
Updating the KMS presubmit prow job to invoke the script that'll do all the setup, create cluster, run tests and collect metrics/logs. This change will enable us to only make modifications in the script that can be tested as part of the presubmit job unlike the changes here that can only be validated post merge.

The changes have been tested in https://github.com/kubernetes/kubernetes/pull/116148 (The current failures are because of the duplicate `kubetest2` command in the script and here).
