### PR TITLE
flagutil: knownClusters: preserve rest.Config

### DIFF
--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -527,9 +527,9 @@ func (o *KubernetesOptions) BuildClusterUncachedRuntimeClients(dryRun bool) (map
 	return clients, utilerrors.NewAggregate(errs)
 }
 
-func (o *KubernetesOptions) KnownClusters(dryRun bool) (sets.String, error) {
+func (o *KubernetesOptions) KnownClusters(dryRun bool) (map[string]rest.Config, error) {
 	if err := o.resolve(dryRun); err != nil {
 		return nil, err
 	}
-	return sets.StringKeySet(o.clusterConfigs), nil
+	return o.clusterConfigs, nil
 }

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -66,7 +67,7 @@ const (
 func Add(
 	mgr controllerruntime.Manager,
 	buildMgrs map[string]controllerruntime.Manager,
-	knownClusters sets.String,
+	knownClusters map[string]rest.Config,
 	cfg config.Getter,
 	opener io.Opener,
 	totURL string,
@@ -78,7 +79,7 @@ func Add(
 func add(
 	mgr controllerruntime.Manager,
 	buildMgrs map[string]controllerruntime.Manager,
-	knownClusters sets.String,
+	knownClusters map[string]rest.Config,
 	cfg config.Getter,
 	opener io.Opener,
 	totURL string,
@@ -199,7 +200,7 @@ const (
 	ClusterStatusNoManager   ClusterStatus = "No-Manager"
 )
 
-func (r *reconciler) syncClusterStatus(interval time.Duration, knownClusters sets.String) func(context.Context) error {
+func (r *reconciler) syncClusterStatus(interval time.Duration, knownClusters map[string]rest.Config) func(context.Context) error {
 	return func(ctx context.Context) error {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()


### PR DESCRIPTION
Do not throw away the rest.Config information for build clusters. We'll use this information in a follow-up PR to check build cluster connectivity, through the checkAuthorizations() function [1].

[1]: https://github.com/kubernetes/test-infra/pull/28371/files#diff-7d688313b319388bc790c0799da5081d6648feaeaf7945b26e5b6a93752b044dR446.

/cc @cjwagner @mpherman2 