### PR TITLE
`label-sync`: store current and previous label when a change is required

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -467,9 +467,9 @@ func rename(repo string, previous, wanted Label) Update {
 }
 
 // Update the label color/description
-func change(repo string, label Label) Update {
-	logrus.WithField("repo", repo).WithField("label", label.Name).WithField("color", label.Color).Info("change")
-	return Update{Why: "change", Current: &label, Wanted: &label, repo: repo}
+func change(repo string, previous, wanted Label) Update {
+	logrus.WithField("repo", repo).WithField("label", previous.Name).WithField("color", previous.Color).Info("change")
+	return Update{Why: "change", Current: &previous, Wanted: &wanted, repo: repo}
 }
 
 // Migrate labels to another label
@@ -584,9 +584,9 @@ func syncLabels(config Configuration, org string, repos RepoLabels) (RepoUpdates
 			case l.Name != cur.Name:
 				actions = append(actions, rename(repo, cur, l))
 			case l.Color != cur.Color:
-				actions = append(actions, change(repo, l))
+				actions = append(actions, change(repo, cur, l))
 			case l.Description != cur.Description:
-				actions = append(actions, change(repo, l))
+				actions = append(actions, change(repo, cur, l))
 			}
 		}
 

--- a/label_sync/main_test.go
+++ b/label_sync/main_test.go
@@ -270,7 +270,7 @@ func TestSyncLabels(t *testing.T) {
 			},
 			expectedUpdates: RepoUpdates{
 				"repo1": {
-					{Why: "change", Current: &Label{Name: "lab1", Description: "Test Label 1", Color: "deadbe"}, Wanted: &Label{Name: "lab1", Description: "Test Label 1", Color: "deadbe"}},
+					{Why: "change", Current: &Label{Name: "lab1", Description: "Test Label 1", Color: "bebeef"}, Wanted: &Label{Name: "lab1", Description: "Test Label 1", Color: "deadbe"}},
 				},
 			},
 		},
@@ -286,7 +286,7 @@ func TestSyncLabels(t *testing.T) {
 			},
 			expectedUpdates: RepoUpdates{
 				"repo1": {
-					{Why: "change", Current: &Label{Name: "lab1", Description: "Test Label 1", Color: "deadbe"}, Wanted: &Label{Name: "lab1", Description: "Test Label 1", Color: "deadbe"}},
+					{Why: "change", Current: &Label{Name: "lab1", Description: "Test Label 5", Color: "deadbe"}, Wanted: &Label{Name: "lab1", Description: "Test Label 1", Color: "deadbe"}},
 				},
 			},
 		},
@@ -396,11 +396,11 @@ func TestSyncLabels(t *testing.T) {
 					{Why: "rename", Wanted: &Label{Name: "lgtm", Description: "LGTM", Color: "00ff00"}, Current: &Label{Name: "LGTM", Description: "LGTM", Color: "00ff00"}},
 				},
 				"repo2": {
-					{Why: "change", Current: &Label{Name: "priority/P0", Description: "P0 Priority", Color: "ff0000"}, Wanted: &Label{Name: "priority/P0", Description: "P0 Priority", Color: "ff0000"}},
+					{Why: "change", Current: &Label{Name: "priority/P0", Description: "P0 Priority", Color: "ee3333"}, Wanted: &Label{Name: "priority/P0", Description: "P0 Priority", Color: "ff0000"}},
 				},
 				"repo3": {
 					{Why: "rename", Wanted: &Label{Name: "priority/P0", Description: "P0 Priority", Color: "ff0000"}, Current: &Label{Name: "PRIORITY/P0", Description: "P0 Priority", Color: "ff0000"}},
-					{Why: "change", Current: &Label{Name: "lgtm", Description: "LGTM", Color: "00ff00"}, Wanted: &Label{Name: "lgtm", Description: "LGTM", Color: "00ff00"}},
+					{Why: "change", Current: &Label{Name: "lgtm", Description: "LGTM", Color: "0000ff"}, Wanted: &Label{Name: "lgtm", Description: "LGTM", Color: "00ff00"}},
 				},
 				"repo4": {
 					{Why: "missing", Wanted: &Label{Name: "lgtm", Description: "LGTM", Color: "00ff00"}},


### PR DESCRIPTION
Save both the current and the wanted version of a label when it needs to be updated.
It's useful for debugging purposes.

/cc @cblecker 