### PR TITLE
ar-s3-sync: set region to us-east-2 to match bucket

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml
@@ -34,7 +34,7 @@ periodics:
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: /var/run/secrets/aws-iam-token/serviceaccount/token
             - name: AWS_REGION
-              value: us-east-1
+              value: us-east-2
           volumeMounts:
             - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
               name: aws-iam-token


### PR DESCRIPTION
the other job overrides this env in the script, whereas we pick it up from the env currently.