### PR TITLE
Remove inline SSH credentials for job pull-npd-e2e-node

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -197,9 +197,7 @@ presubmits:
         args:
         - bash
         - -c
-        - >-
-          ./test/build.sh install-lib &&
-          SSH_USER=${USER} SSH_KEY=${JENKINS_GCE_SSH_PRIVATE_KEY_FILE} make e2e-test
+        - ./test/build.sh install-lib && make e2e-test
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Credentials are already present via `preset-k8s-ssh`, no need for the inline vars. This is also how the other jobs are configured.