### PR TITLE
Enable block profiling in the gerrit component with a sample rate of 0.1s

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -103,6 +104,7 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
+	runtime.SetBlockProfileRate(100_000_000) // 0.1 second sample rate https://github.com/DataDog/go-profiler-notes/blob/main/guide/README.md#block-profiler-limitations
 	pprof.Instrument(o.instrumentationOptions)
 
 	ca, err := o.config.ConfigAgent()


### PR DESCRIPTION
See https://github.com/DataDog/go-profiler-notes/blob/main/guide/README.md#block-profiler-limitations for details.

We're hoping this will help us identify the source of our triggering latency.
/assign @timwangmusic @mpherman2 