### PR TITLE
trigger relevant kind image builds if .go-version changes

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kind.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kind.yaml
@@ -27,7 +27,7 @@ postsubmits:
           - 2921947 # kind-maintainers
     - name: post-kind-push-base-image
       cluster: k8s-infra-prow-build-trusted
-      run_if_changed: '(^images/base)|(^images/Makefile)'
+      run_if_changed: '(^images/base)|(^images/Makefile)|(^.go-version)'
       annotations:
         testgrid-dashboards: sig-testing-kind, sig-k8s-infra-gcb
         testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
@@ -54,7 +54,7 @@ postsubmits:
           - 2921947 # kind-maintainers
     - name: post-kind-push-kindnetd-image
       cluster: k8s-infra-prow-build-trusted
-      run_if_changed: '(^images/kindnetd)|(^images/Makefile)'
+      run_if_changed: '(^images/kindnetd)|(^images/Makefile)|(^.go-version)'
       annotations:
         testgrid-dashboards: sig-testing-kind, sig-k8s-infra-gcb
         testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
@@ -108,7 +108,7 @@ postsubmits:
           - 2921947 # kind-maintainers
     - name: post-kind-push-local-path-provisioner-image
       cluster: k8s-infra-prow-build-trusted
-      run_if_changed: '(^images/local-path-provisioner)|(^images/Makefile)'
+      run_if_changed: '(^images/local-path-provisioner)|(^images/Makefile)|(^.go-version)'
       annotations:
         testgrid-dashboards: sig-testing-kind, sig-k8s-infra-gcb
         testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com


### PR DESCRIPTION
/hold
this is for https://github.com/kubernetes-sigs/kind/pull/3201

it's not needed until after that PR merges, because we already are touching the other paths, but if we merge 3201 then we'll want this going forward

/cc @aojea 