### PR TITLE
Revert of 29011 plus more fixups

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -77,6 +77,11 @@ presubmits:
       base_ref: release-1.8
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.24
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.24

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -30,7 +30,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -55,48 +55,6 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.24-informing, sig-windows-1.24-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-1.24
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-1-24-ccm
-  interval: 24h
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  labels:
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-capz-containerd-1-6-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common-124: "true"
-    preset-capz-windows-parallel: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: release-1.8
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: release-1.24
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.24
-      name: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
-    testgrid-dashboards: sig-windows-1.24-release
-    testgrid-tab-name: capz-windows-containerd-1.24-ccm
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow-1-24
   interval: 24h
   decorate: true
@@ -114,7 +72,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
@@ -23,6 +23,10 @@ presubmits:
       base_ref: release-1.8
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.25
+      path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.25

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -30,7 +30,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -55,48 +55,6 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.25-informing, sig-windows-1.25-release, sig-windows-signal
     testgrid-tab-name: capz-e2e-windows-containerd-1.25
-- name: ci-kubernetes-e2e-capz-containerd-windows-1-25-ccm
-  interval: 2h
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  labels:
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-capz-containerd-1-6-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common-125: "true"
-    preset-capz-windows-parallel: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: release-1.8
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: release-1.25
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.25
-      name: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
-    testgrid-dashboards: sig-windows-1.25-release
-    testgrid-tab-name: capz-e2e-windows-containerd-1.25-ccm
 - name: ci-kubernetes-e2e-capz-containerd-windows-serial-slow-1-25
   interval: 24h
   decorate: true
@@ -114,7 +72,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -22,6 +22,11 @@ presubmits:
       base_ref: release-1.8
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.26
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.26

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -20,7 +20,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -55,45 +55,3 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.26-informing, sig-windows-signal,  sig-windows-1.26-release
     testgrid-tab-name: capz-windows-containerd-1.26
-- name: ci-kubernetes-e2e-capz-master-containerd-windows-1-26-ccm
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: release-1.8
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: release-1.26
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  interval: 2h
-  labels:
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-capz-containerd-1-6-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common-126: "true"
-    preset-capz-windows-parallel: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.26
-      name: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
-    testgrid-dashboards: sig-windows-1.26-release
-    testgrid-tab-name: capz-windows-containerd-1.26-ccm

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -19,15 +19,14 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.7
+      base_ref: release-1.8
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
-# Needed when this job switches to using cluser-api-provider@release-1.8
-#  - org: kubernetes-sigs
-#    repo: cloud-provider-azure
-#    base_ref: release-1.27
-#    path_alias: sigs.k8s.io/cloud-provider-azure
-#    workdir: false
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master # TODO: Update to release-1.27 once it's created
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.27

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -25,15 +25,14 @@ periodics:
     workdir: true
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
-# Needed when this job switches to using cluser-api-provider@release-1.8
-#  - org: kubernetes-sigs
-#    repo: cloud-provider-azure
-#    base_ref: release-1.27
-#    path_alias: sigs.k8s.io/cloud-provider-azure
-#    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master # TODO: Update to release-1.27 once it's created
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   interval: 24h
   labels:
     preset-azure-cred-only: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -393,6 +393,11 @@ periodics:
     repo: azuredisk-csi-driver
     base_ref: master
     path_alias: sigs.k8s.io/azuredisk-csi-driver
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
@@ -11,9 +11,14 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.4
+        base_ref: release-1.8
         path_alias: "sigs.k8s.io/cluster-api-provider-azure"
         workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cloud-provider-azure
+        workdir: false
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Revert of #29011 (which downgraded capz refs from `release-1.8` to `release-1.7` while we were investigating some stability issues that are now resolved) plus fixing up PR job configs which need a reference to cloud-provider-azure repo.

/sig windows
/assign @CecileRobertMichon @jackfrancis 