### PR TITLE
spyglass: fix height notifier in html lens

### DIFF
--- a/prow/spyglass/lenses/html/html.go
+++ b/prow/spyglass/lenses/html/html.go
@@ -121,7 +121,7 @@ func extractDocumentDetails(name string, id int, content []byte) document {
 	for {
 		switch token.Next() {
 		case html.ErrorToken:
-			doc.Content = injectHeightNotifier(doc.Content, name)
+			doc.Content = injectHeightNotifier(doc.Content, doc.ID)
 			// Escape double quotes as we are going to put this into an iframes srcdoc attribute. We can not reference the
 			// src directly because we have to inject the height notifier.
 			// Ref: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc
@@ -166,7 +166,7 @@ func extractDocumentDetails(name string, id int, content []byte) document {
 // injectHeightNotifier injects a small javascript snippet that will tell the iframe container about the height
 // of the iframe. Iframe height can only be set as an absolute value and CORS doesn't allow the container to
 // query the iframe.
-func injectHeightNotifier(content string, name string) string {
+func injectHeightNotifier(content string, id string) string {
 	return `<div id="wrapper">` + content + fmt.Sprintf(`</div><script type="text/javascript">
 window.addEventListener("load", function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
@@ -180,5 +180,5 @@ window.addEventListener("load", function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>`, name)
+</script>`, id)
 }

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
@@ -13,7 +13,7 @@ window.addEventListener(&quot;load&quot;, function(){
     if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
     send_height_to_parent_function = function(){
         var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
-        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html-0&quot;}, &quot;*&quot;);
     }
     send_height_to_parent_function(); //whenever the page is loaded
     window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized


### PR DESCRIPTION
I made ID's unique by appending an index in
https://github.com/kubernetes/test-infra/pull/29545, but I missed fixing the ID in the height notifier that allows dynamic sizing of the lens iframe.