### PR TITLE
integration test: use default namespace explicitly

### DIFF
--- a/prow/test/integration/setup-prow-components.sh
+++ b/prow/test/integration/setup-prow-components.sh
@@ -280,9 +280,9 @@ function deploy_prow() {
   # enough to only redeploy those components who configurations have changed as
   # a result of newly built images (from build_prow_images()).
   pushd "${SCRIPT_ROOT}/config/prow"
-  do_kubectl create configmap config --from-file=./config.yaml --dry-run=client -oyaml | do_kubectl apply -f -
-  do_kubectl create configmap plugins --from-file=./plugins.yaml --dry-run=client -oyaml | do_kubectl apply -f -
-  do_kubectl create configmap job-config --from-file=./jobs --dry-run=client -oyaml | do_kubectl apply -f -
+  do_kubectl create configmap config --from-file=./config.yaml --dry-run=client -oyaml | do_kubectl apply -f - --namespace=default
+  do_kubectl create configmap plugins --from-file=./plugins.yaml --dry-run=client -oyaml | do_kubectl apply -f - --namespace=default
+  do_kubectl create configmap job-config --from-file=./jobs --dry-run=client -oyaml | do_kubectl apply -f - --namespace=default
   popd
 
   deploy_components "${fakepubsub_node_port}"


### PR DESCRIPTION
The existing code fails on kind v0.18.0 (go1.20.2 linux/amd64) on gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master, with the following error (tested in a GKE 1.25 cluster):

    Error from server (NotFound): error when creating "STDIN": namespaces "test-pods" not found

This is a NOP change that fixes it for that environment.

/cc @cjwagner @mpherman2