### PR TITLE
Ensure generating release jobs supports the stable4 version marker

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -16,7 +16,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}"
-    fork-per-release-cron: 0 0-23/2 * * *, 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
+    fork-per-release-cron: 0 0-23/2 * * *, 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-device-plugin-gpu-master
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -33,7 +33,7 @@ periodics:
           cpu: "1"
           memory: 3Gi
 - annotations:
-    fork-per-release-cron: ""
+    fork-per-release-cron: 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.23-blocking, google-gce
@@ -298,13 +298,13 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: ""
+    fork-per-release-cron: 0 21 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: kubemark-1.23-500
   cluster: k8s-infra-prow-build
-  cron: 0 21 * * *
+  cron: 0 17 * * *
   decorate: true
   decoration_config:
     timeout: 2h0m0s
@@ -373,7 +373,7 @@ periodics:
   - 'perfDashPrefix: kubemark-500Nodes-1.23'
   - 'perfDashJobType: performance'
 - annotations:
-    fork-per-release-cron: ""
+    fork-per-release-cron: 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-release-1.23-blocking, sig-scalability-gce, google-gce,
       google-gci

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -33,7 +33,7 @@ periodics:
           cpu: "1"
           memory: 3Gi
 - annotations:
-    fork-per-release-cron: 0 8-23/24 * * *
+    fork-per-release-cron: 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.24-blocking, google-gce
@@ -169,13 +169,13 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: 0 21 * * *
+    fork-per-release-cron: 0 17 * * *, 0 21 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: kubemark-1.24-500
   cluster: k8s-infra-prow-build
-  cron: 0 15 * * *
+  cron: 0 13 * * *
   decorate: true
   decoration_config:
     timeout: 2h0m0s
@@ -244,7 +244,7 @@ periodics:
   - 'perfDashPrefix: kubemark-500Nodes-1.24'
   - 'perfDashJobType: performance'
 - annotations:
-    fork-per-release-cron: 0 8-20/12 * * *
+    fork-per-release-cron: 0 8-20/12 * * *, 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-release-1.24-blocking, sig-scalability-gce, google-gce,
       google-gci

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -33,7 +33,7 @@ periodics:
           cpu: "1"
           memory: 3Gi
 - annotations:
-    fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *
+    fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.25-blocking, google-gce
@@ -169,13 +169,13 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: 0 15 * * *, 0 21 * * *
+    fork-per-release-cron: 0 13 * * *, 0 17 * * *, 0 21 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: kubemark-1.25-500
   cluster: k8s-infra-prow-build
-  cron: 0 9 * * *
+  cron: 0 7 * * *
   decorate: true
   decoration_config:
     timeout: 2h0m0s
@@ -245,7 +245,7 @@ periodics:
   - 'perfDashPrefix: kubemark-500Nodes-1.25'
   - 'perfDashJobType: performance'
 - annotations:
-    fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *
+    fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-release-1.25-blocking, sig-scalability-gce, google-gce,
       google-gci

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -33,7 +33,7 @@ periodics:
           cpu: "1"
           memory: 3Gi
 - annotations:
-    fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
+    fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.26-blocking, google-gce
@@ -169,7 +169,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: 0 9 * * *, 0 15 * * *, 0 21 * * *
+    fork-per-release-cron: 0 7 * * *, 0 13 * * *, 0 17 * * *, 0 21 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "2"
@@ -245,7 +245,7 @@ periodics:
   - 'perfDashPrefix: kubemark-500Nodes-1.26'
   - 'perfDashJobType: performance'
 - annotations:
-    fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
+    fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-release-1.26-blocking, sig-scalability-gce, google-gce,
       google-gci

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -381,7 +381,7 @@ periodics:
     path_alias: k8s.io/perf-tests
   annotations:
     fork-per-release: "true"
-    fork-per-release-cron: 0 3 * * *, 0 9 * * *, 0 15 * * *, 0 21 * * *
+    fork-per-release-cron: 0 3 * * *, 0 7 * * *, 0 13 * * *, 0 17 * * *, 0 21 * * *
     fork-per-release-deletions: "preset-e2e-scalability-periodics-master"
     fork-per-release-replacements: "kubemark-500Nodes -> kubemark-500Nodes-{{.Version}}, extract=ci/latest -> extract=ci/latest-{{.Version}}, gcp-project=k8s-jenkins-blocking-kubemark -> gcp-project-type=scalability-project, us-central1-f -> us-east1-b"
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -177,7 +177,7 @@ periodics:
     path_alias: k8s.io/perf-tests
   annotations:
     fork-per-release: "true"
-    fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
+    fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *
     fork-per-release-deletions: "preset-e2e-scalability-periodics-master"
     fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
@@ -208,7 +209,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/gengo v0.0.0-20220307231824-4627b89bbf1b // indirect

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"text/template"
 
