### PR TITLE
Add missing dind preset to HPA presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -98,6 +98,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - command:


### PR DESCRIPTION
HPA e2e custom metrics presubmit jobs are failing because of `Can't connect to 'docker' daemon.  please fix and retry.` after #29552.

Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/118048/pull-kubernetes-e2e-autoscaling-hpa-cm/1660541809404678144.