### PR TITLE
Update trusted author handling for DCO

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -686,16 +686,15 @@ type Welcome struct {
 
 // Dco is config for the DCO (https://developercertificate.org/) checker plugin.
 type Dco struct {
-	// SkipDCOCheckForMembers is used to skip DCO check for trusted org members
+	// SkipDCOCheckForMembers is used to skip DCO check for org members.
 	SkipDCOCheckForMembers bool `json:"skip_dco_check_for_members,omitempty"`
 	// TrustedApps defines list of apps which commits will not be checked for DCO singoff.
 	// The list should contain usernames of each GitHub App without [bot] suffix.
-	// By default, this option is ignored.
 	TrustedApps []string `json:"trusted_apps,omitempty"`
 	// TrustedOrg is the org whose members' commits will not be checked for DCO signoff
-	// if the skip DCO option is enabled. The default is the PR's org.
+	// if the SkipDCOCheckForMembers option is enabled. The default is the PR's org.
 	TrustedOrg string `json:"trusted_org,omitempty"`
-	// SkipDCOCheckForCollaborators is used to skip DCO check for trusted org members
+	// SkipDCOCheckForCollaborators is used to skip DCO check for repository collaborators.
 	SkipDCOCheckForCollaborators bool `json:"skip_dco_check_for_collaborators,omitempty"`
 	// ContributingRepo is used to point users to a different repo containing CONTRIBUTING.md
 	ContributingRepo string `json:"contributing_repo,omitempty"`

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -79,6 +79,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Dco: map[string]*plugins.Dco{
 			"org/repo": {
 				SkipDCOCheckForMembers:       true,
+				TrustedApps:                  []string{"trusted-app"},
 				TrustedOrg:                   "org",
 				SkipDCOCheckForCollaborators: true,
 				ContributingRepo:             "other-org/other-repo",
@@ -124,14 +125,37 @@ type commentPruner interface {
 }
 
 // filterTrustedUsers checks whether the commits are from a trusted user and returns those that are not
-func filterTrustedUsers(gc gitHubClient, l *logrus.Entry, skipDCOCheckForCollaborators bool, trustedApps []string, trustedOrg, org, repo string, allCommits []github.RepositoryCommit) ([]github.RepositoryCommit, error) {
+func filterTrustedUsers(gc gitHubClient, l *logrus.Entry, config plugins.Dco, org, repo string, allCommits []github.RepositoryCommit) ([]github.RepositoryCommit, error) {
 	untrustedCommits := make([]github.RepositoryCommit, 0, len(allCommits))
 
+	var trustedResponse trigger.TrustedUserResponse
+
 	for _, commit := range allCommits {
-		trustedResponse, err := trigger.TrustedUser(gc, !skipDCOCheckForCollaborators, trustedApps, trustedOrg, commit.Author.Login, org, repo)
-		if err != nil {
-			return nil, fmt.Errorf("Error checking is member trusted: %w", err)
+		trustedResponse.IsTrusted = false
+
+		// Handle TrustedApps separately (since Trigger checks this last and doesn't have member/collaborator configurable handling)
+		for _, trustedApp := range config.TrustedApps {
+			if tUser := strings.TrimSuffix(commit.Author.Login, "[bot]"); tUser == trustedApp {
+				trustedResponse.IsTrusted = true
+				break
+			}
 		}
+
+		if !trustedResponse.IsTrusted && (config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators) {
+			trustedOrg := config.TrustedOrg
+
+			// If SkipDCOCheckforMembers is disabled, make sure the trusted org is empty
+			if !config.SkipDCOCheckForMembers {
+				trustedOrg = ""
+			}
+
+			var err error
+			trustedResponse, err = trigger.TrustedUser(gc, !config.SkipDCOCheckForCollaborators, config.TrustedApps, trustedOrg, commit.Author.Login, org, repo)
+			if err != nil {
+				return nil, fmt.Errorf("Error checking is member trusted: %w", err)
+			}
+		}
+
 		if !trustedResponse.IsTrusted {
 			l.Debugf("Member %s is not trusted", commit.Author.Login)
 			untrustedCommits = append(untrustedCommits, commit)
@@ -296,8 +320,8 @@ func handle(config plugins.Dco, gc gitHubClient, cp commentPruner, log *logrus.E
 		return err
 	}
 
-	if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators {
-		commitsMissingDCO, err = filterTrustedUsers(gc, l, config.SkipDCOCheckForCollaborators, config.TrustedApps, config.TrustedOrg, org, repo, commitsMissingDCO)
+	if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators || len(config.TrustedApps) > 0 {
+		commitsMissingDCO, err = filterTrustedUsers(gc, l, config, org, repo, commitsMissingDCO)
 		if err != nil {
 			l.WithError(err).Infof("Error running trusted org member check against commits in PR")
 			return err

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -369,17 +369,16 @@ dco:
         contributing_path: ' '
         # ContributingRepo is used to point users to a different repo containing CONTRIBUTING.md
         contributing_repo: ' '
-        # SkipDCOCheckForCollaborators is used to skip DCO check for trusted org members
+        # SkipDCOCheckForCollaborators is used to skip DCO check for repository collaborators.
         skip_dco_check_for_collaborators: true
-        # SkipDCOCheckForMembers is used to skip DCO check for trusted org members
+        # SkipDCOCheckForMembers is used to skip DCO check for org members.
         skip_dco_check_for_members: true
         # TrustedApps defines list of apps which commits will not be checked for DCO singoff.
         # The list should contain usernames of each GitHub App without [bot] suffix.
-        # By default, this option is ignored.
         trusted_apps:
             - ""
         # TrustedOrg is the org whose members' commits will not be checked for DCO signoff
-        # if the skip DCO option is enabled. The default is the PR's org.
+        # if the SkipDCOCheckForMembers option is enabled. The default is the PR's org.
         trusted_org: ' '
 # ExternalPlugins is a map of repositories (eg "k/k") to lists of
 # external plugins.


### PR DESCRIPTION
- Separate member and collaborator configurations (since these are separate booleans, it makes more sense to handle them separately rather than tie them together)
- Separate trusted apps from the member and collaborator handling (originally trusted apps couldn't be specified unless one of the skip booleans was set. This doesn't make a whole lot of sense since a trusted app is neither of those.)