### PR TITLE
Update starter manifests to configure github app creds for clonerefs

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -93,11 +93,15 @@ data:
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:v20230426-d32ca9cc84

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -93,12 +93,16 @@ data:
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: gs://your-bucket-name
             path_strategy: explicit
           gcs_credentials_secret: gcs-credentials
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:v20230426-d32ca9cc84
             entrypoint: gcr.io/k8s-prow/entrypoint:v20230426-d32ca9cc84

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -93,11 +93,15 @@ data:
             [Full PR test history](http://<< your-minikube/kind IP >>:30002/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](http://<< your-minikube/kind IP >>:30002/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:latest

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -93,11 +93,15 @@ data:
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:v20230426-d32ca9cc84


### PR DESCRIPTION
It seemed like checking out the code was more difficult than necessary, with all the messing around with SSH keys and known hosts.  Using the github app credentials should be easier.  However, the starter instructions did not provide an example which configures this.  Hopefully by providing this it will make life easier for others getting Prow up and running.