### PR TITLE
CAPV: Changes job frequency for full e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.3.yaml
@@ -6,7 +6,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 24h
+    interval: 48h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
@@ -44,7 +44,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 24h
+    interval: 48h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.4.yaml
@@ -6,7 +6,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 24h
+    interval: 48h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
@@ -44,7 +44,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 24h
+    interval: 48h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
@@ -6,7 +6,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 12h
+    interval: 24h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
@@ -6,7 +6,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 12h
+    interval: 24h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
@@ -82,7 +82,7 @@ periodics:
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    interval: 12h
+    interval: 24h
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere


### PR DESCRIPTION
- Changes the frequency of the e2e tests for older release branches to 48h instead of 24h since there are no improvements that have gone into those releases for some time.
- Changes the frequency of the e2e tests for current and main release branches to 24h instead of 12h.