### PR TITLE
chore: add release-1.27 presubmit test for cloud provider azure

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -51,7 +51,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.27
             command:
               - runner.sh
               - ./scripts/ci-entrypoint.sh


### PR DESCRIPTION
This PR adds cloud provider azure presubmit jobs to reference `1.27` and drops unsupported version of `1.23`