### PR TITLE
Allow release blocking jobs to run in EKS cluster

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1104,8 +1104,8 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 		}
 		// job Pod must qualify for Guaranteed QoS
 		errs := verifyPodQOSGuaranteed(job.Spec, true)
-		if !isCritical(job.Cluster) {
-			errs = append(errs, fmt.Errorf("must run in cluster: k8s-infra-prow-build, found: %v", job.Cluster))
+		if !isCritical(job.Cluster) && !isEKSCluster(job.Cluster) {
+			errs = append(errs, fmt.Errorf("must run in cluster: k8s-infra-prow-build or eks-prow-build-cluster, found: %v", job.Cluster))
 		}
 		if len(errs) > 0 {
 			jobsToFix++


### PR DESCRIPTION
This PR allows release blocking jobs to run in EKS cluster (eks-prow-build-cluster). This cluster is community-owned and has been tested for a few weeks, so it's ready to be used for running release blocking jobs.

/assign @dims 