### PR TITLE
Update kubekins/krte to Go 1.20.2/1.19.7

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,20 +1,20 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.20.1
+    GO_VERSION: 1.20.2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.20.1
+    GO_VERSION: 1.20.2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.19.6
+    GO_VERSION: 1.19.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
@@ -27,31 +27,31 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.20.1
+    GO_VERSION: 1.20.2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: 1.19.6
+    GO_VERSION: 1.19.7
     K8S_RELEASE: latest-1.26
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: 1.19.6
+    GO_VERSION: 1.19.7
     K8S_RELEASE: stable-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: 1.19.6
+    GO_VERSION: 1.19.7
     K8S_RELEASE: stable-1.24
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: 1.19.6
+    GO_VERSION: 1.19.7
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
- Update kubekins/krte to Go 1.20.2/1.19.7

part of https://github.com/kubernetes/release/issues/2948

/assign @saschagrunert @xmudrii @dims @liggitt @justaugustus 
cc @kubernetes/release-engineering 