### PR TITLE
Cluster API: Run full tests with IPv6 in presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -245,8 +245,6 @@ presubmits:
             # enable IPV6 in bootstrap image
             - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
               value: "true"
-            - name: GINKGO_FOCUS
-              value: "\\[IPv6\\] \\[PR-Informing\\] \\[Dualstack\\]"
             - name: IP_FAMILY
               value: "dual"
           # we need privileged mode in order to do docker in docker
@@ -258,7 +256,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-informing-dualstack-ipv6-main
-
   - name: pull-cluster-api-e2e-full-main
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Remove the Ginkgo focus from this job, enabling us to run all tests with IPv6 enabled for this presubmit.