### PR TITLE
Remove quotes from ALL_ARCH argument within ingress-gce e2e job

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -175,7 +175,7 @@ postsubmits:
         - --env=REGISTRY=gcr.io/k8s-ingress-image-push
         - make
         - all-push
-        - ALL_ARCH='amd64 arm64'
+        - ALL_ARCH=amd64 arm64
         - CONTAINER_BINARIES="e2e-test"
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Fixes failing push jobs: https://testgrid.k8s.io/sig-network-ingress-gce-e2e

ALL_ARCH is consumed at [rules.mk](https://github.com/kubernetes/ingress-gce/blob/cb7a8d3ba85d632e26405cd3ad4de76245a7107d/build/rules.mk#L90) in [kubernetes/ingress-gce](https://github.com/kubernetes/ingress-gce) where `addprefix` function (https://www.gnu.org/software/make/manual/html_node/File-Name-Functions.html#index-addprefix)  is used.

If we have `ALL_ARCH='arch1 arch2'` and we then use addprefix as follows:`addprefix push-, $(ALL_ARCH)`, this will output `'arch1` and `arch2'` which is obviously wrong and results in error.

/assign @aojea 
/cc @swetharepakula 

