### PR TITLE
Add more workers for getting presubmits and postsubmits

### DIFF
--- a/prow/cmd/gangway/main.go
+++ b/prow/cmd/gangway/main.go
@@ -161,7 +161,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheWorkers)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -131,7 +131,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating git client.")
 	}
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, ca, gitClient, o.config.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, ca, gitClient, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheWorkers)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -118,7 +118,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(o.config.InRepoConfigCacheSize, configAgent, gitClient, o.config.InRepoConfigCacheCopies, o.config.InRepoConfigCacheWorkers)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
 	}

--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -77,7 +77,7 @@ type InRepoConfigCacheHandler struct {
 func NewInRepoConfigCacheHandler(size int,
 	configAgent prowConfigAgentClient,
 	gitClientFactory git.ClientFactory,
-	count int) (*InRepoConfigCacheHandler, error) {
+	count, workers int) (*InRepoConfigCacheHandler, error) {
 
 	c := &InRepoConfigCacheHandler{
 		presubmitChan:  make(chan InrepoconfigPresubmitRequest),
@@ -89,8 +89,10 @@ func NewInRepoConfigCacheHandler(size int,
 		if err != nil {
 			return nil, err
 		}
-		go cacheClient.handlePresubmit(c.presubmitChan)
-		go cacheClient.handlePostsubmit(c.postsubmitChan)
+		for j := 0; j < workers; j++ {
+			go cacheClient.handlePresubmit(c.presubmitChan)
+			go cacheClient.handlePostsubmit(c.postsubmitChan)
+		}
 	}
 
 	return c, nil

--- a/prow/config/cache_test.go
+++ b/prow/config/cache_test.go
@@ -47,7 +47,7 @@ func TestNewInRepoConfigCacheHandler(t *testing.T) {
 
 		fca := &fakeConfigAgent{}
 		cf := &testClientFactory{}
-		cache, err := NewInRepoConfigCacheHandler(invalid, fca, cf, 1)
+		cache, err := NewInRepoConfigCacheHandler(invalid, fca, cf, 1, 1)
 
 		if err == nil {
 			t.Fatal("Expected non-nil error, got nil")
@@ -68,7 +68,7 @@ func TestNewInRepoConfigCacheHandler(t *testing.T) {
 
 		fca := &fakeConfigAgent{}
 		cf := &testClientFactory{}
-		cache, err := NewInRepoConfigCacheHandler(valid, fca, cf, 1)
+		cache, err := NewInRepoConfigCacheHandler(valid, fca, cf, 1, 1)
 
 		if err != nil {
 			t.Errorf("Expected error 'nil' got '%v'", err.Error())
@@ -827,7 +827,7 @@ func TestGetProwYAMLCachedAndDefaulted(t *testing.T) {
 			cf := &testClientFactory{}
 
 			// Initialize cache. Notice that it relies on a snapshot of the Config with configBefore.
-			cache, err := NewInRepoConfigCacheHandler(10, fca, cf, 10)
+			cache, err := NewInRepoConfigCacheHandler(10, fca, cf, 10, 1)
 			if err != nil {
 				t1.Fatal("could not initialize cache")
 			}

--- a/prow/flagutil/config/config.go
+++ b/prow/flagutil/config/config.go
@@ -45,6 +45,7 @@ type ConfigOptions struct {
 	InRepoConfigCacheSize    int
 	InRepoConfigCacheCopies  int
 	InRepoConfigCacheDirBase string
+	InRepoConfigCacheWorkers int
 }
 
 func (o *ConfigOptions) AddFlags(fs *flag.FlagSet) {
@@ -62,6 +63,8 @@ func (o *ConfigOptions) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&o.InRepoConfigCacheSize, "in-repo-config-cache-size", 100, "Cache size for ProwYAMLs read from in-repo configs. Each host receives its own cache.")
 	fs.IntVar(&o.InRepoConfigCacheCopies, "in-repo-config-cache-copies", 1, "Copy of caches for ProwYAMLs read from in-repo configs.")
 	fs.StringVar(&o.InRepoConfigCacheDirBase, "cache-dir-base", "", "Directory where the repo cache should be mounted.")
+	fs.IntVar(&o.InRepoConfigCacheWorkers, "in-repo-config-cache-workers", 1, "Number of workers getting Presubmits/Postsubmits from cache.")
+
 }
 
 func (o *ConfigOptions) Validate(_ bool) error {
@@ -77,6 +80,9 @@ func (o *ConfigOptions) ValidateConfigOptional() error {
 	}
 	if o.InRepoConfigCacheCopies < 1 {
 		return errors.New("in-repo-config-cache-copies must be at least 1")
+	}
+	if o.InRepoConfigCacheWorkers < 1 {
+		return errors.New("in-repo-config-cache-workers must be at least 1")
 	}
 	return nil
 }

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -587,7 +587,7 @@ func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCacheHandle
 		10,
 		ca,
 		config.NewInRepoConfigGitCache(cf),
-		1)
+		1, 1)
 	if err != nil {
 		t.Errorf("error creating cache: %v", err)
 	}

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -338,7 +338,7 @@ func TestHandleMessage(t *testing.T) {
 			ca.Set(tc.config)
 			fr := fakeReporter{}
 			gitClient, _ := (&flagutil.GitHubOptions{}).GitClientFactory("abc", nil, true)
-			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1)
+			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1, 1)
 			s := Subscriber{
 				Metrics:                  NewMetrics(),
 				ProwJobClient:            fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),
@@ -584,7 +584,7 @@ func TestHandlePeriodicJob(t *testing.T) {
 			ca.Set(tc.config)
 			fr := fakeReporter{}
 			gitClient, _ := (&flagutil.GitHubOptions{}).GitClientFactory("abc", nil, true)
-			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1)
+			cacheHandler, _ := config.NewInRepoConfigCacheHandler(100, ca, gitClient, 1, 1)
 			s := Subscriber{
 				Metrics:                  NewMetrics(),
 				ProwJobClient:            fakeProwJobClient.ProwV1().ProwJobs(ca.Config().ProwJobNamespace),

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -121,7 +121,7 @@ func NewGerritController(
 		newPoolPending:   make(chan bool),
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCacheHandler(configOptions.InRepoConfigCacheSize, cfgAgent, gc, configOptions.InRepoConfigCacheCopies)
+	cacheGetter, err := config.NewInRepoConfigCacheHandler(configOptions.InRepoConfigCacheSize, cfgAgent, gc, configOptions.InRepoConfigCacheCopies, configOptions.InRepoConfigCacheWorkers)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating inrepoconfig cache getter: %v", err)
 	}


### PR DESCRIPTION
Getting presubmits and postsubmits from the cache was happening serially. This should hopefully improve latency by parallelizing calls to get presubmits for.

/assign @listx @timwangmusic
/cc @cjwagner 