### PR TITLE
Set minStartupPods and ginkgo-parallel to 1 for serial execution of tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1400,11 +1400,11 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=1
       - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
+      - --ginkgo-parallel=1
       - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=1
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
   annotations:
@@ -1434,11 +1434,11 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=1
       - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
+      - --ginkgo-parallel=1
       - --image-family=cos-stable
       - --image-project=cos-cloud
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=2
+      - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\] --minStartupPods=1
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
   annotations:


### PR DESCRIPTION
In-place pod resize tests create pods that request resources. Running these tests in parallel on small node clusters causes arbitrary pods to remain unscheduled, timing out the tests, and causing tests to fail.

A quick fix for this is to make the CI jobs run with ginkgo-parallel=1 and minStartupPods=1 to ensure that tests are run in serial, similar to the pull job pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2 . This PR aims to achieve that.