### PR TITLE
revert update to go 1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.20
+      - image: golang:1.19
         command:
         - make
         args:


### PR DESCRIPTION
Reverts https://github.com/kubernetes/test-infra/pull/29383

I think this is causing test failures and is blocking release. We can reintroduce this later after investigation.