### PR TITLE
build registry.k8s.io images on version tag pushes

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -8,6 +8,8 @@ postsubmits:
     decorate: true
     branches:
     - ^main$
+    # release tags
+    - ^v\d+.*
     spec:
       serviceAccountName: gcb-builder
       containers:


### PR DESCRIPTION
cc @ameukam 

we should also consider this for porche (which had ~identical config until now) @justinsb 