### PR TITLE
nfd: export codecov token as environment variable

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -14,6 +14,12 @@ presubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/verify.sh
+        env:
+        - name: CODECOV_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: nfd-creds
+              key: codecov-token
   - name: pull-node-feature-discovery-verify-docs-master
     run_if_changed: "^docs/"
     branches:


### PR DESCRIPTION
So that https://github.com/kubernetes-sigs/node-feature-discovery/pull/1095 can access the token for the coverage uploading.
`codecov-token` is available via https://github.com/kubernetes/test-infra/pull/29082.