### PR TITLE
Adding windows private registry credentials for 1.27 SIG-Windows release job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -39,6 +39,7 @@ periodics:
     preset-capz-windows-parallel: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - command:


### PR DESCRIPTION
Fixes [#117185](https://github.com/kubernetes/kubernetes/issues/117185)

The `Container Runtime blackbox test when starting a container that exists with the expected status` test is passing in https://testgrid.k8s.io/sig-windows-master-release#capz-windows-2022-master and has this configuration set.

/sig windows
/assign @jsturtevant 