### PR TITLE
use standard image pushing job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-gce.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-gce.yaml
@@ -1,0 +1,27 @@
+postsubmits:
+
+  kubernetes/ingress-gce:
+    - name: post-ingress-gce-push-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-gce-e2e, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^master$
+        - ^v[0-9].*
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20230111-cd1b3caf9c
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-ingress-image-push
+              - --scratch-bucket=gs://k8s-ingress-image-push-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
+              - --build-dir=.
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -149,39 +149,6 @@ presubmits:
         - runner.sh
         - hack/run-e2e-gce.sh
 
-postsubmits:
-  kubernetes/ingress-gce:
-  - name: ci-ingress-gce-image-push
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-        args:
-        - --repo=k8s.io/ingress-gce=$(PULL_REFS)
-        - --root=/go/src/
-        - --timeout=320
-        - --scenario=execute
-        - --
-        - --env=VERSION=$(PULL_BASE_REF)
-        - hack/push-multiarch.sh
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        env:
-        - name: ALL_ARCH
-          value: "amd64 arm64"
-        - name: BINARIES
-          value: "e2e-test"
-        - name: REGISTRY
-          value: "gcr.io/k8s-ingress-image-push"
-    annotations:
-      testgrid-dashboards: sig-network-ingress-gce-e2e
-      testgrid-tab-name: ingress-gce-image-push
-      testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
-
 periodics:
 - name: ci-ingress-gce-e2e
   interval: 6h


### PR DESCRIPTION
remove the old postubmit job that is not working and use the standardized job to push images using cloudbuild

https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#image-pushing-jobs