### PR TITLE
feat(prow/repoowners): return all approvers and reviewers only

### DIFF
--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1380,7 +1380,15 @@ type fakeRepoOwners struct {
 	fakeRepo
 }
 
+func (fro fakeRepoOwners) AllApprovers() sets.String {
+	return sets.String{}
+}
+
 func (fro fakeRepoOwners) AllOwners() sets.String {
+	return sets.String{}
+}
+
+func (fro fakeRepoOwners) AllReviewers() sets.String {
 	return sets.String{}
 }
 

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -115,7 +115,15 @@ type fakeOwnersClient struct {
 	dirDenylist       []*regexp.Regexp
 }
 
+func (foc *fakeOwnersClient) AllApprovers() sets.String {
+	return sets.String{}
+}
+
 func (foc *fakeOwnersClient) AllOwners() sets.String {
+	return sets.String{}
+}
+
+func (foc *fakeOwnersClient) AllReviewers() sets.String {
 	return sets.String{}
 }
 

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -77,7 +77,15 @@ type fakeRepoOwners struct {
 	dirDenylist []*regexp.Regexp
 }
 
+func (f *fakeRepoOwners) AllApprovers() sets.String {
+	return sets.String{}
+}
+
 func (f *fakeRepoOwners) AllOwners() sets.String {
+	return sets.String{}
+}
+
+func (f *fakeRepoOwners) AllReviewers() sets.String {
 	return sets.String{}
 }
 

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -60,7 +60,15 @@ type fakeOwnersClient struct {
 	topLevelApprovers sets.String
 }
 
+func (foc *fakeOwnersClient) AllApprovers() sets.String {
+	return sets.String{}
+}
+
 func (foc *fakeOwnersClient) AllOwners() sets.String {
+	return sets.String{}
+}
+
+func (foc *fakeOwnersClient) AllReviewers() sets.String {
 	return sets.String{}
 }
 

--- a/prow/plugins/reward-owners/reward-owners_test.go
+++ b/prow/plugins/reward-owners/reward-owners_test.go
@@ -61,7 +61,15 @@ func (f *fakeRepoOwners) Reviewers(path string) layeredsets.String  { return lay
 func (f *fakeRepoOwners) RequiredReviewers(path string) sets.String { return nil }
 func (f *fakeRepoOwners) TopLevelApprovers() sets.String            { return nil }
 
+func (f *fakeRepoOwners) AllApprovers() sets.String {
+	return ownersBySha[f.sha]
+}
+
 func (f *fakeRepoOwners) AllOwners() sets.String {
+	return ownersBySha[f.sha]
+}
+
+func (f *fakeRepoOwners) AllReviewers() sets.String {
 	return ownersBySha[f.sha]
 }
 

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -218,7 +218,15 @@ type fakeOwnersClient struct {
 	dirIgnorelist     []*regexp.Regexp
 }
 
+func (foc *fakeOwnersClient) AllApprovers() sets.String {
+	return sets.String{}
+}
+
 func (foc *fakeOwnersClient) AllOwners() sets.String {
+	return sets.String{}
+}
+
+func (foc *fakeOwnersClient) AllReviewers() sets.String {
 	return sets.String{}
 }
 

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -255,6 +255,8 @@ type RepoOwner interface {
 	TopLevelApprovers() sets.String
 	Filenames() ownersconfig.Filenames
 	AllOwners() sets.String
+	AllApprovers() sets.String
+	AllReviewers() sets.String
 }
 
 var _ RepoOwner = &RepoOwners{}
@@ -889,17 +891,48 @@ func (o *RepoOwners) TopLevelApprovers() sets.String {
 	return o.entriesForFile(".", o.approvers, true).Set()
 }
 
+// AllOwners returns ALL of the users who are approvers or reviewers,
+// at least for a file across the structure of the repository.
+// If pkg/OWNERS has user1 as approver and user2 as reviewer,
+// and pkg/util has user3 as approver and user4 as reviewer,
+// the function will return user1, user2, user3, and user4.
 func (o *RepoOwners) AllOwners() sets.String {
 	allOwners := sets.NewString()
+
+	allOwners = allOwners.Union(o.AllApprovers())
+	allOwners = allOwners.Union(o.AllReviewers())
+
+	return allOwners
+}
+
+// AllApprovers returns ALL of the users who are approvers,
+// at least for a file across the structure of the repository.
+// If pkg/OWNERS has user1 as approver and user2 as reviewer,
+// and pkg/util has user3 as approver and user4 as reviewer,
+// the function will return user1, and user3.
+func (o *RepoOwners) AllApprovers() sets.String {
+	allApprovers := sets.NewString()
 	for _, pv := range o.approvers {
 		for _, rv := range pv {
-			allOwners = allOwners.Union(rv)
+			allApprovers = allApprovers.Union(rv)
 		}
 	}
+
+	return allApprovers
+}
+
+// AllReviewers returns ALL of the users who are reviewers,
+// at least for a file across the structure of the repository.
+// If pkg/OWNERS has user1 as approver and user2 as reviewer,
+// and pkg/util has user3 as approver and user4 as reviewer,
+// the function will return user2, and user4.
+func (o *RepoOwners) AllReviewers() sets.String {
+	allReviewers := sets.NewString()
 	for _, pv := range o.reviewers {
 		for _, rv := range pv {
-			allOwners = allOwners.Union(rv)
+			allReviewers = allReviewers.Union(rv)
 		}
 	}
-	return allOwners
+
+	return allReviewers
 }

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -889,8 +889,7 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 		},
 	}
 
