### PR TITLE
Add ContribEx as relevant owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -66,6 +66,11 @@ aliases:
     - mrbobbytables
     - nikhita
     - palnabarun
+  sig-contributor-experience-technical-leads:
+    - MadhavJivrajani
+    - Priyankasaggu11929
+    - cblecker
+    - nikhita
   sig-docs-leads:
     - divya-mohan0209
     - jimangel

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/OWNERS
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/OWNERS
@@ -2,8 +2,20 @@
 options:
   no_parent_owners: true
 
-reviewers:
-- sig-k8s-infra-oncall
-approvers:
-- sig-k8s-infra-oncall
-- test-infra-oncall
+filters:
+  ".*":
+    reviewers:
+    - sig-k8s-infra-oncall
+    approvers:
+    - sig-k8s-infra-oncall
+    - test-infra-oncall
+  # ContribEx related jobs that K8s infra owns (currently
+  # only the sig-contirbex-k8s-triage-robot.yaml job) should
+  # be reviewed by ContribEx TLs since it could potentially
+  # constitute a workflow change:
+  # git.k8s.io/community/sig-contributor-experience/charter.md#cross-cutting-and-externally-facing-processes
+  "^sig-contribex-":
+    required_reviewers:
+      - sig-contributor-experience-technical-leads
+    labels:
+      - sig/contributor-experience

--- a/label_sync/OWNERS
+++ b/label_sync/OWNERS
@@ -3,15 +3,16 @@
 filters:
   ".*":
     approvers:
-      - cblecker
+      - sig-contributor-experience-technical-leads
       - spiffxp
     reviewers:
-      - cblecker
+      - sig-contributor-experience-technical-leads
       - spiffxp
     emeritus_approvers:
       - fejta
     labels:
       - area/label_sync
+      - sig/contributor-experience
   "labels\\.yaml":
     required_reviewers:
-      - cblecker
+      - sig-contributor-experience-technical-leads

--- a/prow/plugins/OWNERS
+++ b/prow/plugins/OWNERS
@@ -2,6 +2,12 @@
 
 reviewers:
 - cjwagner
+# Add ContribEx leads as reviewers on changes to plugins
+# since these might be potential changes to the contributor
+# workflow. See link:
+# http://git.k8s.io/community/sig-contributor-experience/charter.md#cross-cutting-and-externally-facing-processes
+required_reviewers:
+- sig-contributor-experience-technical-leads
 approvers:
 - cjwagner
 labels:


### PR DESCRIPTION
This PR consists of 3 commits:

#### Commit 1:

Add a new `sig-contributor-experience-technical-leads` alias in OWNERS_ALIASES

#### Commit 2:

This commit adds guardrails to potential workflow changes.
Workflow changes are to be signed off by ContribEx TLs.

Workflow changes are scoped to:
- Changes to prow plugins
- Changes to the k8s-triage-robot

#### Commit 3:

Add ContribEx as owners of the label_sync tool
(ref https://kubernetes.slack.com/archives/C1TU9EB9S/p1683818540227269)

---

Fixes https://github.com/kubernetes/test-infra/issues/28021
/sig contributor-experience 
/assign @kubernetes/sig-contributor-experience-leads 
/assign @BenTheElder 