### PR TITLE
sig-instrumentation: add pre-submit jobs for logging

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -1,0 +1,137 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-kind-json-logging
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: sig-instrumentation-presubmits
+      testgrid-tab-name: pr-json-logging
+    decorate: true
+    # Not relevant for most PRs.
+    always_run: false
+    # This covers most of the code related to structured, contextual logging.
+    run_if_changed: /staging/src/k8s.io/component-base/logs/
+    # The tests might still be flaky (alpha features!) or this job might get triggered accidentally for
+    # an unrelated PR.
+    optional: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20230406-23cb1879e3-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        # The modified e2e-k8s.sh with support for FEATURE_GATES and RUNTIME_CONFIG comes from
+        # https://github.com/kubernetes-sigs/kind/pull/3023. Once that is in a
+        # kind release, pulling it separately via curl can be removed.
+        - >
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" &&
+          curl -sSL https://github.com/kubernetes-sigs/kind/raw/c8618199912e3949aee0d7a8b966b462e4fb6f0e/hack/ci/e2e-k8s.sh >$(which e2e-k8s.sh) &&
+          chmod u+x $(which e2e-k8s.sh) &&
+          e2e-k8s.sh
+
+        env:
+        # Options from https://github.com/kubernetes-sigs/kind/blob/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L79-L83
+        - name: CLUSTER_LOG_FORMAT
+          value: json
+        - name: KIND_CLUSTER_LOG_LEVEL
+          # Default is 4, but we want to exercise more log calls and get more output.
+          value: "10"
+        - name: FEATURE_GATES
+          value: '{"ContextualLogging":true}'
+        # don't retry conformance tests
+        - name: GINKGO_TOLERATE_FLAKES
+          value: "n"
+        - name: FOCUS
+          value: \[Conformance\]|\[Driver:.csi-hostpath\]
+        # TODO(bentheelder): reduce the skip list further
+        # NOTE: this skip list is from the standard periodic kind job, just to ensure
+        # we don't accidentally select any of these
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 9Gi
+            cpu: 7
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: 9Gi
+            cpu: 7
+
+  - name: pull-kubernetes-kind-text-logging
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: sig-instrumentation-presubmits
+      testgrid-tab-name: pr-text-logging
+    decorate: true
+    # Not relevant for most PRs.
+    always_run: false
+    # This covers most of the code related to structured, contextual logging.
+    run_if_changed: /staging/src/k8s.io/component-base/logs/
+    # The tests might still be flaky (alpha features!) or this job might get triggered accidentally for
+    # an unrelated PR.
+    optional: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20230406-23cb1879e3-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        # The modified e2e-k8s.sh with support for FEATURE_GATES and RUNTIME_CONFIG comes from
+        # https://github.com/kubernetes-sigs/kind/pull/3023. Once that is in a
+        # kind release, pulling it separately via curl can be removed.
+        - >
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" &&
+          curl -sSL https://github.com/kubernetes-sigs/kind/raw/c8618199912e3949aee0d7a8b966b462e4fb6f0e/hack/ci/e2e-k8s.sh >$(which e2e-k8s.sh) &&
+          chmod u+x $(which e2e-k8s.sh) &&
+          e2e-k8s.sh
+
+        env:
+        # Options from https://github.com/kubernetes-sigs/kind/blob/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L79-L83
+        - name: CLUSTER_LOG_FORMAT
+          value: json
+        - name: KIND_CLUSTER_LOG_LEVEL
+          # Default is 4, but we want to exercise more log calls and get more output.
+          value: "10"
+        - name: FEATURE_GATES
+          value: '{"ContextualLogging":true}'
+        # don't retry conformance tests
+        - name: GINKGO_TOLERATE_FLAKES
+          value: "n"
+        - name: FOCUS
+          value: \[Conformance\]|\[Driver:.csi-hostpath\]
+        # TODO(bentheelder): reduce the skip list further
+        # NOTE: this skip list is from the standard periodic kind job, just to ensure
+        # we don't accidentally select any of these
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 9Gi
+            cpu: 7
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: 9Gi
+            cpu: 7

--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -2,6 +2,7 @@ dashboard_groups:
 - name: sig-instrumentation
   dashboard_names:
   - sig-instrumentation-tests
+  - sig-instrumentation-presubmits
   - sig-instrumentation-image-pushes
   - sig-instrumentation-metrics-server
   - sig-instrumentation-custom-metrics-apiserver
@@ -19,6 +20,7 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gce-serial
       base_options: include-filter-by-regex=sig-instrumentation
       description: instrumentation gce serial e2e tests for master branch
+- name: sig-instrumentation-presubmits
 - name: sig-instrumentation-image-pushes
 - name: sig-instrumentation-metrics-server
 - name: sig-instrumentation-custom-metrics-apiserver


### PR DESCRIPTION
This covers JSON and structured, contextual logging for pull requests.  We only had a periodic job before. The new jobs get triggered by changes in the logging infrastructure or by `/test`.

Testing this before merging was asked for in https://github.com/kubernetes/kubernetes/pull/113994#issuecomment-1468734853.