### PR TITLE
Re-enable inplace pod resize CI jobs, slightly expand run-if-changed for inplace resize pull job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1377,75 +1377,74 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: gcp-kubelet-credential-provider
     description: "tests feature gcp kubelet image credential provider"
-# Enable inplace-pod-resize after https://github.com/kubernetes/kubernetes/pull/102884 is merged.
-#- name: ci-cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce
-  #interval: 24h
-  #labels:
-    #preset-service-account: "true"
-    #preset-k8s-ssh: "true"
-    #preset-e2e-containerd: "true"
-  #spec:
-    #containers:
-    #- args:
-      #- --repo=github.com/containerd/containerd=main
-      #- --timeout=180
-      #- --scenario=kubernetes_e2e
-      #- --
-      #- --check-leaked-resources
-      #- --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
-      #- --env=ENABLE_POD_SECURITY_POLICY=true
-      #- --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
-      #- --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
-      #- --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
-      #- --extract=ci/latest
-      #- --gcp-node-image=gci
-      #- --gcp-nodes=1
-      #- --gcp-zone=us-west1-b
-      #- --ginkgo-parallel=30
-      #- --image-family=cos-stable
-      #- --image-project=cos-cloud
-      #- --provider=gce
-      #- --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
-      #- --timeout=150m
-      #image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
-  #annotations:
-    #testgrid-dashboards: sig-node-containerd
-    #testgrid-tab-name: cos-cgroupv2-inplace-pod-resize-containerd-e2e
-    #description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v2
-#- name: ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce
-  #interval: 48h
-  #labels:
-    #preset-service-account: "true"
-    #preset-k8s-ssh: "true"
-    #preset-e2e-containerd: "true"
-  #spec:
-    #containers:
-    #- args:
-      #- --repo=github.com/containerd/containerd=main
-      #- --timeout=180
-      #- --scenario=kubernetes_e2e
-      #- --
-      #- --check-leaked-resources
-      #- --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
-      #- --env=ENABLE_POD_SECURITY_POLICY=true
-      #- --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
-      #- --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
-      #- --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
-      #- --extract=ci/latest
-      #- --gcp-node-image=gci
-      #- --gcp-nodes=1
-      #- --gcp-zone=us-west1-b
-      #- --ginkgo-parallel=30
-      #- --image-family=cos-stable
-      #- --image-project=cos-cloud
-      #- --provider=gce
-      #- --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
-      #- --timeout=150m
-      #image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
-  #annotations:
-    #testgrid-dashboards: sig-node-containerd
-    #testgrid-tab-name: cos-cgroupv1-inplace-pod-resize-containerd-e2e
-    #description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v1
+- name: ci-cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+  spec:
+    containers:
+    - args:
+      - --repo=github.com/containerd/containerd=main
+      - --timeout=180
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
+      - --env=ENABLE_POD_SECURITY_POLICY=true
+      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+      - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-nodes=1
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --image-family=cos-stable
+      - --image-project=cos-cloud
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
+      - --timeout=150m
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: cos-cgroupv2-inplace-pod-resize-containerd-e2e
+    description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v2
+- name: ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce
+  interval: 48h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+  spec:
+    containers:
+    - args:
+      - --repo=github.com/containerd/containerd=main
+      - --timeout=180
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
+      - --env=ENABLE_POD_SECURITY_POLICY=true
+      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/workspace/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+      - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-nodes=1
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --image-family=cos-stable
+      - --image-project=cos-cloud
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
+      - --timeout=150m
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: cos-cgroupv1-inplace-pod-resize-containerd-e2e
+    description: Runs cluster e2e test with FOCUS=[Feature:InPlacePodVerticalScaling] enabling all alpha features with cgroup v1
 - name: ci-kubernetes-node-release-branch-1-24
   interval: 24h
   labels:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1598,7 +1598,7 @@ presubmits:
   - name: pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
     optional: true
     always_run: false
-    run_if_changed: 'test/e2e/node/pod_resize.go'
+    run_if_changed: 'test/e2e/node/pod_resize.go|pkg/kubelet/kubelet.go|pkg/kubelet/kubelet_pods.go|pkg/kubelet/kuberuntime/kuberuntime_manager.go'
     skip_report: true
     branches:
     # TODO(releng): Remove once repo default branch has been renamed


### PR DESCRIPTION
CI jobs were commented out earlier awaiting PR https://github.com/kubernetes/kubernetes/pull/102884 merge.
This PR adds back in-place pod resize CI jobs now that the PR has merged. It also slightly expands on the changes that would trigger the pull job for in-place pod resize e2e tests.