### PR TITLE
sig-scalability/watchlist: increase the worker node instance type

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -166,7 +166,7 @@ periodics:
           - --extract=ci/latest
           - --gcp-node-image=gci
           - --gcp-master-size=n1-standard-32
-          - --gcp-node-size=e2-standard-8
+          - --gcp-node-size=e2-standard-16
           - --gcp-nodes=1
           - --gcp-project-type=scalability-project
           - --provider=gce
@@ -230,7 +230,7 @@ periodics:
           - --extract=ci/latest
           - --gcp-node-image=gci
           - --gcp-master-size=n1-standard-32
-          - --gcp-node-size=e2-standard-8
+          - --gcp-node-size=e2-standard-16
           - --gcp-nodes=1
           - --gcp-project-type=scalability-project
           - --provider=gce


### PR DESCRIPTION
The [latest](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-watch-list-off/1658765757233762304) run for the `watch-list-off` test shows that the test binary (a job) wasn't scheduled because there were no nodes with sufficient resources (CPU)  to run the job.

I'm proposing to increase the worker node type to `e2-standard-16`


xref: https://github.com/kubernetes/enhancements/issues/3157
xref: https://github.com/kubernetes/test-infra/pull/29531