### PR TITLE
Use extract=local for HPA presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -98,8 +98,9 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
+        - --build=quick
         - --cluster=hpa
-        - --extract=ci/latest
+        - --extract=local
         - --gcp-node-image=gci
         - --gcp-project=k8s-jkns-gci-autoscaling
         - --gcp-zone=us-west1-b


### PR DESCRIPTION
The test is currently using the latest master version instead of the target github CI branch for `test /pull...` commands.