### PR TITLE
sig-instrumentation: fix pre-submit jobs for logging

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -18,6 +18,7 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20230406-23cb1879e3-master
@@ -86,6 +87,7 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20230406-23cb1879e3-master


### PR DESCRIPTION
e2e-k8s.sh needs the source code in $GOPATH/src/k8s.io/kubernetes.