### PR TITLE
Updating remaining windows 1.24 jobs to use capz release-1.6

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -30,14 +30,11 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    # The Windows 1.24 jobs should stay on CAPZ release-1.6 for now because later versions build CNM and CCM
+    # images from k-sigs/cluster-provider-azure repo and the container image builds are not working.
+    base_ref: release-1.6
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: release-1.24
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
   spec:
     containers:
     - command:


### PR DESCRIPTION
This job was missed in https://github.com/kubernetes/test-infra/pull/29468 :(

/assign @jsturtevant @mboersma 
/sig windows