### PR TITLE
Revert "Make CRI-O installer script obsolete"

### DIFF
--- a/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
+++ b/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
@@ -24,50 +24,18 @@
           "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -24,45 +24,13 @@
           "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -72,7 +40,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -19,45 +19,13 @@
           "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -67,7 +35,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
@@ -26,45 +26,13 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -79,7 +47,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -26,45 +26,13 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -79,7 +47,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -39,45 +39,13 @@
           "source": "data:,%5Bcrio.runtime%5D%0Aenable_pod_events%20%3D%20true%0A"
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -92,7 +60,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -31,45 +31,13 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -84,7 +52,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -31,45 +31,13 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -84,7 +52,7 @@
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -31,45 +31,13 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/05-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/10-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0A%5Bcrio.runtime.runtimes%5D%0A%5Bcrio.runtime.runtimes.test-handler%5D%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runc.conf",
-        "contents": {
-          "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxoaiD0cWxOMRBjORYLkAAAAD//xWgUHldAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
-        },
-        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -89,7 +57,7 @@
         "name": "swap-enable.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/templates/base/05-log-level.conf
+++ b/jobs/e2e_node/crio/templates/base/05-log-level.conf
@@ -1,2 +1,0 @@
-[crio.runtime]
-log_level = "debug"

--- a/jobs/e2e_node/crio/templates/base/10-crun.conf
+++ b/jobs/e2e_node/crio/templates/base/10-crun.conf
@@ -1,3 +1,0 @@
-[crio.runtime]
-[crio.runtime.runtimes]
-[crio.runtime.runtimes.test-handler]

--- a/jobs/e2e_node/crio/templates/base/20-runc.conf
+++ b/jobs/e2e_node/crio/templates/base/20-runc.conf
@@ -1,4 +1,0 @@
-[crio.runtime]
-default_runtime = "runc"
-[crio.runtime.runtimes]
-[crio.runtime.runtimes.runc]

--- a/jobs/e2e_node/crio/templates/base/30-infra-container.conf
+++ b/jobs/e2e_node/crio/templates/base/30-infra-container.conf
@@ -1,2 +1,0 @@
-[crio.runtime]
-drop_infra_ctr = false

--- a/jobs/e2e_node/crio/templates/base/crio-install.yaml
+++ b/jobs/e2e_node/crio/templates/base/crio-install.yaml
@@ -1,22 +1,4 @@
 ---
-storage:
-  files:
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: crio-install.service
@@ -28,15 +10,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/base/selinux.yaml
+++ b/jobs/e2e_node/crio/templates/base/selinux.yaml
@@ -17,8 +17,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp

--- a/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
@@ -11,22 +11,6 @@ storage:
       contents:
         local: kubelet-e2e.te
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -39,8 +23,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -56,15 +38,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -11,22 +11,6 @@ storage:
       contents:
         local: kubelet-e2e.te
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -39,8 +23,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -73,15 +55,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
@@ -11,22 +11,6 @@ storage:
       contents:
         local: kubelet-e2e.te
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -39,8 +23,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -73,15 +55,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
@@ -16,22 +16,6 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -44,8 +28,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -97,15 +79,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
@@ -16,22 +16,6 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -44,8 +28,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -97,15 +79,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
@@ -20,22 +20,6 @@ storage:
       contents:
         local: 40-evented-pleg.conf
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -48,8 +32,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -101,15 +83,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
@@ -16,22 +16,6 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -44,8 +28,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -97,15 +79,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_serial.yaml
@@ -16,22 +16,6 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -44,8 +28,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -97,15 +79,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -16,22 +16,6 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
-    - path: /etc/crio/crio.conf.d/05-log-level.conf
-      contents:
-        local: 05-log-level.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/10-crun.conf
-      contents:
-        local: 10-crun.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/20-runc.conf
-      contents:
-        local: 20-runc.conf
-      mode: 0644
-    - path: /etc/crio/crio.conf.d/30-infra-container.conf
-      contents:
-        local: 30-infra-container.conf
-      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -44,8 +28,6 @@ systemd:
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
-        ExecStartPre=mkdir -p /var/lib/kubelet
-        ExecStartPre=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
         ExecStart=semodule -i /root/kubelet-e2e.pp
@@ -111,15 +93,13 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
-        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
-        ExecStartPre=bash -c '\
-          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
-        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
-        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
-        ExecStart=systemctl enable --now crio.service
+        ExecStartPre=/usr/bin/bash -c '\
+          /usr/bin/curl --fail --retry 5 \
+            --retry-delay 3 --silent --show-error \
+            -o /usr/local/crio-nodee2e-installer.sh  \
+            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
+          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
+        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
Reverts kubernetes/test-infra#29025

Looks like the CRI-O systemd unit is not running correctly, I have to dig into this:
https://prow.k8s.io/log?job=ci-crio-cgroupv1-node-e2e-conformance&id=1635667367214190592


PTAL @harche @haircommander 