### PR TITLE
Add a PR job to test with PodAndContainerStatsFromCRI

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -99,6 +99,52 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-serial-slow-hpa
       testgrid-num-columns-recent: '30'
+  - name: pull-kubernetes-e2e-capz-windows-alpha-features
+    decorate: true
+    always_run: false
+    optional: true
+    path_alias: k8s.io/kubernetes
+    branches:
+      - master
+      - main
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-1-7-latest: "true"
+      preset-capz-windows-common-pull: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: main
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cloud-provider-azure
+        workdir: false
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+          command:
+            - runner.sh
+            - ./scripts/ci-conformance.sh
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+          env:
+            - name: NODE_FEATURE_GATES
+              value: "PodAndContainerStatsFromCRI=true"
+    annotations:
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-capz-windows-alpha-features
+      testgrid-num-columns-recent: '30'
   kubernetes-sigs/windows-testing:
   - name: pull-e2e-capz-windows-2022-extension
     decorate: true


### PR DESCRIPTION
Adding a PR job to run tests with feature gate PodAndContainerStatsFromCRI enabled on Windows.

This will be used to test changes implemented in https://github.com/kubernetes/kubernetes/pull/116968 to get Windows stats only from CRI.

/sig windows

/assign @jsturtevant 
