### PR TITLE
ClusterAPI: enable CC tests on release-1.3 e2e-mink8s

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
@@ -135,7 +135,7 @@ periodics:
       - "./scripts/ci-e2e.sh"
       env:
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[ClusterClass\\]"
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       # Because of that we usually would test with v1.20, but because ClusterClass


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Previous PR fixed the issue (https://github.com/kubernetes/test-infra/pull/29094).

xref: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-1.3#capi-e2e-mink8s-release-1-3

Just forgot that we can additionally enable the CC tests on the job.