### PR TITLE
rename oci-proxy to registry and bump golang-job limits

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   kubernetes/registry.k8s.io:
   # TODO(bentheelder): rerun_auth_config (let a github team re-run these, I probably need to join a team...)
-  - name: post-oci-proxy-push-images
+  - name: post-registry-push-images
     cluster: k8s-infra-prow-build-trusted
     annotations:
         testgrid-dashboards: sig-k8s-infra-gcb

--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -77,6 +77,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-oci-proxy
+    testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'
     testgrid-tab-name: kops-grid-gcr-mirror-canary

--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml
@@ -1,12 +1,12 @@
 presubmits:
   kubernetes/registry.k8s.io:
-  - name: pull-oci-proxy-verify
+  - name: pull-registry-verify
     cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     annotations:
-      testgrid-dashboards: sig-k8s-infra-oci-proxy
-      testgrid-tab-name: pull-oci-proxy-verify
+      testgrid-dashboards: sig-k8s-infra-registry
+      testgrid-tab-name: pull-registry-verify
       testgrid-num-failures-to-alert: '6'
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
@@ -19,18 +19,18 @@ presubmits:
         - VERIFY_SHELLCHECK=false
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 2
-            memory: 4Gi
-  - name: pull-oci-proxy-shellcheck
+            cpu: 4
+            memory: 8Gi
+  - name: pull-registry-shellcheck
     cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     annotations:
-      testgrid-dashboards: sig-k8s-infra-oci-proxy
-      testgrid-tab-name: pull-oci-proxy-shellcheck
+      testgrid-dashboards: sig-k8s-infra-registry
+      testgrid-tab-name: pull-registry-shellcheck
       testgrid-num-failures-to-alert: '6'
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
@@ -47,13 +47,13 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-  - name: pull-oci-proxy-test
+  - name: pull-registry-test
     cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     annotations:
-      testgrid-dashboards: sig-k8s-infra-oci-proxy
-      testgrid-tab-name: pull-oci-proxy-test
+      testgrid-dashboards: sig-k8s-infra-registry
+      testgrid-tab-name: pull-registry-test
       testgrid-num-failures-to-alert: '6'
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
@@ -64,18 +64,18 @@ presubmits:
         - test
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 2
-            memory: 4Gi
-  - name: pull-oci-proxy-build
+            cpu: 4
+            memory: 8Gi
+  - name: pull-registry-build
     cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     annotations:
-      testgrid-dashboards: sig-k8s-infra-oci-proxy
-      testgrid-tab-name: pull-oci-proxy-build
+      testgrid-dashboards: sig-k8s-infra-registry
+      testgrid-tab-name: pull-registry-build
       testgrid-num-failures-to-alert: '6'
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
@@ -87,8 +87,8 @@ presubmits:
         - build
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi

--- a/config/testgrids/kubernetes/sig-k8s-infra/config.yaml
+++ b/config/testgrids/kubernetes/sig-k8s-infra/config.yaml
@@ -9,7 +9,7 @@ dashboard_groups:
   - sig-k8s-infra-gcb
   - sig-k8s-infra-groups
   - sig-k8s-infra-k8sio
-  - sig-k8s-infra-oci-proxy
+  - sig-k8s-infra-registry
   - sig-k8s-infra-porche
   - sig-k8s-infra-prow
 
@@ -20,6 +20,6 @@ dashboards:
 - name: sig-k8s-infra-gcb
 - name: sig-k8s-infra-groups
 - name: sig-k8s-infra-k8sio
-- name: sig-k8s-infra-oci-proxy
+- name: sig-k8s-infra-registry
 - name: sig-k8s-infra-porche
 - name: sig-k8s-infra-prow


### PR DESCRIPTION
we renamed the repo a long time ago.
time to squeeze in cleaning up the job names while there's still a code freeze there.

also: we have more go code now and we're unnecessarily limiting the go jobs's CPU requests. they will run faster and end quicker this way, and these are infrequent as-needed presubmits, not expensive ongoing periodics.

primarily upped CPU, but at that point the memory allocations didn't make sense to bumped by the same 2x factor.