### PR TITLE
Fix filter via state

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -63,13 +63,15 @@ function optionsForRepo(repository: string): RepoOptions {
 
     opts.types[type] = true;
     opts.clusters[cluster] = true;
+    opts.states[state] = true;
+
+    
     const repoKey = `${org}/${repo}`;
     if (repoKey) {
       opts.repos[repoKey] = true;
     }
     if (!repository || repository === repoKey) {
       opts.jobs[job] = true;
-      opts.states[state] = true;
 
       if (pulls.length) {
         for (const pull of pulls) {


### PR DESCRIPTION
This PR is meant to fix the option to filter via the state for a given repository, previously, states could get dropped from the URL params if they weren't parsed as options

This function iterates over all the build items and since in our case we passed a repository parameter it tries to compare it to repoKey which is a combination of org/repo metadata inside the BuildItem, however, it's possible that the repoKey doesn't match the repository even if they are equivalent due to missing fields - this causes the state of these Items to be never marked as valid, in our case for the pending items there was no match of repository and repoKey which caused the pending state to never be marked as true in the opts.states map, hence, it was dropped from args.

This ambiguity can be resolved by moving opts.states[state] = true; out of the If condition - which makes sense for us, since even if a state hasn't been seen in a repo yet - we should display empty results, not adding it as an option can lead to ambiguity. 

Fixes #29061
