### PR TITLE
Extend ListedIssueEvent to expose more events API

### DIFF
--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -2111,8 +2111,15 @@ func TestListRepoTeams(t *testing.T) {
 }
 func TestListIssueEvents(t *testing.T) {
 	ts := simpleTestServer(t, "/repos/org/repo/issues/1/events", []ListedIssueEvent{
-		{Event: IssueActionLabeled},
-		{Event: IssueActionClosed},
+		{
+			ID:       1,
+			Event:    IssueActionClosed,
+			CommitID: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		},
+		{
+			ID:    2,
+			Event: IssueActionOpened,
+		},
 	}, http.StatusOK)
 	defer ts.Close()
 	c := getClient(ts.URL)
@@ -2123,11 +2130,14 @@ func TestListIssueEvents(t *testing.T) {
 		t.Errorf("Expected two events, found %d: %v", len(events), events)
 		return
 	}
-	if events[0].Event != IssueActionLabeled {
+	if events[0].Event != IssueActionClosed {
 		t.Errorf("Wrong event for index 0: %v", events[0])
 	}
-	if events[1].Event != IssueActionClosed {
+	if events[1].Event != IssueActionOpened {
 		t.Errorf("Wrong event for index 1: %v", events[1])
+	}
+	if events[0].CommitID != "6dcb09b5b57875f334f61aebed695e2e4193db5e" {
+		t.Errorf("Wrong commit id for index 0: %v", events[0])
 	}
 }
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -769,10 +769,46 @@ type IssueEvent struct {
 // ListedIssueEvent represents an issue event from the events API (not from a webhook payload).
 // https://developer.github.com/v3/issues/events/
 type ListedIssueEvent struct {
-	Event     IssueEventAction `json:"event"` // This is the same as IssueEvent.Action.
-	Actor     User             `json:"actor"`
-	Label     Label            `json:"label"`
-	CreatedAt time.Time        `json:"created_at"`
+	ID  int64  `json:"id,omitempty"`
+	URL string `json:"url,omitempty"`
+
+	// The User that generated this event.
+	Actor User `json:"actor"`
+
+	// This is the same as IssueEvent.Action
+	Event IssueEventAction `json:"event"`
+
+	CreatedAt time.Time `json:"created_at"`
+	Issue     Issue     `json:"issue,omitempty"`
+
+	// Only present on certain events.
+	Assignee          User            `json:"assignee,omitempty"`
+	Assigner          User            `json:"assigner,omitempty"`
+	CommitID          string          `json:"commit_id,omitempty"`
+	Milestone         Milestone       `json:"milestone,omitempty"`
+	Label             Label           `json:"label"`
+	Rename            Rename          `json:"rename,omitempty"`
+	LockReason        string          `json:"lock_reason,omitempty"`
+	ProjectCard       ProjectCard     `json:"project_card,omitempty"`
+	DismissedReview   DismissedReview `json:"dismissed_review,omitempty"`
+	RequestedReviewer User            `json:"requested_reviewer,omitempty"`
+	ReviewRequester   User            `json:"review_requester,omitempty"`
+}
+
+// Rename contains details for 'renamed' events.
+type Rename struct {
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
+}
+
+// DismissedReview represents details for 'dismissed_review' events.
+type DismissedReview struct {
+	// State represents the state of the dismissed review.DismissedReview
+	// Possible values are: "commented", "approved", and "changes_requested".
+	State             string `json:"state,omitempty"`
+	ReviewID          int64  `json:"review_id,omitempty"`
+	DismissalMessage  string `json:"dismissal_message,omitempty"`
+	DismissalCommitID string `json:"dismissal_commit_id,omitempty"`
 }
 
 // IssueCommentEventAction enumerates the triggers for this


### PR DESCRIPTION
Extend ListedIssueEvent to expose more of the events API (not from a webhook payload) for consuming through the prow/github interface.
https://developer.github.com/v3/issues/events/

/sig testing