### PR TITLE
kubernetes-e2e-gce-cos-alpha-features: add e2e tests containing Feature:WatchList

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -359,7 +359,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=api/all=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-cos-alpha-features
-        - --test_args=--ginkgo.focus=\[Feature:(GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|RetroactiveDefaultStorageClass|RecoverVolumeExpansionFailure|CSINodeExpandSecret)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:(WatchList|GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|RetroactiveDefaultStorageClass|RecoverVolumeExpansionFailure|CSINodeExpandSecret)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
         resources:


### PR DESCRIPTION
This makes `kubernetes-e2e-gce-cos-alpha-features` job cover e2e tests containing Feature:WatchList.

Note that as of today we don't have any tests that would cover the feature.
This PR enables adding new tests for the alpha feature.

The `WatchList` feature was added in https://github.com/kubernetes/kubernetes/pull/115402
More info about the feature in https://github.com/kubernetes/enhancements/issues/3157