### PR TITLE
Re-enable SSH vars and switch to COS-97-LTS

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -187,7 +187,9 @@ presubmits:
         - name: ZONE
           value: us-central1-a
         - name: IMAGE_FAMILY
-          value: cos-stable
+        # TODO: update to `cos-stable` once NPD dependencies have been upgraded.
+        # See https://github.com/kubernetes/test-infra/issues/29308#issuecomment-1522523412
+          value: cos-97-lts
         - name: IMAGE_PROJECT
           value: cos-cloud
         - name: BOSKOS_PROJECT_TYPE
@@ -197,7 +199,9 @@ presubmits:
         args:
         - bash
         - -c
-        - ./test/build.sh install-lib && make e2e-test
+        - >-
+          ./test/build.sh install-lib &&
+          SSH_USER=${USER} SSH_KEY=${JENKINS_GCE_SSH_PRIVATE_KEY_FILE} make e2e-test
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'


### PR DESCRIPTION
## What does this PR do?
As a temporal mitigation to #29308, I rollbacked #29330 and switched to COS family `cos-97-lts`, which is still supported and uses an older OpenSSH version that will not be broken (`OpenSSH_8.5p1`).

This is just a temporary mitigation: we still need to switch to `cos-stable` and upgrade dependencies in NPD, but since this is taking longer than expected and there are a couple of PRs in NPD blocked, I think it's best that we unblock for now.