### PR TITLE
Add pull-release-test-canary job on EKS cluster

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -57,6 +57,25 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
+  - name: pull-release-test-canary
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: k8s.io/release
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+        imagePullPolicy: Always
+        command:
+        - make
+        - test
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-test-canary
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
   - name: pull-release-integration-test
     always_run: true
     decorate: true


### PR DESCRIPTION
This PR adds `pull-release-test-canary` job that runs on the new eks-prow-build-cluster. 🤞 

/assign @upodroid 
cc @kubernetes/release-engineering 