### PR TITLE
Windows hyperv periodic jobs and misc windows testgrid config cleanup

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
@@ -9,6 +9,16 @@ presets:
   - name: K8S_SSH_PRIVATE_KEY_PATH
     value: /etc/ssh-key-secret/ssh-private # from preset-k8s-ssh label
 - labels:
+    preset-capz-containerd-1-6-latest: "true"
+  env:
+  - name: WINDOWS_CONTAINERD_URL
+    value: "https://github.com/containerd/containerd/releases/download/v1.6.18/containerd-1.6.18-windows-amd64.tar.gz"
+- labels:
+    preset-capz-containerd-1-7-latest: "true"
+  env:
+  - name: WINDOWS_CONTAINERD_URL
+    value: "https://github.com/containerd/containerd/releases/download/v1.7.0-rc.1/containerd-1.7.0-rc.1-windows-amd64.tar.gz"
+- labels:
     preset-windows-repo-list: "true"
   env:
   - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
       preset-capz-windows-2019: "true"
-      preset-capz-containerd-latest: "true"
+      preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
     extra_refs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -19,7 +19,7 @@ periodics:
   labels:
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-124: "true"
     preset-capz-windows-parallel: "true"
@@ -65,7 +65,7 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-capz-windows-common-124: "true"
     preset-capz-windows-2019: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
       preset-capz-windows-2019: "true"
-      preset-capz-containerd-latest: "true"
+      preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
     extra_refs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -19,7 +19,7 @@ periodics:
   labels:
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-125: "true"
     preset-capz-windows-parallel: "true"
@@ -65,7 +65,7 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-capz-windows-common-125: "true"
     preset-capz-windows-2019: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
       preset-capz-windows-2019: "true"
-      preset-capz-containerd-latest: "true"
+      preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
     extra_refs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -30,7 +30,7 @@ periodics:
   labels:
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-126: "true"
     preset-capz-windows-parallel: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
       preset-capz-windows-2019: "true"
-      preset-capz-containerd-latest: "true"
+      preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -67,7 +67,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common-main: "true"
-      preset-capz-containerd-latest: "true"
+      preset-capz-containerd-1-6-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -156,7 +156,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common-main: "true"
-      preset-capz-containerd-latest: "true"
+      preset-capz-containerd-1-6-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -26,11 +26,8 @@ presets:
   env:
   - name: WINDOWS_FLAVOR
     value: "containerd-2022"
-- labels:
-    preset-capz-containerd-latest: "true"
-  env:
-  - name: WINDOWS_CONTAINERD_URL
-    value: "https://github.com/containerd/containerd/releases/download/v1.6.18/containerd-1.6.18-windows-amd64.tar.gz"
+  - name: WINDOWS_SERVER_VERSION
+    value: "windows-2022"
 - labels:
     preset-capz-serial-slow: "true"
   env:
@@ -86,7 +83,7 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-capz-windows-common-main: "true"
     preset-capz-windows-2019: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-parallel: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -126,7 +123,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-capz-windows-common-main: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
     preset-windows-private-registry-cred: "true"
@@ -177,7 +174,7 @@ periodics:
     preset-azure-cred-only: "true"
     preset-capz-windows-common-main: "true"
     preset-capz-windows-2019: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
     preset-windows-private-registry-cred: "true"
   extra_refs:
@@ -226,7 +223,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-capz-windows-common-main: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -272,7 +269,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-capz-windows-common-main: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
     preset-windows-private-registry-cred: "true"
@@ -325,7 +322,7 @@ periodics:
     preset-azure-cred-only: "true"
     preset-windows-private-registry-cred: "true"
     preset-capz-windows-common-main: "true"
-    preset-capz-containerd-latest: "true"
+    preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -493,53 +490,3 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master
-- name: ci-kubernetes-e2e-capz-master-windows-service-proxy
-  interval: 12h
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
-    preset-capz-windows-2022: "true"
-    preset-windows-private-registry-cred: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: release-1.7
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes-sigs
-    repo: windows-testing
-    base_ref: master
-    path_alias: k8s.io/windows-testing
-    workdir: true
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: master
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
-        command:
-          - "runner.sh"
-          - "./capz/run-capz-e2e.sh"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2
-            memory: "9Gi"
-        env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
-          - name: WINDOWS_KPNG
-            value: "true"
-          - name: WINDOWS_CONTAINERD_URL
-            value: "https://github.com/containerd/containerd/releases/download/v1.7.0-beta.3/containerd-1.7.0-beta.3-windows-amd64.tar.gz"
-  annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: capz-master-windows-service-proxy

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
@@ -1,0 +1,95 @@
+periodics:
+- name: ci-kubernetes-e2e-capz-master-windows-service-proxy
+  interval: 12h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2022: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-capz-containerd-1-7-latest: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.7
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+        command:
+          - "runner.sh"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: WINDOWS_KPNG
+            value: "true"
+  annotations:
+    testgrid-alert-email: sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-experimental
+    testgrid-tab-name: capz-master-windows-service-proxy
+- name: ci-kubernetes-e2e-capz-master-windows-hyperv
+  interval: 12h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2022: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-capz-containerd-1-7-latest: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.7
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+        command:
+          - "runner.sh"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: HYPERV
+            value: "true"
+  annotations:
+    testgrid-alert-email: sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-experimental
+    testgrid-tab-name: capz-master-windows-hyperv

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -13,6 +13,7 @@ dashboard_groups:
     - sig-windows-containerd-runtime-signal
     - sig-windows-push-images
     - sig-windows-soak-tests
+    - sig-windows-experimental
 
 dashboards:
 - name: sig-windows-signal
@@ -24,6 +25,7 @@ dashboards:
 - name: sig-windows-presubmit
 - name: sig-windows-gce
 - name: sig-windows-push-images
+- name: sig-windows-experimental
 - name: sig-windows-soak-tests
   dashboard_tab:
     - name: soak-tests-capz-windows


### PR DESCRIPTION
- Making sig-windows-expiermental testgrid group
- Moving windows-service-proxy tests under experimental group
- Adding new HyperV tests under experimental group
- Renaming existing container-latest preset label to containerd-1-6-latest
- Making new contianerd-1-7-latest preset label
- Updating env vars set for preset-capz-windows-2022

/sig windows
/hold for https://github.com/kubernetes-sigs/windows-testing/pull/363
/assign @jsturtevant 