### PR TITLE
Add description for aborted jobs in jenkins, trigger

### DIFF
--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -303,6 +303,7 @@ func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, jbs map[string]Build)
 		toCancel.SetComplete()
 		prevState := toCancel.Status.State
 		toCancel.Status.State = prowapi.AbortedState
+		toCancel.Status.Description = "Aborted as the newer version of this job is running."
 		c.log.WithFields(pjutil.ProwJobFields(&toCancel)).
 			WithField("from", prevState).
 			WithField("to", toCancel.Status.State).Info("Transitioning states.")

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -38,6 +38,10 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
+const (
+	abortedDescription = "Aborted by trigger plugin."
+)
+
 func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) error {
 	org, repo, a := orgRepoAuthor(pr.PullRequest)
 	author := string(a)
@@ -180,6 +184,7 @@ func abortAllJobs(c Client, pr *github.PullRequest) error {
 			continue
 		}
 		job.Status.State = prowapi.AbortedState
+		job.Status.Description = abortedDescription
 		// We use Update and not Patch here, because we are not the authority of the .Status.State field
 		// and must not overwrite changes made to it in the interim by the responsible agent.
 		// The accepted trade-off for now is that this leads to failure if unrelated fields where changed

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -625,7 +625,7 @@ func TestAbortAllJobs(t *testing.T) {
 				t.Fatalf("failed to get prowjob: %v", err)
 			}
 
-			if isAborted := pj.Status.State == prowapi.AbortedState; isAborted != tc.expectedAbortedProwJob {
+			if isAborted := (pj.Status.State == prowapi.AbortedState && pj.Status.Description == abortedDescription); isAborted != tc.expectedAbortedProwJob {
 				t.Errorf("IsAborted: %t, but expected aborted: %t", isAborted, tc.expectedAbortedProwJob)
 			}
 		})


### PR DESCRIPTION
/fixes https://github.com/kubernetes/test-infra/issues/28946

The findings in the linked issue are correct, I found additionally one more place in Jenkins when terminating dupes.