### PR TITLE
pull-kubernetes-verify-strict-lint: optional strict linting of PRs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -44,6 +44,44 @@ presubmits:
           requests:
             cpu: 7
             memory: 12Gi
+  - name: pull-kubernetes-verify-strict-lint
+    cluster: k8s-infra-prow-build
+    decorate: true
+    # This entire job is currently experimental. If it turns out to be useful,
+    # the job can be removed and the same check can run as part of pull-kubernetes-verify
+    # by removing the exclusion of verify-golangci-lint-pr.sh in hack/make-rules/verify.sh.
+    always_run: false
+    optional: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: sig-testing-misc
+      description: Runs golangci-lint with a stricter configuration for new code.
+      testgrid-alert-email: patrick.ohly@intel.com
+      testgrid-num-failures-to-alert: "15"
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - /bin/sh
+        - "if [ -x hack/verify-golangci-lint-pr.sh ]; then hack/verify-golangci-lint-pr.sh; fi"
+        resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
+          limits:
+            cpu: 7
+            memory: 12Gi
+          requests:
+            cpu: 7
+            memory: 12Gi
   - name: pull-kubernetes-verify-go-canary
     cluster: k8s-infra-prow-build
     always_run: false


### PR DESCRIPTION
This complements https://github.com/kubernetes/kubernetes/pull/109728: including the stricter linting of PRs in "make verify" would make the new linter warnings merge-blocking, so instead these new checks run in an optional presubmit job.

This PR could be merged before that other PR because the new script doesn't need to exist. If this was merged first, the other PR could be tested to ensure that its content works as intended.
