### PR TITLE
Configure the image-promoter to use the new manifest location.

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -1,7 +1,6 @@
 postsubmits:
   kubernetes-sigs/promo-tools:
-    # TODO(releng): Rename to 'kpromo' once tools are merged
-    - name: post-cip-push-image-cip
+    - name: post-kpromo-push-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-blocking, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb

--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       testgrid-dashboards: sig-k8s-infra-k8sio
     decorate: true
     skip_report: false
-    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
+    run_if_changed: 'registry.k8s.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
     max_concurrency: 10
     branches:
     - ^main$
@@ -19,7 +19,7 @@ presubmits:
         - /kpromo
         args:
         - cip
-        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
         - --use-prow-manifest-diff
         resources:
           limits:
@@ -36,7 +36,7 @@ presubmits:
     decorate: true
     optional: true
     skip_report: false
-    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
+    run_if_changed: 'registry.k8s.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
     max_concurrency: 10
     branches:
     - ^vuln-check-test$
@@ -48,7 +48,7 @@ presubmits:
         - /kpromo
         args:
         - cip
-        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
         - --use-prow-manifest-diff
         - --vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -30,7 +30,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h
-    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
+    run_if_changed: 'registry.k8s.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
     # Never run more than 1 job at a time. This is because we don't want to run
     # into a case where an older manifest PR merge gets run last (after a newer
     # one).
@@ -49,7 +49,7 @@ postsubmits:
         - /kpromo
         args:
         - cip
-        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
         - --use-prow-manifest-diff
         - --confirm
         env:
@@ -246,7 +246,7 @@ periodics:
       - /kpromo
       args:
       - cip
-      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
       - --confirm
       env:
       - name: GOMAXPROCS


### PR DESCRIPTION
Part of: https://github.com/kubernetes/enhancements/issues/3720

/cc @kubernetes/release-engineering @BenTheElder @dims 

We need to merge these PRs in the following order:
- https://github.com/kubernetes-sigs/promo-tools/pull/669
- bump kpromo by merging https://github.com/kubernetes-sigs/promo-tools/pull/753
- https://github.com/kubernetes/k8s.io/pull/4808
- https://github.com/kubernetes/k8s.io/pull/4934
- This PR
- Remove the GCR registries from the manifests on the 28th of March. Separate PR in k/k8s.io

