### PR TITLE
make pull-kubernetes-e2e-gce-100-performance manually invoked by /test …

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -1327,7 +1327,7 @@ presubmits:
           requests:
             cpu: "4"
             memory: 6Gi
-  - always_run: true
+  - always_run: false
     branches:
     - release-1.23
     cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -1060,7 +1060,7 @@ presubmits:
           requests:
             cpu: "4"
             memory: 6Gi
-  - always_run: true
+  - always_run: false
     branches:
     - release-1.24
     cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -1064,7 +1064,7 @@ presubmits:
           requests:
             cpu: "4"
             memory: 6Gi
-  - always_run: true
+  - always_run: false
     branches:
     - release-1.25
     cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1124,7 +1124,7 @@ presubmits:
           requests:
             cpu: "4"
             memory: 6Gi
-  - always_run: true
+  - always_run: false
     branches:
     - release-1.26
     cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -4,7 +4,7 @@ presubmits:
   # Some elements (like access tokens) are removed to speed up testing.
   - name: pull-kubernetes-e2e-gce-100-performance
     cluster: k8s-infra-prow-build
-    always_run: true
+    always_run: false
     skip_report: false
     max_concurrency: 12
     skip_branches:

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -31,9 +31,6 @@ dashboards:
     base_options: width=10
     alert_options:
       alert_mail_to_addresses: bentheelder+alerts@google.com, antonio.ojea.garcia@gmail.com
-  - name: pull-kubernetes-e2e-gce-100-performance
-    test_group_name: pull-kubernetes-e2e-gce-100-performance
-    base_options: width=10
   - name: pull-kubernetes-node-e2e-containerd
     test_group_name: pull-kubernetes-node-e2e-containerd
     base_options: width=10

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -27,7 +27,6 @@ jobs:
   - pull-kubernetes-conformance-kind-ga-only-parallel
   - pull-kubernetes-dependencies
   - pull-kubernetes-e2e-gce
-  - pull-kubernetes-e2e-gce-100-performance
   - pull-kubernetes-e2e-gce-ubuntu-containerd
   - pull-kubernetes-e2e-kind
   - pull-kubernetes-e2e-kind-ipv6


### PR DESCRIPTION
pull-kubernetes-e2e-gce-100-performance instead of `always_run: true`

We can see if the equivalent periodic job starts to break frequently, and Kubernetes must cut costs this year to avoid shutting down everything. If the release-blocking periodic breaks frequently then we have signal to consider a revert.

This is the first change I'm proposing after talking to SIG Scalability representatives about reviewing our scalability CI jobs and what levers we might be able to pull there.

/assign @wojtek-t
/hold



