### PR TITLE
integration test: use default namespace explicitly (again)

### DIFF
--- a/prow/test/integration/config/prow/cluster/200_ingress.yaml
+++ b/prow/test/integration/config/prow/cluster/200_ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: strip-path-prefix
+  namespace: default
   annotations:
     # Rewrite path to strip the first prefix from the URL path.  E.g., if the
     # inbound traffic says it is for /fakeghserver/foo, then this rule rewrites
@@ -63,6 +64,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: no-strip-path-prefix
+  namespace: default
 spec:
   ingressClassName: "nginx"
   rules:

--- a/prow/test/integration/config/prow/cluster/sub.yaml
+++ b/prow/test/integration/config/prow/cluster/sub.yaml
@@ -103,6 +103,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sub
+  namespace: default
 rules:
   - apiGroups:
       - prow.k8s.io
@@ -118,6 +119,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sub
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/prow/test/integration/lib.sh
+++ b/prow/test/integration/lib.sh
@@ -273,6 +273,7 @@ function wait_for_readiness() {
     if  >/dev/null 2>&1 do_kubectl wait pod \
       --for=condition=ready \
       --selector=app="${component}" \
+      --namespace=default \
       --timeout=5s; then
       return
     else


### PR DESCRIPTION
This is a followup to 30ecf3c928 (integration test: use default namespace explicitly, 2023-05-08). Again, these fixes were necessitated when running the integration tests in a GKE 1.25 environment.

/cc @cjwagner @mpherman2 