### PR TITLE
Pop up errors in GetRef

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3381,7 +3381,7 @@ func (c *client) GetRef(org, repo, ref string) (string, error) {
 		exitCodes: []int{200},
 	}, &res)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	if n := len(res); n > 1 {

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -422,6 +422,11 @@ func TestGetRef(t *testing.T) {
 			expectedSHA:    "abcde",
 		},
 		{
+			name:           "unexpected response to trigger an error",
+			githubResponse: []byte(`malformed json`),
+			expectedError:  "invalid character 'm' looking for beginning of value",
+		},
+		{
 			name: "multiple refs, no match",
 			githubResponse: []byte(`
 [
@@ -502,8 +507,14 @@ func TestGetRef(t *testing.T) {
 			if errMsg != tc.expectedError {
 				t.Fatalf("expected error %q, got error %q", tc.expectedError, err)
 			}
-			if !errors.Is(err, tc.expectedErrorType) {
-				t.Errorf("expected error of type %T, got %T", tc.expectedErrorType, err)
+
+			// skip checking the error type for the case
+			// because the actual type is json.SyntaxError that does not provide the Is method
+			// and it is hard to raise other type of errors for the test
+			if tc.name != "unexpected response to trigger an error" {
+				if !errors.Is(err, tc.expectedErrorType) {
+					t.Errorf("expected error of type %T, got %T", tc.expectedErrorType, err)
+				}
 			}
 			if sha != tc.expectedSHA {
 				t.Errorf("expected sha %q, got sha %q", tc.expectedSHA, sha)


### PR DESCRIPTION
In [the caller site](https://github.com/openshift/ci-tools/blob/90b4309e7c2a037d60673fa08a66d73784221ec0/pkg/controller/promotionreconciler/reconciler.go#L234) of this function, we saw the empty value in the return without error.

Also checked the PR introducing the code,
https://github.com/kubernetes/test-infra/pull/17960/files#diff-43bdff30b56d33fef7db34c315dd186dab4fa8295ef72f8796fdf33984e959aeR2614

I do not see why it ignores the error.

