### PR TITLE
pull-kubernetes-verify-strict-lint: fix invocation

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -72,6 +72,7 @@ presubmits:
         - runner.sh
         args:
         - /bin/sh
+        - "-c"
         - "if [ -x hack/verify-golangci-lint-pr.sh ]; then hack/verify-golangci-lint-pr.sh; fi"
         resources:
           # Consider reducing memory limits after govet memory usage issue is


### PR DESCRIPTION
"-c" is needed to have /bin/sh execute the commands.
