### PR TITLE
use eks-prow-build-cluster cluster to run some capdo jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-1.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.1$
@@ -12,6 +13,13 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230321-36677f7c05-1.23
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-test-release-1-1
@@ -19,6 +27,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.1$
@@ -27,6 +36,13 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230321-36677f7c05-1.23
         command:
         - "./scripts/ci-build.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-build-release-1-1
@@ -34,6 +50,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.1$
@@ -44,6 +61,13 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-verify-release-1-1
@@ -51,6 +75,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.1$
@@ -61,6 +86,13 @@ presubmits:
         - make
         args:
         - lint
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-lint-release-1-1

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-2.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.2$
@@ -12,6 +13,13 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.24
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-test-release-1-2
@@ -19,6 +27,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.2$
@@ -27,6 +36,13 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.24
         command:
         - "./scripts/ci-build.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-build-release-1-2
@@ -34,6 +50,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.2$
@@ -44,6 +61,13 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-verify-release-1-2
@@ -51,6 +75,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^release-1.2$
@@ -61,6 +86,13 @@ presubmits:
         - make
         args:
         - lint
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-lint-release-1-2

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
@@ -12,6 +13,13 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.25
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-test
@@ -19,6 +27,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
@@ -27,6 +36,13 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-1.25
         command:
         - "./scripts/ci-build.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-build
@@ -34,6 +50,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
@@ -44,6 +61,13 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-verify
@@ -51,6 +75,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
@@ -61,6 +86,13 @@ presubmits:
         - make
         args:
         - lint
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-lint


### PR DESCRIPTION
this will run the following CAPDO jobs in the aws cluster that does not require any secrets

/assign @xmudrii @saschagrunert @puerco @timoreimann 
cc @kubernetes/release-engineering 