### PR TITLE
Create sig-node-conformance job for 1.24 release branch

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1446,3 +1446,37 @@ periodics:
     #testgrid-dashboards: sig-node-containerd
     #testgrid-tab-name: cos-cgroupv1-inplace-pod-resize-containerd-e2e
     #description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v1
+- name: ci-kubernetes-node-release-branch-1-24
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+        args:
+          - --repo=k8s.io/kubernetes=release-1.24
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-central1-a
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.24.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          requests:
+            memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: node-conformance-release-1.24
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: Node conformance tests in release branch 1.24

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.24.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.24.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-97:
+    image_family: cos-97-lts
+    project: cos-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
## What does this PR do?
Create a new periodic job to test branch `release-1.24`. For now, I think it's good to start with NodeConformance, as they are the most stable tests. I'm using the COS version officially supported by Google for Kubernetes 1.24.

This is a PoC for #28627. After this, I will add jobs for branches 1.25 and 1.26 as well.