### PR TITLE
Adding the `e2e-hub` KMM's job to the branch protection.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -553,7 +553,8 @@ branch-protection:
         kernel-module-management:
           required_status_checks:
             contexts:
-              - in-cluster-build
+              - e2e
+              - e2e-hub
         kube-batch:
           required_status_checks:
             contexts:


### PR DESCRIPTION
Also renamed `in-cluster-build` to `e2e` as the job name is changing.