### PR TITLE
fix azure disk windows e2e test failure

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -708,11 +708,6 @@ presubmits:
         base_ref: release-1.8
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.26
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master
@@ -749,7 +744,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2022
     decorate: true
-    always_run: false
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - (master)|(^release-.+$)
@@ -764,11 +759,6 @@ presubmits:
         base_ref: release-1.8
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.24
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -378,9 +378,6 @@ presubmits:
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
-    branches:
-    - master
-    - release-1.26
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -392,11 +389,6 @@ presubmits:
         base_ref: release-1.8
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: master
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master


### PR DESCRIPTION
fix azure disk windows e2e test failure: 
it's now failed with following error:
```
docker manifest create capzci.azurecr.io/azure-cloud-node-manager:a352df3 --amend capzci.azurecr.io/azure-cloud-node-manager:a352df3-linux-amd64 --amend capzci.azurecr.io/azure-cloud-node-manager:a352df3-windows-ltsc2022-amd64
capzci.azurecr.io/azure-cloud-node-manager:a352df3-windows-ltsc2022-amd64 is a manifest list
```