### PR TITLE
Fix test-handler setup in CRI-O jobs

### DIFF
--- a/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
+++ b/jobs/e2e_node/crio/crio-with-1G-hugepages.ign
@@ -37,7 +37,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -37,7 +37,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -32,7 +32,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign
@@ -32,7 +32,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -32,7 +32,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_evented_pleg.ign
+++ b/jobs/e2e_node/crio/crio_evented_pleg.ign
@@ -37,7 +37,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
+++ b/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign
@@ -37,7 +37,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -37,7 +37,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -37,7 +37,7 @@
         "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLC7JktTiEt2MxLyUnNSiWC5AAAAA//+Arrt/awAAAA=="
+          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/templates/base/20-runtimes.conf
+++ b/jobs/e2e_node/crio/templates/base/20-runtimes.conf
@@ -2,4 +2,6 @@
 default_runtime = "runc"
 
 [crio.runtime.runtimes.runc]
+
 [crio.runtime.runtimes.test-handler]
+runtime_path = "/usr/local/bin/runc"


### PR DESCRIPTION
The runtime path has to be set otherwise CRI-O ignores the handler.

Fixes https://github.com/kubernetes/kubernetes/issues/116874

PTAL @haircommander @sairameshv @harche 