### PR TITLE
Add sample gcs_browser_prefix config for starter-s3

### DIFF
--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -66,6 +66,7 @@ data:
 
     deck:
      spyglass:
+       gcs_browser_prefix: 'https://s3.console.aws.amazon.com/s3/buckets/'
        lenses:
        - lens:
            name: metadata


### PR DESCRIPTION
This should help AWS users get up and running with the AWS S3 artifacts browser.