### PR TITLE
Fix ingress-gce e2e image building

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -173,10 +173,11 @@ postsubmits:
         - --
         - --env=VERSION=$(PULL_BASE_REF)
         - --env=REGISTRY=gcr.io/k8s-ingress-image-push
-        - make
-        - all-push
-        - ALL_ARCH=amd64 arm64
-        - CONTAINER_BINARIES=e2e-test
+        - --env=BINARY=e2e-test
+        - |
+          make build CONTAINER_BINARIES="${BINARY}"
+          VERBOSE=1 CONTAINER_BINARIES="${BINARY}" REGISTRY="${REGISTRY}" ALL_ARCH="amd64 arm64" make all-push
+          VERBOSE=1 CONTAINER_BINARIES="${BINARY}" REGISTRY="${REGISTRY}" make push
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
I expected and tested e2e-test image build
as a multiarch. Unfortunately, the last command
did not push a new manifest with a list of images
for both architectures.