### PR TITLE
Revert temporary changes to periodic-cluster-api-provider-aws-e2e-eks-canary

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -45,8 +45,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  # Changed from 12 hours to reduce amount of runs because job is broken
-  interval: 24h
+  interval: 12h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -72,19 +71,15 @@ periodics:
       # Parallelize tests
       - name: GINKGO_ARGS
         value: "-nodes 20 -skip='\\[ClusterClass\\]'"
-      # set GOMAXPROCS to match the CPU limit.  This informs the Go runtime of the number of
-      # compile jobs/tests to run in parallel.
-      - name: GOMAXPROCS
-        value: "4"
       securityContext:
         privileged: true
       resources:
         limits:
-          cpu: 4
-          memory: "18Gi"
+          cpu: 2
+          memory: "9Gi"
         requests:
-          cpu: 4
-          memory: "18Gi"
+          cpu: 2
+          memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
     testgrid-tab-name: periodic-aws-e2e-main-canary


### PR DESCRIPTION
We made some temporary changes to `periodic-cluster-api-provider-aws-e2e-eks-canary` to try to make it work. It turned out that the issue was related to missing permissions and this is now fixed. That said, let's revert those temporary changes to ensure this job is inline with the non-canary one (`periodic-cluster-api-provider-aws-e2e`).

/assign @dims 