### PR TITLE
Add maximum change processing worker pool size

### DIFF
--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -93,9 +93,10 @@ func TestFlags(t *testing.T) {
 					InRepoConfigCacheSize:                 100,
 					InRepoConfigCacheCopies:               1,
 				},
-				dryRun:                 false,
-				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
-				changeWorkerPoolSize:   1,
+				dryRun:                  false,
+				instrumentationOptions:  flagutil.DefaultInstrumentationOptions(),
+				changeWorkerPoolSize:    1,
+				maxChangeWorkerPollSize: 1,
 			}
 			if tc.expected != nil {
 				tc.expected(expected)


### PR DESCRIPTION
In this change we add a parameter in options that specify a `maxChangeWorkerPoolSize`. We have seen a significant delay in new changes getting served by worker goroutines. Having a higher number of workers may help mitigate the issue.

/cc @cjwagner @listx @mpherman2 