### PR TITLE
config: Temporarily change frequency of cla bot checker

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -88,7 +88,8 @@ periodics:
         secretName: k8s-triage-robot-github-token
 
 - name: ci-k8s-triage-robot-cla
-  interval: 10m
+  # TODO(MadhavJivrajani): change interval back to 10m once EasyCLA issues are fixed.
+  interval: 24h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
If an easyCLA issue persists for a prolonged time,
the bot can get spammy.
   
One workaround is adding the cncf-cla:no label manually
but most folks will not have access to do that.
    
Till the easyCLA issue is fixed, increasing the frequency to 1d.

Raised concerns:
- https://github.com/kubernetes/community/issues/7174
- https://kubernetes.slack.com/archives/C1TU9EB9S/p1678351853346579
- https://kubernetes.slack.com/archives/C01672LSZL0/p1678333533824339

/sig contributor-experience
/priority important-soon