### PR TITLE
bump golang version for descheduler for 1.27.0-rc

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: golang:1.20.2
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: golang:1.20.2
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: golang:1.20.2
         command:
         - make
         args:


### PR DESCRIPTION
descheduler builds are failing for 1.27.0-rc.0 because apiserver dependency can only compile with 1.20 now

https://github.com/kubernetes-sigs/descheduler/pull/1100
https://github.com/kubernetes/apiserver/issues/92