### PR TITLE
Run watchlist tests on public cluster

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -162,6 +162,7 @@ periodics:
         args:
           - --check-leaked-resources
           - --env=CONTAINER_IMAGE=registry-sandbox.k8s.io/pause:3.1 #TODO(ameukam): revert when registry.k8s.io is ready
+          - --env=KUBE_GCE_PRIVATE_CLUSTER=false #TODO(#29500): revert when private cluster setup is fixed
           - --extract=ci/latest
           - --gcp-node-image=gci
           - --gcp-master-size=n1-standard-32
@@ -225,6 +226,7 @@ periodics:
           - --check-leaked-resources
           - --env=CL2_ENABLE_WATCH_LIST_FEATURE=true
           - --env=CONTAINER_IMAGE=registry-sandbox.k8s.io/pause:3.1 #TODO(ameukam): revert when registry.k8s.io is ready
+          - --env=KUBE_GCE_PRIVATE_CLUSTER=false #TODO(#29500): revert when private cluster setup is fixed
           - --extract=ci/latest
           - --gcp-node-image=gci
           - --gcp-master-size=n1-standard-32


### PR DESCRIPTION
This is a temporary workaround around https://github.com/kubernetes/test-infra/issues/29500

The proper solution is to fix scalability jobs private cluster setup, but it looks like a non-trivial task compared to this change.