### PR TITLE
[WIP] kubernetes-sigs/cluster-api move v1.2 jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
@@ -1,6 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -45,6 +46,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-18-1-19
@@ -52,6 +57,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -96,6 +102,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-19-1-20
@@ -103,6 +113,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -147,6 +158,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-20-1-21
@@ -154,6 +169,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -198,6 +214,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-21-1-22
@@ -205,6 +225,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -250,6 +271,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-22-1-23
@@ -257,6 +282,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -302,6 +328,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-23-1-24
@@ -309,6 +339,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -353,6 +384,10 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-24-1-25
@@ -360,6 +395,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -404,6 +440,10 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2-1-25-1-26

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
   decoration_config:
@@ -22,12 +23,17 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-test-release-1-2
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
   decoration_config:
@@ -58,12 +64,17 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-test-mink8s-release-1-2
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v0-3-to-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
   decoration_config:
@@ -109,12 +120,17 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-upgrade-v0-3-to-release-1-2
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v1-1-to-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
   decoration_config:
@@ -158,12 +174,17 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-upgrade-v1-1-to-release-1-2
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
   decoration_config:
@@ -200,12 +221,17 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-release-1-2
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-2
+  cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
   decoration_config:
@@ -249,6 +275,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
     testgrid-tab-name: capi-e2e-mink8s-release-1-2

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-2.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-release-1-2
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -16,10 +17,18 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-build-release-1-2
   - name: pull-cluster-api-apidiff-release-1-2
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -36,10 +45,18 @@ presubmits:
         - runner.sh
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.24
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 2000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-apidiff-release-1-2
   - name: pull-cluster-api-verify-release-1-2
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -58,10 +75,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-verify-release-1-2
   - name: pull-cluster-api-test-release-1-2
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -80,10 +102,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-test-release-1-2
   - name: pull-cluster-api-test-mink8s-release-1-2
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -110,10 +137,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-test-mink8s-release-1-2
   - name: pull-cluster-api-e2e-release-1-2
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -141,10 +173,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-e2e-release-1-2
   - name: pull-cluster-api-e2e-informing-release-1-2
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -175,10 +212,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-e2e-informing-release-1-2
   - name: pull-cluster-api-e2e-informing-ipv6-release-1-2
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -212,10 +254,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-e2e-informing-ipv6-release-1-2
   - name: pull-cluster-api-e2e-full-release-1-2
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -247,10 +294,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-e2e-full-release-1-2
   - name: pull-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-2
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -292,6 +344,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.2
       testgrid-tab-name: capi-pr-e2e-release-1-2-1-25-1-26


### PR DESCRIPTION
Configures all cluster-api jobs related to release v1.2 to use the new eks-prow-build-cluster instead of the default one.

xref:
* https://github.com/kubernetes-sigs/cluster-api/issues/8689