### PR TITLE
k8s-infra: Add canary for ci-kubernetes-kind-e2e-json-logging

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -251,3 +251,80 @@ periodics:
         limits:
           cpu: 6
           memory: "24Gi"
+
+- interval: 1h
+  cluster: eks-prow-build-cluster
+  # This combines tests from ci-kubernetes-kind-conformance and sig-storage
+  # and runs them with JSON output in all components which support that.
+  # Also enables contextual logging and (to get more coverage) dynamic
+  # resource allocation.
+  name: ci-kubernetes-kind-e2e-json-logging-eks-canary
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kind-json-logging-master-eks-canary
+    description: Conformance and storage tests with JSON logging enabled using sigs.k8s.io/kind
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 150m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230324-c487e233e1-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      # The modified e2e-k8s.sh with support for FEATURE_GATES and RUNTIME_CONFIG comes from
+      # https://github.com/kubernetes-sigs/kind/pull/3023. Once that PR is merged and a
+      # kind release is done, pulling it separately via curl can be removed.
+      - >
+        curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" &&
+        curl -sSL https://github.com/pohly/kind/raw/e2e-feature-gates/hack/ci/e2e-k8s.sh >$(which e2e-k8s.sh) &&
+        chmod u+x $(which e2e-k8s.sh) &&
+        e2e-k8s.sh
+
+      env:
+      # Options from https://github.com/kubernetes-sigs/kind/blob/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L79-L83
+      - name: CLUSTER_LOG_FORMAT
+        value: json
+      - name: GOMAXPROCS
+        value: "7"
+      - name: KIND_CLUSTER_LOG_LEVEL
+        # Default is 4, but we want to exercise more log calls and get more output.
+        value: "10"
+      - name: FEATURE_GATES
+        value: '{"DynamicResourceAllocation":true,"ContextualLogging":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"resource.k8s.io/v1alpha2":"true"}'
+      # don't retry conformance tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
+      - name: FOCUS
+        value: \[Conformance\]|\[Driver:.csi-hostpath\]|DynamicResourceAllocation
+      # TODO(bentheelder): reduce the skip list further
+      # NOTE: this skip list is from the standard periodic kind job, just to ensure
+      # we don't accidentally select any of these
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7


### PR DESCRIPTION
Add a canary job for ci-kubernetes-kind-e2e-json-logging running on an EKS cluster.
Failure or flakiness is expected.