### PR TITLE
Reduce periodic-capa-e2e-eks-canary to 24 hours

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -45,9 +45,8 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  # Changed from 12 hours to reduce time spent waiting for job to run
-  # TODO(xmudrii): rollback to 12 hours
-  interval: 1h
+  # Changed from 12 hours to reduce amount of runs because job is broken
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
The job is broken and needs debugging. It doesn't make sense to run it every hour. We run the original job every 12 hours, let's run this job every 24 hours.

/assign @dims @ameukam 