### PR TITLE
Revert "nfd: export codecov token as environment variable"

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -14,12 +14,6 @@ presubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/verify.sh
-        env:
-        - name: CODECOV_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: nfd-creds
-              key: codecov-token
   - name: pull-node-feature-discovery-verify-docs-master
     run_if_changed: "^docs/"
     branches:


### PR DESCRIPTION
Fix the 'secret "nfd-creds" not found' error in prow, getting our CI back to working state.

This reverts commit 7e3a952ddc4e2850bbe3e087757965e1a8f5e118.