### PR TITLE
`tide`: select merge method by org-repo-branch triple

### DIFF
--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -555,7 +555,7 @@ func (m *mergeChecker) isAllowedToMerge(crc *CodeReviewCommon) (string, error) {
 // overridden by GitHub labels.
 func (mc *mergeChecker) prMergeMethod(c config.Tide, crc *CodeReviewCommon) *types.PullRequestMergeType {
 	repo := config.OrgRepo{Org: crc.Org, Repo: crc.Repo}
-	method := c.MergeMethod(repo)
+	method := c.OrgRepoBranchMergeMethod(repo, crc.BaseRefName)
 	squashLabel := c.SquashLabel
 	rebaseLabel := c.RebaseLabel
 	mergeLabel := c.MergeLabel


### PR DESCRIPTION
This is a follow up #27962.
Despite being a really small and (apparently) simple change it really modifies the way `tide` merges PRs when a user leverage the new configuration format.