### PR TITLE
Fix crash in Gangway when gcp headers are missing

### DIFF
--- a/prow/config/gangway.go
+++ b/prow/config/gangway.go
@@ -155,11 +155,17 @@ func (c *Config) IdentifyAllowedClient(md *metadata.MD) (*AllowedApiClient, erro
 		// create. Otherwise, any caller could trigger any Prow Job, which is far from
 		// ideal from a security standpoint.
 		case "gcp":
-			v := md.Get("x-endpoint-api-consumer-type")[0]
-			if client.GCP.EndpointApiConsumerType != "PROJECT" {
-				return nil, fmt.Errorf("unsupported GCP API consumer type: %q", v)
+			v := md.Get("x-endpoint-api-consumer-type")
+			if len(v) == 0 {
+				return nil, errors.New("missing x-endpoint-api-consumer-type header")
 			}
-			v = md.Get("x-endpoint-api-consumer-number")[0]
+			if client.GCP.EndpointApiConsumerType != "PROJECT" {
+				return nil, fmt.Errorf("unsupported GCP API consumer type: %q", v[0])
+			}
+			v = md.Get("x-endpoint-api-consumer-number")
+			if len(v) == 0 {
+				return nil, errors.New("missing x-endpoint-api-consumer-number header")
+			}
 
 			// Now check whether we can find the same information in the Config's allowlist.
 			//
@@ -167,7 +173,7 @@ func (c *Config) IdentifyAllowedClient(md *metadata.MD) (*AllowedApiClient, erro
 			// elements match here. That case (where there are duplicate clients
 			// with the same EndpointApiConsumerNumber) is taken care of during
 			// validation.
-			if client.GCP.EndpointApiConsumerNumber == v {
+			if client.GCP.EndpointApiConsumerNumber == v[0] {
 				return &client, nil
 			}
 		}


### PR DESCRIPTION
I want to use gangway (great work!) in our infra with envoyproxy as rest<->grpc transcoder. During testing, I noticed that gangway crashes if a user is mistaken and forgets to add desired headers. The crash is attached below:

```
{"component":"gangway","file":"k8s.io/test-infra/prow/kube/config.go:76","func":"k8s.io/test-infra/prow/kube.LoadClusterConfigs","level":"info","msg":"Loading cluster contexts...","severity":"info","time":"2023-04-05T06:49:03Z"}
{"client":"github","component":"gangway","file":"k8s.io/test-infra/prow/github/client.go:918","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"Throttle(0, 0, *)","severity":"info","time":"2023-04-05T06:49:03Z"}
{"component":"gangway","file":"k8s.io/test-infra/prow/cmd/gangway/main.go:129","func":"main.(*interruptableServer).ListenAndServe","level":"info","msg":"serving gRPC on port 32000","severity":"info","time":"2023-04-05T06:49:03Z"}
panic: runtime error: index out of range [0] with length 0

goroutine 436 [running]:
k8s.io/test-infra/prow/config.(*Config).IdentifyAllowedClient(0xc00068e700, 0xc00000e5f8)
        k8s.io/test-infra/prow/config/gangway.go:158 +0x3b7
k8s.io/test-infra/prow/gangway.(*Gangway).CreateJobExecution(0xc000419260, {0x22f9f68?, 0xc000822810?}, 0xc0000ac4b0)
        k8s.io/test-infra/prow/gangway/gangway.go:83 +0x3b1
k8s.io/test-infra/prow/gangway._Prow_CreateJobExecution_Handler.func1({0x22f9f68, 0xc000822810}, {0x1e39840?, 0xc0000ac4b0})
        k8s.io/test-infra/prow/gangway/gangway_grpc.pb.go:124 +0x78
github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1({0x22f9f68, 0xc000822810}, {0x1e39840, 0xc0000ac4b0}, 0xc0008b9af0?, 0xc000206798)
        github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0x87
k8s.io/test-infra/prow/gangway._Prow_CreateJobExecution_Handler({0x1cffc20?, 0xc000419260}, {0x22f9f68, 0xc000822810}, 0xc0003de9c0, 0xc000216e70)
        k8s.io/test-infra/prow/gangway/gangway_grpc.pb.go:126 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000174fc0, {0x22ffc40, 0xc0006716c0}, 0xc0004767e0, 0xc000761a70, 0x3218a80, 0x0)
        google.golang.org/grpc@v1.47.0/server.go:1283 +0xcfd
google.golang.org/grpc.(*Server).handleStream(0xc000174fc0, {0x22ffc40, 0xc0006716c0}, 0xc0004767e0, 0x0)
        google.golang.org/grpc@v1.47.0/server.go:1620 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.47.0/server.go:922 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.47.0/server.go:920 +0x28a

```

I know these headers are needed, but gangway should not crash because of a malformed request. This PR aims to fix that issue.