### PR TITLE
Cluster API: Remove fail-fast setting in tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -96,8 +96,6 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: GINKGO_ARGS
-            value: "--fail-fast=false" # set the value of fail-fast to false to get results for every test.
           - name: GINKGO_SKIP
             value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
@@ -143,8 +141,6 @@ periodics:
           # enable IPV6 in bootstrap image
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
-          - name: GINKGO_ARGS
-            value: "--fail-fast=false" # set the value of fail-fast to false to get results for every test.
           - name: GINKGO_SKIP
             value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Remove setting `--fail-fast=false` manually in tests. This behaviour is now on by default in the CAPI repo's `ci-e2e.sh` script