### PR TITLE
update master node image in ci-containerd-e2e-ubuntu-gce

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -134,7 +134,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-85-13310-1308-1
+      - --env=KUBE_GCE_MASTER_IMAGE=cos-93-16623-341-29
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
updates the kube master image to cos-93-16623-341-29, since cos-85 used an old version of bash (4.3) which errored on array expansion of unbound variable. cos-93 family has bash (4.4) which does not cause this error.

Fixes : kubernetes/kubernetes#116873