### PR TITLE
use systemd cgroup driver in kubelet for containerd-e2e-ubuntu

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -17,7 +17,7 @@ presets:
   - name: NON_MASQUERADE_CIDR
     value: 0.0.0.0/0
   - name: KUBELET_TEST_ARGS
-    value: --runtime-cgroups=/system.slice/containerd.service
+    value: --runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
 - labels:
     preset-e2e-containerd-image-load: "true"
   env:
@@ -134,7 +134,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-93-16623-341-29
+      - --env=KUBE_GCE_MASTER_IMAGE=cos-97-16919-235-48
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
- use systemd cgroup driver in kubelet
- update cos image to cos-97

Fixes failing [sig-node-containerd#containerd-e2e-ubuntu](https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu) tests after systemd changes in https://github.com/kubernetes/test-infra/pull/28992