### PR TITLE
Update openstack image-pushing for new project name

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-provider-os.yaml
+++ b/config/jobs/image-pushing/k8s-staging-provider-os.yaml
@@ -25,8 +25,8 @@ postsubmits:
             args:
               # this is the project GCB will run in, which is the same as the GCR
               # images are pushed to.
-              - --project=k8s-staging-cloud-provider-os
+              - --project=k8s-staging-provider-os
               # This is the same as above, but with -gcb appended.
-              - --scratch-bucket=gs://k8s-staging-cloud-provider-os-gcb
+              - --scratch-bucket=gs://k8s-staging-provider-os-gcb
               - --env-passthrough=PULL_BASE_REF
               - .


### PR DESCRIPTION
Openstack cloud provider had an inconsistent legacy project configuration. It was cleaned up in https://github.com/kubernetes/k8s.io/pull/4891 and became `k8s-staging-provider-os`.