### PR TITLE
Team specific pod timeouts

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -251,22 +251,22 @@ spec:
                         type: string
                     type: object
                   pod_pending_timeout:
-                    description: PodPendingTimeout is after how long the controller
-                      will perform a garbage collection on pending pods. Specific
+                    description: PodPendingTimeout defines how long the controller
+                      will wait to perform garbage collection on pending pods. Specific
                       for OrgRepo or Cluster. If not set, it has a fallback inside
                       plank field.
                     type: string
                   pod_running_timeout:
-                    description: PodRunningTimeout is after how long the controller
-                      will abort a prowjob pod stuck in running state. Specific for
-                      OrgRepo or Cluster. If not set, it has a fallback inside plank
-                      field.
-                    type: string
-                  pod_unscheduled_timeout:
-                    description: PodUnscheduledTimeout is after how long the controller
-                      will abort a prowjob stuck in an unscheduled state. Specific
+                    description: PodRunningTimeout defines how long the controller
+                      will wait to abort a prowjob pod stuck in running state. Specific
                       for OrgRepo or Cluster. If not set, it has a fallback inside
                       plank field.
+                    type: string
+                  pod_unscheduled_timeout:
+                    description: PodUnscheduledTimeout defines how long the controller
+                      will wait to abort a prowjob stuck in an unscheduled state.
+                      Specific for OrgRepo or Cluster. If not set, it has a fallback
+                      inside plank field.
                     type: string
                   resources:
                     description: Resources holds resource requests and limits for

--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -250,6 +250,24 @@ spec:
                         description: Name is the name of a kubernetes secret.
                         type: string
                     type: object
