### PR TITLE
Drop GOMAXPROCS environment variable from ci-benchmark-scheduler-perf-master-eks-canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -90,8 +90,6 @@ periodics:
       args:
       - ./test/integration/scheduler_perf
       env:
-      - name: GOMAXPROCS
-        value: "6"
       - name: KUBE_TIMEOUT
         value: --timeout=2h25m
       - name: TEST_PREFIX


### PR DESCRIPTION
This PR drops GOMAXPROCS environment variable from ci-benchmark-scheduler-perf-master-eks-canary job. Hopefully we don't need it any longer now that https://github.com/kubernetes/kubernetes/pull/117885 is merged.

/assign @dims 