### PR TITLE
Skipping tests in 1.24 Windows jobs that require etcd images

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -82,6 +82,10 @@ periodics:
           - "./scripts/ci-conformance.sh"
         securityContext:
           privileged: true
+        env:
+        # Skip tests that require etcd image for 1.24 Windows jobs because the etcd image referenced in this branch does not container Windows images.
+        - name: GINKGO_SKIP
+          value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Aggregator.Should.be.able.to.support.the.1.17.Sample.API.Server|be.restarted.with.a.GRPC.liveness.probe
         resources:
           requests:
             cpu: 2


### PR DESCRIPTION
1.25 is the first release where the etcd images used in tested containered Windows images.

We skipped these jobs in v1.23 too
https://github.com/kubernetes/test-infra/commit/550126ffcf730d8a3d06df6b9bfd4458e5936e8d#diff-cb152af5453eae6d0df32278cd31e9a8b5daeb62853c11beacf5187d03d0705bL47

/sig windows
/assign @jsturtevant @CecileRobertMichon @xmudrii 