### PR TITLE
remove SecurityContextDeny

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -173,7 +173,7 @@ periodics:
       - --env=KUBE_AUTOSCALER_MIN_NODES=3
       - --env=KUBE_AUTOSCALER_MAX_NODES=6
       - --env=KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
-      - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
+      - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
@@ -235,7 +235,7 @@ periodics:
       - --env=KUBE_AUTOSCALER_MIN_NODES=1
       - --env=KUBE_AUTOSCALER_MAX_NODES=6
       - --env=KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
-      - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
+      - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
         - --env=KUBE_AUTOSCALER_MIN_NODES=3
         - --env=KUBE_AUTOSCALER_MAX_NODES=6
         - --env=KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
-        - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
+        - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
         - --env=ENABLE_POD_PRIORITY=true
         - --extract=local
         - --gcp-node-image=gci


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

This PR delete all SecurityContextDeny admission plugin related functions and tests because it's going to be removed. See https://github.com/kubernetes/kubernetes/issues/111516.
https://github.com/kubernetes/kubernetes/pull/117548

Which issue(s) this PR fixes:

This is step two of https://github.com/kubernetes/kubernetes/issues/111516.

Does this PR introduce a user-facing change?

The SecurityContextDeny admission plugin is going deprecated and will be removed in future versions.
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: https://github.com/kubernetes/enhancements/issues/3785
- [Other doc]: https://k8s.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny
- [Issue]: https://github.com/kubernetes/kubernetes/issues/111516