### PR TITLE
use eks-prow-build-cluster cluster to run some periodics capg jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -1,132 +1,148 @@
 periodics:
-- name: periodic-cluster-api-provider-gcp-build-main
-  interval: 4h
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-gcp
-    base_ref: main
-    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-      command:
-      - "runner.sh"
-      - "./scripts/ci-build.sh"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
-    testgrid-tab-name: capg-build-main
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-gcp-test-main
-  interval: 4h
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-gcp
-    base_ref: main
-    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-      args:
-      - "runner.sh"
-      - "./scripts/ci-test.sh"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
-    testgrid-tab-name: capg-test-main
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-gcp-make-conformance-main
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  decorate: true
-  decoration_config:
-    timeout: 3h
-  interval: 12h
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-gcp
-    base_ref: main
-    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-        env:
-          - name: "BOSKOS_HOST"
-            value: "boskos.test-pods.svc.cluster.local"
-        command:
-          - "runner.sh"
-          - "./scripts/ci-conformance.sh"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
-    testgrid-tab-name: capg-conformance-main
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  decorate: true
-  decoration_config:
-    timeout: 3h
-  interval: 12h
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-gcp
-      base_ref: main
-      path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
-    - org: kubernetes-sigs
-      repo: image-builder
-      base_ref: master
-      path_alias: "sigs.k8s.io/image-builder"
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-        env:
-          - name: "BOSKOS_HOST"
-            value: "boskos.test-pods.svc.cluster.local"
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: USE_CI_ARTIFACTS
-            value: "true"
-        command:
-          - "runner.sh"
-          - "./scripts/ci-conformance.sh"
-          - "--init-image"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp, sig-release-master-informing
-    testgrid-tab-name: capg-conformance-main-ci-artifacts
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+  - name: periodic-cluster-api-provider-gcp-build-main
+    interval: 4h
+    decorate: true
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-gcp
+        base_ref: main
+        path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+          command:
+            - "runner.sh"
+            - "./scripts/ci-build.sh"
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: capg-build-main
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: "2"
+  - name: periodic-cluster-api-provider-gcp-test-main
+    interval: 4h
+    decorate: true
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-gcp
+        base_ref: main
+        path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+          args:
+            - "runner.sh"
+            - "./scripts/ci-test.sh"
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: capg-test-main
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: "2"
+  - name: periodic-cluster-api-provider-gcp-make-conformance-main
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    interval: 12h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-gcp
+        base_ref: main
+        path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: capg-conformance-main
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: "2"
+  - name: periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    interval: 12h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-gcp
+        base_ref: main
+        path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+      - org: kubernetes-sigs
+        repo: image-builder
+        base_ref: master
+        path_alias: "sigs.k8s.io/image-builder"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: E2E_ARGS
+              value: "-kubetest.use-ci-artifacts"
+            - name: USE_CI_ARTIFACTS
+              value: "true"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+            - "--init-image"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp, sig-release-master-informing
+      testgrid-tab-name: capg-conformance-main-ci-artifacts
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io, release-team@kubernetes.io
+      testgrid-num-failures-to-alert: "2"


### PR DESCRIPTION
this will run the following jobs in the aws cluster that does not require any secrets

- periodic-cluster-api-provider-gcp-build-main
- periodic-cluster-api-provider-gcp-test-main

/assign @xmudrii @saschagrunert @puerco @timoreimann 
cc @kubernetes/release-engineering 