### PR TITLE
capz: add 1.10 milestone, remove release-1.7

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -496,9 +496,9 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.9
+    main: v1.10
+    release-1.9: v1.9
     release-1.8: v1.8
-    release-1.7: v1.7
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0
@@ -1653,7 +1653,7 @@ external_plugins:
     events:
     - issue_comment
     - pull_request
-    endpoint: http://cherrypicker  
+    endpoint: http://cherrypicker
   kubernetes-sigs/node-feature-discovery:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Pins the main milestone applier to [v1.10](https://github.com/kubernetes-sigs/cluster-api-provider-azure/milestone/32) and removes the now-unsupported release-1.7 branch.