### PR TITLE
Add missing --cgroup-driver=systemd to kubelet flags.

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1464,7 +1464,7 @@ periodics:
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-central1-a
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.24.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"


### PR DESCRIPTION
## What does this PR do?
#28910 introduced a new job, which is entirely red. After investigating at the failure in https://github.com/kubernetes/test-infra/issues/28627#issuecomment-1458535732, it seems that I was missing the `--cgroup-driver=systemd` flag in `kubelet-flags`.

The containerd config used in the image already has this mode properly set ([source](https://github.com/kubernetes/test-infra/blob/45cd826350a9e3591edbc73fe0fe0d27817399b1/jobs/e2e_node/containerd/config-systemd.toml#L29)).

/cc @bobbypage @SergeyKanzhelev @xmcqueen 