### PR TITLE
Fix greenhouse deployment yaml and Readme.

### DIFF
--- a/greenhouse/README.md
+++ b/greenhouse/README.md
@@ -28,9 +28,9 @@ We use this with [Prow](./../prow), to set it up we do the following:
    ```
  - Create the Kubernetes service so jobs can talk to it conveniently: `kubectl apply -f greenhouse/service.yaml`
  - Create a `StorageClass` / `PersistentVolumeClaim` for fast cache storage, we use `kubectl apply -f greenhouse/gce-fast-storage.yaml` for 3TB of pd-ssd storage
- - Finally build, push, and deploy with `bazel run //greenhouse:production.apply --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64`
+ - Finally deploy with `kubectl apply -f greenhouse/deployment.yaml`
    <!--TODO(bentheelder): make this easier to consume by other users?-->
-   - NOTE: other uses will likely need to tweak this step to their needs, particular the service and storage definitions
+   - NOTE: other uses will likely need to tweak this step to their needs, in particular the service and storage definitions
 
 
 ## Optional Setup:

--- a/greenhouse/deployment.yaml
+++ b/greenhouse/deployment.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: greenhouse
@@ -20,6 +20,9 @@ metadata:
     app: greenhouse
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: greenhouse
   template:
     metadata:
       labels:


### PR DESCRIPTION
Bazel was deleted a long time ago and the deployment yaml is from an older version of k8s.