### PR TITLE
fix job broken in master->main transition

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubeadm
-      base_ref: master
+      base_ref: main
       path_alias: k8s.io/kubeadm
     always_run: true
     optional: true


### PR DESCRIPTION
Fixes the following during **kubernetes-sigs/kube-storage-version-migrator** builds:
```
$ PWD=/home/prow/go/src/k8s.io/kubeadm  git fetch https://github.com/kubernetes/kubeadm.git master (runtime: 4.956720185s)
fatal: couldn't find remote ref master
```