### PR TITLE
logexporter: Capture kubelet's /metrics at the end of tests

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -832,6 +832,15 @@ function dump_node_info() {
   fi
 
   kubectl get nodes -o yaml > "${nodes_dir}/kubectl_get_nodes.yaml" || true
+
+  api_node_names=()
+  api_node_names+=($( kubectl get nodes -o 'template={{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' ))
+  if [[ "${#api_node_names[@]}" -le 5 ]]; then
+    for node_name in "${api_node_names[@]}"; do
+      mkdir -p "${nodes_dir}/${node_name}"
+      kubectl get --raw "/api/v1/nodes/${node_name}/proxy/metrics" > "${nodes_dir}/${node_name}/kubelet_metrics.txt" || true
+    done
+  fi
 }
 
 function detect_node_failures() {


### PR DESCRIPTION
/metrics is roughly ~120-150kb and often captures important metrics relating to overall test behavior that is useful for after-the-fact analysis and discovery (that could lead to new tests). Attempt to save the /metrics during log-dump phase.

Discussed briefly in slack https://kubernetes.slack.com/archives/C09QZ4DQB/p1677870251316299 with Ben