### PR TITLE
`tide`: maintain org ordering within the search query

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -624,9 +624,15 @@ func (sc *statusController) search() []CodeReviewCommon {
 	orgs := sets.StringKeySet(orgExceptions)
 	queries := openPRsQueries(orgs.List(), repos.List(), orgExceptions)
 	if !sc.usesGitHubAppsAuth {
+		//The queries for each org need to have their order maintained, otherwise it may be falsely flagged for changing
+		var orgs []string
+		for org := range queries {
+			orgs = append(orgs, org)
+		}
+		sort.Strings(orgs)
 		var query string
-		for _, orgQuery := range queries {
-			query += " " + orgQuery
+		for _, org := range orgs {
+			query += " " + queries[org]
 		}
 		queries = map[string]string{"": query}
 	}


### PR DESCRIPTION
When using `tide` without apps auth, we are having issues with the tide status appearing on the context. I have tracked the issue down to `tide` repeatedly believing that the search query has changed nearly every loop. This causes the search to turn up the same, old PRs to add the status to. It takes it forever to get to the newer ones, and sometimes it never does.

I, further, tracked the issue down to the ordering of the orgs within the query. This part seems to be what is changing each time, while the actual content remains the same. Due to that, the following code flags the query as having changed and resets the start time: https://github.com/kubernetes/test-infra/blob/92cc5eed74193aaee75a5dab5042d0e9498c6688/prow/tide/status.go#L660-L664  If we order the orgs within the query, this should cease.