### PR TITLE
Reverting sig-windows 1.24 jobs to use capz release-1.7

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -74,7 +74,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.8
+      base_ref: release-1.7
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -72,7 +72,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.7
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs


### PR DESCRIPTION
The Windows e2e tests started failing when we moved them to capz release 1.8 so we'll switch it back to 1.7 until we can root cause the issue.

The issue looks related to building the linux ccm / cnm images (which is new behavior in release-1.8 of capz)
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-1-24/1646909760076779520/build-log.txt

```log
Build Linux Azure amd64 cloud controller manager
make: Entering directory '/home/prow/go/src/sigs.k8s.io/cloud-provider-azure'
make ARCH=amd64 build-ccm-image
make[1]: Entering directory '/home/prow/go/src/sigs.k8s.io/cloud-provider-azure'
docker buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
ERROR: no builder "img-builder" found
img-builder
```
https://testgrid.k8s.io/sig-windows-signal#capz-windows-containerd-1.24

/sig windows
/assign @jsturtevant @CecileRobertMichon 