### PR TITLE
openshift/hypershift: update dashboard after renamed tests

### DIFF
--- a/config/testgrids/openshift/hypershift.yaml
+++ b/config/testgrids/openshift/hypershift.yaml
@@ -1,174 +1,269 @@
 test_groups:
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-agent-ovn
-  name: 4.13-conformance-agent-ovn
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-aws-ovn
-  name: 4.13-conformance-aws-ovn
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-aws-ovn-proxy
-  name: 4.13-conformance-aws-ovn-proxy
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-mce-aws-ovn
-  name: 4.13-conformance-mce-aws-ovn
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-e2e-aws-ovn-periodic-conformance-serial
-  name: 4.13-e2e-aws-ovn-periodic-conformance-serial
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-e2e-conformance-kubevirt
-  name: 4.13-e2e-conformance-kubevirt
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-e2e-aws-periodic
-  name: 4.13-e2e-aws-periodic
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-e2e-ibmcloud-iks
-  name: 4.13-e2e-ibmcloud-iks
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-e2e-ibmcloud-roks
-  name: 4.13-e2e-ibmcloud-roks
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-e2e-powervs-periodic
-  name: 4.13-e2e-powervs-periodic
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-conformance-agent-ovn
-  name: 4.12-conformance-agent-ovn
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-conformance-aws-ovn
-  name: 4.12-conformance-aws-ovn
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-conformance-aws-ovn-proxy
-  name: 4.12-conformance-aws-ovn-proxy
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-conformance-mce-aws-ovn
-  name: 4.12-conformance-mce-aws-ovn
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-e2e-aws-ovn-periodic-conformance-serial
-  name: 4.12-e2e-aws-ovn-periodic-conformance-serial
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-e2e-conformance-kubevirt
-  name: 4.12-e2e-conformance-kubevirt
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-e2e-aws-periodic
-  name: 4.12-e2e-aws-periodic
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-e2e-ibmcloud-iks
-  name: 4.12-e2e-ibmcloud-iks
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-e2e-ibmcloud-roks
-  name: 4.12-e2e-ibmcloud-roks
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-4.12-e2e-powervs-periodic
-  name: 4.12-e2e-powervs-periodic
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.11-periodics-4.11-aws-conformance
-  name: 4.11-aws-conformance
-  
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-powervs
+  name: 4.14-powervs
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-kubevirt-mce-conformance
+  name: 4.14-kubevirt-mce-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-kubevirt-conformance
+  name: 4.14-kubevirt-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-ibmcloud-roks
+  name: 4.14-ibmcloud-roks
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-ibmcloud-iks
+  name: 4.14-ibmcloud-iks
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-proxy-conformance
+  name: 4.14-aws-ovn-proxy-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-mce-conformance
+  name: 4.14-aws-ovn-mce-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance-serial
+  name: 4.14-aws-ovn-conformance-serial
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance
+  name: 4.14-aws-ovn-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn
+  name: 4.14-aws-ovn
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-agent-ovn-conformance
+  name: 4.14-agent-ovn-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-powervs
+  name: 4.13-powervs
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-kubevirt-mce-conformance
+  name: 4.13-kubevirt-mce-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-kubevirt-conformance
+  name: 4.13-kubevirt-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-ibmcloud-roks
+  name: 4.13-ibmcloud-roks
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-ibmcloud-iks
+  name: 4.13-ibmcloud-iks
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn-proxy-conformance
+  name: 4.13-aws-ovn-proxy-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn-mce-conformance
+  name: 4.13-aws-ovn-mce-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn-conformance-serial
+  name: 4.13-aws-ovn-conformance-serial
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn-conformance
+  name: 4.13-aws-ovn-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn
+  name: 4.13-aws-ovn
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-agent-ovn-conformance
+  name: 4.13-agent-ovn-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-powervs
+  name: 4.12-powervs
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-kubevirt-mce-conformance
+  name: 4.12-kubevirt-mce-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-kubevirt-conformance
+  name: 4.12-kubevirt-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-ibmcloud-roks
+  name: 4.12-ibmcloud-roks
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-ibmcloud-iks
+  name: 4.12-ibmcloud-iks
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-aws-ovn-proxy-conformance
+  name: 4.12-aws-ovn-proxy-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-aws-ovn-mce-conformance
+  name: 4.12-aws-ovn-mce-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-aws-ovn-conformance-serial
+  name: 4.12-aws-ovn-conformance-serial
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-aws-ovn-conformance
+  name: 4.12-aws-ovn-conformance
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-aws-ovn
+  name: 4.12-aws-ovn
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.12-periodics-e2e-agent-ovn-conformance
+  name: 4.12-agent-ovn-conformance
 
 dashboards:
 - name: redhat-hypershift
   dashboard_tab:
