### PR TITLE
Remove gpu machines from serial image config

### DIFF
--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -6,15 +6,6 @@ images:
     image: ubuntu-gke-2204-1-24-v20220623
     machine: n1-standard-2 # These tests need a lot of memory
     project: ubuntu-os-gke-cloud
-  cos-stable2:
-    image_family: cos-93-lts # deprecated after October 2023 (https://cloud.google.com/container-optimized-os/docs/release-notes)
-    project: cos-cloud
-    machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data<test/e2e_node/jenkins/gci-init-gpu.yaml,gci-update-strategy=update_disabled"
-    resources:
-      accelerators:
-        - type: nvidia-tesla-k80
-          count: 2
   cos-stable1:
     image_family: cos-89-lts # deprecated after March 2023 (https://cloud.google.com/container-optimized-os/docs/release-notes)
     project: cos-cloud


### PR DESCRIPTION
We don't need GPU machines for node e2e serial tests. We removed the gpu device plugin tests back in
https://github.com/kubernetes/kubernetes/pull/106348

Let's remove the GPU machines since they are more expensive for CI infra and result in flakes due to machine resource unavailability.