### PR TITLE
Add cherry-pick bot for pd csi driver and filestore driver

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1607,6 +1607,18 @@ external_plugins:
       - issue_comment
       - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
+    endpoint: http://cherrypicker
+  kubernetes-sigs/gcp-filestore-csi-driver:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
+    endpoint: http://cherrypicker  
   kubernetes-sigs/node-feature-discovery:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Refer to https://github.com/kubernetes/test-infra/pull/29034

The usage is commenting on origin pr with

```
// Example
/cherrypick release-1.8
```
This will create a pr directly and only needs 1 approval.


[exampe](https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/1728#issuecomment-1448257806)
