### PR TITLE
Add entries for s390x conformance for v1.27/1.26/1.25

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -330,19 +330,16 @@ dashboards:
   dashboard_tab:
     - name: Periodic s390x conformance test on local cluster
       test_group_name: s390x-conformance
-      description: Runs conformance tests by using kubetest against latest master version of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.23
-      test_group_name: s390x-conformance-v1.23
-      description: Runs conformance tests by using kubetest against latest v1.23 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.22
-      test_group_name: s390x-conformance-v1.22
-      description: Runs conformance tests by using kubetest against latest v1.22 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.21
-      test_group_name: s390x-conformance-v1.21
-      description: Runs conformance tests by using kubetest against latest v1.21 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.20
-      test_group_name: s390x-conformance-v1.20
-      description: Runs conformance tests by using kubetest against latest v1.20 branch HEAD of kubernetes on local s390x cluster
+      description: Runs conformance tests by using kubetest2 against latest master version of kubernetes on local s390x cluster
+    - name: Periodic s390x conformance test on local cluster , v1.27
+      test_group_name: s390x-conformance-v1.27
+      description: Runs conformance tests by using kubetest2 against latest v1.27 branch HEAD of kubernetes on local s390x cluster
+    - name: Periodic s390x conformance test on local cluster , v1.26
+      test_group_name: s390x-conformance-v1.26
+      description: Runs conformance tests by using kubetest2 against latest v1.26 branch HEAD of kubernetes on local s390x cluster
+    - name: Periodic s390x conformance test on local cluster , v1.25
+      test_group_name: s390x-conformance-v1.25
+      description: Runs conformance tests by using kubetest2 against latest v1.25 branch HEAD of kubernetes on local s390x cluster
 
 # CEL Conformance Tests
 - name: google-cel
@@ -372,14 +369,12 @@ test_groups:
 #IBM s390x test results
 - name: s390x-conformance
   gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x
-- name: s390x-conformance-v1.23
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.23
-- name: s390x-conformance-v1.22
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.22
-- name: s390x-conformance-v1.21
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.21
-- name: s390x-conformance-v1.20
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.20
+- name: s390x-conformance-v1.27
+  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.27
+- name: s390x-conformance-v1.26
+  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.26
+- name: s390x-conformance-v1.25
+  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.25
 
 # google-osconfig
 - name: osconfig-unstable


### PR DESCRIPTION
This PR adds entries for s390x conformance for K8s v1.27/1.26/1.25
Removed entries for older versions.