### PR TITLE
Fix sample prow-controller-manager roles so they can "get" pods

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -1071,6 +1071,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -1073,6 +1073,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -1115,6 +1115,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -1071,6 +1071,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/experimental/controller_manager.yaml
+++ b/config/prow/experimental/controller_manager.yaml
@@ -92,6 +92,7 @@ rules:
       - list
       - watch
       - create
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Prow doesn't work if you use these example yaml files because it expects to have "get" access on pods in the test-pods namespace.