### PR TITLE
Set the feature gate for the HPA metrics for Windows upstream tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -368,6 +368,8 @@ presubmits:
               value: "1"
             - name: KUBETEST_WINDOWS_CONFIG
               value: "upstream-windows-serial-slow.yaml"
+            - name: K8S_FEATURE_GATE
+              value: "HPAContainerMetrics=true"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
In https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3388 we are removing the hardcoded version of the feature gate so it can be adjusted on an as needed basis.  This make sure the HPA feature is enabled for Windows slow tests.