+                  pod_pending_timeout:
+                    description: PodPendingTimeout is after how long the controller
+                      will perform a garbage collection on pending pods. Specific
+                      for OrgRepo or Cluster. If not set, it has a fallback inside
+                      plank field.
+                    type: string
+                  pod_running_timeout:
+                    description: PodRunningTimeout is after how long the controller
+                      will abort a prowjob pod stuck in running state. Specific for
+                      OrgRepo or Cluster. If not set, it has a fallback inside plank
+                      field.
+                    type: string
+                  pod_unscheduled_timeout:
+                    description: PodUnscheduledTimeout is after how long the controller
+                      will abort a prowjob stuck in an unscheduled state. Specific
+                      for OrgRepo or Cluster. If not set, it has a fallback inside
+                      plank field.
+                    type: string
                   resources:
                     description: Resources holds resource requests and limits for
                       utility containers used to decorate a PodSpec.

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -526,13 +526,13 @@ type DecorationConfig struct {
 	// defined explicitly on prowjob.
 	DefaultMemoryRequest *resource.Quantity `json:"default_memory_request,omitempty"`
 
-	// PodPendingTimeout is after how long the controller will perform a garbage
+	// PodPendingTimeout defines how long the controller will wait to perform garbage
 	// collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
 	PodPendingTimeout *metav1.Duration `json:"pod_pending_timeout,omitempty"`
-	// PodRunningTimeout is after how long the controller will abort a prowjob pod
+	// PodRunningTimeout defines how long the controller will wait to abort a prowjob pod
 	// stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
 	PodRunningTimeout *metav1.Duration `json:"pod_running_timeout,omitempty"`
-	// PodUnscheduledTimeout is after how long the controller will abort a prowjob
+	// PodUnscheduledTimeout defines how long the controller will wait to abort a prowjob
 	// stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
 	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
 }

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -525,6 +525,16 @@ type DecorationConfig struct {
 	// set the same as this request. Could be overridden by memory request
 	// defined explicitly on prowjob.
 	DefaultMemoryRequest *resource.Quantity `json:"default_memory_request,omitempty"`
+
+	// PodPendingTimeout is after how long the controller will perform a garbage
+	// collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+	PodPendingTimeout *metav1.Duration `json:"pod_pending_timeout,omitempty"`
+	// PodRunningTimeout is after how long the controller will abort a prowjob pod
+	// stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+	PodRunningTimeout *metav1.Duration `json:"pod_running_timeout,omitempty"`
+	// PodUnscheduledTimeout is after how long the controller will abort a prowjob
+	// stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
 }
 
 type CensoringOptions struct {
@@ -733,6 +743,18 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 
 	if merged.DefaultMemoryRequest == nil {
 		merged.DefaultMemoryRequest = def.DefaultMemoryRequest
+	}
+
+	if merged.PodPendingTimeout == nil {
+		merged.PodPendingTimeout = def.PodPendingTimeout
+	}
+
+	if merged.PodRunningTimeout == nil {
+		merged.PodRunningTimeout = def.PodRunningTimeout
+	}
+
+	if merged.PodUnscheduledTimeout == nil {
+		merged.PodUnscheduledTimeout = def.PodUnscheduledTimeout
 	}
 
 	return &merged

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -27,6 +27,7 @@ import (
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -168,6 +169,21 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		in, out := &in.DefaultMemoryRequest, &out.DefaultMemoryRequest
 		x := (*in).DeepCopy()
 		*out = &x
+	}
+	if in.PodPendingTimeout != nil {
+		in, out := &in.PodPendingTimeout, &out.PodPendingTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.PodRunningTimeout != nil {
+		in, out := &in.PodRunningTimeout, &out.PodRunningTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.PodUnscheduledTimeout != nil {
+		in, out := &in.PodUnscheduledTimeout, &out.PodUnscheduledTimeout
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -625,13 +625,13 @@ func (c *Controller) ReportTemplateForRepo(refs *prowapi.Refs) *template.Templat
 // Plank is config for the plank controller.
 type Plank struct {
 	Controller `json:",inline"`
-	// PodPendingTimeout is after how long the controller will perform a garbage
+	// PodPendingTimeout defines how long the controller will wait to perform a garbage
 	// collection on pending pods. Defaults to 10 minutes.
 	PodPendingTimeout *metav1.Duration `json:"pod_pending_timeout,omitempty"`
-	// PodRunningTimeout is after how long the controller will abort a prowjob pod
+	// PodRunningTimeout defines how long the controller will wait to abort a prowjob pod
 	// stuck in running state. Defaults to two days.
 	PodRunningTimeout *metav1.Duration `json:"pod_running_timeout,omitempty"`
-	// PodUnscheduledTimeout is after how long the controller will abort a prowjob
+	// PodUnscheduledTimeout defines how long the controller will wait to abort a prowjob
 	// stuck in an unscheduled state. Defaults to 5 minutes.
 	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -5167,6 +5167,70 @@ default_decoration_config_entries:
 			},
 		},
 		{
+			name: "org, repo, cluster specific timeouts",
+			raw: `
+default_decoration_config_entries:
+  - repo: "org"
+    config:
+      pod_running_timeout: 3h
+      pod_pending_timeout: 2h
+      pod_unscheduled_timeout: 1h
+  - repo: "org/repo"
+    config:
+      pod_running_timeout: 2h
+      pod_pending_timeout: 1h
+      pod_unscheduled_timeout: 3h
+  - repo: "org/foo"
+    config:
+      pod_running_timeout: 1h
+      pod_pending_timeout: 2h
+      pod_unscheduled_timeout: 3h
+  - cluster: "trusted"
+    config:
+      pod_running_timeout: 30m
+      pod_pending_timeout: 45m
+      pod_unscheduled_timeout: 15m
+`,
+			expected: []*DefaultDecorationConfigEntry{
+				{
+					OrgRepo: "org",
+					Cluster: "",
+					Config: &prowapi.DecorationConfig{
+						PodRunningTimeout:     &metav1.Duration{Duration: 3 * time.Hour},
+						PodPendingTimeout:     &metav1.Duration{Duration: 2 * time.Hour},
+						PodUnscheduledTimeout: &metav1.Duration{Duration: 1 * time.Hour},
+					},
+				},
+				{
+					OrgRepo: "org/repo",
+					Cluster: "",
+					Config: &prowapi.DecorationConfig{
+						PodRunningTimeout:     &metav1.Duration{Duration: 2 * time.Hour},
+						PodPendingTimeout:     &metav1.Duration{Duration: 1 * time.Hour},
+						PodUnscheduledTimeout: &metav1.Duration{Duration: 3 * time.Hour},
+					},
+				},
+				{
+					OrgRepo: "org/foo",
+					Cluster: "",
+					Config: &prowapi.DecorationConfig{
+						PodRunningTimeout:     &metav1.Duration{Duration: 1 * time.Hour},
+						PodPendingTimeout:     &metav1.Duration{Duration: 2 * time.Hour},
+						PodUnscheduledTimeout: &metav1.Duration{Duration: 3 * time.Hour},
+					},
+				},
+				{
+					OrgRepo: "",
+					Cluster: "trusted",
+					Config: &prowapi.DecorationConfig{
+						PodRunningTimeout:     &metav1.Duration{Duration: 30 * time.Minute},
+						PodPendingTimeout:     &metav1.Duration{Duration: 45 * time.Minute},
+						PodUnscheduledTimeout: &metav1.Duration{Duration: 15 * time.Minute},
+					},
+				},
+			},
+		},
+		{
 			name: "both formats, expect error",
 			raw: `
 default_decoration_configs:

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -663,13 +663,13 @@ plank:
                 key: ' '
                 # Name is the name of a kubernetes secret.
                 name: ' '
-            # PodPendingTimeout is after how long the controller will perform a garbage
+            # PodPendingTimeout defines how long the controller will wait to perform garbage
             # collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
             pod_pending_timeout: 0s
-            # PodRunningTimeout is after how long the controller will abort a prowjob pod
+            # PodRunningTimeout defines how long the controller will wait to abort a prowjob pod
             # stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
             pod_running_timeout: 0s
-            # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+            # PodUnscheduledTimeout defines how long the controller will wait to abort a prowjob
             # stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
             pod_unscheduled_timeout: 0s
             # Resources holds resource requests and limits for utility
@@ -841,13 +841,13 @@ plank:
                 key: ' '
                 # Name is the name of a kubernetes secret.
                 name: ' '
-            # PodPendingTimeout is after how long the controller will perform a garbage
+            # PodPendingTimeout defines how long the controller will wait to perform garbage
             # collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
             pod_pending_timeout: 0s
-            # PodRunningTimeout is after how long the controller will abort a prowjob pod
+            # PodRunningTimeout defines how long the controller will wait to abort a prowjob pod
             # stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
             pod_running_timeout: 0s
-            # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+            # PodUnscheduledTimeout defines how long the controller will wait to abort a prowjob
             # stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
             pod_unscheduled_timeout: 0s
             # Resources holds resource requests and limits for utility
@@ -924,13 +924,13 @@ plank:
     # JobURLPrefixDisableAppendStorageProvider disables that the storageProvider is
     # automatically appended to the JobURLPrefix.
     jobURLPrefixDisableAppendStorageProvider: true
-    # PodPendingTimeout is after how long the controller will perform a garbage
+    # PodPendingTimeout defines how long the controller will wait to perform a garbage
     # collection on pending pods. Defaults to 10 minutes.
     pod_pending_timeout: 0s
-    # PodRunningTimeout is after how long the controller will abort a prowjob pod
+    # PodRunningTimeout defines how long the controller will wait to abort a prowjob pod
     # stuck in running state. Defaults to two days.
     pod_running_timeout: 0s
-    # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+    # PodUnscheduledTimeout defines how long the controller will wait to abort a prowjob
     # stuck in an unscheduled state. Defaults to 5 minutes.
     pod_unscheduled_timeout: 0s
     # ReportTemplateString compiles into ReportTemplate at load time.

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -663,6 +663,15 @@ plank:
                 key: ' '
                 # Name is the name of a kubernetes secret.
                 name: ' '
+            # PodPendingTimeout is after how long the controller will perform a garbage
+            # collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+            pod_pending_timeout: 0s
+            # PodRunningTimeout is after how long the controller will abort a prowjob pod
+            # stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+            pod_running_timeout: 0s
+            # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+            # stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+            pod_unscheduled_timeout: 0s
             # Resources holds resource requests and limits for utility
             # containers used to decorate a PodSpec.
             resources:
@@ -832,6 +841,15 @@ plank:
                 key: ' '
                 # Name is the name of a kubernetes secret.
                 name: ' '
+            # PodPendingTimeout is after how long the controller will perform a garbage
+            # collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+            pod_pending_timeout: 0s
+            # PodRunningTimeout is after how long the controller will abort a prowjob pod
+            # stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+            pod_running_timeout: 0s
+            # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+            # stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+            pod_unscheduled_timeout: 0s
             # Resources holds resource requests and limits for utility
             # containers used to decorate a PodSpec.
             resources:

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -450,7 +450,13 @@ func (r *reconciler) syncPendingJob(ctx context.Context, pj *prowv1.ProwJob) (*r
 		case corev1.PodPending:
 			var requeueAfter time.Duration
 			maxPodPending := r.config().Plank.PodPendingTimeout.Duration
+			if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.PodPendingTimeout != nil {
+				maxPodPending = pj.Spec.DecorationConfig.PodPendingTimeout.Duration
+			}
 			maxPodUnscheduled := r.config().Plank.PodUnscheduledTimeout.Duration
+			if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.PodUnscheduledTimeout != nil {
+				maxPodUnscheduled = pj.Spec.DecorationConfig.PodUnscheduledTimeout.Duration
+			}
 			if pod.Status.StartTime.IsZero() {
 				if time.Since(pod.CreationTimestamp.Time) >= maxPodUnscheduled {
 					// Pod is stuck in unscheduled state longer than maxPodUncheduled
@@ -496,6 +502,9 @@ func (r *reconciler) syncPendingJob(ctx context.Context, pj *prowv1.ProwJob) (*r
 				break
 			}
 			maxPodRunning := r.config().Plank.PodRunningTimeout.Duration
+			if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.PodRunningTimeout != nil {
+				maxPodRunning = pj.Spec.DecorationConfig.PodRunningTimeout.Duration
+			}
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodRunning {
 				// Pod is still running. Do nothing.
 				return nil, nil


### PR DESCRIPTION
Add Org/Repo/Cluster specific pod timeouts in `DecorationConfig` for overriding values set in the `plank:` stanza

Fixes: https://github.com/kubernetes/test-infra/issues/26614