### PR TITLE
sig-node: capture kind cluster logs after failure to bring up cluster

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -29,8 +29,8 @@ periodics:
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
           test/e2e/dra/kind-build-image.sh dra/node:latest &&
-          kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           trap 'kind export logs "${ARTIFACTS}/kind"' EXIT &&
+          kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation
 
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1220,8 +1220,8 @@ presubmits:
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
           test/e2e/dra/kind-build-image.sh dra/node:latest &&
-          kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           trap 'kind export logs "${ARTIFACTS}/kind"' EXIT &&
+          kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation
 
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
On May 12, bringing up the kind cluster broke for no obvious reason (unrelated change in k/k, no job changes). To debug this, we need whatever logs `kind export logs` may be able to provide, even when `kind create cluster` failed.