### PR TITLE
bootstrap.py: perform "blobless" clones

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -285,7 +285,7 @@ def checkout(call, repo, repo_path, branch, pull, ssh='', git_cache='', clean=Fa
     retries = 3
     for attempt in range(retries):
         try:
-            call([git, 'fetch', '--quiet', '--tags', repository(repo, ssh)] + refs)
+            call([git, 'fetch', '--filter=blob:none', '--quiet', '--tags', repository(repo, ssh)] + refs)
             break
         except subprocess.CalledProcessError as cpe:
             if attempt >= retries - 1:


### PR DESCRIPTION
Should significantly reduce time and bandwidth cloning github.com/kubernetes/kubernetes in particular.

https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

pod-utils hopefully next ref https://github.com/kubernetes/test-infra/issues/26590 https://github.com/kubernetes/test-infra/issues/18226#issuecomment-1454182981

bootstrap.py is simpler to tweak and AFAIK nobody else is using it besides kubernetes CI (and if they are, it's officially unsupported for years now anyhow) but affects a *ton* of Kubernetes CI jobs still, this is a single flag that is similar to a shallow clone without the broken `git describe` issue.

The only downside here is commands like `git blame` and `git checkout` can take longer as they have to fetch the missing blobs for the refs. We still fetch the history tree, tags, and the current blobs for the refs we fetch.

It seems _very_ unlikely that we have any regression from this change ™️ but it should speed things up, and help inform changing pod-utils defaults.

/hold
cc @listx 