### PR TITLE
use eks-prow-build-cluster cluster to run more periodics/presubmits capg jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-2.yaml
@@ -2,6 +2,7 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-build-release-1-2
   interval: 4h
   decorate: true
+  cluster: eks-prow-build-cluster
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-gcp
@@ -17,6 +18,13 @@ periodics:
       command:
       - "runner.sh"
       - "./scripts/ci-build.sh"
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-build-release-1-2
@@ -25,6 +33,7 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-test-release-1-2
   interval: 4h
   decorate: true
+  cluster: eks-prow-build-cluster
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-gcp
@@ -40,6 +49,13 @@ periodics:
       args:
       - "runner.sh"
       - "./scripts/ci-test.sh"
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-test-release-1-2

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-3.yaml
@@ -2,6 +2,7 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-build-release-1-3
   interval: 4h
   decorate: true
+  cluster: eks-prow-build-cluster
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-gcp
@@ -17,6 +18,13 @@ periodics:
       command:
       - "runner.sh"
       - "./scripts/ci-build.sh"
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-build-release-1-3
@@ -25,6 +33,7 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-test-release-1-3
   interval: 4h
   decorate: true
+  cluster: eks-prow-build-cluster
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-gcp
@@ -40,6 +49,13 @@ periodics:
       args:
       - "runner.sh"
       - "./scripts/ci-test.sh"
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-test-release-1-3

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -5,6 +5,7 @@ presubmits:
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     spec:
@@ -13,9 +14,12 @@ presubmits:
         command:
         - "./scripts/ci-test.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-test
@@ -24,6 +28,7 @@ presubmits:
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     spec:
@@ -32,9 +37,12 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build
@@ -42,6 +50,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -58,9 +67,12 @@ presubmits:
         - "runner.sh"
         - "./scripts/ci-make.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make
@@ -69,6 +81,7 @@ presubmits:
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    cluster: eks-prow-build-cluster
     labels:
       # required for shellcheck in container.
       preset-dind-enabled: "true"
@@ -84,6 +97,13 @@ presubmits:
         - "verify"
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-verify
@@ -276,6 +296,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     always_run: true
     optional: true
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
     branches:
@@ -287,6 +308,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main
@@ -295,6 +323,7 @@ presubmits:
     optional: true
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    cluster: eks-prow-build-cluster
     extra_refs:
       - org: kubernetes
         repo: test-infra
@@ -320,6 +349,13 @@ presubmits:
           exit $result
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-coverage

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-2.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
       - ^release-1.2$
@@ -13,9 +14,12 @@ presubmits:
         command:
         - "./scripts/ci-test.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-test-release-release-1-2
@@ -23,6 +27,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
       - ^release-1.2$
@@ -32,9 +37,12 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build-release-release-1-2
@@ -42,6 +50,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -58,9 +67,12 @@ presubmits:
         - "runner.sh"
         - "./scripts/ci-make.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make-release-release-1-2

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-3.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.3$
@@ -13,9 +14,12 @@ presubmits:
         command:
         - "./scripts/ci-test.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-test-release-1-3
@@ -23,6 +27,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.3$
@@ -32,9 +37,12 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build-release-1-3
@@ -42,6 +50,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -58,9 +67,12 @@ presubmits:
         - "runner.sh"
         - "./scripts/ci-make.sh"
         resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
           requests:
-            memory: "6Gi"
-            cpu: "2"
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make-release-1-3
@@ -68,6 +80,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     labels:
       # required for shellcheck in container.
@@ -84,6 +97,13 @@ presubmits:
         - "verify"
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-verify-release-1-3
@@ -231,6 +251,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     always_run: true
     optional: true
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
     branches:
@@ -242,6 +263,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main-release-1-3
@@ -249,6 +277,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     extra_refs:
       - org: kubernetes
@@ -275,6 +304,13 @@ presubmits:
           exit $result
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-coverage-release-1-3


### PR DESCRIPTION
this will run the following jobs in the aws cluster that does not require any secrets
adding the others jobs

follow up of https://github.com/kubernetes/test-infra/pull/29438

/assign @xmudrii @saschagrunert @puerco @richardcase  
cc @kubernetes/release-engineering 