### PR TITLE
Fix sharding by using a pointer for global Blunderbuss config

### DIFF
--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -19,6 +19,7 @@ limitations under the License.
 // from the AST of a given file.
 //
 // Example:
+//
 //	cm, err := NewCommentMap("example_config.go")
 //
 //	yamlSnippet, err := cm.GenYaml(&plugins.Configuration{
@@ -40,8 +41,7 @@ limitations under the License.
 //
 // yamlSnippet, err := cm.GenYaml(PopulateStruct(&plugins.Configuration{}))
 //
-//
-// 	yamlSnippet will be assigned a string containing the following YAML:
+//	yamlSnippet will be assigned a string containing the following YAML:
 //
 //	# Approve is the configuration for the Approve plugin.
 //	approve:
@@ -61,7 +61,6 @@ limitations under the License.
 //
 //		# IgnoreReviewState causes the approve plugin to ignore the GitHub review state. Otherwise: * an APPROVE github review is equivalent to leaving an \"/approve\" message. * A REQUEST_CHANGES github review is equivalent to leaving an /approve cancel\" message.
 //		ignore_review_state: false
-//
 package genyaml
 
 import (
@@ -297,6 +296,9 @@ func fieldType(field *ast.Field, recurse bool) (string, bool) {
 		case *ast.SelectorExpr:
 			// SelectorExpr are not object types yet reference one, thus continue with DFS.
 			isSelect = true
+		case *ast.StarExpr:
+			// Encountered a pointer--overwrite typeName with ast.Expr
+			typeName = fmt.Sprint(x.X)
 		}
 
 		return recurse || isSelect

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -831,7 +831,7 @@ func TestHandlePluginConfig(t *testing.T) {
 			}},
 		},
 		Blunderbuss: plugins.Blunderbuss{
-			BlunderbussConfig: plugins.BlunderbussConfig{
+			BlunderbussConfig: &plugins.BlunderbussConfig{
 				ExcludeApprovers: true,
 			}},
 	}