+	gyaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/yaml"
 
 	v1 "k8s.io/api/core/v1"
@@ -483,6 +484,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to generate postsubmits: %v.\n", err)
 	}
+
+	// We need to use FutureLineWrap because "fork-per-release-cron" is too long
+	// causing the annotation value to be split into two lines.
+	// We use gopkg.in/yaml here because sigs.k8s.io/yaml doesn't export this
+	// function. sigs.k8s.io/yaml uses gopkg.in/yaml under the hood.
+	gyaml.FutureLineWrap()
 
 	output, err := yaml.Marshal(map[string]interface{}{
 		"periodics":   newPeriodics,

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	gyaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/config"
@@ -137,6 +138,12 @@ func main() {
 		log.Fatalf("Failed to load job config: %v\n", err)
 	}
 	updateEverything(&c, o.oldVersion, o.newVersion)
+
+	// We need to use FutureLineWrap because "fork-per-release-cron" is too long
+	// causing the annotation value to be split into two lines.
+	// We use gopkg.in/yaml here because sigs.k8s.io/yaml doesn't export this
+	// function. sigs.k8s.io/yaml uses gopkg.in/yaml under the hood.
+	gyaml.FutureLineWrap()
 
 	output, err := yaml.Marshal(map[string]interface{}{
 		"presubmits":  c.PresubmitsStatic,

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -140,7 +140,8 @@ def regenerate_files(generate_tests_bin, test_config):
         _fg=True)
 
 def go_version_kubernetes_master():
-    resp = requests.get('https://raw.githubusercontent.com/kubernetes/kubernetes/master/.go-version')
+    resp = requests.get(
+        'https://raw.githubusercontent.com/kubernetes/kubernetes/master/.go-version')
     resp.raise_for_status()
     data = resp.content.decode("utf-8")
     return data

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -25,6 +25,7 @@ import re
 import sh
 import ruamel.yaml as yaml
 
+import requests
 
 TEST_CONFIG_YAML = "test_config.yaml"
 JOB_CONFIG = "../config/jobs"
@@ -96,7 +97,7 @@ def rotate_files(rotator_bin, branch_path, current_version):
             _fg=True)
 
 
-def fork_new_file(forker_bin, branch_path, prowjob_path, current_version):
+def fork_new_file(forker_bin, branch_path, prowjob_path, current_version, go_version):
     print("Forking new file...")
     next_version = (current_version[0], current_version[1] + 1)
     filename = '%d.%d.yaml' % (next_version[0], next_version[1])
@@ -104,6 +105,7 @@ def fork_new_file(forker_bin, branch_path, prowjob_path, current_version):
         job_config=os.path.abspath(prowjob_path),
         output=os.path.abspath(os.path.join(branch_path, filename)),
         version='%d.%d' % next_version,
+        go_version=go_version,
         _fg=True)
 
 
@@ -137,6 +139,11 @@ def regenerate_files(generate_tests_bin, test_config):
         yaml_config_path=test_config,
         _fg=True)
 
+def go_version_kubernetes_master():
+    resp = requests.get('https://raw.githubusercontent.com/kubernetes/kubernetes/master/.go-version')
+    resp.raise_for_status()
+    data = resp.content.decode("utf-8")
+    return data
 
 def main():
     if os.environ.get('BUILD_WORKSPACE_DIRECTORY'):
@@ -153,6 +160,9 @@ def main():
     version = check_version(branch_job_dir_abs)
     print("Current version: %d.%d" % (version[0], version[1]))
 
+    go_version = go_version_kubernetes_master()
+    print("Current Go Version: %s" % go_version)
+
     files = get_config_files(branch_job_dir_abs)
     if len(files) > max_config_count:
         print("There should be a maximum of %s release branch configs." % max_config_count)
@@ -163,7 +173,7 @@ def main():
     rotate_files(rotator_bin, branch_job_dir_abs, version)
 
     fork_new_file(forker_bin, branch_job_dir_abs,
-                  os.path.join(cur_file_dir, JOB_CONFIG), version)
+                  os.path.join(cur_file_dir, JOB_CONFIG), version, go_version)
 
     update_generated_config(os.path.join(cur_file_dir, TEST_CONFIG_YAML), version)
 


### PR DESCRIPTION
This is a follow-up on https://github.com/kubernetes/sig-release/issues/2094

- Fixes an issue where `make -C releng prepare-release-branch` fails due to unset Go version
  - This is fixed by automatically fetching the Go version for k/k master branch
    - This should be okay because that Go version is used by `config_forker`, used to generate configs for the new release branch. The new release branch uses the same version as master when generating jobs for that branch
- Fixes issue with crons where crons are missing for the stable4 jobs
  - I'm not sure if crons are okay, so please someone check to make sure it's alright

/assign @saschagrunert @cici37 @cpanato 
cc @kubernetes/release-engineering 