### PR TITLE
kOps: Make kuberouter presubmit optional

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1123,6 +1123,7 @@ def generate_presubmits_network_plugins():
             optional = True
         if plugin == 'kuberouter':
             networking_arg = 'kube-router'
+            optional = True
         if plugin == 'weave':
             distro = 'u2204'
             k8s_version = '1.22'

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -658,7 +658,7 @@ presubmits:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.kuberouter\/|pkg\/model\/components\/containerd\.go)'
     always_run: false
-    optional: false
+    optional: true
     skip_report: false
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
I think this is a better option than reverting to 1.26 for testing.

Ref: https://github.com/kubernetes/kops/pull/15319 https://github.com/kubernetes/kops/pull/15322

/cc @olemarkus @rifelpet 