### PR TITLE
Use the `git-custom-k8s-auth` image for components that talk to external k8s clusters

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -4,17 +4,17 @@ baseImageOverrides:
   k8s.io/test-infra/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/cmd/deck: gcr.io/k8s-prow/git-gke-gcloud-auth:v20221221-af5c6c8c0d
+  k8s.io/test-infra/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
+  k8s.io/test-infra/prow/cmd/deck: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git-gke-gcloud-auth:v20221221-af5c6c8c0d
+  k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/gangway: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/grandmatriarch: gcr.io/cloud-builders/gcloud@sha256:5b49dfb5e366dd75a5fc6d5d447be584f8f229c5a790ee0c3b0bd0cf70ec41dd
   k8s.io/test-infra/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/hook: gcr.io/k8s-prow/git:v20220215-ddc3ad9
+  k8s.io/test-infra/prow/cmd/hook: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/initupload: gcr.io/k8s-prow/git:v20220215-ddc3ad9
@@ -22,12 +22,12 @@ baseImageOverrides:
   k8s.io/test-infra/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/git-gke-gcloud-auth:v20221221-af5c6c8c0d
+  k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/sub: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/tide: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/tot: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-gke-gcloud-auth:v20221221-af5c6c8c0d
+  k8s.io/test-infra/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/admission: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/mkpj: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/mkpod: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d


### PR DESCRIPTION
Taking #28277 to production

/cc @BenTheElder @xmudrii @ameukam @dims
