### PR TITLE
Add kueue jobs to config

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -5,8 +5,7 @@ periodics:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: periodic-kueue-test-unit-main
       description: "Run periodic kueue unit tests"
-      testgrid-num-columns-recent: '6'
-      testgrid-num-failures-to-alert: "1"
+      testgrid-num-columns-recent: '15'
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -34,8 +33,7 @@ periodics:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: periodic-kueue-test-integration-main
       description: "Run periodic kueue test-integration"
-      testgrid-num-columns-recent: '6'
-      testgrid-num-failures-to-alert: "1"
+      testgrid-num-columns-recent: '15'
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -55,48 +53,12 @@ periodics:
           args:
             - test-integration
   - interval: 24h
-    name: periodic-kueue-test-e2e-main-1-23
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-23
-      description: "Run periodic kueue end to end tests for Kubernetes 1.23"
-      testgrid-num-columns-recent: '6'
-      testgrid-num-failures-to-alert: "1"
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: master
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.23.12
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-  - interval: 24h
     name: periodic-kueue-test-e2e-main-1-24
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: periodic-kueue-test-e2e-main-1-24
       description: "Run periodic kueue end to end tests for Kubernetes 1.24"
-      testgrid-num-columns-recent: '6'
-      testgrid-num-failures-to-alert: "1"
+      testgrid-num-columns-recent: '15'
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -130,8 +92,7 @@ periodics:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: periodic-kueue-test-e2e-main-1-25
       description: "Run periodic kueue end to end tests for Kubernetes 1.25"
-      testgrid-num-columns-recent: '6'
-      testgrid-num-failures-to-alert: "1"
+      testgrid-num-columns-recent: '15'
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -165,8 +126,7 @@ periodics:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: periodic-kueue-verify-main
       description: "Run periodic kueue verify checks"
-      testgrid-num-columns-recent: '6'
-      testgrid-num-failures-to-alert: "1"
+      testgrid-num-columns-recent: '15'
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -1,0 +1,187 @@
+periodics:
+  - interval: 24h
+    name: periodic-kueue-test-unit-main
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-main
+      description: "Run periodic kueue unit tests"
+      testgrid-num-columns-recent: '6'
+      testgrid-num-failures-to-alert: "1"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: master
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: golang:1.19
+          env:
+            - name: GO_TEST_FLAGS
+              value: "-race -count 3"
+          command:
+            - make
+          args:
+            - test
+  - interval: 24h
+    name: periodic-kueue-test-integration-main
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-integration-main
+      description: "Run periodic kueue test-integration"
+      testgrid-num-columns-recent: '6'
+      testgrid-num-failures-to-alert: "1"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: master
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: golang:1.19
+          command:
+            - make
+          args:
+            - test-integration
+  - interval: 24h
+    name: periodic-kueue-test-e2e-main-1-23
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-main-1-23
+      description: "Run periodic kueue end to end tests for Kubernetes 1.23"
+      testgrid-num-columns-recent: '6'
+      testgrid-num-failures-to-alert: "1"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: master
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.23.12
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - interval: 24h
+    name: periodic-kueue-test-e2e-main-1-24
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-main-1-24
+      description: "Run periodic kueue end to end tests for Kubernetes 1.24"
+      testgrid-num-columns-recent: '6'
+      testgrid-num-failures-to-alert: "1"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: master
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.24.7
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - interval: 24h
+    name: periodic-kueue-test-e2e-main-1-25
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-main-1-25
+      description: "Run periodic kueue end to end tests for Kubernetes 1.25"
+      testgrid-num-columns-recent: '6'
+      testgrid-num-failures-to-alert: "1"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: master
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.25.3
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - interval: 24h
+    name: periodic-kueue-verify-main
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-verify-main
+      description: "Run periodic kueue verify checks"
+      testgrid-num-columns-recent: '6'
+      testgrid-num-failures-to-alert: "1"
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: master
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: golang:1.19
+          command:
+            - make
+          args:
+            - verify


### PR DESCRIPTION
This pr adds a config yaml to `config/jobs/kubernetes-sigs/kueue` to  run these tests periodically for kueue.

I'm not familar with both test-infra and kueue. So please point it out if some configuration is wrong.

Here're something that I'm not very clear:
1. `testgrid-alert-email`  for `kueue`?
~~2. I see there is a `kueue-presubmits.yaml` can `testgrid-dashboards` and `testgrid-tab-name` have the same name with tests in `kueue-presubmits.yaml`?~~
