### PR TITLE
k8s-infra: sync images to AR region southamerica-east1

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
@@ -29,5 +29,5 @@ periodics:
               export PATH=$PATH:$GOPATH/bin
               apt update && apt install parallel -qqy
               go install github.com/google/go-containerregistry/cmd/gcrane@latest
-              parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: us-west3 us-west4
+              parallel "gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod {}-docker.pkg.dev/k8s-artifacts-prod/images" ::: us-west3 us-west4 southamerica-east1
               gcrane cp --recursive --allow-nondistributable-artifacts us.gcr.io/k8s-artifacts-prod gcr.io/k8s-artifacts-prod


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/4924

Ensure images exists in Artifact Registry repository created in `southamerica-east1` region.
