### PR TITLE
Avoid failure when collecting logs

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -831,14 +831,18 @@ function dump_node_info() {
     printf "%s\n" "${WINDOWS_NODE_NAMES[@]}" > "${nodes_dir}/windows_node_names.txt"
   fi
 
-  kubectl get nodes -o yaml > "${nodes_dir}/kubectl_get_nodes.yaml" || true
+  # If we are not able to reach the server, just bail out as the other
+  # kubectl calls below will fail anyway (we don't want to error out collecting logs)
+  kubectl version || return 0
+
+  kubectl get nodes -o yaml > "${nodes_dir}/kubectl_get_nodes.yaml"
 
   api_node_names=()
   api_node_names+=($( kubectl get nodes -o 'template={{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' ))
   if [[ "${#api_node_names[@]}" -le 5 ]]; then
     for node_name in "${api_node_names[@]}"; do
       mkdir -p "${nodes_dir}/${node_name}"
-      kubectl get --raw "/api/v1/nodes/${node_name}/proxy/metrics" > "${nodes_dir}/${node_name}/kubelet_metrics.txt" || true
+      kubectl get --raw "/api/v1/nodes/${node_name}/proxy/metrics" > "${nodes_dir}/${node_name}/kubelet_metrics.txt"
     done
   fi
 }


### PR DESCRIPTION
Please see failures here:
https://prow.k8s.io/?job=pull-containerd-node-e2e

Specific log:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/containerd_containerd/8159/pull-containerd-node-e2e/1640525240285007872

failure snippet:
```
No nodes found!
Detecting nodes in the cluster
WARNING: The following filter keys were not present in any resource : name, zone
WARNING: The following filter keys were not present in any resource : name, zone
INSTANCE_GROUPS=
NODE_NAMES=
WINDOWS_INSTANCE_GROUPS=
WINDOWS_NODE_NAMES=
E0328 01:53:16.667051   82217 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.667785   82217 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.669596   82217 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.671209   82217 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.672793   82217 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
The connection to the server localhost:8080 was refused - did you specify the right host or port?
E0328 01:53:16.743304   82226 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.743951   82226 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.745740   82226 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.747379   82226 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
E0328 01:53:16.749203   82226 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
The connection to the server localhost:8080 was refused - did you specify the right host or port?
2023/03/28 01:53:16 process.go:155: Step '/workspace/log-dump.sh /logs/artifacts' finished in 8.779437206s
```

Why is this failing?:
We usually add `|| true` for kubectl calls to prevent failure when collecting logs. In https://github.com/kubernetes/test-infra/commit/175af56c755084a97c7cdc38d733cf82f55f2e5b we failed to account for the apiserver being down/missing. 

How are we fixing:
we use the exit code from `kubectl version` to see if the apiserver is alive and reachable and just return from the method when that command fails.