### PR TITLE
Kustomize: add priority label requirement and include PRs as missing label targets

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -793,13 +793,19 @@ require_matching_label:
   org: kubernetes-sigs
   repo: kustomize
   issues: true
-  prs: false
+  prs: true
   regexp: ^kind/
+- missing_label: needs-priority
+  org: kubernetes-sigs
+  repo: kustomize
+  issues: true
+  prs: true
+  regexp: ^priority/
 - missing_label: needs-triage
   org: kubernetes-sigs
   repo: kustomize
   issues: true
-  prs: false
+  prs: true
   regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -798,7 +798,7 @@ require_matching_label:
 - missing_label: needs-priority
   org: kubernetes-sigs
   repo: kustomize
-  issues: true
+  issues: false
   prs: true
   regexp: ^priority/
 - missing_label: needs-triage


### PR DESCRIPTION
The idea is to help with our experiment in better managing the PR backlog by making it easier to filter on all the standard metadata dimensions (kind/priority/triage).

/cc @natasha41575 @annasong20 