### PR TITLE
spyglass: html lens should work with files of same name

### DIFF
--- a/prow/spyglass/lenses/html/html.go
+++ b/prow/spyglass/lenses/html/html.go
@@ -41,6 +41,7 @@ type Lens struct{}
 
 type document struct {
 	Filename string
+	ID       string
 	Title    string
 	Content  string
 }
@@ -81,14 +82,14 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 	}
 
 	documents := make([]document, 0)
-	for _, artifact := range artifacts {
+	for i, artifact := range artifacts {
 		content, err := artifact.ReadAll()
 		if err != nil {
 			logrus.WithError(err).WithField("artifact_url", artifact.CanonicalLink()).Warn("failed to read content")
 			continue
 		}
 		name := filepath.Base(artifact.CanonicalLink())
-		documents = append(documents, extractDocumentDetails(name, content))
+		documents = append(documents, extractDocumentDetails(name, i, content))
 	}
 
 	template, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
@@ -106,9 +107,10 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 
 // extractDocumentDetails parses the HTML to extract the title and
 // meta description tag, if present.
-func extractDocumentDetails(name string, content []byte) document {
+func extractDocumentDetails(name string, id int, content []byte) document {
 	doc := document{
 		Filename: name,
+		ID:       fmt.Sprintf("%s-%d", name, id),
 		Title:    name,
 		Content:  string(content),
 	}

--- a/prow/spyglass/lenses/html/template.html
+++ b/prow/spyglass/lenses/html/template.html
@@ -13,7 +13,7 @@
     {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok, so we hide on first resize request */}}
     <tr class="initial" id="{{.Filename}}-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="{{.Content}}" title="{{.Filename}}" sandbox="allow-scripts allow-popups allow-same-origin" id="{{.Filename}}" width="100%" scrolling="no"></iframe>
+        <iframe srcdoc="{{.Content}}" title="{{.Filename}}" sandbox="allow-scripts allow-popups allow-same-origin" id="{{.ID}}" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     {{end}}

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="initial" id="file.html-tr">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
@@ -2,13 +2,13 @@
   <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
     
     <tr class="header section-expander">
-      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html <abbr class="icon material-icons" title="Loki is a log aggregation system">info</abbr></h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
     <tr class="initial" id="file.html-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="<div id=&quot;wrapper&quot;><body>&quot;Hello world!&quot;</body></div><script type=&quot;text/javascript&quot;>
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><meta name=&quot;description&quot; content=&quot;Loki is a log aggregation system&quot;></head><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>File 1</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="initial" id="file.html-tr">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>File 1</title><body></body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
@@ -2,13 +2,13 @@
   <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
     
     <tr class="header section-expander">
-      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>Custom Title</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>File 2</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
     <tr class="initial" id="file.html-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>Custom Title</title><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>File 2</title><body></body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
@@ -8,7 +8,7 @@
     
     <tr class="initial" id="file.html-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="<div id=&quot;wrapper&quot;><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><body>&quot;Hello world!&quot;</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
@@ -2,13 +2,13 @@
   <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
     
     <tr class="header section-expander">
-      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html <abbr class="icon material-icons" title="Loki is a log aggregation system">info</abbr></h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>Custom Title</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
     <tr class="initial" id="file.html-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><meta name=&quot;description&quot; content=&quot;Loki is a log aggregation system&quot;></head><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>Custom Title</title><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     


### PR DESCRIPTION
The html lens uses the file name as the ID, but it can happen that you have the same named file in multiple directories. This causes the accordion to be opened for anything but the first file, this fixes that by appending an index to the file name in the ID.

Example of the behavior of multiple same-named files: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-install-analysis-all/1658789484122083328
