### PR TITLE
changed cos-89-lts to cos-stable for pull-npd-e2e-test

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -187,7 +187,7 @@ presubmits:
         - name: ZONE
           value: us-central1-a
         - name: IMAGE_FAMILY
-          value: cos-89-lts
+          value: cos-stable
         - name: IMAGE_PROJECT
           value: cos-cloud
         - name: BOSKOS_PROJECT_TYPE


### PR DESCRIPTION
I am not certain about this.  I've got a low-priority [PR over in node-problem-detector](https://github.com/kubernetes/node-problem-detector/pull/745), failing due to a 404 on pulling `cos-89-lts`.  This looks like the solution I saw applied [elsewhere](https://github.com/kubernetes/test-infra/pull/25970).