### PR TITLE
sig-node: specify the same zone as existing periodics and remove the upload

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -299,14 +299,13 @@ periodics:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=master
       - --repo=github.com/containerd/containerd=main
-      - --upload=gs://kubernetes-jenkins/pr-logs
       - --service-account=/etc/service-account/service-account.json
       - --timeout=90
       - --scenario=kubernetes_e2e
       - --
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-central1-b
+      - --gcp-zone=us-west1-b
       - '--node-test-args=--standalone-mode=true --feature-gates=AllAlpha=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -340,14 +339,13 @@ periodics:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=master
       - --repo=github.com/containerd/containerd=main
-      - --upload=gs://kubernetes-jenkins/pr-logs
       - --service-account=/etc/service-account/service-account.json
       - --timeout=90
       - --scenario=kubernetes_e2e
       - --
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-central1-b
+      - --gcp-zone=us-west1-b
       - '--node-test-args=--standalone-mode=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true
       - --provider=gce


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/29558 as the tests don't appear to be running correctly:

https://testgrid.k8s.io/sig-node-release-blocking#node-kubelet-containerd-standalone-mode

