### PR TITLE
reduce ci-golang-tip-k8s-1-23 interval from 4h to 24h

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -52,7 +52,7 @@ periodics:
           cpu: 4
           memory: "16Gi"
 
-- interval: 4h
+- interval: 24h
   name: ci-golang-tip-k8s-1-23
   cluster: k8s-infra-prow-build
   tags:


### PR DESCRIPTION
ref: #28894 

NOTE As scale folks informed: Yes, perhaps we should update past 1.23 now, but the important thing is scale regressions from go changes, as signal for whether go upgrades regress, so it's actually *intended* that this isn't at k8s HEAD (for more stable comparisons).

So we want to keep this job, but we should be able to run it less frequently.
Current proposal is from every 4 hours to daily.

@kubernetes/sig-scalability 
/cc @wojtek-t @shyamjvs @marseel @mborsz

FYI @dims @liggitt re: golang stability CI