### PR TITLE
make peribolos less verbose

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1188,7 +1188,7 @@ func (c *client) doRequest(ctx context.Context, method, path, accept, org string
 	//
 	// See https://pkg.go.dev/net/http#Header.Set for more info.
 	req.Header["X-GitHub-Api-Version"] = []string{githubApiVersion}
-	c.logger.Infof("Using GitHub REST API Version: %s", githubApiVersion)
+	c.logger.Debugf("Using GitHub REST API Version: %s", githubApiVersion)
 	if header := c.authHeader(); len(header) > 0 {
 		req.Header.Set("Authorization", header)
 	}


### PR DESCRIPTION
#28340 introduced thhe `X-GitHub-Api-Version` version header and printed a log message for every single GitHub API call. That has made the peribolos log excessively verbose and redundant (especially given that the GitHub API version is a compile-time constant). This PR reduces the log level to debug to make the logs easier to read.