### PR TITLE
update release-utils jobs to use go1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - go
@@ -25,7 +25,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
needed for: https://github.com/kubernetes-sigs/release-utils/pull/73

/assign @saschagrunert @ameukam @xmudrii 
cc @kubernetes/release-engineering 