### PR TITLE
:sparkles: Kubebuilder: Update go version to use 1.20 instead of 1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         command:
         - ./test.sh
         resources:


### PR DESCRIPTION
## Description

:sparkles: Update go version to use 1.20 instead of 1.19