### PR TITLE
fix kueue branch in config/jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -12,7 +12,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: master
+        base_ref: main
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: master
+        base_ref: main
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -65,7 +65,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: master
+        base_ref: main
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -99,7 +99,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: master
+        base_ref: main
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -133,7 +133,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: master
+        base_ref: main
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:


### PR DESCRIPTION
jobs to run kueue tests are using the wrong branch.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-kueue-verify-main/1635652519843598336
this pr should fix it