### PR TITLE
cleanup k8s.gcr.io references

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -18,7 +18,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-all
     testgrid-tab-name: periodic-manifest-lists
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
-    description: "OWNER: sig-cluster-lifecycle; an e2e test for verifying manifest list images at k8s.gcr.io"
+    description: "OWNER: sig-cluster-lifecycle; an e2e test for verifying manifest list images at registry.k8s.io"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -34,8 +34,3 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false
-  - name: "test-infra images"
-    prefix: "k8s.gcr.io/test-infra"
-    repo: "https://github.com/kubernetes/test-infra"
-    summarise: false
-    consistentImages: false

--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -142,8 +142,7 @@ run_tests() {
 
   # build and load the conformance image into the kind nodes
   make build ARCH=amd64
-  kind load docker-image k8s.gcr.io/conformance-amd64:${VERSION} ||
-      kind load docker-image registry.k8s.io/conformance-amd64:${VERSION}
+  kind load docker-image registry.k8s.io/conformance-amd64:${VERSION}
 
   # patch the image in manifest
   sed -i "s|conformance-amd64:.*|conformance-amd64:${VERSION}|g" conformance-e2e.yaml


### PR DESCRIPTION
This leaves valid references, which can be tricky to determine.

Remaining:
``` console
$ git grep -n k8s.gcr.io
config/jobs/image-pushing/README.md:163:[gcr instructions]: https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/README.md
config/jobs/kubernetes/kops/build_jobs.py:459:        # A one-off scenario testing the k8s.gcr.io mirror
config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:11:    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:22:        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:39:    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:51:        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml:33:    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml:52:        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml:249:      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
experiment/print-job-image-summary.sh:56:      - k8s.gcr.io                                    $(image_include_exclude "k8s\.gcr\.io" "^$")
jobs/e2e_node/containerd/config-systemd.toml:35:# Enable registry.k8s.io as the primary mirror for k8s.gcr.io
jobs/e2e_node/containerd/config-systemd.toml:37:[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
jobs/e2e_node/containerd/config-systemd.toml:38:  endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]
jobs/e2e_node/containerd/config.toml:29:# Enable registry.k8s.io as the primary mirror for k8s.gcr.io
jobs/e2e_node/containerd/config.toml:31:[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
jobs/e2e_node/containerd/config.toml:32:  endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]
label_sync/labels.md:393:| <a id="area/k8s.gcr.io" href="#area/k8s.gcr.io">`area/k8s.gcr.io`</a> | Code in k8s.gcr.io/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
label_sync/labels.yaml:1025:        description: Code in k8s.gcr.io/
label_sync/labels.yaml:1026:        name: area/k8s.gcr.io
```

> ```
> config/jobs/image-pushing/README.md:163:[gcr instructions]: https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/README.md
> ```

This is still the correct link

> ```
> config/jobs/kubernetes/kops/build_jobs.py:459:        # A one-off scenario testing the k8s.gcr.io mirror
> config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:11:    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
> > config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:22:        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
> config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:39:    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
> config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml:51:        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
> config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml:33:    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
> config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml:52:        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
> config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml:249:      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
> ```

These are the correctly configured jobs for https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io
That directory will eventually be wound down, but we're not there yet. When the k8s.io repo is ready, we'll update here as part of that. This is a complex change part of a larger KEP to freeze GCR and switch to registry.k8s.io

> ```
> experiment/print-job-image-summary.sh:56:      - k8s.gcr.io                                    $(image_include_exclude "k8s\.gcr\.io" "^$")
> ```

This is an old script just printing what images are in use in our CI jobs.
It's still relevant to list if any are coming from k8s.gcr.io, I'd argue more relevant than ever now (since none should be, but someone might on accident)

> ```
> jobs/e2e_node/containerd/config-systemd.toml:35:# Enable registry.k8s.io as the primary mirror for k8s.gcr.io
> jobs/e2e_node/containerd/config-systemd.toml:37:[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
> jobs/e2e_node/containerd/config-systemd.toml:38:  endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]
> jobs/e2e_node/containerd/config.toml:29:# Enable registry.k8s.io as the primary mirror for k8s.gcr.io
> jobs/e2e_node/containerd/config.toml:31:[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
> jobs/e2e_node/containerd/config.toml:32:  endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]
> ```

All of this is configuring CI environments to pull form registry.k8s.io for any k8s.gcr.io images, this requires a reference to the old registry to remap it to the new one and is working as intended.

> ```
> label_sync/labels.md:393:| <a id="area/k8s.gcr.io" href="#area/k8s.gcr.io">`area/k8s.gcr.io`</a> | Code in k8s.gcr.io/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
> label_sync/labels.yaml:1025:        description: Code in k8s.gcr.io/
> label_sync/labels.yaml:1026:        name: area/k8s.gcr.io
> ```

This label is for https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io again.