### PR TITLE
fix loopclosure issues in tests

### DIFF
--- a/prow/plugins/trick-or-treat/trick-or-treat_test.go
+++ b/prow/plugins/trick-or-treat/trick-or-treat_test.go
@@ -45,6 +45,8 @@ func TestImages(t *testing.T) {
 		t.Run(imgURL, func(t *testing.T) {
 			t.Parallel()
 			for i := 0; i < 3; i++ {
+				// copy to scoped variable, get rid of loopclosure linting error
+				imgURL := imgURL
 				toobig, err := github.ImageTooBig(imgURL)
 				if err != nil {
 					t.Errorf("Failed reading image: %v", err)

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -1980,6 +1980,8 @@ func TestUpdateSize(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		// copy to scoped variable, get rid of loopclosure linting error
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client, err := GetConfigMapClient(fake.NewSimpleClientset().CoreV1(), ns, nil, kube.DefaultClusterAlias)

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -890,6 +890,8 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 	}
 
 	for _, test := range tests {
+		// copy to scoped variable, get rid of loopclosure linting error
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Running scenario %q", test.name)


### PR DESCRIPTION
`make go-lint` fails on clean master right now for incoming PRs. Fix the loopclosure issues per https://github.com/golang/go/wiki/CommonMistakes guidance.