### PR TITLE
`tide`: preserve branch merge type ordering 

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"text/template"
@@ -429,16 +428,7 @@ func (t *Tide) OrgRepoBranchMergeMethod(orgRepo OrgRepo, branch string) types.Pu
 
 	// 2. Branch level regex match
 	if orgFound && repoFound {
-		branches := t.MergeType[orgRepo.Org].Repos[repo].Branches
-		keys := make([]string, 0, len(branches))
-
-		for k := range branches {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		for _, key := range keys {
-			branchConfig := branches[key]
+		for _, branchConfig := range t.MergeType[orgRepo.Org].Repos[repo].Branches {
 			if branchConfig.Regexpr.MatchString(branch) {
 				return branchConfig.MergeType
 			}

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -428,7 +428,9 @@ func (t *Tide) OrgRepoBranchMergeMethod(orgRepo OrgRepo, branch string) types.Pu
 
 	// 2. Branch level regex match
 	if orgFound && repoFound {
-		for _, branchConfig := range t.MergeType[orgRepo.Org].Repos[repo].Branches {
+		repo := t.MergeType[orgRepo.Org].Repos[repo]
+		for _, configuredBranch := range repo.BranchesOrder {
+			branchConfig := repo.Branches[configuredBranch]
 			if branchConfig.Regexpr.MatchString(branch) {
 				return branchConfig.MergeType
 			}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -693,6 +693,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"test-infra": {
+									BranchesOrder: []string{"master"},
 									Branches: map[string]TideBranchMergeType{
 										"master": {
 											Regexpr:   regexp.MustCompile("master"),
@@ -938,6 +939,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"test-infra": {
+									BranchesOrder: []string{"master"},
 									Branches: map[string]TideBranchMergeType{
 										"master": {
 											Regexpr:   regexp.MustCompile("master"),
@@ -963,6 +965,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"test-infra": {
+									BranchesOrder: []string{"master"},
 									Branches: map[string]TideBranchMergeType{
 										"master": {
 											Regexpr:   regexp.MustCompile("master"),
@@ -988,6 +991,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"test-infra": {
+									BranchesOrder: []string{`release-\d+(.\d+)?`},
 									Branches: map[string]TideBranchMergeType{
 										`release-\d+(.\d+)?`: {
 											Regexpr:   regexp.MustCompile(`release-\d+(.\d+)?`),
@@ -1013,6 +1017,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"test-infra": {
+									BranchesOrder: []string{`ma.*`, `mast.*`},
 									Branches: map[string]TideBranchMergeType{
 										`ma.*`: {
 											Regexpr:   regexp.MustCompile(`ma.*`),
@@ -1042,6 +1047,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"golang": {
 							Repos: map[string]TideRepoMergeType{
 								"*": {
+									BranchesOrder: []string{"main"},
 									Branches: map[string]TideBranchMergeType{
 										"main": {
 											Regexpr:   regexp.MustCompile("main"),
@@ -1069,6 +1075,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"kops": {
+									BranchesOrder: []string{"main"},
 									Branches: map[string]TideBranchMergeType{
 										"main": {
 											Regexpr:   regexp.MustCompile("main"),
@@ -1095,6 +1102,7 @@ func TestOrgRepoMatchMergeMethod(t *testing.T) {
 						"kubernetes": {
 							Repos: map[string]TideRepoMergeType{
 								"kops": {
+									BranchesOrder: []string{"main"},
 									Branches: map[string]TideBranchMergeType{
 										"main": {
 											Regexpr:   regexp.MustCompile("main"),


### PR DESCRIPTION
Due to #29039 branch merge types get sorted alphabetically before searching for a match. 
This is somehow unexpected from a user standpoint who wants to apply the following configuration:
```yaml
tide:
  merge_method:
    kubernetes:
      test-infra:
        master: merge
        '.+': squash
```
In the previous scenario I want `master` to be matched before `.+`, but because of sorting I get the opposite, that is the `.+` regex swallowing essentially everything.
This PR attempts to preserve the branches' ordering as it was specified by the user in the `.yaml` configuration file.

I have assessed several libraries as [gitlab.com/c0b/go-ordered-json](https://pkg.go.dev/gitlab.com/c0b/go-ordered-json) but I then came to the conclusion that a simple regex offers these pros:
- it does the job
- less code
- no need to import another library

/cc @SergeyKanzhelev @petr-muller @jmguzik 