### PR TITLE
[releng] 1.27: Add 1.28 and remove 1.22 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -441,24 +441,24 @@ slack:
 
 milestone_applier:
   kubernetes/enhancements:
-    master: v1.27
+    master: v1.28
   kubernetes/kubernetes:
-    master: v1.27
+    master: v1.28
+    release-1.27: v1.27
     release-1.26: v1.26
     release-1.25: v1.25
     release-1.24: v1.24
     release-1.23: v1.23
-    release-1.22: v1.22
   kubernetes/org:
-    main: v1.27
+    main: v1.28
   kubernetes/release:
-    master: v1.27
+    master: v1.28
   kubernetes/sig-release:
-    master: v1.27
+    master: v1.28
   kubernetes/test-infra:
-    master: v1.27
+    master: v1.28
   kubernetes/k8s.io:
-    main: v1.27
+    main: v1.28
   kubernetes/kops:
     master: v1.27
     release-1.26: v1.26


### PR DESCRIPTION
Pending 1.27 branch cut:
/hold

/sig release
/area release-eng
cc: https://github.com/orgs/kubernetes/teams/release-engineering