### PR TITLE
Enable `lgtm_acts_as_approve` for k-sigs/testgrid-json-exporter

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -103,6 +103,7 @@ approve:
   - kubernetes-sigs/security-profiles-operator
   - kubernetes-sigs/slack-infra
   - kubernetes-sigs/tejolote
+  - kubernetes-sigs/testgrid-json-exporter
   - kubernetes-sigs/zeitgeist
   - kubernetes/community
   - kubernetes/k8s.io


### PR DESCRIPTION
This unifies the behavior for this SIG Release related repository.

PTAL @kubernetes/sig-release-leads 