### PR TITLE
add iproute2 to KRTE

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -59,6 +59,7 @@ RUN echo "Installing Packages ..." \
             file \
             git \
             gnupg2 \
+            iproute2 \
             kmod \
             lsb-release \
             mercurial \


### PR DESCRIPTION
We use ip addr or ipinfo when doing dockerized build for rsync

see: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kind/3157/pull-kind-e2e-kubernetes-1-27/1649154486473592832

> build/../build/common.sh: line 604: ifconfig: command not found

Apparently the build can continue on, but we should have all the right tools installed.

I patched this for kubekins-e2e a while back thinking we'd already done this for KRTE. Seems not ...