### PR TITLE
Filter out kubectl repo for closing issues

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -152,6 +152,7 @@ periodics:
         org:kubernetes-csi
         is:issue
         -repo:kubernetes-sigs/kind
+        -repo:kubernetes/kubectl
         -label:lifecycle/frozen
         -label:"help wanted"
         -label:"good first issue"


### PR DESCRIPTION
After talking with @BenTheElder about https://github.com/kubernetes/kubectl/issues/1420 I think we should try not auto closing issues in the kubectl repo.

This PR filters out kubectl from the job that auto closes issues.

/assign @BenTheElder