### PR TITLE
registry.k8s.io presubmit: don't call defunct install-shellcheck script

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml
@@ -37,9 +37,8 @@ presubmits:
       containers:
       - image: golang
         command:
-        - bash
-        - -c
-        - hack/tools/ci-install-shellcheck.sh && make shellcheck
+        - make
+        - shellcheck
         resources:
           limits:
             cpu: 2


### PR DESCRIPTION
cleanup after https://github.com/kubernetes/registry.k8s.io/pull/230

we auto manage shellcheck under make now