### PR TITLE
Blockade changes to `k8s.gcr.io` folder in k/k8s.io

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -304,6 +304,11 @@ blockades:
   exceptionregexps:
   - ^prow/(ANNOUNCEMENTS|README)\.md$
   explanation: "All Prow documentation (Markdown files) have moved to https://github.com/kubernetes-sigs/prow as part of https://github.com/kubernetes-sigs/prow/issues/4. Instructions for updating existing docs are at https://docs.prow.k8s.io/docs/contribution-guidelines/#updating-existing-docs."
+- repos:
+  - kubernetes/k8s.io
+  blockregexps:
+  - ^k8s.gcr.io/
+  explanation: "k8s.gcr.io Image registry is frozen from April 2023. Please update the manifests in registry.k8s.io folder instead"
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
We need to merge these PRs first:
- #29037 
- https://github.com/kubernetes/k8s.io/pull/4934

/hold

/cc @ameukam @BenTheElder @dims 

I'm blockading the old registry folder immediately after 4934(which will be merged when kpromo is configured to promote from registry.k8s.io) is merged to avoid missing images from being promoted. I will delete the old registries from the manifests at the end of March and sync the contents of the https://git.k8s.io/k8s.io/registry.k8s.io to https://git.k8s.io/k8s.io/k8s.gcr.io one final time.
