### PR TITLE
Fix CAPC build commands

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -69,8 +69,7 @@ presubmits:
         command:
         - bash
         - -c
-        - >
-          mv /mybin ./bin && make build
+        - make build
         resources:
           requests:
             memory: "8Gi"
@@ -101,8 +100,7 @@ presubmits:
         command:
         - bash
         - -c
-        - >
-          mv /mybin ./bin && make test
+        - make test
         resources:
           requests:
             memory: "8Gi"


### PR DESCRIPTION
## Summary

The CAPC projects CI continues to bork. The latest runs indicate there's an issue with the `mv mybin` cmd that I believe originates from the commands invoked for the presubmits.

> mv: cannot stat '/mybin': No such file or directory

\- [Prow job output](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-cloudstack/232/capi-provider-cloudstack-presubmit-build/1653439177208893440)

This PR removes the `mv` command in favor of calling make only. This may not be sufficient for a release, but it should fix the CI so PRs can merge. We can address releasing concerns separately.