### PR TITLE
Fix failing testgrid job for vulnerability scanning

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -28,7 +28,7 @@ periodics:
       - |
         set -euo pipefail
         apt update && apt -y install jq
-        wget -q -O /usr/local/bin/snyk https://github.com/snyk/cli/releases/download/v1.993.0/snyk-linux && chmod +x /usr/local/bin/snyk
+        wget -q -O /usr/local/bin/snyk https://static.snyk.io/cli/latest/snyk-linux && chmod +x /usr/local/bin/snyk
         mkdir -p "${ARTIFACTS}"
         if [ -z "${SNYK_TOKEN}" ]; then
           echo "SNYK_TOKEN env var is not set, required for snyk scan"

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -66,7 +66,7 @@ periodics:
 
         # container images scan
         echo "Fetch the list of k8s images"
-        curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release | grep 'PackageName: registry.k8s.io/' | awk '{print $2}' > images
+        curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release | grep "SPDXID: SPDXRef-Package-registry.k8s.io" | grep -v sha256 | cut -d- -f3- | sed 's/-/\//' | sed 's/-v1/:v1/' > images
         while read image; do
           echo "Running container image scan.."
           EXIT_CODE=0


### PR DESCRIPTION
Job has been failing for more than a month: https://testgrid.k8s.io/sig-security-snyk-scan#ci-kubernetes-snyk-master

- Fixes hardcoded snyk version
- Makes image list generation compatible to recent changes to SPDX SBOM generation

/cc nehalohia27 ericsmalling
/sig security testing k8s-infra release architecture