-	for i := range tests {
-		test := tests[i]
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Running scenario %q", test.name)
@@ -1345,5 +1344,51 @@ func TestRepoOwners_AllOwners(t *testing.T) {
 	foundOwners := ro.AllOwners()
 	if !foundOwners.Equal(sets.NewString(expectedOwners...)) {
 		t.Errorf("Expected Owners: %v\tFound Owners: %v ", expectedOwners, foundOwners.List())
+	}
+}
+
+func TestRepoOwners_AllApprovers(t *testing.T) {
+	expectedApprovers := []string{"alice", "bob", "cjwagner", "mml"}
+	ro := &RepoOwners{
+		approvers: map[string]map[*regexp.Regexp]sets.String{
+			"":                    regexpAll("cjwagner"),
+			"src":                 regexpAll(),
+			"src/dir":             regexpAll("bob"),
+			"src/dir/conformance": regexpAll("mml"),
+			"src/dir/subdir":      regexpAll("alice", "bob"),
+			"vendor":              regexpAll("alice"),
+		},
+		reviewers: map[string]map[*regexp.Regexp]sets.String{
+			"":               regexpAll("alice", "bob"),
+			"src/dir":        regexpAll("alice", "matthyx"),
+			"src/dir/subdir": regexpAll("alice", "bob"),
+		},
+	}
+	foundApprovers := ro.AllApprovers()
+	if !foundApprovers.Equal(sets.NewString(expectedApprovers...)) {
+		t.Errorf("Expected approvers: %v\tFound approvers: %v ", expectedApprovers, foundApprovers.List())
+	}
+}
+
+func TestRepoOwners_AllReviewers(t *testing.T) {
+	expectedReviewers := []string{"alice", "bob", "matthyx"}
+	ro := &RepoOwners{
+		approvers: map[string]map[*regexp.Regexp]sets.String{
+			"":                    regexpAll("cjwagner"),
+			"src":                 regexpAll(),
+			"src/dir":             regexpAll("bob"),
+			"src/dir/conformance": regexpAll("mml"),
+			"src/dir/subdir":      regexpAll("alice", "bob"),
+			"vendor":              regexpAll("alice"),
+		},
+		reviewers: map[string]map[*regexp.Regexp]sets.String{
+			"":               regexpAll("alice", "bob"),
+			"src/dir":        regexpAll("alice", "matthyx"),
+			"src/dir/subdir": regexpAll("alice", "bob"),
+		},
+	}
+	foundReviewers := ro.AllReviewers()
+	if !foundReviewers.Equal(sets.NewString(expectedReviewers...)) {
+		t.Errorf("Expected reviewers: %v\tFound reviewers: %v ", expectedReviewers, foundReviewers.List())
 	}
 }


### PR DESCRIPTION
This feature adds the ability to return specifically all approvers only, and all reviewers only, from a RepoOwners structure.

Closes #29414 