### PR TITLE
update tejolote jobs to use go1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: k8s-infra-prow-build
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: k8s-infra-prow-build
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
needed for https://github.com/kubernetes-sigs/tejolote/pull/46

/assign @puerco @xmudrii @saschagrunert 
cc @kubernetes/release-managers 