--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -64,7 +64,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 	two := 2
 	yamlSnippet, err := plugins.CommentMap.GenYaml(&plugins.Configuration{
 		Blunderbuss: plugins.Blunderbuss{
-			BlunderbussConfig: plugins.BlunderbussConfig{
+			BlunderbussConfig: &plugins.BlunderbussConfig{
 				ReviewerCount:         &two,
 				MaxReviewerCount:      3,
 				ExcludeApprovers:      true,

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -693,7 +693,7 @@ func TestHandlePullRequestShardedConfig(t *testing.T) {
 	fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 	c := &plugins.Configuration{
 		Blunderbuss: plugins.Blunderbuss{
-			BlunderbussConfig: plugins.BlunderbussConfig{
+			BlunderbussConfig: &plugins.BlunderbussConfig{
 				ReviewerCount:    &tc.reviewerCount,
 				MaxReviewerCount: 0,
 				ExcludeApprovers: false,
@@ -897,7 +897,7 @@ func TestHandleGenericCommentShardedConfig(t *testing.T) {
 
 			config := &plugins.Configuration{
 				Blunderbuss: plugins.Blunderbuss{
-					BlunderbussConfig: plugins.BlunderbussConfig{
+					BlunderbussConfig: &plugins.BlunderbussConfig{
 						IgnoreAuthors:         []string{"bob"},
 						ReviewerCount:         &defaultReviewerCount,
 						UseStatusAvailability: false,
@@ -922,7 +922,10 @@ func TestHandleGenericCommentShardedConfig(t *testing.T) {
 
 func TestHandleGenericCommentEvent(t *testing.T) {
 	pc := plugins.Agent{
-		PluginConfig: &plugins.Configuration{},
+		PluginConfig: &plugins.Configuration{
+			Blunderbuss: plugins.Blunderbuss{
+				BlunderbussConfig: &plugins.BlunderbussConfig{},
+			}},
 	}
 	ce := github.GenericCommentEvent{}
 	handleGenericCommentEvent(pc, ce)
@@ -930,7 +933,10 @@ func TestHandleGenericCommentEvent(t *testing.T) {
 
 func TestHandlePullRequestEvent(t *testing.T) {
 	pc := plugins.Agent{
-		PluginConfig: &plugins.Configuration{},
+		PluginConfig: &plugins.Configuration{
+			Blunderbuss: plugins.Blunderbuss{
+				BlunderbussConfig: &plugins.BlunderbussConfig{},
+			}},
 	}
 	pre := github.PullRequestEvent{}
 	handlePullRequestEvent(pc, pre)
@@ -949,8 +955,11 @@ func TestHelpProvider(t *testing.T) {
 		configInfoIncludes []string
 	}{
 		{
-			name:               "Empty config",
-			config:             &plugins.Configuration{},
+			name: "Empty config",
+			config: &plugins.Configuration{
+				Blunderbuss: plugins.Blunderbuss{
+					BlunderbussConfig: &plugins.BlunderbussConfig{},
+				}},
 			enabledRepos:       enabledRepos,
 			configInfoIncludes: []string{configString(0)},
 		},
@@ -958,7 +967,7 @@ func TestHelpProvider(t *testing.T) {
 			name: "ReviewerCount specified",
 			config: &plugins.Configuration{
 				Blunderbuss: plugins.Blunderbuss{
-					BlunderbussConfig: plugins.BlunderbussConfig{
+					BlunderbussConfig: &plugins.BlunderbussConfig{
 						ReviewerCount: &[]int{2}[0],
 					}},
 			},

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -1731,34 +1731,52 @@ func TestBlunderbussMergeFrom(t *testing.T) {
 				Orgs: map[string]BlunderbussOrgConfig{"org": {
 					Repos: map[string]BlunderbussRepoConfig{"org/repo-1": {}}}}},
 			to: &Blunderbuss{
-				BlunderbussConfig: BlunderbussConfig{}},
+				BlunderbussConfig: &BlunderbussConfig{}},
 			expected: &Blunderbuss{
-				BlunderbussConfig: BlunderbussConfig{},
+				BlunderbussConfig: &BlunderbussConfig{},
 				Orgs: map[string]BlunderbussOrgConfig{"org": {
 					Repos: map[string]BlunderbussRepoConfig{"org/repo-1": {}}}}},
 		},
 		{
 			name: "Merging org/repo config with global config succeeds",
 			from: &Blunderbuss{
-				BlunderbussConfig: BlunderbussConfig{}},
+				BlunderbussConfig: &BlunderbussConfig{}},
 			to: &Blunderbuss{
 				Orgs: map[string]BlunderbussOrgConfig{"org": {
 					Repos: map[string]BlunderbussRepoConfig{"org/repo-1": {}}}}},
 			expected: &Blunderbuss{
-				BlunderbussConfig: BlunderbussConfig{},
+				BlunderbussConfig: &BlunderbussConfig{},
 				Orgs: map[string]BlunderbussOrgConfig{"org": {
 					Repos: map[string]BlunderbussRepoConfig{"org/repo-1": {}}}}},
 		},
 		{
 			name:     "Merging identical global configs succeeds",
-			from:     &Blunderbuss{BlunderbussConfig: BlunderbussConfig{}},
-			to:       &Blunderbuss{BlunderbussConfig: BlunderbussConfig{}},
-			expected: &Blunderbuss{BlunderbussConfig: BlunderbussConfig{}},
+			from:     &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			to:       &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:     "Merging from nil config succeeds",
+			from:     nil,
+			to:       &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:     "Merging to nil global config succeeds",
+			from:     &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			to:       &Blunderbuss{BlunderbussConfig: nil},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:     "Merging from config with nil global config succeeds",
+			from:     &Blunderbuss{BlunderbussConfig: nil},
+			to:       &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
 		},
 		{
 			name:           "Merging differing global configs fails",
-			from:           &Blunderbuss{BlunderbussConfig: BlunderbussConfig{MaxReviewerCount: 1}},
-			to:             &Blunderbuss{BlunderbussConfig: BlunderbussConfig{MaxReviewerCount: 2}},
+			from:           &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{MaxReviewerCount: 1}},
+			to:             &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{MaxReviewerCount: 2}},
 			expectedErrMsg: "global configurations for blunderbuss do not match",
 		},
 		{
@@ -2163,7 +2181,7 @@ func TestHasConfigFor(t *testing.T) {
 				fuzzedConfig.Triggers = nil
 				fuzzedConfig.Welcome = nil
 				fuzzedConfig.ExternalPlugins = nil
-				fuzzedConfig.Blunderbuss = Blunderbuss{BlunderbussConfig: BlunderbussConfig{}}
+				fuzzedConfig.Blunderbuss = Blunderbuss{}
 				return fuzzedConfig, !reflect.DeepEqual(fuzzedConfig, &Configuration{}), nil, nil
 			},
 		},

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -72,6 +72,8 @@ blunderbuss:
             # IgnoreDrafts instructs the plugin to ignore assigning reviewers
             # to the PR that is in Draft state. Default it's false.
             ignore_drafts: true
+            # Repos allows sharding for repository-specific Blunderbuss settings, provided under keys using
+            # the format organization/repository.
             repos:
                 "":
                     # ExcludeApprovers controls whether approvers are considered to be

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -234,7 +234,7 @@ func TestLoad(t *testing.T) {
 		cfg := &Configuration{
 			Owners: Owners{LabelsDenyList: []string{"approved", "lgtm"}},
 			Blunderbuss: Blunderbuss{
-				BlunderbussConfig: BlunderbussConfig{ReviewerCount: func() *int { i := 2; return &i }()}},
+				BlunderbussConfig: &BlunderbussConfig{ReviewerCount: func() *int { i := 2; return &i }()}},
 			CherryPickUnapproved: CherryPickUnapproved{
 				BranchRegexp: "^release-.*$",
 				BranchRe:     regexp.MustCompile("^release-.*$"),


### PR DESCRIPTION
Using a pointer lets sharding determine whether a config had been provided so they can be properly compared. If one is not provided, this also instantiates one in `setDefaults()`, which is called following the sharding logic.

Additionally, sets target type for pointers when generating documentation YAML so that comments properly display.

Followup to:
- #28169 
