### PR TITLE
Update starter manifests to configure github app creds/urls for decoration

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -93,11 +93,18 @@ data:
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit
+          github_api_endpoints:
+            - http://ghproxy
+            - https://api.github.com
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:v20230426-d32ca9cc84

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -93,12 +93,19 @@ data:
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: gs://your-bucket-name
             path_strategy: explicit
           gcs_credentials_secret: gcs-credentials
+          github_api_endpoints:
+            - http://ghproxy
+            - https://api.github.com
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:v20230426-d32ca9cc84
             entrypoint: gcr.io/k8s-prow/entrypoint:v20230426-d32ca9cc84

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -93,11 +93,18 @@ data:
             [Full PR test history](http://<< your-minikube/kind IP >>:30002/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](http://<< your-minikube/kind IP >>:30002/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit
+          github_api_endpoints:
+            - http://ghproxy
+            - https://api.github.com
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:latest

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -93,11 +93,18 @@ data:
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-      default_decoration_configs:
-        "*":
+      default_decoration_config_entries:
+        - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit
+          github_api_endpoints:
+            - http://ghproxy
+            - https://api.github.com
+          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_private_key_secret:
+            name: github-token
+            key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
             clonerefs: gcr.io/k8s-prow/clonerefs:v20230426-d32ca9cc84


### PR DESCRIPTION
Seems like this was missing from the example config, but it useful to have as it allows code to be checked out from github.

Also updated the config to use `default_decoration_config_entries` instead of `default_decoration_configs` as this seems to be the preferred way to configure decoration config based on the comments here: https://github.com/kubernetes/test-infra/blob/master/prow/config/config.go#L669


