### PR TITLE
fix azure file test failure on 1.23

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
@@ -109,7 +109,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.8
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -155,7 +155,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.8
+        base_ref: release-1.7
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -324,7 +324,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: azurefile-csi-driver
@@ -382,7 +382,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: azurefile-csi-driver


### PR DESCRIPTION
 CSIMigrationAzureFile is turned on by default from k8s 1.24, that could explain why only 1.23 fails:


CSIMigrationAzureFile: {​​​​​​​​Default: tr iue, PreRelease: featuregate.Beta}​​​​​​​​, // On by default in 1.24 (requires Azure File CSI driver)

[kubernetes/kube_features.go at release-1.24 · kubernetes/kubernetes (github.com)](https://github.com/kubernetes/kubernetes/blob/release-1.24/pkg/features/kube_features.go#L918)
    
so either we set CSIMigrationAzureFile as true in capz 1.23 or provide cloud-provider config for intree azure file driver

    
revert to base_ref: release-1.7 only for azure file test could solve the issue