### PR TITLE
CAPV: Remove thumbprint from e2e config

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -17,11 +17,6 @@ presets:
       secretKeyRef:
         name: capv-ci-overrides
         key: vsphere-password
-  - name: VSPHERE_TLS_THUMBPRINT
-    valueFrom:
-      secretKeyRef:
-        name: capv-ci-overrides
-        key: vsphere-server-thumbprint
   - name: VM_SSH_PUB_KEY
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
To unblock the e2e tests on the `main` branch. This is being tracked in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1859