### PR TITLE
Updating sig-windows jobs so they get forker per release correctly

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -11,7 +11,7 @@ presets:
     value: "Standard_D4s_v3"
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-capz-windows-containerd
+  - name: pull-kubernetes-e2e-capz-windows
     decorate: true
     always_run: false
     optional: true
@@ -47,11 +47,12 @@ presubmits:
             cpu: 2
             memory: "9Gi"
     annotations:
+      fork-per-release: "true"
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-capz-windows-containerd
+      testgrid-tab-name: pull-kubernetes-e2e-capz-windows
       testgrid-num-columns-recent: '30'
   kubernetes-sigs/windows-testing:
-  - name: pull-e2e-capz-containerd-windows-2022-extension
+  - name: pull-e2e-capz-windows-2022-extension
     decorate: true
     always_run: false
     optional: true
@@ -66,7 +67,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
       preset-windows-private-registry-cred: "true"
-      preset-capz-windows-common-main: "true"
+      preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -78,6 +79,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
           command:
             - "runner.sh"
+            - "KUBERNETES_VERSION=latest"
             - "./capz/run-capz-e2e.sh"
           securityContext:
             privileged: true
@@ -92,8 +94,8 @@ presubmits:
             value: \[sig-windows\] # run just a subset to speed up testing time
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-e2e-capz-windows-containerd-extension
-  - name: pull-e2e-run-capz-sh-containerd-windows-2022-hyperv
+      testgrid-tab-name: pull-e2e-capz-windows-extension
+  - name: pull-e2e-run-capz-sh-windows-2022-hyperv
     decorate: true
     always_run: false
     optional: true
@@ -108,7 +110,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
       preset-windows-private-registry-cred: "true"
-      preset-capz-windows-common-main: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-containerd-1-7-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -119,6 +122,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
           command:
             - "runner.sh"
+            - "KUBERNETES_VERSION=latest"
             - "./capz/run-capz-e2e.sh"
           securityContext:
             privileged: true
@@ -131,16 +135,14 @@ presubmits:
             value: "windows-2022"
           - name: HYPERV
             value: "true"
-          - name: WINDOWS_CONTAINERD_URL
-            value: "https://github.com/containerd/containerd/releases/download/v1.7.0-beta.4/containerd-1.7.0-beta.4-windows-amd64.tar.gz"
           - name: GINKGO_FOCUS
             value: \[Feature:WindowsHyperVContainers\] # run just a subset to speed up testing time
           - name: GINKGO_SKIP
             value: \[LinuxOnly\] #must set some value otherwise default is used.  The focus of WindowsHyperVContainers will select just those tests
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-e2e-run-capz-sh-containerd-windows-2022-hyperv
-  - name: pull-e2e-capz-containerd-windows-2022-extension-gmsa
+      testgrid-tab-name: pull-e2e-run-capz-sh-windows-2022-hyperv
+  - name: pull-e2e-capz-windows-2022-extension-gmsa
     decorate: true
     always_run: false
     optional: true
@@ -155,7 +157,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
       preset-windows-private-registry-cred: "true"
-      preset-capz-windows-common-main: "true"
+      preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -167,6 +169,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
           command:
             - "runner.sh"
+            - "KUBERNETES_VERSION=latest"
             - "./capz/run-capz-e2e.sh"
           securityContext:
             privileged: true
@@ -187,4 +190,4 @@ presubmits:
             value: \[LinuxOnly\] #must set some value otherwise default is used.  The focus of GMSA will select just those tests
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-e2e-capz-windows-containerd-extension-gmsa
+      testgrid-tab-name: pull-e2e-capz-windows-extension-gmsa

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -1,9 +1,7 @@
 presets:
 - labels:
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
   env:
-  - name: "KUBERNETES_VERSION"
-    value: "latest"
   - name: E2E_ARGS
     value: "-kubetest.use-ci-artifacts"
   - name: WINDOWS
@@ -73,7 +71,7 @@ presets:
     - name: GMSA
       value: "true"
 periodics:
