### PR TITLE
sig-cl: update manifest-list e2e

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -17,8 +17,8 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-all
     testgrid-tab-name: periodic-manifest-lists
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle; an e2e test for verifying manifest list images at registry.k8s.io"
     testgrid-num-columns-recent: "20"
-    testgrid-num-failures-to-alert: "4"
+    testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "48"


### PR DESCRIPTION
- switch alert email to kubeadm email, since the main SIG CL mail should not be used.
- switch report to 2 failures (instead of 4)

xref https://github.com/kubernetes/kubeadm/issues/2873
