### PR TITLE
Stop setting WINDOWS_FLAVOR env var in CAPZ Windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -24,8 +24,6 @@ presets:
 - labels:
     preset-capz-windows-2022: "true"
   env:
-  - name: WINDOWS_FLAVOR
-    value: "containerd-2022"
   - name: WINDOWS_SERVER_VERSION
     value: "windows-2022"
 - labels:


### PR DESCRIPTION
`WINDOWS_FLAVOR` was replaced by `WINDOWS_SERVER_VERSION` in CAPZ a long time ago and setting it is causing some problems with pre-submit jobs selecting an incorrect template.

/sig windows
/assign @jsturtevant 