### PR TITLE
upgrade migration test from aks-engine to capz for azure file driver

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
     spec:
@@ -51,7 +51,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -76,7 +76,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -101,7 +101,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -151,7 +151,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -202,7 +202,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -255,7 +255,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -311,7 +311,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -470,7 +470,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
     spec:
@@ -544,7 +544,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -598,7 +598,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -655,7 +655,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -709,7 +709,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -766,7 +766,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -825,7 +825,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -867,7 +867,7 @@ presubmits:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - master
-    - release-1.26
+    - ^release-.+$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -5,8 +5,7 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
     spec:
@@ -50,8 +49,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -75,8 +73,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -100,8 +97,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -150,8 +146,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -201,8 +196,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -254,8 +248,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -310,8 +303,7 @@ presubmits:
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -469,8 +461,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
     spec:
@@ -543,8 +534,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -597,8 +587,7 @@ presubmits:
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -654,8 +643,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -708,8 +696,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -765,8 +752,7 @@ presubmits:
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -824,8 +810,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -866,8 +851,7 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
-    - master
-    - ^release-.+$
+    - (master)|(^release-.+$)
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -229,46 +229,50 @@ presubmits:
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
+    branches:
+    - master
+    - release-1.26
     labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
       preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
     extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.8
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cloud-provider-azure
+        workdir: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --provider=skeleton
-        - --deployment=aksengine
-        - --aksengine-admin-username=azureuser
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.23
-        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/test/e2e/manifest/migration.json
-        - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-        # Specific test args
-        - --test-azure-file-csi-driver
-        securityContext:
-          privileged: true
-        env:
-          - name: AZURE_STORAGE_DRIVER
-            value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-          - name: TEST_MIGRATION
-            value: "true"
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+          command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+          args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+              make e2e-test
+          securityContext:
+            privileged: true
+          env:
+            - name: AZURE_STORAGE_DRIVER
+              value: "kubernetes.io/azure-file" # In-tree Azure file storage class
+            - name: TEST_MIGRATION
+              value: "true"
+            - name: NODE_MACHINE_TYPE # CAPZ config
+              value: "Standard_D2s_v3"
+            - name: DISABLE_ZONE # azurefile-csi-driver config
+              value: "true"
+            - name: KUBERNETES_VERSION # CAPZ config
+              value: "latest"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pr-azurefile-csi-driver-e2e-migration
@@ -348,49 +352,59 @@ presubmits:
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
+    branches:
+    - master
+    - release-1.26
     labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-azure-windows: "true"
       preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-windows: "true"
+      preset-azure-anonymous-pull: "true"
     extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.8
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cloud-provider-azure
+        workdir: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --provider=skeleton
-        - --deployment=aksengine
-        - --aksengine-admin-username=azureuser
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.24
-        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/test/e2e/manifest/migration-windows.json
-        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-        # Specific test args
-        - --test-azure-file-csi-driver
-        securityContext:
-          privileged: true
-        env:
-          - name: AZURE_STORAGE_DRIVER
-            value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-          - name: TEST_MIGRATION
-            value: "true"
-          - name: TEST_WINDOWS
-            value: "true"
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+          command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+          args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+              make e2e-test
+          securityContext:
+            privileged: true
+          env:
+            - name: AZURE_STORAGE_DRIVER
+              value: "kubernetes.io/azure-file" # In-tree Azure file storage class
+            - name: TEST_MIGRATION
+              value: "true"
+            - name: DISABLE_ZONE # azurefile-csi-driver config
+              value: "true"
+            - name: KUBERNETES_VERSION # CAPZ config
+              value: "latest-1.25"
+            - name: WINDOWS # azuredisk-csi-driver config
+              value: "true"
+            - name: TEST_WINDOWS # CAPZ config
+              value: "true"
+            - name: WINDOWS_SERVER_VERSION # CAPZ config
+              value: "windows-2022"
+            - name: NODE_MACHINE_TYPE # CAPZ config
+              value: "Standard_D4s_v3"
+            - name: WORKER_MACHINE_COUNT # CAPZ config
+              value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pr-azurefile-csi-driver-e2e-migration-windows
@@ -485,7 +499,7 @@ presubmits:
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.23"
+              value: "latest-1.24"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
             - name: EXTERNAL_E2E_TEST_SMB # azurefile-csi-driver config
@@ -584,7 +598,7 @@ presubmits:
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.23"
+              value: "latest-1.26"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
@@ -638,7 +652,7 @@ presubmits:
             - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.23"
+              value: "latest-1.25"
             - name: WORKER_MACHINE_COUNT
               value: "0" # Don't create any linux worker nodes
     annotations:
@@ -692,7 +706,7 @@ presubmits:
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.23"
+              value: "latest-1.24"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
@@ -749,7 +763,7 @@ presubmits:
             - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.23"
+              value: "latest-1.26"
             - name: WORKER_MACHINE_COUNT
               value: "0" # Don't create any linux worker nodes
     annotations:

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -376,9 +376,11 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-e2e-capz
     decorate: true
-    always_run: false
-    optional: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
+    branches:
+    - master
+    - release-1.26
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -390,6 +392,11 @@ presubmits:
         base_ref: release-1.8
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cloud-provider-azure
+        workdir: false
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
@@ -407,8 +414,10 @@ presubmits:
           env:
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
+            - name: KUBERNETES_VERSION # CAPZ config
+              value: "latest"
     annotations:
       testgrid-dashboards: provider-azure-blobfuse-csi-driver
-      testgrid-tab-name: pull-blob-csi-driver-e2e-capz
+      testgrid-tab-name: pr-blob-csi-driver-e2e-capz
       description: "Run E2E tests on a capz cluster for Blob CSI driver."
       testgrid-num-columns-recent: '30'


### PR DESCRIPTION
 - upgrade migration test from aks-engine to capz for azure file driver
 - run azuredisk e2e test on all release branches