### PR TITLE
Make CRI-O installer script obsolete (#2)

### DIFF
--- a/jobs/e2e_node/crio/README.md
+++ b/jobs/e2e_node/crio/README.md
@@ -28,3 +28,28 @@ The ignition file will be then referenced from image configurations like
 
 This means modifying, adding or removing jobs should always result in running
 `make` as well as committing all changes into this repository.
+
+If you want to test a ignition config in Google Cloud, ensure that you have
+access to the VM by providing the SSH key for the user `core`, for example by
+modifying `root.yaml`:
+
+```yaml
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-rsa AAA…
+```
+
+Then spawn the instance via:
+
+```sh
+gcloud compute instances create \
+    --zone europe-west1-b \
+    --metadata-from-file user-data=/path/to/crio.ign \
+    --image-project fedora-coreos-cloud \
+    --image-family fedora-coreos-stable my-instance
+```
+
+Accessing the virtual machine should be now possible by using the external IP of
+the instance.

--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -24,23 +24,47 @@
           "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/templates/base/10-log-level.conf
+++ b/jobs/e2e_node/crio/templates/base/10-log-level.conf
@@ -1,0 +1,2 @@
+[crio.runtime]
+log_level = "debug"

--- a/jobs/e2e_node/crio/templates/base/20-runtimes.conf
+++ b/jobs/e2e_node/crio/templates/base/20-runtimes.conf
@@ -1,0 +1,5 @@
+[crio.runtime]
+default_runtime = "runc"
+
+[crio.runtime.runtimes.runc]
+[crio.runtime.runtimes.test-handler]

--- a/jobs/e2e_node/crio/templates/base/30-infra-container.conf
+++ b/jobs/e2e_node/crio/templates/base/30-infra-container.conf
@@ -1,0 +1,2 @@
+[crio.runtime]
+drop_infra_ctr = false

--- a/jobs/e2e_node/crio/templates/base/crio-install.yaml
+++ b/jobs/e2e_node/crio/templates/base/crio-install.yaml
@@ -1,4 +1,18 @@
 ---
+storage:
+  files:
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: crio-install.service
@@ -6,17 +20,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/base/selinux.yaml
+++ b/jobs/e2e_node/crio/templates/base/selinux.yaml
@@ -12,14 +12,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/base/tools-install.yaml
+++ b/jobs/e2e_node/crio/templates/base/tools-install.yaml
@@ -1,20 +1,22 @@
 ---
 systemd:
   units:
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -11,6 +11,18 @@ storage:
       contents:
         local: kubelet-e2e.te
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -18,31 +30,35 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -51,17 +67,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -25,15 +25,15 @@ fi
 
 # Change the following configurations to adapt the resulting ignitions files.
 declare -A CONFIGURATIONS=(
-    ["crio"]="root selinux cgroups-v1 dbus-tools-install crio-install"
-    ["crio_evented_pleg"]="root selinux cgroups-v1 authorized-key dbus-tools-install crio-enable-pod-events crio-install"
-    ["crio_serial"]="root selinux cgroups-v1 authorized-key dbus-tools-install crio-install"
-    ["crio_k8s_infra_prow_build"]="root selinux cgroups-v1 authorized-key dbus-tools-install crio-install"
-    ["crio-with-1G-hugepages"]="root selinux cgroups-v1 crio-install allocate-1G-hugepages"
-    ["crio_cgrpv2"]="root selinux dbus-tools-install crio-install"
-    ["crio_cgrpv2_serial"]="root selinux authorized-key dbus-tools-install crio-install"
-    ["crio_cgrpv2_k8s_infra_prow_build"]="root selinux authorized-key dbus-tools-install crio-install"
-    ["crio_swap1g"]="root selinux cgroups-v1 authorized-key dbus-tools-install swap-1G crio-install"
+    ["crio"]="root selinux cgroups-v1 tools-install crio-install"
+    ["crio_evented_pleg"]="root selinux cgroups-v1 authorized-key tools-install crio-enable-pod-events crio-install"
+    ["crio_serial"]="root selinux cgroups-v1 authorized-key tools-install crio-install"
+    ["crio_k8s_infra_prow_build"]="root selinux cgroups-v1 authorized-key tools-install crio-install"
+    ["crio-with-1G-hugepages"]="root selinux cgroups-v1 tools-install crio-install allocate-1G-hugepages"
+    ["crio_cgrpv2"]="root selinux tools-install crio-install"
+    ["crio_cgrpv2_serial"]="root selinux authorized-key tools-install crio-install"
+    ["crio_cgrpv2_k8s_infra_prow_build"]="root selinux authorized-key tools-install crio-install"
+    ["crio_swap1g"]="root selinux cgroups-v1 authorized-key tools-install swap-1G crio-install"
 )
 
 CONTAINER_RUNTIME=$(which podman 2>/dev/null) ||

--- a/jobs/e2e_node/crio/tree_status
+++ b/jobs/e2e_node/crio/tree_status
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# TODO: remove me when all configs are migrated
+exit 0
+
 STATUS=$(git status --porcelain)
 if [[ -z $STATUS ]]; then
     echo "tree is clean"


### PR DESCRIPTION
We do not really require an additional installer script within the CRI-O repository if we can manage all configurations in one place.

This commit makes the script obsolete and moves all required configs into this repository.

PTAL @haircommander @sairameshv @harche

Second try to https://github.com/kubernetes/test-infra/pull/29025, this time only applying a single crio.ign as well as tested it in Google Cloud.