-  - name: 4.13-conformance-agent-ovn
+  - name: 4.14-powervs
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-conformance-agent-ovn
-  - name: 4.13-conformance-aws-ovn
+    test_group_name: 4.14-powervs
+  - name: 4.14-kubevirt-mce-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-conformance-aws-ovn
-  - name: 4.13-conformance-aws-ovn-proxy
+    test_group_name: 4.14-kubevirt-mce-conformance
+  - name: 4.14-kubevirt-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-conformance-aws-ovn-proxy
-  - name: 4.13-conformance-mce-aws-ovn
+    test_group_name: 4.14-kubevirt-conformance
+  - name: 4.14-ibmcloud-roks
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-conformance-mce-aws-ovn
-  - name: 4.13-e2e-aws-ovn-periodic-conformance-serial
+    test_group_name: 4.14-ibmcloud-roks
+  - name: 4.14-ibmcloud-iks
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-e2e-aws-ovn-periodic-conformance-serial
-  - name: 4.13-e2e-aws-periodic
+    test_group_name: 4.14-ibmcloud-iks
+  - name: 4.14-aws-ovn-proxy-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-e2e-aws-periodic
-  - name: 4.13-e2e-conformance-kubevirt
+    test_group_name: 4.14-aws-ovn-proxy-conformance
+  - name: 4.14-aws-ovn-mce-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-e2e-conformance-kubevirt
-  - name: 4.13-e2e-ibmcloud-iks
+    test_group_name: 4.14-aws-ovn-mce-conformance
+  - name: 4.14-aws-ovn-conformance-serial
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-e2e-ibmcloud-iks
-  - name: 4.13-e2e-ibmcloud-roks
+    test_group_name: 4.14-aws-ovn-conformance-serial
+  - name: 4.14-aws-ovn-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-e2e-ibmcloud-roks
-  - name: 4.13-e2e-powervs-periodic
+    test_group_name: 4.14-aws-ovn-conformance
+  - name: 4.14-aws-ovn
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.13-e2e-powervs-periodic
-  - name: 4.12-conformance-agent-ovn
+    test_group_name: 4.14-aws-ovn
+  - name: 4.14-agent-ovn-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-conformance-agent-ovn
-  - name: 4.12-conformance-aws-ovn
+    test_group_name: 4.14-agent-ovn-conformance
+  - name: 4.13-powervs
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-conformance-aws-ovn
-  - name: 4.12-conformance-aws-ovn-proxy
+    test_group_name: 4.13-powervs
+  - name: 4.13-kubevirt-mce-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-conformance-aws-ovn-proxy
-  - name: 4.12-conformance-mce-aws-ovn
+    test_group_name: 4.13-kubevirt-mce-conformance
+  - name: 4.13-kubevirt-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-conformance-mce-aws-ovn
-  - name: 4.12-e2e-aws-ovn-periodic-conformance-serial
+    test_group_name: 4.13-kubevirt-conformance
+  - name: 4.13-ibmcloud-roks
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-e2e-aws-ovn-periodic-conformance-serial
-  - name: 4.12-e2e-aws-periodic
+    test_group_name: 4.13-ibmcloud-roks
+  - name: 4.13-ibmcloud-iks
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-e2e-aws-periodic
-  - name: 4.12-e2e-conformance-kubevirt
+    test_group_name: 4.13-ibmcloud-iks
+  - name: 4.13-aws-ovn-proxy-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-e2e-conformance-kubevirt
-  - name: 4.12-e2e-ibmcloud-iks
+    test_group_name: 4.13-aws-ovn-proxy-conformance
+  - name: 4.13-aws-ovn-mce-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-e2e-ibmcloud-iks
-  - name: 4.12-e2e-ibmcloud-roks
+    test_group_name: 4.13-aws-ovn-mce-conformance
+  - name: 4.13-aws-ovn-conformance-serial
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-e2e-ibmcloud-roks
-  - name: 4.12-e2e-powervs-periodic
+    test_group_name: 4.13-aws-ovn-conformance-serial
+  - name: 4.13-aws-ovn-conformance
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.12-e2e-powervs-periodic
-  - name: 4.11-aws-conformance
+    test_group_name: 4.13-aws-ovn-conformance
+  - name: 4.13-aws-ovn
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.11-aws-conformance
+    test_group_name: 4.13-aws-ovn
+  - name: 4.13-agent-ovn-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.13-agent-ovn-conformance
+  - name: 4.12-powervs
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-powervs
+  - name: 4.12-kubevirt-mce-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-kubevirt-mce-conformance
+  - name: 4.12-kubevirt-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-kubevirt-conformance
+  - name: 4.12-ibmcloud-roks
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-ibmcloud-roks
+  - name: 4.12-ibmcloud-iks
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-ibmcloud-iks
+  - name: 4.12-aws-ovn-proxy-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-aws-ovn-proxy-conformance
+  - name: 4.12-aws-ovn-mce-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-aws-ovn-mce-conformance
+  - name: 4.12-aws-ovn-conformance-serial
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-aws-ovn-conformance-serial
+  - name: 4.12-aws-ovn-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-aws-ovn-conformance
+  - name: 4.12-aws-ovn
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-aws-ovn
+  - name: 4.12-agent-ovn-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.12-agent-ovn-conformance


### PR DESCRIPTION
After https://github.com/openshift/release/pull/37630, need to update the dashboard with the new job names