### PR TITLE
Cluster API: override GINKGO_ARGS fail-fast for e2e periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -94,6 +94,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: GINKGO_ARGS
+            value: "--fail-fast=false" # set the value of fail-fast to false to get results for every test.
           - name: GINKGO_SKIP
             value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Override the value of GINKGO_ARGS for the Cluster API periodic e2e main test. This is designed to allow full periodic test runs each time the test runs, giving more coverage.

