### PR TITLE
Update CRI-O jobs to match new configs

### DIFF
--- a/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
+++ b/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
@@ -24,18 +24,47 @@
           "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "tools-install.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -19,23 +19,47 @@
           "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
@@ -26,13 +26,37 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -42,12 +66,12 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -26,13 +26,37 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -42,12 +66,12 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -39,13 +39,37 @@
           "source": "data:,%5Bcrio.runtime%5D%0Aenable_pod_events%20%3D%20true%0A"
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -55,12 +79,12 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -31,13 +31,37 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -47,12 +71,12 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -31,13 +31,37 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -47,12 +71,12 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -31,13 +31,37 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+        },
+        "mode": 420
       }
     ]
   },
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStart=semodule -i /root/kubelet-e2e.pp\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "selinux-install.service"
       },
@@ -47,9 +71,9 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install requried tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-tools-install.service"
+        "name": "tools-install.service"
       },
       {
         "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=crio-install.service\nConditionFirstBoot=no\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \\\"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB \u0026\u0026 sudo chmod 600 /var/swapfile \u0026\u0026 sudo mkswap /var/swapfile \u0026\u0026 sudo swapon /var/swapfile \u0026\u0026 free -h\\\"\n\n[Install]\nWantedBy=multi-user.target\n",
@@ -57,7 +81,7 @@
         "name": "swap-enable.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '\\\n  /usr/bin/curl --fail --retry 5 \\\n    --retry-delay 3 --silent --show-error \\\n    -o /usr/local/crio-nodee2e-installer.sh  \\\n    https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer \u0026\u0026 \\\n  /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=fa0d058141343ee38b8339ea41f580c361271372\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }

--- a/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio-with-1G-hugepages.yaml
@@ -11,6 +11,18 @@ storage:
       contents:
         local: kubelet-e2e.te
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -18,14 +30,35 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: tools-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Download and install requried tools.
+        Before=crio-install.service
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=rpm-ostree install \
+          -y \
+          --apply-live \
+          --allow-inactive \
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -34,17 +67,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2.yaml
@@ -11,6 +11,18 @@ storage:
       contents:
         local: kubelet-e2e.te
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -18,31 +30,35 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -51,17 +67,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_k8s_infra_prow_build.yaml
@@ -16,6 +16,18 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -23,14 +35,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
@@ -53,20 +67,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -75,17 +91,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgrpv2_serial.yaml
@@ -16,6 +16,18 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -23,14 +35,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
@@ -53,20 +67,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -75,17 +91,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_evented_pleg.yaml
@@ -20,6 +20,18 @@ storage:
       contents:
         local: 40-evented-pleg.conf
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -27,14 +39,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
@@ -57,20 +71,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -79,17 +95,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
+++ b/jobs/e2e_node/crio/templates/crio_k8s_infra_prow_build.yaml
@@ -16,6 +16,18 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -23,14 +35,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
@@ -53,20 +67,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -75,17 +91,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_serial.yaml
+++ b/jobs/e2e_node/crio/templates/crio_serial.yaml
@@ -16,6 +16,18 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -23,14 +35,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
@@ -53,20 +67,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -75,17 +91,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -16,6 +16,18 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
+    - path: /etc/crio/crio.conf.d/10-log-level.conf
+      contents:
+        local: 10-log-level.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-runtimes.conf
+      contents:
+        local: 20-runtimes.conf
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/30-infra-container.conf
+      contents:
+        local: 30-infra-container.conf
+      mode: 0644
 systemd:
   units:
     - name: selinux-install.service
@@ -23,14 +35,16 @@ systemd:
       contents: |
         [Unit]
         Description=Setup SELinux policy
-        After=network-online.target
+        After=tools-install.service
 
         [Service]
         Type=oneshot
         ExecStartPre=setenforce 1
         ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
         ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
-        ExecStart=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
         [Install]
         WantedBy=multi-user.target
@@ -53,20 +67,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: dbus-tools-install.service
+    - name: tools-install.service
       enabled: true
       contents: |
         [Unit]
-        Description=Download and install dbus-tools.
+        Description=Download and install requried tools.
         Before=crio-install.service
         After=network-online.target
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/rpm-ostree install \
+        ExecStart=rpm-ostree install \
+          -y \
           --apply-live \
           --allow-inactive \
-          dbus-tools
+          dbus-tools \
+          checkpolicy
 
         [Install]
         WantedBy=multi-user.target
@@ -89,17 +105,21 @@ systemd:
       contents: |
         [Unit]
         Description=Download and install crio binaries and configurations.
-        After=network-online.target
+        After=selinux-install.service
 
         [Service]
         Type=oneshot
-        ExecStartPre=/usr/bin/bash -c '\
-          /usr/bin/curl --fail --retry 5 \
-            --retry-delay 3 --silent --show-error \
-            -o /usr/local/crio-nodee2e-installer.sh  \
-            https://raw.githubusercontent.com/cri-o/cri-o/fa0d058141343ee38b8339ea41f580c361271372/scripts/node_e2e_installer && \
-          /usr/bin/ln -s /usr/bin/runc /usr/local/bin/runc'
-        ExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh
+        Environment="COMMIT=fa0d058141343ee38b8339ea41f580c361271372"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=ln -sf /usr/bin/runc /usr/local/bin/runc
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
+              bash -s -- -t $COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
+        ExecStart=systemctl enable --now crio.service
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/tree_status
+++ b/jobs/e2e_node/crio/tree_status
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# TODO: remove me when all configs are migrated
-exit 0
-
 STATUS=$(git status --porcelain)
 if [[ -z $STATUS ]]; then
     echo "tree is clean"


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/test-infra/pull/29051, because we have a successful run in:

https://prow.k8s.io/log?job=ci-crio-cgroupv1-node-e2e-conformance&id=1636017755310264320

PTAL @haircommander @harche @sairameshv 