### PR TITLE
create provider-azure-1.27-signal

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/README.md
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/README.md
@@ -5,5 +5,5 @@ Job configurations for https://testgrid.k8s.io/provider-azure.
 To generate the job configurations for 1.23, 1.24, 1.25, 1.26, and master branch:
 
 ```bash
-./generate.sh 1.23 1.24 1.25 1.26 master
+./generate.sh 1.24 1.25 1.26 1.27 master
 ```

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
@@ -8,7 +8,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.23
+      - release-1.27
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -53,7 +53,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.23
+      - release-1.27
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -100,7 +100,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.23
+      - release-1.27
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -109,7 +109,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.7
+        base_ref: release-1.8
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -146,7 +146,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.23
+      - release-1.27
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -155,7 +155,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.7
+        base_ref: release-1.8
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -194,7 +194,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.23
+      - release-1.27
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -232,7 +232,7 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.23
+      - release-1.27
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -266,7 +266,7 @@ presubmits:
 
 periodics:
 - interval: 3h
-  name: capz-conformance-1-23
+  name: capz-conformance-1-27
   decorate: true
   decoration_config:
     timeout: 3h
@@ -283,7 +283,7 @@ periodics:
     workdir: true
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -296,7 +296,7 @@ periodics:
       - name: E2E_ARGS
         value: "-kubetest.use-ci-artifacts"
       - name: KUBERNETES_VERSION
-        value: "latest-1.23"
+        value: "latest-1.27"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
       securityContext:
@@ -306,13 +306,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.23-signal
+    testgrid-dashboards: provider-azure-1.27-signal
     testgrid-tab-name: capz-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-1-23
+  name: capz-azure-file-1-27
   decorate: true
   decoration_config:
     timeout: 3h
@@ -324,7 +324,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: azurefile-csi-driver
@@ -332,11 +332,11 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -354,7 +354,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.23"
+        value: "latest-1.27"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
@@ -364,13 +364,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.23-signal
+    testgrid-dashboards: provider-azure-1.27-signal
     testgrid-tab-name: capz-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-vmss-1-23
+  name: capz-azure-file-vmss-1-27
   decorate: true
   decoration_config:
     timeout: 3h
@@ -382,7 +382,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.7
+    base_ref: release-1.8
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: azurefile-csi-driver
@@ -390,11 +390,11 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -412,7 +412,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.23"
+        value: "latest-1.27"
       - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
@@ -424,13 +424,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.23-signal
+    testgrid-dashboards: provider-azure-1.27-signal
     testgrid-tab-name: capz-azure-file-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-1-23
+  name: capz-azure-disk-1-27
   decorate: true
   decoration_config:
     timeout: 3h
@@ -450,11 +450,11 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -471,7 +471,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.23"
+        value: "latest-1.27"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
@@ -481,13 +481,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.23-signal
+    testgrid-dashboards: provider-azure-1.27-signal
     testgrid-tab-name: capz-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-vmss-1-23
+  name: capz-azure-disk-vmss-1-27
   decorate: true
   decoration_config:
     timeout: 3h
@@ -507,11 +507,11 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.23
+    base_ref: release-1.27
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -528,7 +528,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.23"
+        value: "latest-1.27"
       - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
@@ -540,7 +540,7 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.23-signal
+    testgrid-dashboards: provider-azure-1.27-signal
     testgrid-tab-name: capz-azure-disk-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -11,10 +11,10 @@ dashboard_groups:
       - provider-azure-cloud-provider-azure-1-26-presubmit
       - provider-azure-presubmit
       - provider-azure-master-signal
+      - provider-azure-1.27-signal
       - provider-azure-1.26-signal
       - provider-azure-1.25-signal
       - provider-azure-1.24-signal
-      - provider-azure-1.23-signal
 
 dashboards:
   - name: provider-azure-azuredisk-csi-driver
@@ -27,7 +27,7 @@ dashboards:
   - name: provider-azure-cloud-provider-azure-1-26-presubmit
   - name: provider-azure-presubmit
   - name: provider-azure-master-signal
+  - name: provider-azure-1.27-signal
   - name: provider-azure-1.26-signal
   - name: provider-azure-1.25-signal
   - name: provider-azure-1.24-signal
-  - name: provider-azure-1.23-signal


### PR DESCRIPTION
This PR
- updates dashboard group of Provider-Azure at `https://testgrid.k8s.io/provider-azure`
- adds release-1.27.yaml at _`test-infra/config/jobs/kubernetes/sig-cloud-provider/azure/`_

Note: running `./generate 1.27` resulted the `release-1.27.yaml`. There was no manual editing of commands done. Notice the interesting diff https://github.com/kubernetes/test-infra/pull/29301/files#diff-1c42aead100c01be0e7f77ab94518e0ea7ce31f61b29fe8791fc1edd3a61115fL37.