### PR TITLE
Update azuredisk-csi-driver-config.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -799,7 +799,7 @@ presubmits:
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.24"
+              value: "latest-1.26"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:


### PR DESCRIPTION
fix pull-azuredisk-csi-driver-e2e-capz-windows-2022 test failure:
cloud-node-manager-windows-xx pod could not start up in 1.24 cluster.