### PR TITLE
Add GOMAXPROCS to ci-benchmark-scheduler-perf-master-eks-canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -232,6 +232,8 @@ periodics:
       args:
       - ./test/integration/scheduler_perf
       env:
+      - name: GOMAXPROCS
+        value: "6"
       - name: KUBE_TIMEOUT
         value: --timeout=2h25m
       - name: TEST_PREFIX


### PR DESCRIPTION
ci-benchmark-scheduler-perf-master-eks-canary is constantly failing for some reason. I'm not sure if this job is performance sensitive, and to rule this out, this PR sets GOMAXPROCS for this job.

/assign @dims 