### PR TITLE
Try ipv6/kind and kubeadm/kind CI jobs on EKS

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -89,6 +89,48 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 
+- name: ci-kubernetes-e2e-kubeadm-kinder-eks-canary-1-27
+  cluster: eks-prow-build-cluster
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm
+    testgrid-tab-name: kubeadm-kinder-eks-canary-1-27
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-1.27
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "regular-1.27"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-26
   cluster: k8s-infra-prow-build
   interval: 12h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -177,6 +177,54 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-dashboards: sig-k8s-infra-canaries, sig-release-job-config-errors
+    testgrid-num-columns-recent: "6"
+    testgrid-tab-name: kind-ipv6-1.27-parallel-eks-canary
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-1.27
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-kubernetes-kind-ipv6-e2e-parallel-eks-canary-1-27
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+        value: "true"
+      - name: IP_FAMILY
+        value: ipv6
+      - name: FOCUS
+        value: .
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+      - name: PARALLEL
+        value: "true"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230330-8e9af88c7d-1.27
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 9Gi
+        requests:
+          cpu: "7"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-dashboards: sig-k8s-infra-canaries, sig-release-job-config-errors
     testgrid-tab-name: verify-1.27-eks-canary
   cluster: eks-prow-build-cluster
   decorate: true


### PR DESCRIPTION
To test various aspects of the EKS prow cluster, trying a couple of different jobs we don't have running there yet
- copy `ci-kubernetes-e2e-kubeadm-kinder-1-27` into `ci-kubernetes-e2e-kubeadm-kinder-eks-canary-1-27` : to test ipv6
- copy` ci-kubernetes-kind-ipv6-e2e-parallel-1-27` to `ci-kubernetes-kind-ipv6-e2e-parallel-eks-canary-1-27` : to test kubeadm