### PR TITLE
Add smg247 to reviewers

### DIFF
--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -7,6 +7,7 @@ reviewers:
   - petr-muller
   - stevekuznetsov
   - droslean
+  - smg247
 approvers:
   - cblecker
   - cjwagner


### PR DESCRIPTION
I would like to continue to be more active in Prow, with the eventual goal of gaining approver status. For now, I would like to add myself as a reviewer.