### PR TITLE
Use `--with-git-dir` for kpromo image job

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -19,6 +19,7 @@ postsubmits:
               - --project=k8s-staging-artifact-promoter
               - --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .
             env:
               - name: LOG_TO_STDOUT


### PR DESCRIPTION
We need the git dir to allow kpromo to inject the correct version.

PTAL @kubernetes/release-engineering 