### PR TITLE
Azure: install CSI drivers for k8s 1.23+

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -40,8 +40,8 @@ EOF
 # we need to define the full image URL so it can be autobumped
 tmp="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master"
 kubekins_e2e_image="${tmp/\-master/}"
-installCSIdrivers=""
-installCSIAzureFileDrivers=""
+installCSIdrivers=" ./deploy/install-driver.sh master local,snapshot,enable-avset &&"
+installCSIAzureFileDrivers=" ./deploy/install-driver.sh master local &&"
 
 for release in "$@"; do
   output="${dir}/release-${release}.yaml"
@@ -59,11 +59,6 @@ for release in "$@"; do
     kubernetes_version+="-${release}"
     ccm_branch="release-${release}"
     capz_periodic_branch_name=${capz_release}
-  fi
-
-  if [[ "${release}" == "master" || "${release}" == "1.23" ]]; then
-    installCSIdrivers=" ./deploy/install-driver.sh master local,snapshot,enable-avset &&"
-    installCSIAzureFileDrivers=" ./deploy/install-driver.sh master local &&"
   fi
 
   cat >"${output}" <<EOF


### PR DESCRIPTION
Fixes the generate script to reflect the changes already in the generated files so that it doesn't generate a diff. CSI drivers should be installed for every version 1.23 and above (and are required for 1.24+).

/assign @andyzhangx @nawazkh 