### PR TITLE
Activate `blockade` plugin for the k8s.io repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1107,6 +1107,7 @@ plugins:
 
   kubernetes/k8s.io:
     plugins:
+    - blockade
     - milestone
     - override
 


### PR DESCRIPTION
I forgot to activate the plugin in #29052 

/cc @BenTheElder @dims 

Will this work on existing PRs or just new PRs?