### PR TITLE
Update custom-metrics-apiserver to go 1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         command:
         - make
         args:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         command:
         - make
         args:


### PR DESCRIPTION
Required by https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/151.