### PR TITLE
Add JobSet presubmit for integration tests

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
@@ -18,3 +18,18 @@ presubmits:
         - make
         args:
         - test
+  - name: pull-jobset-test-integration-main
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-jobset-test-integration-main
+      description: "Run jobset integration tests"
+    spec:
+      containers:
+      - image: golang:1.19
+        command:
+        - make
+        args:
+        - test-integration


### PR DESCRIPTION
Add JobSet presubmit for integration tests added in https://github.com/kubernetes-sigs/jobset/pull/8

DO NOT MERGE until the linked PR above is submitted.

cc @ahg-g 