### PR TITLE
Add GNU C compiler for arm64 architecture

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -34,11 +34,13 @@ RUN mkdir -p /go/src/k8s.io/kubernetes \
     && ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
 
 # preinstall:
-# - graphviz package for graphing profiles
 # - bc for shell to junit
+# - gcc-aarch64-linux-gnu for cross-compile arm64 binaries
+# - graphviz package for graphing profiles
 # - rpm for building RPMs with Bazel
 RUN apt-get update && \
     apt-get install -y bc \
+    gcc-aarch64-linux-gnu \
     graphviz \
     rpm && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Enable cross compilation for building arm64 binaries in amd64 env

xRef: 

* K8s: https://github.com/kubernetes/kubernetes/pull/117017  (Enable building and running ARM64 test binaries)
* Test-infra: https://github.com/kubernetes/test-infra/pull/29192  (Execute node_e2e on ARM machines)