### PR TITLE
Add k8s-conform-s390x-k8s bucket to additional allowed buckets list

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -181,6 +181,7 @@ deck:
     - k8s-ovn
     - containerd-integration
     - ppc64le-kubernetes
+    - k8s-conform-s390x-k8s
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
The entries are updated regularly in testgrid for s390x conformance jobs however 'job history' throws below error:
```
failed to get job history: could not instantiate storage bucket: bucket not in allowed list; you may allow it by including it in `deck.additional_allowed_buckets`: bucket "k8s-conform-s390x-k8s" not in allowed list ([containerd-integration k8s-ovn kubernetes-jenkins ppc64le-kubernetes])
```
ref: https://testgrid.k8s.io/conformance-s390x#Periodic%20s390x%20conformance%20test%20on%20local%20cluster

