### PR TITLE
Revert "Include PR's head Ref in ProwJob refs"

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -106,7 +106,6 @@ func createRefs(pr github.PullRequest, baseSHA string) prowapi.Refs {
 				Number:     number,
 				Author:     pr.User.Login,
 				SHA:        pr.Head.SHA,
-				Ref:        pr.Head.Ref,
 				Title:      pr.Title,
 				Link:       pr.HTMLURL,
 				AuthorLink: pr.User.HTMLURL,


### PR DESCRIPTION
This completely broke Prow, so we need to revert it. I'll try another approach in a follow up PR.
Ref: https://kubernetes.slack.com/archives/C7J9RP96G/p1680020553428789