### PR TITLE
Updating sig-windows oot cloud-provider jobs to run every 2 hours

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -56,7 +56,7 @@ periodics:
     testgrid-dashboards: sig-release-1.25-informing, sig-windows-1.25-release, sig-windows-signal
     testgrid-tab-name: capz-e2e-windows-containerd-1.25
 - name: ci-kubernetes-e2e-capz-containerd-windows-1-25-ccm
-  interval: 24h
+  interval: 2h
   decorate: true
   decoration_config:
     timeout: 4h0m0s

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -70,7 +70,7 @@ periodics:
     base_ref: release-1.26
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
-  interval: 24h
+  interval: 2h
   labels:
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"


### PR DESCRIPTION
Updating these jobs to run more frequently as part of investigation for https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2591 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3227

/sig windows
/assign @jackfrancis @CecileRobertMichon @jsturtevant 