### PR TITLE
Update kubebuilder k8s version to 1.27 and remove 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -19,6 +19,36 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
+  - name: pull-kubebuilder-e2e-k8s-1-27-1
+    decorate: true
+    always_run: true
+    optional: false
+    path_alias: sigs.k8s.io/kubebuilder
+    branches:
+      - ^master$
+      - ^feature/plugins-.+$
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+          command:
+            # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
+            - runner.sh
+            # this MUST be a relative directory with "./" or the runner will fail to find the file
+            - ./test_e2e.sh
+          env:
+            - name: KIND_K8S_VERSION
+              value: "v1.27.1"
+          resources:
+            requests:
+              cpu: 4000m
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: kubebuilder-e2e-1-27-1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
   - name: pull-kubebuilder-e2e-k8s-1-26-0
     decorate: true
     always_run: true
@@ -76,36 +106,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder-e2e-1-25-3
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-24-7
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.24.7"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-24-7
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
It's a part of "Update k8s version to 1.27" in Kubebuilder
@camilamacedo86 could you please review it? :)