### PR TITLE
Add ExternalSecret for eks-prow-build-cluster-kubeconfig to Prow control plane

### DIFF
--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -130,3 +130,16 @@ spec:
   - key: capdo-quayio-registry-secret
     name: config.json
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-eks-prow-build-cluster
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build-trusted
+  data:
+  - key: eks-prow-build-cluster-kubeconfig
+    name: kubeconfig
+    version: latest


### PR DESCRIPTION
Add ExternalSecret for eks-prow-build-cluster-kubeconfig to Prow control plane.

Reference: https://github.com/kubernetes/k8s.io/pull/4905

/assign @dims 