### PR TITLE
Drop GOMAXPROCS from ci-kubernetes-unit-eks-canary and ci-kubernetes-kind-e2e-json-logging-eks-canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -292,8 +292,6 @@ periodics:
       # Options from https://github.com/kubernetes-sigs/kind/blob/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L79-L83
       - name: CLUSTER_LOG_FORMAT
         value: json
-      - name: GOMAXPROCS
-        value: "7"
       - name: KIND_CLUSTER_LOG_LEVEL
         # Default is 4, but we want to exercise more log calls and get more output.
         value: "10"

--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -51,11 +51,6 @@ periodics:
       runAsGroup: 2010
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230406-23cb1879e3-master
-        env:
-        # set GOMAXPROCS to match the CPU limit.  This informs the Go runtime of the number of
-        # compile jobs/tests to run in parallel.
-        - name: GOMAXPROCS
-          value: "4"
         securityContext:
           allowPrivilegeEscalation: false
         command:


### PR DESCRIPTION
ci-kubernetes-unit-eks-canary and ci-kubernetes-kind-e2e-json-logging-eks-canary had GOMAXPROCS environment variable explicitly set to mitigate flakes when running in the new EKS-based Prow build cluster. @dims added logic to automatically determine GOMAXPROCS in k/k, so we shouldn't need to explicitly set GOMAXPROCS any longer. Both jobs have logs such as:

```
+++ [0509 10:11:18] Setting GOMAXPROCS: 7
```

I propose that we leave these two canary jobs but without GOMAXPROCS for a few days before migrating them to the new cluster.

/assign @dims @pkprzekwas 