### PR TITLE
k8s-infra: add canary jobs for eks

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -27,3 +27,90 @@ periodics:
         requests:
           cpu: 100m
           memory: 512Mi
+
+- interval: 1h
+  name: ci-kubernetes-unit-eks-canary
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: ci-kubernetes-unit-eks-canary
+    testgrid-days-of-results: '1'
+    testgrid-create-test-group: 'true'
+  decorate: true
+  cluster: eks-prow-build-cluster
+  extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    # unit tests have no business requiring root or doing privileged operations
+    securityContext:
+      # NOTE: these are arbitrary non-root values. They don't exist in the
+      # image and don't need to, the unit tests should only write to TMPDIR
+      runAsUser: 2001
+      runAsGroup: 2010
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+        securityContext:
+          allowPrivilegeEscalation: false
+        command:
+          - make
+          - test
+        # TODO: direct copy from pull-kubernetes-bazel-test, tune these
+        resources:
+          limits:
+            cpu: 4
+            memory: "36Gi"
+          requests:
+            cpu: 4
+            memory: "36Gi"
+
+- interval: 1h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-kind-e2e-parallel-eks-canary
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kind-master-parallel-eks-canary
+    description: Uses kubetest to run e2e tests against a latest kubernetes master cluster created with sigs.k8s.io/kind
+    testgrid-num-columns-recent: '6'
+    fork-per-release: "true"
+    fork-per-release-periodic-interval: 1h 2h 6h 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230222-b5208facd4-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: FOCUS
+        value: "."
+      # TODO(bentheelder): reduce the skip list further
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7


### PR DESCRIPTION
Add variants of `ci-kubernetes-kind-e2e-parallel` and `ci-kubernetes-unit` to running specifically on the EKS builder.

Failure of those jobs is expected and monitoring of them is not recommended.