### PR TITLE
Add prow features and plugins for Gateway API

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -940,6 +940,24 @@ require_matching_label:
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 - missing_label: needs-triage
   org: kubernetes-sigs
+  repo: gateway-api
+  issues: true
+  prs: true
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If Gateway API community members determine this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-priority
+  org: kubernetes-sigs
+  repo: gateway-api
+  issues: true
+  prs: true
+  regexp: ^priority/
+- missing_label: needs-triage
+  org: kubernetes-sigs
   repo: metrics-server
   issues: true
   prs: true

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1631,6 +1631,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/gateway-api:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/ibm-powervs-block-csi-driver:
   - name: cherrypicker
     events:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1393,6 +1393,12 @@ plugins:
     - milestone
     - override
 
+  kubernetes-sigs/gateway-api:
+    plugins:
+    - milestone
+    - milestonestatus
+    - release-note
+
   kubernetes-sigs/image-builder:
     plugins:
     - mergecommitblocker


### PR DESCRIPTION
This adds `needs-triage` and `needs-priority` for [Gateway API](https://github.com/kubernetes-sigs/gateway-api), and also enables a couple of plugins including the `cherrypicker`.

Intends to resolve https://github.com/kubernetes-sigs/gateway-api/issues/1800