### PR TITLE
[release-v1.27] Enforce Code Freeze for Kubernetes 1.27

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -667,6 +667,32 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+      - master
+      - release-1.27
+    labels:
+      - lgtm
+      - approved
+      - "cncf-cla: yes"
+    missingLabels:
+      - do-not-merge
+      - do-not-merge/blocked-paths
+      - do-not-merge/cherry-pick-not-approved
+      - do-not-merge/contains-merge-commits
+      - do-not-merge/hold
+      - do-not-merge/invalid-commit-message
+      - do-not-merge/invalid-owners-file
+      - do-not-merge/needs-kind
+      - do-not-merge/needs-sig
+      - do-not-merge/release-note-label-needed
+      - do-not-merge/work-in-progress
+      - needs-rebase
+  - repos:
+      - kubernetes/kubernetes
+    milestone: v1.27
+    includedBranches:
+      - master
+      - release-1.27
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes 1.27 Code Freeze is scheduled to start at [01:00 UTC Wednesday 15th March 2023 / 17:00 PDT Tuesday 14th March 2023](https://everytimezone.com/s/c4971746)

/hold
The hold should ONLY be cancelled by the Release Team Leads when the 1.27 Release Team is ready around the Code Freeze deadline.

/priority critical-urgent
/cc @kubernetes/release-team-leads @kubernetes/release-engineering 
/assign @dims 