### PR TITLE
Change CLA bot freq to 24h

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -88,7 +88,8 @@ periodics:
         secretName: k8s-triage-robot-github-token
 
 - name: ci-k8s-triage-robot-cla
-  interval: 10m
+  # TODO(MadhavJivrajani): See if this can be left at 24h or restored to 10m.
+  interval: 24h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Change CLA bot freq to 24h
Seems like a similar problem with EasyCLA: https://github.com/kubernetes-sigs/cloud-provider-kind/pull/1 

Thinking of if we can just change the frequency to 24h

/assign @dims 