### PR TITLE
Kops - Increase instance size for cilium-eni tests

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -86,6 +86,9 @@ def build_test(cloud='aws',
     if networking == 'cilium' and distro == 'u2204'and kops_version == '1.23':
         return None
 
+    if extra_flags is None:
+        extra_flags = []
+
     if cloud == 'aws':
         kops_image = distro_images[distro]
         kops_ssh_user = distros_ssh_user[distro]
@@ -147,7 +150,7 @@ def build_test(cloud='aws',
         env['CLUSTER_NAME'] = f"e2e-{name_hash[0:10]}-{name_hash[12:17]}.test-cncf-aws.k8s.io"
         env['KOPS_STATE_STORE'] = 's3://k8s-kops-prow'
         env['KUBE_SSH_USER'] = kops_ssh_user
-        if extra_flags is not None:
+        if extra_flags:
             env['KOPS_EXTRA_FLAGS'] = " ".join(extra_flags)
         if irsa and cloud == "aws":
             env['KOPS_IRSA'] = "true"
@@ -267,9 +270,10 @@ def presubmit_test(branch='master',
         kops_ssh_user = 'prow'
         kops_ssh_key_path = '/etc/ssh-key-secret/ssh-private'
 
+    if extra_flags is None:
+        extra_flags = []
+
     if irsa and cloud == "aws" and scenario is None:
-        if extra_flags is None:
-            extra_flags = []
         extra_flags.append("--discovery-store=s3://k8s-kops-prow/discovery")
 
     marker, k8s_deploy_url, test_package_bucket, test_package_dir = k8s_version_info(k8s_version)
@@ -286,7 +290,7 @@ def presubmit_test(branch='master',
         env['CLOUD_PROVIDER'] = cloud
         env['CLUSTER_NAME'] = f"e2e-{name_hash[0:10]}-{name_hash[11:16]}.test-cncf-aws.k8s.io"
         env['KOPS_STATE_STORE'] = 's3://k8s-kops-prow'
-        if extra_flags is not None:
+        if extra_flags:
             env['KOPS_EXTRA_FLAGS'] = " ".join(extra_flags)
         if irsa and cloud == "aws":
             env['KOPS_IRSA'] = "true"

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -413,7 +413,7 @@ def generate_grid():
             for distro in distro_options:
                 for k8s_version in k8s_versions:
                     for kops_version in kops_versions:
-                        if networking == 'cilium-eni' and kops_version in ['1.24', '1.25']:
+                        if networking == 'cilium-eni' and kops_version in ['1.25']:
                             continue
                         results.append(
                             build_test(cloud="aws",

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -94,6 +94,10 @@ def build_test(cloud='aws',
         kops_ssh_user = distros_ssh_user[distro]
         kops_ssh_key_path = '/etc/aws-ssh/aws-ssh-private'
 
+        if networking == 'cilium-eni':
+            # Needed for higher "IPs per node" limits
+            extra_flags.append('--node-size=t3.large')
+
     elif cloud == 'gce':
         kops_image = None
         kops_ssh_user = 'prow'

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -4550,7 +4550,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k23-ko26-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k23-docker
   cron: '42 18 * * 2'
   labels:
@@ -4579,7 +4579,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4605,6 +4605,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -4613,7 +4614,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k23-ko26-docker
   cron: '21 7 * * 5'
   labels:
@@ -4642,7 +4643,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4668,6 +4669,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -4676,7 +4678,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k23-ko26-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k23-docker
   cron: '14 2 * * 0'
   labels:
@@ -4705,7 +4707,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4731,6 +4733,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -4739,7 +4742,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k23-ko26-docker
   cron: '18 0 * * 2'
   labels:
@@ -4768,7 +4771,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4794,6 +4797,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -4802,7 +4806,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k23-ko26-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k23-docker
   cron: '45 18 * * 6'
   labels:
@@ -4831,7 +4835,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -4858,6 +4862,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -4866,7 +4871,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k23-ko26-docker
   cron: '50 11 * * 0'
   labels:
@@ -4895,7 +4900,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -4922,6 +4927,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -4930,7 +4936,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k23-ko26-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k23-docker
   cron: '21 21 * * 2'
   labels:
@@ -4959,7 +4965,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4985,6 +4991,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -4993,7 +5000,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k23-ko26-docker
   cron: '7 17 * * 2'
   labels:
@@ -5022,7 +5029,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5048,6 +5055,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -5056,7 +5064,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k23-ko26-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k23-docker
   cron: '23 7 * * *'
   labels:
@@ -5085,7 +5093,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5111,6 +5119,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -5119,7 +5128,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k23-ko26-docker
   cron: '45 23 * * *'
   labels:
@@ -5148,7 +5157,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5174,6 +5183,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -5182,7 +5192,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k23-ko26-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k23-docker
   cron: '38 10 * * 1'
   labels:
@@ -5211,7 +5221,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5237,6 +5247,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -5245,7 +5256,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k23-ko26-docker
   cron: '32 22 * * 1'
   labels:
@@ -5274,7 +5285,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=docker" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=docker --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5300,6 +5311,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24066,7 +24078,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k26-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k23
   cron: '7 14 * * 2'
   labels:
@@ -24095,7 +24107,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24121,6 +24133,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24129,7 +24142,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k23
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k23-ko26
   cron: '6 4 * * 6'
   labels:
@@ -24158,7 +24171,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24184,6 +24197,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24192,7 +24206,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k23-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k24
   cron: '4 13 * * 1'
   labels:
@@ -24221,7 +24235,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -24247,6 +24261,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24255,7 +24270,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k24
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k24-ko26
   cron: '26 20 * * 6'
   labels:
@@ -24284,7 +24299,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -24310,6 +24325,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24318,7 +24334,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k24-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k25
   cron: '26 19 * * 3'
   labels:
@@ -24347,7 +24363,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -24373,6 +24389,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24381,7 +24398,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k25
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k25-ko26
   cron: '19 17 * * 2'
   labels:
@@ -24410,7 +24427,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -24436,6 +24453,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24444,7 +24462,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k25-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k26
   cron: '12 17 * * 4'
   labels:
@@ -24473,7 +24491,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -24499,6 +24517,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24507,7 +24526,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-amzn2-k26-ko26
   cron: '29 15 * * 5'
   labels:
@@ -24536,7 +24555,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20230221.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -24562,6 +24581,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24570,7 +24590,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k26-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k23
   cron: '6 7 * * 4'
   labels:
@@ -24599,7 +24619,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24625,6 +24645,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24633,7 +24654,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k23
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k23-ko26
   cron: '27 1 * * 3'
   labels:
@@ -24662,7 +24683,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24688,6 +24709,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24696,7 +24718,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k23-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k24
   cron: '57 20 * * 6'
   labels:
@@ -24725,7 +24747,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -24751,6 +24773,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24759,7 +24782,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k24
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k24-ko26
   cron: '15 17 * * 6'
   labels:
@@ -24788,7 +24811,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -24814,6 +24837,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24822,7 +24846,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k24-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k25
   cron: '59 10 * * 2'
   labels:
@@ -24851,7 +24875,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -24877,6 +24901,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24885,7 +24910,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k25
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k25-ko26
   cron: '26 12 * * 1'
   labels:
@@ -24914,7 +24939,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -24940,6 +24965,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -24948,7 +24974,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k25-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k26
   cron: '49 0 * * 1'
   labels:
@@ -24977,7 +25003,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -25003,6 +25029,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25011,7 +25038,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb10-k26-ko26
   cron: '28 2 * * 4'
   labels:
@@ -25040,7 +25067,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20230222-1299' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -25066,6 +25093,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25074,7 +25102,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb10-k26-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k23
   cron: '33 10 * * 5'
   labels:
@@ -25103,7 +25131,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -25130,6 +25158,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25138,7 +25167,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k23
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k23-ko26
   cron: '8 8 * * 6'
   labels:
@@ -25167,7 +25196,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --validation-wait=20m \
@@ -25194,6 +25223,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25202,7 +25232,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k23-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k24
   cron: '18 9 * * 6'
   labels:
@@ -25231,7 +25261,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -25258,6 +25288,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25266,7 +25297,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k24
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k24-ko26
   cron: '24 8 * * 2'
   labels:
@@ -25295,7 +25326,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --validation-wait=20m \
@@ -25322,6 +25353,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25330,7 +25362,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k24-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k25
   cron: '4 7 * * 1'
   labels:
@@ -25359,7 +25391,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -25386,6 +25418,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25394,7 +25427,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k25
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k25-ko26
   cron: '57 13 * * 4'
   labels:
@@ -25423,7 +25456,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -25450,6 +25483,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25458,7 +25492,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k25-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k26
   cron: '54 13 * * 2'
   labels:
@@ -25487,7 +25521,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -25514,6 +25548,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25522,7 +25557,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k26-ko26
   cron: '31 19 * * 0'
   labels:
@@ -25551,7 +25586,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-beta-3493.1.0-hvm' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -25578,6 +25613,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25586,7 +25622,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k26-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k23
   cron: '10 19 * * 3'
   labels:
@@ -25615,7 +25651,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -25641,6 +25677,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25649,7 +25686,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k23
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k23-ko26
   cron: '23 21 * * 0'
   labels:
@@ -25678,7 +25715,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -25704,6 +25741,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25712,7 +25750,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k23-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k24
   cron: '1 8 * * 5'
   labels:
@@ -25741,7 +25779,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -25767,6 +25805,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25775,7 +25814,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k24
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k24-ko26
   cron: '39 13 * * 1'
   labels:
@@ -25804,7 +25843,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -25830,6 +25869,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25838,7 +25878,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k24-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k25
   cron: '27 14 * * 2'
   labels:
@@ -25867,7 +25907,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -25893,6 +25933,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25901,7 +25942,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k25
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k25-ko26
   cron: '18 8 * * 4'
   labels:
@@ -25930,7 +25971,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -25956,6 +25997,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -25964,7 +26006,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k25-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k26
   cron: '37 12 * * 1'
   labels:
@@ -25993,7 +26035,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -26019,6 +26061,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26027,7 +26070,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k26-ko26
   cron: '52 14 * * 0'
   labels:
@@ -26056,7 +26099,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.1.0_HVM-20230216-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -26082,6 +26125,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26090,7 +26134,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k26-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k23
   cron: '12 9 * * *'
   labels:
@@ -26119,7 +26163,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -26145,6 +26189,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26153,7 +26198,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k23
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k23-ko26
   cron: '45 19 * * *'
   labels:
@@ -26182,7 +26227,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -26208,6 +26253,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26216,7 +26262,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k23-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k24
   cron: '7 10 * * *'
   labels:
@@ -26245,7 +26291,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -26271,6 +26317,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26279,7 +26326,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k24
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k24-ko26
   cron: '37 11 * * *'
   labels:
@@ -26308,7 +26355,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -26334,6 +26381,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26342,7 +26390,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k24-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k25
   cron: '53 4 * * *'
   labels:
@@ -26371,7 +26419,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -26397,6 +26445,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26405,7 +26454,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k25
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k25-ko26
   cron: '16 22 * * *'
   labels:
@@ -26434,7 +26483,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -26460,6 +26509,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26468,7 +26518,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k25-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k26
   cron: '19 6 * * *'
   labels:
@@ -26497,7 +26547,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -26523,6 +26573,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26531,7 +26582,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k26-ko26
   cron: '26 0 * * *'
   labels:
@@ -26560,7 +26611,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230302' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -26586,6 +26637,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26594,7 +26646,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k26-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k23
   cron: '29 0 * * 2'
   labels:
@@ -26623,7 +26675,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -26649,6 +26701,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26657,7 +26710,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k23
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k23-ko26
   cron: '2 12 * * 2'
   labels:
@@ -26686,7 +26739,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -26712,6 +26765,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26720,7 +26774,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k23-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k24
   cron: '42 11 * * 6'
   labels:
@@ -26749,7 +26803,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -26775,6 +26829,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26783,7 +26838,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k24
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.24", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k24-ko26
   cron: '18 12 * * 5'
   labels:
@@ -26812,7 +26867,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.24.txt \
           --test=kops \
@@ -26838,6 +26893,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.24'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26846,7 +26902,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k24-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k25
   cron: '16 21 * * 2'
   labels:
@@ -26875,7 +26931,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -26901,6 +26957,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26909,7 +26966,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k25
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k25-ko26
   cron: '47 9 * * 4'
   labels:
@@ -26938,7 +26995,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt \
           --test=kops \
@@ -26964,6 +27021,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'
@@ -26972,7 +27030,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k25-ko26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k26
   cron: '2 7 * * 4'
   labels:
@@ -27001,7 +27059,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -27027,6 +27085,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -27035,7 +27094,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k26
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.26", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k26-ko26
   cron: '49 23 * * 1'
   labels:
@@ -27064,7 +27123,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.26/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt \
           --test=kops \
@@ -27090,6 +27149,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.26'

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -322,7 +322,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-etcd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--node-size=t3.large --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-eni"}
 - name: e2e-kops-aws-cni-cilium-eni
   cron: '13 5-23/8 * * *'
   labels:
@@ -351,7 +351,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230303' --channel=alpha --networking=cilium-eni --container-runtime=containerd --node-size=t3.large --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -377,7 +377,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/extra_flags: --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''


### PR DESCRIPTION
Our e2e jobs are failing with an inconsistent batch of tests per execution. 

https://testgrid.k8s.io/kops-grid#kops-grid-cilium-eni-u2204-k26

The test failures all log pod events with:

`Mar  2 07:28:54.045: INFO: At 2023-03-02 07:24:20 +0000 UTC - event for sample-webhook-deployment-865554f4d9-ss6ln: {kubelet i-088b181e525ca14c0} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "8b2f400a805891401d305ac125f22384e436a62426eea0a5b00e6373d40e1f81": plugin type="cilium-cni" name="cilium" failed (add): unable to allocate IP via local cilium agent: [POST /ipam][502] postIpamFailure  No more IPs available`

Previously these clusters were using t3.medium which supports [18 IPs per instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI). The test failures log 25+ pods running on the node, leading me to believe we're exceeding the "IPs per instance" limits of the instance type. This increases the node size to t3.large which doubles the limit.