### PR TITLE
[sig-windows-networking] Add AKS 1.26 with AzureCNI prowjobs

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -63,6 +63,12 @@ dashboards:
   - name: aks-ltsc2022-azurecni-1.25
     description: Runs Kubernetes E2E tests on an AKS deployment (1.25 release) with LTSC 2022 nodes and AzureCNI.
     test_group_name: aks-e2e-ltsc2022-azurecni-1.25
+  - name: aks-ltsc2019-azurecni-1.26
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.26 release) with LTSC 2019 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2019-azurecni-1.26
+  - name: aks-ltsc2022-azurecni-1.26
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.26 release) with LTSC 2022 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2022-azurecni-1.26
 - name: sig-windows-containerd-runtime-signal
   dashboard_tab:
   - name: win-2019-containerd-master-integration
@@ -96,6 +102,10 @@ test_groups:
   gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.25
 - name: aks-e2e-ltsc2022-azurecni-1.25
   gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.25
+- name: aks-e2e-ltsc2019-azurecni-1.26
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.26
+- name: aks-e2e-ltsc2022-azurecni-1.26
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.26
 # Containerd Runtime integration test groups
 - name: integration-containerd-windows-ltsc2019
   gcs_prefix: containerd-integration/logs/windows-ltsc2019


### PR DESCRIPTION
Add two more test groups for the AKS with AzureCNI 1.26 release testing.