### PR TITLE
make cachesync timeout configurable

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -113,35 +113,35 @@ const (
 )
 
 type options struct {
-	config                 configflagutil.ConfigOptions
-	pluginsConfig          pluginsflagutil.PluginOptions
-	instrumentation        prowflagutil.InstrumentationOptions
-	kubernetes             prowflagutil.KubernetesOptions
-	github                 prowflagutil.GitHubOptions
-	tideURL                string
-	hookURL                string
-	oauthURL               string
-	githubOAuthConfigFile  string
-	cookieSecretFile       string
-	redirectHTTPTo         string
-	hiddenOnly             bool
-	pregeneratedData       string
-	staticFilesLocation    string
-	templateFilesLocation  string
-	showHidden             bool
-	spyglass               bool
-	spyglassFilesLocation  string
-	storage                prowflagutil.StorageClientOptions
-	gcsCookieAuth          bool
-	rerunCreatesJob        bool
-	allowInsecure          bool
-	timeoutListingProwJobs int
-	dryRun                 bool
-	tenantIDs              flagutil.Strings
+	config                configflagutil.ConfigOptions
+	pluginsConfig         pluginsflagutil.PluginOptions
+	instrumentation       prowflagutil.InstrumentationOptions
+	kubernetes            prowflagutil.KubernetesOptions
+	github                prowflagutil.GitHubOptions
+	tideURL               string
+	hookURL               string
+	oauthURL              string
+	githubOAuthConfigFile string
+	cookieSecretFile      string
+	redirectHTTPTo        string
+	hiddenOnly            bool
+	pregeneratedData      string
+	staticFilesLocation   string
+	templateFilesLocation string
+	showHidden            bool
+	spyglass              bool
+	spyglassFilesLocation string
+	storage               prowflagutil.StorageClientOptions
+	gcsCookieAuth         bool
+	rerunCreatesJob       bool
+	allowInsecure         bool
+	controllerManager     prowflagutil.ControllerManagerOptions
+	dryRun                bool
+	tenantIDs             flagutil.Strings
 }
 
 func (o *options) Validate() error {
-	for _, group := range []pkgFlagutil.OptionGroup{&o.kubernetes, &o.github, &o.config, &o.pluginsConfig} {
+	for _, group := range []pkgFlagutil.OptionGroup{&o.kubernetes, &o.github, &o.config, &o.pluginsConfig, &o.controllerManager} {
 		if err := group.Validate(o.dryRun); err != nil {
 			return err
 		}
@@ -182,11 +182,12 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.gcsCookieAuth, "gcs-cookie-auth", false, "Use storage.cloud.google.com instead of signed URLs")
 	fs.BoolVar(&o.rerunCreatesJob, "rerun-creates-job", false, "Change the re-run option in Deck to actually create the job. **WARNING:** Only use this with non-public deck instances, otherwise strangers can DOS your Prow instance")
 	fs.BoolVar(&o.allowInsecure, "allow-insecure", false, "Allows insecure requests for CSRF and GitHub oauth.")
-	fs.IntVar(&o.timeoutListingProwJobs, "timeout-listing-prowjobs", 30, "Timeout for listing prowjobs in seconds.")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Whether or not to make mutating API calls to GitHub.")
 	fs.Var(&o.tenantIDs, "tenant-id", "The tenantID(s) used by the ProwJobs that should be displayed by this instance of Deck. This flag can be repeated.")
 	o.config.AddFlags(fs)
 	o.instrumentation.AddFlags(fs)
+	o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
+	o.controllerManager.AddFlags(fs)
 	o.kubernetes.AddFlags(fs)
 	o.github.AddFlags(fs)
 	o.github.AllowAnonymous = true
@@ -365,7 +366,7 @@ func main() {
 				logrus.Info("Manager stopped gracefully.")
 			}
 		}()
-		mgrSyncCtx, mgrSyncCtxCancel := context.WithTimeout(context.Background(), time.Duration(o.timeoutListingProwJobs)*time.Second)
+		mgrSyncCtx, mgrSyncCtxCancel := context.WithTimeout(context.Background(), o.controllerManager.TimeoutListingProwJobs)
 		defer mgrSyncCtxCancel()
 		if synced := mgr.GetCache().WaitForCacheSync(mgrSyncCtx); !synced {
 			logrus.Fatal("Timed out waiting for cachesync")

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -88,6 +88,9 @@ func TestOptions_Validate(t *testing.T) {
 			name: "minimal set ok",
 			input: options{
 				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 			},
 			expectedErr: false,
 		},
@@ -99,7 +102,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "ok with oauth",
 			input: options{
-				config:                configflagutil.ConfigOptions{ConfigPath: "test"},
+				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 				oauthURL:              "website",
 				githubOAuthConfigFile: "something",
 				cookieSecretFile:      "yum",
@@ -109,7 +115,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "missing github config with oauth",
 			input: options{
-				config:           configflagutil.ConfigOptions{ConfigPath: "test"},
+				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 				oauthURL:         "website",
 				cookieSecretFile: "yum",
 			},
@@ -118,7 +127,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "missing cookie with oauth",
 			input: options{
-				config:                configflagutil.ConfigOptions{ConfigPath: "test"},
+				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 				oauthURL:              "website",
 				githubOAuthConfigFile: "something",
 			},
@@ -127,7 +139,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "hidden only and show hidden are mutually exclusive",
 			input: options{
-				config:     configflagutil.ConfigOptions{ConfigPath: "test"},
+				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 				hiddenOnly: true,
 				showHidden: true,
 			},
@@ -136,7 +151,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "show hidden and tenantIds are mutually exclusive",
 			input: options{
-				config:     configflagutil.ConfigOptions{ConfigPath: "test"},
+				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 				hiddenOnly: false,
 				showHidden: true,
 				tenantIDs:  setTenantIDs,
@@ -146,7 +164,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "hiddenOnly and tenantIds are mutually exclusive",
 			input: options{
-				config:     configflagutil.ConfigOptions{ConfigPath: "test"},
+				config: configflagutil.ConfigOptions{ConfigPath: "test"},
+				controllerManager: flagutil.ControllerManagerOptions{
+					TimeoutListingProwJobsDefault: 30 * time.Second,
+				},
 				hiddenOnly: true,
 				showHidden: false,
 				tenantIDs:  setTenantIDs,
@@ -607,13 +628,15 @@ func Test_gatherOptions(t *testing.T) {
 		{
 			name: "minimal flags work",
 			expected: func(o *options) {
-				o.timeoutListingProwJobs = 30
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 			},
 		},
 		{
 			name: "default static files location",
 			expected: func(o *options) {
-				o.timeoutListingProwJobs = 30
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 				o.spyglassFilesLocation = "/lenses"
 				o.staticFilesLocation = "/static"
 				o.templateFilesLocation = "/template"
@@ -623,7 +646,8 @@ func Test_gatherOptions(t *testing.T) {
 			name:       "ko data path",
 			koDataPath: "ko-data",
 			expected: func(o *options) {
-				o.timeoutListingProwJobs = 30
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 				o.spyglassFilesLocation = "ko-data/lenses"
 				o.staticFilesLocation = "ko-data/static"
 				o.templateFilesLocation = "ko-data/template"
@@ -636,7 +660,8 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.config.ConfigPath = "/random/value"
-				o.timeoutListingProwJobs = 30
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 			},
 		},
 		{

--- a/prow/cmd/horologium/main_test.go
+++ b/prow/cmd/horologium/main_test.go
@@ -350,6 +350,10 @@ func TestFlags(t *testing.T) {
 	}{
 		{
 			name: "minimal flags work",
+			expected: func(o *options) {
+				o.controllerManager.TimeoutListingProwJobs = 60 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 60 * time.Second
+			},
 		},
 		{
 			name: "explicitly set --config-path",
@@ -358,6 +362,8 @@ func TestFlags(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.config.ConfigPath = "/random/value"
+				o.controllerManager.TimeoutListingProwJobs = 60 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 60 * time.Second
 			},
 		},
 		{
@@ -367,6 +373,8 @@ func TestFlags(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.dryRun = false
+				o.controllerManager.TimeoutListingProwJobs = 60 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 60 * time.Second
 			},
 		},
 		{
@@ -376,12 +384,16 @@ func TestFlags(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.dryRun = true
+				o.controllerManager.TimeoutListingProwJobs = 60 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 60 * time.Second
 			},
 		},
 		{
 			name: "dry run defaults to true",
 			expected: func(o *options) {
 				o.dryRun = true
+				o.controllerManager.TimeoutListingProwJobs = 60 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 60 * time.Second
 			},
 		},
 	}

--- a/prow/cmd/tide/main_test.go
+++ b/prow/cmd/tide/main_test.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -38,6 +39,10 @@ func Test_gatherOptions(t *testing.T) {
 	}{
 		{
 			name: "minimal flags work",
+			expected: func(o *options) {
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
+			},
 		},
 		{
 			name: "explicitly set --config-path",
@@ -46,6 +51,8 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.config.ConfigPath = "/random/value"
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 			},
 		},
 		{
@@ -55,6 +62,8 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.dryRun = false
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 			},
 		},
 		{
@@ -66,6 +75,8 @@ func Test_gatherOptions(t *testing.T) {
 				o.storage = flagutil.StorageClientOptions{
 					GCSCredentialsFile: "/creds",
 				}
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 			},
 		},
 		{
@@ -77,6 +88,8 @@ func Test_gatherOptions(t *testing.T) {
 				o.storage = flagutil.StorageClientOptions{
 					S3CredentialsFile: "/creds",
 				}
+				o.controllerManager.TimeoutListingProwJobs = 30 * time.Second
+				o.controllerManager.TimeoutListingProwJobsDefault = 30 * time.Second
 			},
 		},
 	}

--- a/prow/flagutil/controller_manager.go
+++ b/prow/flagutil/controller_manager.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+type ControllerManagerOptions struct {
+	TimeoutListingProwJobs        time.Duration
+	TimeoutListingProwJobsDefault time.Duration
+}
+
+func (o *ControllerManagerOptions) AddFlags(fs *flag.FlagSet) {
+	fs.DurationVar(&o.TimeoutListingProwJobs, "timeout-listing-prowjobs", o.TimeoutListingProwJobsDefault, "Timeout for listing prowjobs.")
+}
+
+func (o *ControllerManagerOptions) Validate(_ bool) error {
+
+	if o.TimeoutListingProwJobsDefault == 0 {
+		return fmt.Errorf("programmer error: TimeoutListingProwJobsDefault cannot be 0; please set it before calling AddFlags() for ControllerManagerOptions")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Tide, Horologium, and Deck all call WaitForCacheSync [1]. However only Deck allows the timeout to be configurable through its own `timeoutListingProwJobs` (--timeout-listing-prowjobs) flag.

Here we promote this flag to be sharable across other components. Tide and Horologium both make use of this new flag. Also, the default value has been raised to 60 seconds (up from 30 seconds). This new 60 second timeout affects both Deck and Tide, which used to have a 30 second timeout.

Also, we replace the `cacheSyncCtx` and `cacheSyncCancel` variable names in Horologium with `mgrSyncCtx` and `mgrSyncCtxCancel`, respectively, for consistency.

[1]: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.6/pkg/cache#Informers.WaitForCacheSync

/cc @cjwagner 