### PR TITLE
Reverting sig-windows release jobs to CAPZ 1.7 as mitigation for CCM images not building

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -30,7 +30,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -55,6 +55,48 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.24-informing, sig-windows-1.24-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-1.24
+- name: ci-kubernetes-e2e-capz-master-containerd-windows-1-24-ccm
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  labels:
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-windows-common-124: "true"
+    preset-capz-windows-parallel: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.8
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.24
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./scripts/ci-conformance.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-1.24
+      name: ""
+      resources:
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.24-release
+    testgrid-tab-name: capz-windows-containerd-1.24-ccm
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow-1-24
   interval: 24h
   decorate: true
@@ -72,7 +114,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -30,7 +30,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -55,6 +55,48 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.25-informing, sig-windows-1.25-release, sig-windows-signal
     testgrid-tab-name: capz-e2e-windows-containerd-1.25
+- name: ci-kubernetes-e2e-capz-containerd-windows-1-25-ccm
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  labels:
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-windows-common-125: "true"
+    preset-capz-windows-parallel: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.8
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.25
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./scripts/ci-conformance.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-1.25
+      name: ""
+      resources:
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.25-release
+    testgrid-tab-name: capz-e2e-windows-containerd-1.25-ccm
 - name: ci-kubernetes-e2e-capz-containerd-windows-serial-slow-1-25
   interval: 24h
   decorate: true
@@ -72,7 +114,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -20,7 +20,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -55,3 +55,45 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.26-informing, sig-windows-signal,  sig-windows-1.26-release
     testgrid-tab-name: capz-windows-containerd-1.26
+- name: ci-kubernetes-e2e-capz-master-containerd-windows-1-26-ccm
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.8
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.26
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  interval: 24h
+  labels:
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-windows-common-126: "true"
+    preset-capz-windows-parallel: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./scripts/ci-conformance.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-1.26
+      name: ""
+      resources:
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.26-release
+    testgrid-tab-name: capz-windows-containerd-1.26-ccm


### PR DESCRIPTION
Starting with CAPZ v1.8 all clusters are provisioned with the out-of-tree cloud controller manager and unfortunately the SIG-Windows jobs targeting release jobs are having issues building the CCM images.

This reverts the release-1.24, release-1.25, and release-1.26 SIG-Windows jobs to a previously known / good state and also adds a new job for each release to build/test with the cloud-provider-azure out-of-tree CCM.

/sig windows
/assign @jsturtevant @CecileRobertMichon 