### PR TITLE
Use `--with-git-dir` for SPO image job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-security-profiles-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-security-profiles-operator.yaml
@@ -17,6 +17,7 @@ postsubmits:
             args:
               - --project=k8s-staging-sp-operator
               - --scratch-bucket=gs://k8s-staging-sp-operator-gcb
+              - --with-git-dir
               - .
             env:
               - name: LOG_TO_STDOUT


### PR DESCRIPTION
We need the git dir to inject the right versions.

PTAL @jhrozek @JAORMX @pjbgf @ccojocar 