### PR TITLE
Bump kpromo image to v3.5.1

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -43,7 +43,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -87,7 +87,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -115,7 +115,7 @@ presubmits:
       - name: promote-to-primary
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b@sha256:c075e38f1aba081824a3afc1cce63f1b0571f201de9b72397ab1000bb627420b
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -125,7 +125,7 @@ presubmits:
       - name: promote-to-mirrors
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b@sha256:c075e38f1aba081824a3afc1cce63f1b0571f201de9b72397ab1000bb627420b
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -135,7 +135,7 @@ presubmits:
       - name: promote-to-mirrors-staging
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20230209-v3.4.11-54-ga7bc54b@sha256:c075e38f1aba081824a3afc1cce63f1b0571f201de9b72397ab1000bb627420b
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -44,7 +44,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
         command:
         - /kpromo
         args:
@@ -110,7 +110,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
       command:
       - /kpromo
       args:
@@ -141,7 +141,7 @@ periodics:
     serviceAccountName: k8s-infra-promoter
     containers:
     - name: promote-to-mirrors
-      image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
       command:
       - /kpromo
       args:
@@ -170,7 +170,7 @@ periodics:
           name: aws-iam-token
           readOnly: true
     - name: promote-to-mirrors-staging
-      image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+      image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
       command:
       - /kpromo
       args:
@@ -241,7 +241,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.12-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.5.1-0
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Bump the image promoter jobs to v3.5.1

/cc @kubernetes/release-engineering  
/assign @jeremyrickard @xmudrii 

/hold

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
