### PR TITLE
Avoid panic on invalid URI in clone_uri override

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -176,15 +176,18 @@ func gitCtxForRefs(refs prowapi.Refs, baseDir string, env []string, user, token 
 	}
 
 	if token != "" {
-		u, _ := url.Parse(g.repositoryURI)
-		if user != "" {
-			u.User = url.UserPassword(user, token)
-		} else {
-			// GitHub requires that the personal access token is set as a username.
-			// e.g., https://<token>:x-oauth-basic@github.com/owner/repo.git
-			u.User = url.UserPassword(token, "x-oauth-basic")
+		u, err := url.Parse(g.repositoryURI)
+		// Ignore invalid URL from a CloneURI override (e.g. git@github.com:owner/repo)
+		if err == nil {
+			if user != "" {
+				u.User = url.UserPassword(user, token)
+			} else {
+				// GitHub requires that the personal access token is set as a username.
+				// e.g., https://<token>:x-oauth-basic@github.com/owner/repo.git
+				u.User = url.UserPassword(token, "x-oauth-basic")
+			}
+			g.repositoryURI = u.String()
 		}
-		g.repositoryURI = u.String()
 	}
 
 	return g


### PR DESCRIPTION
When clone_uri was set to an ssh URL and there were also github app credentials configured, clonerefs would panic when it failed to parse the URI but still tried to inject github app token into it anyway.

Fixes #29400
