### PR TITLE
Add periodic-cluster-api-provider-aws-e2e-eks-canary job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -40,6 +40,52 @@ periodics:
     testgrid-tab-name: periodic-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-aws-e2e-eks-canary
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  # Changed from 12 hours to reduce time spent waiting for job to run
+  # TODO(xmudrii): rollback to 12 hours
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: main
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.25
+      command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      env:
+      - name: BOSKOS_HOST
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: AWS_REGION
+        value: "us-west-2"
+      # Parallelize tests
+      - name: GINKGO_ARGS
+        value: "-nodes 20 -skip='\\[ClusterClass\\]'"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: "9Gi"
+        requests:
+          cpu: 2
+          memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: periodic-aws-e2e-main-canary
+    testgrid-num-columns-recent: "6"
 - name: periodic-cluster-api-provider-aws-eks-e2e
   decorate: true
   decoration_config:


### PR DESCRIPTION
This PR adds `periodic-cluster-api-provider-aws-e2e-eks-canary` on EKS build cluster to make sure that boskos is working correctly. There are two differences compared to the original job:

- interval is 1 hour instead of 12 hours to avoid waiting so long for the first run
- testgrid annotations are changed so that we don't ping cluster lifecycle folks in case test is failing

/assign @ameukam @dims 
/hold
to double check boskos