### PR TITLE
secrets-store: update run_if_changed for image push

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-csi-secrets-store.yaml
+++ b/config/jobs/image-pushing/k8s-staging-csi-secrets-store.yaml
@@ -11,7 +11,7 @@ postsubmits:
         testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-k8s-infra-gcb
       decorate: true
       # we only need to run if necessary (e.g.: the version was bumped)
-      run_if_changed: '^docker\/'
+      run_if_changed: 'docker/Makefile'
       # this causes the job to only run on the master branch. Remove it if your
       # job makes sense on every branch (unless it's setting a `latest` tag it
       # probably does).


### PR DESCRIPTION
Update `run_if_changed` to only run the image push job on changes to the `Makefile`. The version is bumped in the `Makefile` at the time of release. This change will enable us to update the base images in `docker` dir without triggering the image build. 

/assign @tam7t 