### PR TITLE
ci-kubernetes-kind-e2e-json-logging: use resource.k8s.io/v1alpha2

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -52,7 +52,7 @@ periodics:
       - name: FEATURE_GATES
         value: '{"DynamicResourceAllocation":true,"ContextualLogging":true}'
       - name: RUNTIME_CONFIG
-        value: '{"resource.k8s.io/v1alpha1":"true"}'
+        value: '{"resource.k8s.io/v1alpha2":"true"}'
       # don't retry conformance tests
       - name: GINKGO_TOLERATE_FLAKES
         value: "n"


### PR DESCRIPTION
After the API break for 1.27 this week, the job started failing because v1alpha1 is no longer supported.

https://github.com/kubernetes/kubernetes/pull/116299