### PR TITLE
kubernetes-sigs/cluster-api pin CAPI v1.2 release upgrade tests to certain versions

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
@@ -289,7 +289,7 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.23"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "stable-1.24"
+        value: "v1.24.13"
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.3-0"
       - name: COREDNS_VERSION_UPGRADE_TO
@@ -338,9 +338,9 @@ periodics:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.24"
+            value: "v1.24.13"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "stable-1.25"
+            value: "v1.25.9"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.4-0"
           - name: COREDNS_VERSION_UPGRADE_TO
@@ -389,9 +389,9 @@ periodics:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.25"
+            value: "v1.25.9"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "stable-1.26"
+            value: "v1.26.4"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.6-0"
           - name: COREDNS_VERSION_UPGRADE_TO


### PR DESCRIPTION
Pins the Kubernetes versions for CAPI's v1.2 release branch tests to certain versions.

Pins the versions for Kubernetes v1.24, v1.25 and v1.26 to workaround registry pull failures.

Affected jobs:
* [capi-e2e-release-1-2-1-23-1-24](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-1.2#capi-e2e-release-1-2-1-23-1-24)
* [capi-e2e-release-1-2-1-24-1-25](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-1.2#capi-e2e-release-1-2-1-24-1-25)
* [capi-e2e-release-1-2-1-25-1-26](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-1.2#capi-e2e-release-1-2-1-25-1-26)

See xref: https://github.com/kubernetes-sigs/cluster-api/issues/8710 .

This jobs will get dropped after the v1.5 CAPI release anyway (scheduled for July 25th). 