### PR TITLE
capc: remove custom service accounts to assume default accounts

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -62,7 +62,6 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-cloudstack
         testgrid-tab-name: pr-build
       spec:
-        serviceaccountName: presubmits-build-account
         automountServiceAccountToken: false
         containers:
         - name: build-container
@@ -95,7 +94,6 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-cloudstack
         testgrid-tab-name: pr-unit-test
       spec:
-        serviceaccountName: presubmits-build-account
         automountServiceAccountToken: false
         containers:
         - name: build-container


### PR DESCRIPTION
CAPC is receiving [errors from presubmit checks](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/pull/226) that seem to be related to the service account used.

@ameukam [suggested removing](https://kubernetes.slack.com/archives/CCK68P2Q2/p1678286346220099) the custom service accounts so the system uses defaults.

Its unclear to me whether this will actually fix the problem so clarification is also appreciated.