### PR TITLE
feat(prow/plugins/lgtm): support threshold of review approved count

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -360,6 +360,9 @@ type Lgtm struct {
 	// StickyLgtmTeam specifies the GitHub team whose members are trusted with sticky LGTM,
 	// which eliminates the need to re-lgtm minor fixes/updates.
 	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
+	// ReviewerCount is the minimum number of approved reviewers.
+	// Defaults 1 reviewers.
+	ReviewerCount *int `json:"request_count,omitempty"`
 }
 
 // Jira holds the config for the jira plugin.

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -46,7 +46,8 @@ var (
 	// LGTMLabel is the name of the lgtm label applied by the lgtm plugin
 	LGTMLabel = labels.LGTM
 	// LGTMRe is the regex that matches lgtm comments
-	LGTMRe = regexp.MustCompile(`(?mi)^/lgtm(?: no-issue)?\s*$`)
+	LGTMRe              = regexp.MustCompile(`(?mi)^/lgtm(?: no-issue)?\s*$`)
+	LGTMNeedMoreLabelRe = regexp.MustCompile(`(?i)^needs-(\d+)-more-lgtm$`)
 	// LGTMCancelRe is the regex that matches lgtm cancel comments
 	LGTMCancelRe        = regexp.MustCompile(`(?mi)^/(remove-lgtm|lgtm cancel)\s*$`)
 	removeLGTMLabelNoti = "New changes are detected. LGTM label has been removed."


### PR DESCRIPTION
- The plugin will add `lgtm` label in the pull request when at least `ReviewerCount` people agreed with `/lgtm` or review approves.
- Any valid reviewer againsted, it will reset the accumulated votes and remove the `lgtm` label if existed, the againsted vote will not be accumulated in the next lgtm voting.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>