### PR TITLE
refactor flag validation

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -50,6 +50,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	pkgFlagutil "k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -140,19 +141,10 @@ type options struct {
 }
 
 func (o *options) Validate() error {
-	if err := o.kubernetes.Validate(false); err != nil {
-		return err
-	}
-	if err := o.github.Validate(o.dryRun); err != nil {
-		return err
-	}
-
-	if err := o.config.Validate(o.dryRun); err != nil {
-		return err
-	}
-
-	if err := o.pluginsConfig.Validate(o.dryRun); err != nil {
-		return err
+	for _, group := range []pkgFlagutil.OptionGroup{&o.kubernetes, &o.github, &o.config, &o.pluginsConfig} {
+		if err := group.Validate(o.dryRun); err != nil {
+			return err
+		}
 	}
 
 	if o.oauthURL != "" {

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -30,6 +29,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
+	pkgFlagutil "k8s.io/test-infra/pkg/flagutil"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/cron"
@@ -67,12 +67,10 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func (o *options) Validate() error {
-	if err := o.kubernetes.Validate(o.dryRun); err != nil {
-		return err
-	}
-
-	if err := o.config.Validate(o.dryRun); err != nil {
-		return errors.New("--config-path is required")
+	for _, group := range []pkgFlagutil.OptionGroup{&o.kubernetes, &o.config} {
+		if err := group.Validate(o.dryRun); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Use the style found in tide (use of a for-loop) to make things simpler.

As part of this refactor we clean up deck/main.go where we used to do

    if err := o.kubernetes.Validate(false); err != nil {
       return err
    }

unnecessarily (there was no need to pass in `false` because the boolean is ignored in the o.kubernetes.Validate()). Instead we now just pass in `o.dryRun` like we do for the other flag bundles.

One slight difference is in horologium/main.go, where we used to return a hardcoded

    return errors.New("--config-path is required")

for `o.config.Validate()` upon encountering an error. However we now just return the error that was actually generated by `o.config.Validate()` instead, just like we do in tide.

/cc @cjwagner @mpherman2 