### PR TITLE
fix expected exit directly without waiting for lister ready

### DIFF
--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -350,11 +350,12 @@ func (c *controller) createPipelineRun(pContext, namespace string, p *pipelinev1
 		return p, err
 	}
 	// Block until the pipelinerun is in the lister, otherwise we may attempt to create it again
-	err = wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
-		_, err := c.getPipelineRun(pContext, namespace, p.Name)
-		return err == nil, err
+	var errOut error
+	wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+		_, errOut = c.getPipelineRun(pContext, namespace, p.Name)
+		return errOut == nil, nil
 	})
-	return p, err
+	return p, errOut
 }
 
 func (c *controller) now() metav1.Time {


### PR DESCRIPTION
the poll stops directly if there is an error returned according to the function description:

```go
// ConditionFunc returns true if the condition is satisfied, or an error
// if the loop should be aborted.
type ConditionFunc func() (done bool, err error)
```