### PR TITLE
nfd: add nfd e2e test infra server and codecov keys

### DIFF
--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -97,3 +97,22 @@ spec:
     - key: cluster-api-provider-vsphere-vcenter-thumbprint
       name: vsphere-server-thumbprint
       version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: nfd-creds
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: node-feature-discovery
+  data:
+    - key: codecovToken
+      name: codecov-token
+      version: latest
+    - key: sshPrivateKey
+      name: ssh-privatekey
+      version: latest
+    - key: serverIP
+      name: server-ip
+      version: latest


### PR DESCRIPTION
Add ExternalSecret to fetch codecov token and a remote server keys from google secret manager for the kubernetes-sigs/node-feature-discovery project tests.