### PR TITLE
Use systemd cgroup and stable containerd in pull-kubernetes-node-e2e-containerd-sidecar-containers

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1810,27 +1810,26 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-presubmits
-      testgrid-tab-name: pr-node-kubelet-containerd-sidecar-conatiners
+      testgrid-tab-name: pr-node-kubelet-containerd-sidecar-containers
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230328-17e539c80f-master
         args:
         - --root=/go/src
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=github.com/containerd/containerd=main
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --service-account=/etc/service-account/service-account.json
         - --timeout=90
         - --scenario=kubernetes_e2e
         - --
-        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
         - --deployment=node
         - --gcp-zone=us-central1-b
-        - '--node-test-args=--feature-gates=SidecarContainers=true --service-feature-gates=SidecarContainers=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - '--node-test-args=--feature-gates=SidecarContainers=true --service-feature-gates=SidecarContainers=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true
         - --provider=gce
         - --test_args=--nodes=8 --focus="\[NodeFeature:SidecarContainers\]|\[NodeAlphaFeature:SidecarContainers\]" --skip="\[Flaky\]|\[Serial\]"
         - --timeout=65m
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
         env:
         - name: GOPATH
           value: /go


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/116429/pull-kubernetes-node-e2e-containerd-sidecar-containers/1641047929496014848/

```
W0329 12:21:55.195]   Mar 29 12:16:54.617: INFO: At 2023-03-29 12:15:57 +0000 UTC - event for init-container-fails-before-sidecar-starts: {kubelet tmp-node-e2e-64cf1522-ubuntu-gke-2204-1-24-v20230328} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: expected cgroupsPath to be of format "slice:prefix:name" for systemd cgroups, got "/kubepods/burstable/podb0df767f-f366-4b31-9f27-5324c645a296/37a641adc6bef083175ba40e3d1a6cf817bda90a9c215e1bb77f4c999f95f077" instead: unknown
W0329 12:21:55.196]   Mar 29 12:16:54.617: INFO: At 2023-03-29 12:16:12 +0000 UTC - event for init-container-fails-before-sidecar-starts: {kubelet tmp-node-e2e-64cf1522-ubuntu-gke-2204-1-24-v20230328} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: expected cgroupsPath to be of format "slice:prefix:name" for systemd cgroups, got "/kubepods/burstable/podb0df767f-f366-4b31-9f27-5324c645a296/289739cfd6688918ce40b5cb0c176974eec45a9b9a4f834d6a0dec0e280a2062" instead: unknown
W0329 12:21:55.196]   Mar 29 12:16:54.617: INFO: At 2023-03-29 12:16:26 +0000 UTC - event for init-container-fails-before-sidecar-starts: {kubelet tmp-node-e2e-64cf1522-ubuntu-gke-2204-1-24-v20230328} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: expected cgroupsPath to be of format "slice:prefix:name" for systemd cgroups, got "/kubepods/burstable/podb0df767f-f366-4b31-9f27-5324c645a296/eb0a4681923624a08a851e4a3ac218c791c162b68850cda425ea23ea8ef3b4f4" instead: unknown
W0329 12:21:55.196]   Mar 29 12:16:54.617: INFO: At 2023-03-29 12:16:41 +0000 UTC - event for init-container-fails-before-sidecar-starts: {kubelet tmp-node-e2e-64cf1522-ubuntu-gke-2204-1-24-v20230328} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: expected cgroupsPath to be of format "slice:prefix:name" for systemd cgroups, got "/kubepods/burstable/podb0df767f-f366-4b31-9f27-5324c645a296/cf7b47986235317f6c62e0b260d601c4989f34cb3edcc14e764ce9fedaed1c06" instead: unknown
```

I am not sure what's changed... but the `pull-kubernetes-node-e2e-containerd-sidecar-containers` job fails since today.
I guess the cgroup driver setting is changed for an unknown reason.

This explicitly sets kubelet to use the systemd cgroup driver and prevents the job from using `containerd:main`, as it can be updated at any time.

/cc @matthyx @SergeyKanzhelev 