### PR TITLE
update zetigeist jobs to use go1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -38,7 +38,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
need for: https://github.com/kubernetes-sigs/zeitgeist/pull/450

/assign @saschagrunert @xmudrii  @ameukam 
cc @kubernetes-sigs/release-engineering 