### PR TITLE
Fix typos in gerritInterface names and cleanup.

### DIFF
--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	// tideEnablementLabel is the Gerrit label that has to be voted for enabling
-	// tide. By default a PR is not considered by tide unless the author of the
+	// Tide. By default a PR is not considered by Tide unless the author of the
 	// PR toggled this label.
 	tideEnablementLabel = "Prow-Auto-Submit"
 	// ref:
@@ -86,8 +86,8 @@ func (gcc *gerritContextChecker) MissingRequiredContexts([]string) []string {
 }
 
 type gerritClient interface {
-	QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters ...string) ([]gerrit.ChangeInfo, error)
-	GetChange(instance, id string, addtionalFeilds ...string) (*gerrit.ChangeInfo, error)
+	QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, additionalFilters ...string) ([]gerrit.ChangeInfo, error)
+	GetChange(instance, id string, additionalFields ...string) (*gerrit.ChangeInfo, error)
 	GetBranchRevision(instance, project, branch string) (string, error)
 	SubmitChange(instance, id string, wait bool) (*gerrit.ChangeInfo, error)
 	SetReview(instance, id, revision, message string, _ map[string]string) error
@@ -136,7 +136,7 @@ func NewGerritController(
 // Enforcing interface implementation check at compile time
 var _ provider = (*GerritProvider)(nil)
 
-// GerritProvider implements provider, used by tide Controller for
+// GerritProvider implements provider, used by Tide Controller for
 // interacting directly with Gerrit.
 //
 // Tide Controller should only use GerritProvider for communicating with Gerrit.
@@ -180,10 +180,10 @@ func newGerritProvider(
 	}
 }
 
-// Query returns all PRs from configured gerrit org/repos.
+// Query returns all PRs from configured Gerrit org/repos.
 func (p *GerritProvider) Query() (map[string]CodeReviewCommon, error) {
-	// lastUpdate is used by gerrit adapter for achieving incremental query. In
-	// tide case we want to get everything so use default time.Time, which
+	// lastUpdate is used by Gerrit adapter for achieving incremental query. In
+	// Tide case we want to get everything so use default time.Time, which
 	// should be 1970,1,1.
 	var lastUpdate time.Time
 
@@ -195,8 +195,6 @@ func (p *GerritProvider) Query() (map[string]CodeReviewCommon, error) {
 		changes  []gerrit.ChangeInfo
 	}
 	resChan := make(chan changesFromProject)
-	// This is querying serially, which would safely guard against quota issues.
-	// TODO(chaodai): parallize this to boot the performance.
 	for instance, projs := range p.cfg().Tide.Gerrit.Queries.AllRepos() {
 		instance, projs := instance, projs
 		for projName, projFilter := range projs {
@@ -354,8 +352,8 @@ func (p *GerritProvider) prMergeMethod(crc *CodeReviewCommon) *types.PullRequest
 		return nil
 	}
 
-	// Translate merge methods to types that git could understand. The merge
-	// methods for gerrit are documented at
+	// Translate merge methods to types that Git could understand. The merge
+	// methods for Gerrit are documented at
 	// https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#repository.
 	// Git can only understand MergeIfNecessary, MergeMerge, MergeRebase, MergeSquash.
 	switch pr.SubmitType {


### PR DESCRIPTION
- Fixed typos and case consistency of Tide, Git, and Gerrit.
- Removed a stale TODO and comment that no longer applied.