### PR TITLE
CAPZ: Run CAPI e2e tests if test files changed

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -156,6 +156,7 @@ presubmits:
   - name: pull-cluster-api-provider-azure-capi-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
+    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-e2e.sh|Makefile'
     optional: true
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -202,6 +202,7 @@ presubmits:
   - name: pull-cluster-api-provider-azure-capi-e2e-v1beta1
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
+    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-e2e.sh|Makefile'
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
Automatically trigger the CAPI e2e test whenever some of the test suite and scripts change so it runs on PRs like https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3298. 