### PR TITLE
Run a ingress-gce script

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -166,14 +166,17 @@ postsubmits:
         - --scenario=execute
         - --
         - --env=VERSION=$(PULL_BASE_REF)
-        - --env=REGISTRY=gcr.io/k8s-ingress-image-push
-        - make
-        - all-push
-        - ALL_ARCH=amd64 arm64
-        - CONTAINER_BINARIES=e2e-test
+        - hack/push-multiarch.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        env:
+        - name: ALL_ARCH
+          value: "amd64 arm64"
+        - name: BINARIES
+          value: "e2e-test"
+        - name: REGISTRY
+          value: "gcr.io/k8s-ingress-image-push"
     annotations:
       testgrid-dashboards: sig-network-ingress-gce-e2e
       testgrid-tab-name: ingress-gce-image-push


### PR DESCRIPTION
It is tricky to run a list of commands inside
config yamls. To do that it's better to run
a script. The script builds & pushes the e2e-test
image on multiarch.