### PR TITLE
Include PR's head Ref in ProwJob refs

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -106,6 +106,7 @@ func createRefs(pr github.PullRequest, baseSHA string) prowapi.Refs {
 				Number:     number,
 				Author:     pr.User.Login,
 				SHA:        pr.Head.SHA,
+				Ref:        pr.Head.Ref,
 				Title:      pr.Title,
 				Link:       pr.HTMLURL,
 				AuthorLink: pr.User.HTMLURL,


### PR DESCRIPTION
This PR proposes that we include PR's head ref (i.e. the branch that the PR was created from) in the ProwJob refs. We already have a field for that in the API, but we don't set that field at all. This PR ensures we set this field.

The use case for this is that some tools require the name of the head branch to work properly.

/assign @cblecker @cjwagner @stevekuznetsov 