### PR TITLE
run image promo periodic nightly instead of hourly

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -216,9 +216,9 @@ periodics:
       - org: kubernetes
         slug: release-managers
 
-# ci-k8sio-image-promo runs every 1 hour, to make sure that the destination
-# GCRs do not deviate away from the intent of the manifest.
-- interval: 1h
+# ci-k8sio-image-promo runs daily as a backstop on top of the postsubmit
+# ~midnight pacific
+- cron: '0 7 * * *'
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
   # Run only 1 of image promotion postsubmit and periodic at the same time.


### PR DESCRIPTION
/hold

Context: this long thread https://kubernetes.slack.com/archives/CJH2GBF7Y/p1678861049737169 + SIG K8s Infra meeting

TLDR this should be a backstop for the post-submit job and we can afford to run it less often, and preferably not when it will conflict with releases