### PR TITLE
Adjust limits and GOMAXPROCS for periodic-cluster-api-provider-aws-e2e-eks-canary

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -73,15 +73,19 @@ periodics:
       # Parallelize tests
       - name: GINKGO_ARGS
         value: "-nodes 20 -skip='\\[ClusterClass\\]'"
+      # set GOMAXPROCS to match the CPU limit.  This informs the Go runtime of the number of
+      # compile jobs/tests to run in parallel.
+      - name: GOMAXPROCS
+        value: "4"
       securityContext:
         privileged: true
       resources:
         limits:
-          cpu: 2
-          memory: "9Gi"
+          cpu: 4
+          memory: "18Gi"
         requests:
-          cpu: 2
-          memory: "9Gi"
+          cpu: 4
+          memory: "18Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
     testgrid-tab-name: periodic-aws-e2e-main-canary


### PR DESCRIPTION
periodic-cluster-api-provider-aws-e2e-eks-canary is consistently failing for various reasons. To try to fix that issue, this PR:

- doubles limits for that job (the original job doesn't have any limits set, but we require limits to be set for jobs in running in the EKS cluster)
- explicitly sets GOMAXPROCS (to avoid a potential issue similar to the issue that we had with unit tests)

I don't expect this to fix the actual issue with this test, but let's hope that we'll see at least some improvements.

/assign @dims 