### PR TITLE
prow/clone: Retry git fetch for longer

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -201,6 +201,10 @@ var (
 		400 * time.Millisecond,
 		800 * time.Millisecond,
 		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		15 * time.Second,
+		30 * time.Second,
 	}
 )
 


### PR DESCRIPTION
A temporary DNS or network issue could take more than a few seconds to resolve; continue trying to git fetch for at least a minute before giving up.