### PR TITLE
Add cluster-provider-azure ref to build-win-soak-tests job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -198,6 +198,10 @@ periodics:
         base_ref: main
         path_alias: "sigs.k8s.io/cluster-api-provider-azure"
         workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: "sigs.k8s.io/cloud-provider-azure"
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230321-850d5bc856-master


### PR DESCRIPTION
The Windows Soak tests jobs are [failing](https://storage.googleapis.com/kubernetes-jenkins/logs/build-win-soak-test-cluster/1637257775937490944/build-log.txt) after this PR has been merged:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3233

The `build-win-soak-test-cluster` job is using `KUBERNETES_VERSION=latest` which triggers the AZURE CCM build: https://github.com/CecileRobertMichon/cluster-api-provider-azure/blob/4a7b93d0a5f8170874559e8c4c0760ea0e3a4f41/hack/util.sh#L53-L56

This PR adds `cloud-provider-azure` as an `extra_ref` to the `build-win-soak-test-cluster` job, required for building Azure CCM