### PR TITLE
Update COS family in job ci-cos-containerd-e2e-cos-gce

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -810,7 +810,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-89-lts
+      - --image-family=cos-101-lts
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8


### PR DESCRIPTION
#### What does this PR do?
Update the COS family used in job `ci-cos-containerd-e2e-cos-gce`.

This job is using COS 89, which besides being deprecated, uses containerd 1.4 (also deprecated and doesn't support CRI API v1). This PR updates to COS 101, which uses containerd 1.6.

Fixes https://github.com/kubernetes/kubernetes/issues/116944

/kind failing-test
/sig node
/cc @akhilerm @SergeyKanzhelev 