-- name: ci-kubernetes-e2e-capz-master-containerd-windows
+- name: ci-kubernetes-e2e-capz-master-windows
   interval: 3h
   decorate: true
   decoration_config:
@@ -83,7 +81,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-windows-parallel: "true"
@@ -103,6 +101,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
           - "./scripts/ci-conformance.sh"
         securityContext:
           privileged: true
@@ -112,10 +111,11 @@ periodics:
             memory: "9Gi"
   annotations:
     fork-per-release: "true"
+    fork-per-release-replacements: "KUBERNETES_VERSION=latest -> KUBERNETES_VERSION=latest-{{.Version}}"
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-containerd-master
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow
+    testgrid-tab-name: capz-windows-master
+- name: ci-kubernetes-e2e-capz-master-windows-serial-slow
   interval: 24h
   decorate: true
   decoration_config:
@@ -124,7 +124,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
@@ -149,6 +149,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -164,8 +165,8 @@ periodics:
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-containerd-master-serial-slow
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow-hpa
+    testgrid-tab-name: capz-windows-master-serial-slow
+- name: ci-kubernetes-e2e-capz-master-windows-serial-slow-hpa
   interval: 24h
   decorate: true
   decoration_config:
@@ -174,7 +175,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
@@ -215,7 +216,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-master-serial-slow-hpa
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-2022
+- name: ci-kubernetes-e2e-capz-master-windows-2022
   interval: 3h
   decorate: true
   decoration_config:
@@ -224,7 +225,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-windows-private-registry-cred: "true"
   extra_refs:
@@ -247,6 +248,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -260,8 +262,8 @@ periodics:
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: capz-windows-containerd-2022-master
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-2022-serial-slow
+    testgrid-tab-name: capz-windows-2022-master
+- name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow
   interval: 24h
   decorate: true
   decoration_config:
@@ -270,7 +272,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
@@ -295,6 +297,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -312,8 +315,8 @@ periodics:
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: capz-windows-containerd-2022-master-serial-slow
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-2022-serial-slow-hpa
+    testgrid-tab-name: capz-windows-2022-master-serial-slow
+- name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow-hpa
   interval: 24h
   decorate: true
   decoration_config:
@@ -323,7 +326,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-windows-private-registry-cred: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
   extra_refs:
@@ -346,6 +349,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -363,7 +367,7 @@ periodics:
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: capz-windows-containerd-2022-master-serial-slow-hpa
+    testgrid-tab-name: capz-windows-2022-master-serial-slow-hpa
 - name: ci-kubernetes-e2e-azuredisk-capz-windows-2019
   interval: 48h
   decorate: true
@@ -433,6 +437,7 @@ periodics:
 #       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
 #         command:
 #           - runner.sh
+#           - "KUBERNETES_VERSION=latest"
 #           - ./scripts/ci-entrypoint.sh
 #         args:
 #           - bash
@@ -457,7 +462,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-windows-private-registry-cred: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -478,6 +483,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         env:
           - name: WINDOWS_CONTAINERD_URL

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
@@ -8,7 +8,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
     preset-windows-private-registry-cred: "true"
     preset-capz-containerd-1-7-latest: "true"
@@ -32,6 +32,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -55,7 +56,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-capz-windows-common-main: "true"
+    preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
     preset-windows-private-registry-cred: "true"
     preset-capz-containerd-1-7-latest: "true"
@@ -79,6 +80,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230330-8e9af88c7d-master
         command:
           - "runner.sh"
+          - "KUBERNETES_VERSION=latest"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/28145

Updating the Windows master jobs so they get forked correctly
- rename `preset-capz-windows-common-main` to `preset-capz-windows-common` since remaining env vars are release independent
- remove `KUBERNETES_VERSION` env var from presets
- set `KUBERNETES_VERSION=latest` in the container args
- add fork-per-release-replacements: "KUBERNETES_VERSION=latest -> KUBERNETES_VERSION=latest-{{.Version}}" to jobs that should get forked
- also fork a serial-slow job
- remove containerd from a bunch of job names since that is the only container runtime we test

/sig windows