### PR TITLE
update promo-tools job to use go1.20

### DIFF
--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -152,7 +152,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
needed for https://github.com/kubernetes-sigs/promo-tools/pull/863


/assign @saschagrunert @xmudrii @puerco 
cc @kubernetes/release-engineering 