### PR TITLE
Separate test grid dashboard for containerd

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release/1.7
     decorate: true
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,containerd-presubmits
       testgrid-tab-name: pull-containerd-build
       description: build artifacts
     labels:
@@ -43,7 +43,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,containerd-presubmits
       testgrid-tab-name: pull-containerd-node-e2e
       description: run node e2e tests
     labels:
@@ -94,7 +94,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,containerd-presubmits
       testgrid-tab-name: pull-containerd-node-e2e-1-7
       description: run node e2e tests
     labels:
@@ -145,7 +145,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,containerd-presubmits
       testgrid-tab-name: pull-containerd-node-e2e-1-6
       description: run node e2e tests
     labels:
@@ -196,7 +196,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,containerd-presubmits
       testgrid-tab-name: pull-containerd-sandboxed-node-e2e
       description: run node e2e tests sandboxed
     labels:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -55,7 +55,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-node-containerd
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
     testgrid-tab-name: containerd-build
     description: "builds development in progress branch of upstream containerd"
 - name: ci-containerd-build-1-6
@@ -74,7 +74,7 @@ periodics:
           - --env=DEPLOY_DIR=release-1.6
           - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:
-    testgrid-dashboards: sig-node-containerd
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
     testgrid-tab-name: containerd-build-1.6
     description: "builds release/1.6 branch of upstream containerd"
 - name: ci-containerd-build-test-images
@@ -97,7 +97,7 @@ periodics:
         securityContext:
           privileged: true
   annotations:
-    testgrid-dashboards: sig-node-containerd
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
     testgrid-tab-name: containerd-build-test-images
     description: "builds test images for development in progress branch of upstream containerd"
 - name: ci-containerd-build-1-7
@@ -116,7 +116,7 @@ periodics:
           - --env=DEPLOY_DIR=release-1.7
           - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:
-    testgrid-dashboards: sig-node-containerd
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
     testgrid-tab-name: containerd-build-1.7
     description: "builds release/1.7 branch of upstream containerd"
 - interval: 1h

--- a/config/testgrids/kubernetes/containerd/OWNERS
+++ b/config/testgrids/kubernetes/containerd/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# Synced to the root OWNERS file in k8s.io/kops as of 12/02/22
+approvers:
+- dims
+- mikebrow
+reviewers:
+- dims
+- mikebrow
+labels:
+- sig/node

--- a/config/testgrids/kubernetes/containerd/config.yaml
+++ b/config/testgrids/kubernetes/containerd/config.yaml
@@ -1,0 +1,9 @@
+dashboard_groups:
+- name: containerd
+  dashboard_names:
+  - containerd-presubmits
+  - containerd-periodic
+
+dashboards:
+  - name: containerd-periodic
+  - name: containerd-presubmits

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -48,6 +48,7 @@ var (
 	companies = []string{
 		"canonical",
 		"cos",
+		"containerd",
 		"cri-o",
 		"istio",
 		"googleoss",


### PR DESCRIPTION
Surface CI jobs for containerd in a separate dashboard for release 🟢 CI signal