### PR TITLE
SIG instrumentation: reduce log verbosity

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -48,7 +48,7 @@ periodics:
         value: json
       - name: KIND_CLUSTER_LOG_LEVEL
         # Default is 4, but we want to exercise more log calls and get more output.
-        value: "10"
+        value: "6"
       - name: FEATURE_GATES
         value: '{"DynamicResourceAllocation":true,"ContextualLogging":true}'
       - name: RUNTIME_CONFIG

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -41,7 +41,7 @@ presubmits:
           value: json
         - name: KIND_CLUSTER_LOG_LEVEL
           # Default is 4, but we want to exercise more log calls and get more output.
-          value: "10"
+          value: "6"
         - name: FEATURE_GATES
           value: '{"ContextualLogging":true}'
         # don't retry conformance tests
@@ -110,7 +110,7 @@ presubmits:
           value: text
         - name: KIND_CLUSTER_LOG_LEVEL
           # Default is 4, but we want to exercise more log calls and get more output.
-          value: "10"
+          value: "6"
         - name: FEATURE_GATES
           value: '{"ContextualLogging":true}'
         # don't retry conformance tests


### PR DESCRIPTION
The cluster log dumps from kind only contain the tail of e.g. kube-controller-manager. The start with output from less frequently used controllers is missing.

Reducing the overall verbosity might help.