### PR TITLE
WIP: allow saving loading inrepoconfigcache from disk

### DIFF
--- a/prow/cache/cache.go
+++ b/prow/cache/cache.go
@@ -44,7 +44,7 @@ import (
 
 // LRUCache is the actual concurrent non-blocking cache.
 type LRUCache struct {
-	*sync.Mutex
+	*sync.RWMutex
 	*simplelru.LRU
 	callbacks Callbacks
 }
@@ -128,7 +128,7 @@ func NewLRUCache(size int,
 	}
 
 	return &LRUCache{
-		&sync.Mutex{},
+		&sync.RWMutex{},
 		cache,
 		callbacks,
 	}, nil
@@ -306,7 +306,7 @@ func (lruCache *LRUCache) AddResolvedEntry(
 func (lruCache *LRUCache) GetSuccessfullyResolvedEntries() map[interface{}]interface{} {
 	resolved := make(map[interface{}]interface{})
 
-	lruCache.Lock()
+	lruCache.RLock()
 	for _, k := range lruCache.Keys() {
 		promise, _ := lruCache.Get(k)
 
@@ -329,7 +329,7 @@ func (lruCache *LRUCache) GetSuccessfullyResolvedEntries() map[interface{}]inter
 
 		resolved[k] = p.val
 	}
-	lruCache.Unlock()
+	lruCache.RUnlock()
 
 	return resolved
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/kubernetes/test-infra/pull/28200.

The main things missing from that PR are (1) tests, and (2) type handling. This PR addresses the type handling part so that we know to marshal/unmarshal from proper types (and not just use the empty interface type directly). It also adds some unit tests to check that we can save the cache to disk and load it back (save/load roundtrip).