### PR TITLE
Update Milestone Applier config for CAPI v1.4

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -468,7 +468,8 @@ milestone_applier:
     release-1.17: v1.17
     release-1.16: v1.16
   kubernetes-sigs/cluster-api:
-    main: v1.4
+    main: v1.5
+    release-1.4: v1.4
     release-1.3: v1.3
     release-1.2: v1.2
     release-1.1: v1.1


### PR DESCRIPTION
Add config for CAPI release-1.4 branch and for the next v1.5 release of Cluster API to the milestone-applier plugin.

Related to https://github.com/kubernetes-sigs/cluster-api/issues/7672