### PR TITLE
Fixed get pods bug in prow-controller-manager

### DIFF
--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -1110,6 +1110,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - delete
       - list
       - watch


### PR DESCRIPTION
During attempts to run Prow on local Minikube cluster with the help of starter-s3-kind.yaml stuck with an error in prow-controller-manager, which fails on getting list of pods:
```
{"component":"prow-controller-manager","error":"failed pod resource authorization check: unable to \"get\" pods","file":"k8s.io/test-infra/prow/cmd/prow-controller-manager/main.go:189","func":"main.main","level":"error","msg":"Failed to construct build cluster managers. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.","severity":"error","time":"2023-04-26T10:56:37Z"}
```
This error causes next error:
```
{"component":"prow-controller-manager","controller":"plank","error":"nonretryable error: no build client found for cluster \"default\"","file":"k8s.io/test-infra/prow/plank/reconciler.go:279","func":"k8s.io/test-infra/prow/plank.(*reconciler).defaultReconcile","job":"echo-test","level":"error","msg":"Reconciliation failed with terminal error and will not be requeued","name":"0120350c-e421-11ed-a0ae-ba580ce759ea","severity":"error","state":"triggered","time":"2023-04-26T10:56:38Z","type":"periodic"}
```
Full log:
```
{"component":"prow-controller-manager","file":"k8s.io/test-infra/prow/kube/config.go:76","func":"k8s.io/test-infra/prow/kube.LoadClusterConfigs","level":"info","msg":"Loading cluster contexts...","severity":"info","time":"2023-04-26T10:59:21Z"}
{"component":"prow-controller-manager","error":"failed pod resource authorization check: unable to \"get\" pods","file":"k8s.io/test-infra/prow/cmd/prow-controller-manager/main.go:189","func":"main.main","level":"error","msg":"Failed to construct build cluster managers. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.","severity":"error","time":"2023-04-26T10:59:21Z"}
I0426 10:59:21.617685       1 leaderelection.go:248] attempting to acquire leader lease prow/prow-controller-manager-leader-lock...
I0426 10:59:39.171495       1 leaderelection.go:258] successfully acquired lease prow/prow-controller-manager-leader-lock
{"level":"info","ts":1682506779.182239,"msg":"Starting EventSource","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","source":"kind source: *v1.ProwJob"}
{"level":"info","ts":1682506779.1861322,"msg":"Starting Controller","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob"}
{"level":"info","ts":1682506779.1891189,"msg":"Starting workers","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","worker count":10}
{"component":"prow-controller-manager","controller":"plank","error":"nonretryable error: no build client found for cluster \"default\"","file":"k8s.io/test-infra/prow/plank/reconciler.go:279","func":"k8s.io/test-infra/prow/plank.(*reconciler).defaultReconcile","job":"echo-test","level":"error","msg":"Reconciliation failed with terminal error and will not be requeued","name":"6c6a85f7-e421-11ed-a0ae-ba580ce759ea","severity":"error","state":"triggered","time":"2023-04-26T10:59:39Z","type":"periodic"}
```
So, after adding "get" verb to prow-controller-manager Role in test-pods namespace this problem is gone:
```
{"component":"prow-controller-manager","file":"k8s.io/test-infra/prow/kube/config.go:76","func":"k8s.io/test-infra/prow/kube.LoadClusterConfigs","level":"info","msg":"Loading cluster contexts...","severity":"info","time":"2023-04-26T11:00:43Z"}
I0426 11:00:43.940921       1 leaderelection.go:248] attempting to acquire leader lease prow/prow-controller-manager-leader-lock...
I0426 11:01:02.160272       1 leaderelection.go:258] successfully acquired lease prow/prow-controller-manager-leader-lock
{"level":"info","ts":1682506862.1761672,"msg":"Starting EventSource","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","source":"kind source: *v1.ProwJob"}
{"level":"info","ts":1682506862.1858206,"msg":"Starting EventSource","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","source":"&{{%!s(*v1.Pod=&{{ } {      0 {{0 0 <nil>}} <nil> <nil> map[] map[] [] []  []} {[] [] [] []  <nil> <nil>  map[]   <nil>  false false false <nil> <nil> []   <nil>  [] []  <nil> <nil> [] <nil> <nil> <nil> map[] [] <nil> <nil>} { []      [] <nil> [] []  []}}) %!s(*cache.informerCache=&{0xc00014ef60}) %!s(chan error=<nil>) %!s(func()=<nil>)}}"}
{"level":"info","ts":1682506862.1861424,"msg":"Starting EventSource","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","source":"&{{%!s(*v1.Pod=&{{ } {      0 {{0 0 <nil>}} <nil> <nil> map[] map[] [] []  []} {[] [] [] []  <nil> <nil>  map[]   <nil>  false false false <nil> <nil> []   <nil>  [] []  <nil> <nil> [] <nil> <nil> <nil> map[] [] <nil> <nil>} { []      [] <nil> [] []  []}}) %!s(*cache.informerCache=&{0xc0003973a0}) %!s(chan error=<nil>) %!s(func()=<nil>)}}"}
{"level":"info","ts":1682506862.186264,"msg":"Starting Controller","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob"}
{"level":"info","ts":1682506862.288442,"msg":"Starting workers","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","worker count":10}
{"component":"prow-controller-manager","controller":"plank","file":"k8s.io/test-infra/prow/plank/reconciler.go:619","from":"triggered","func":"k8s.io/test-infra/prow/plank.(*reconciler).syncTriggeredJob","job":"echo-test","level":"info","msg":"Transitioning states.","name":"6c6a85f7-e421-11ed-a0ae-ba580ce759ea","severity":"info","state":"pending","time":"2023-04-26T11:01:02Z","to":"pending","type":"periodic"}
```
/sig testing
/area prow
/size XS