### PR TITLE
Fix typo with `post-test-infra-push-git-custom-k8s-auth` prow job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -129,7 +129,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-prow
-        - images/git-gke-gcloud-auth/
+        - images/git-custom-k8s-auth/
   - name: post-test-infra-deploy-prow
     cluster: test-infra-trusted
     run_if_changed: '^(config/prow/cluster/|config/prow/Makefile$|Makefile.base.mk$)'


### PR DESCRIPTION
/cc @xmudrii @ameukam @dims 


Fixing a typo

Can the person who approves this PR rerun this job with the latest config after it merges?

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-git-custom-k8s-auth/1633164768317542400

Thanks