### PR TITLE
🌱 Enable periodic GH Bug Triage project board syncing for v1.28

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -27,7 +27,7 @@ periodics:
             secretKeyRef:
               name: k8s-release-enhancements-triage-github-token
               key: token
-- name: periodic-sync-bug-triage-github-project-beta-1-27
+- name: periodic-sync-bug-triage-github-project-beta-1-28
   interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -48,7 +48,7 @@ periodics:
         - name: PROJECT_NUMBER
           value: "80"
         - name: MILESTONE
-          value: "v1.27"
+          value: "v1.28"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Signed-off by: Furkat Gofurov (furkat.gofurov@suse.com)

Assuming we will be reusing the [same](https://github.com/orgs/kubernetes/projects/80) GH Bug Triage project board used in previous release (it was renamed from v1.27 to v1.28), this PR updates the periodic prow job so that it syncs the Bug Triage board with  issues/PRs' targeting v1.28 milestone.


/assign @helayoty 
/cc @gracenng @leonardpahlke 