### PR TITLE
ci-kind-dra: checkout k/k source code

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -12,6 +12,11 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master


### PR DESCRIPTION
A periodic job must explicitly define which source code it needs...

Related-to: https://github.com/kubernetes/test-infra/issues/29063