### PR TITLE
Communicate problem when multiple tide/* labels set

### DIFF
--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -530,8 +530,8 @@ func (m *mergeChecker) isAllowedToMerge(crc *CodeReviewCommon) (string, error) {
 	}
 	mergeMethod, err := m.prMergeMethod(m.config().Tide, crc)
 	if err != nil {
-		// This should be impossible.
-		return "", fmt.Errorf("Programmer error! Failed to determine a merge method: %w", err)
+		// Can happen when tide has conflicting labels: merge, squash, rebase
+		return "PR has conflicting merge method override labels", nil
 	}
 	if mergeMethod == types.MergeRebase && !pr.CanBeRebased {
 		return "PR can't be rebased", nil

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -41,6 +41,8 @@ import (
 )
 
 func TestExpectedStatus(t *testing.T) {
+	mergeLabel := "tide/merge-method-merge"
+	squashLabel := "tide/merge-method-squash"
 	neededLabelsWithAlt := []string{"need-1", "need-2", "need-a-very-super-duper-extra-not-short-at-all-label-name,need-3"}
 	neededLabels := []string{"need-1", "need-2", "need-a-very-super-duper-extra-not-short-at-all-label-name"}
 	forbiddenLabels := []string{"forbidden-1", "forbidden-2"}
@@ -100,6 +102,12 @@ func TestExpectedStatus(t *testing.T) {
 
 			state: github.StatusPending,
 			desc:  fmt.Sprintf(statusNotInPool, " Needs need-a-very-super-duper-extra-not-short-at-all-label-name or need-3 label."),
+		},
+		{
+			name:   "check multiple /tide labels result in conflict message",
+			labels: append(append([]string{}, neededLabels...), mergeLabel, squashLabel),
+			state:  github.StatusError,
+			desc:   fmt.Sprintf(statusNotInPool, " PR has conflicting merge method override labels"),
 		},
 		{
 			name:              "has forbidden labels",
@@ -816,7 +824,11 @@ func TestExpectedStatus(t *testing.T) {
 
 			ca := &config.Agent{}
 			ca.Set(&config.Config{ProwConfig: config.ProwConfig{Tide: config.Tide{
-				TideGitHubConfig: config.TideGitHubConfig{DisplayAllQueriesInStatus: tc.displayAllTideQueries}}}})
+				TideGitHubConfig: config.TideGitHubConfig{
+					DisplayAllQueriesInStatus: tc.displayAllTideQueries,
+					MergeLabel:                mergeLabel,
+					SquashLabel:               squashLabel,
+				}}}})
 			mmc := newMergeChecker(ca.Config, &fgc{})
 
 			sc, err := newStatusController(


### PR DESCRIPTION
When multiple tide/* labels are set, tide communicated this problem only in logs, there was no info for the user. This PR addresses this issue.