### PR TITLE
nfd: add temporary verify job

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -42,3 +42,23 @@ presubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/build.sh
+  - name: node-feature-discovery-temporary
+    branches:
+    - ^master
+    decorate: true
+    always_run: false
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: verify-temporary
+      description: "Verify source code of node-feature-discovery: check formatting, lint etc."
+    spec:
+      containers:
+      - image: golang:1.20
+        command:
+        - scripts/test-infra/verify.sh
+        env:
+        - name: CODECOV_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: nfd-creds
+              key: codecov-token


### PR DESCRIPTION
This is a temporary prowJob to verify that external NFD credentials are available in the Prow cluster and accessible.