### PR TITLE
Reduce EKS pull-release-test-canary to double default allocation

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -72,11 +72,11 @@ presubmits:
         - test
         resources:
           limits:
-            memory: 9Gi
-            cpu: 7
+            memory: 2Gi
+            cpu: 500m
           requests:
-            memory: 9Gi
-            cpu: 7
+            memory: 2Gi
+            cpu: 500m
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-test-canary


### PR DESCRIPTION
It is my understanding these jobs should have been using these defaults before I added the very high request:
https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/build/cpu-limit-range_limitrange.yaml
https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/build/mem-limit-range_limitrange.yaml