### PR TITLE
Add pull-aws-ebs-csi-driver-test-e2e-external-eks-windows presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -1,5 +1,30 @@
 presubmits:
   kubernetes-sigs/aws-ebs-csi-driver:
+  - name: pull-aws-ebs-csi-driver-test-e2e-external-eks-windows
+    always_run: true
+    optional: true
+    decorate: true
+    skip_branches:
+    - gh-pages
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-external-eks-windows
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver
+      testgrid-tab-name: test-e2e-external-eks-windows
+      description: aws ebs csi driver External Storage tests for Windows on pull request
+      testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-test-helm-chart
     always_run: true
     decorate: true


### PR DESCRIPTION
A new Makefile target was introduced in the aws-ebs-csi-driver project to test the driver on Windows. This PR updates the aws-ebs-csi-driver-presubmits.yaml config to run the new target on pull requests.

For more context see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1521.