### PR TITLE
config: Restore CLA bot frequency to 10 mins

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -88,8 +88,7 @@ periodics:
         secretName: k8s-triage-robot-github-token
 
 - name: ci-k8s-triage-robot-cla
-  # TODO(MadhavJivrajani): change interval back to 10m once EasyCLA issues are fixed.
-  interval: 24h
+  interval: 10m
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Restoring CLA bot frequency that was changed in https://github.com/kubernetes/test-infra/pull/28969

EasyCLA seems to have fixed the issue, xref: https://github.com/communitybridge/easycla/issues/3843

/assign @nikhita @ameukam 