### PR TITLE
dra: lock down KinD to v0.19.0

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -27,8 +27,9 @@ periodics:
         - -xc
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          test/e2e/dra/kind-build-image.sh dra/node:latest &&
+          curl -sSL --output "${PATH%%:*}/kind" https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64 &&
+          chmod u+x "${PATH%%:*}/kind" &&
+          kind build node-image --base-image gcr.io/k8s-staging-kind/base:v20230515-01914134-containerd_v1.7.1@sha256:468fc430a6848884b786c5cd2f1c03e7a0977f04fb129a2cda2a19ec986ddacb --image dra/node:latest &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1218,8 +1218,9 @@ presubmits:
         - -xc
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          test/e2e/dra/kind-build-image.sh dra/node:latest &&
+          curl -sSL --output "${PATH%%:*}/kind" https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64 &&
+          chmod u+x "${PATH%%:*}/kind" &&
+          kind build node-image --base-image gcr.io/k8s-staging-kind/base:v20230515-01914134-containerd_v1.7.1@sha256:468fc430a6848884b786c5cd2f1c03e7a0977f04fb129a2cda2a19ec986ddacb --image dra/node:latest &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation


### PR DESCRIPTION
Some recent change in the latest nightly KinD broke the DRA jobs. Probably it was https://github.com/kubernetes-sigs/kind/pull/3241 which led to

     May 20 01:44:08 kind-control-plane kubelet[1610]: E0520 01:44:08.725026    1610 run.go:74] "command failed" err="failed to run Kubelet: invalid configuration: cgroup [\"kubelet\"] has some missing paths: /sys/fs/cgroup/hugetlb/kubelet.slice, /sys/fs/cgroup/cpuset/kubelet.slice"

To ensure that KinD release and the base image don't drift apart, both are now specified with exact version resp. image hash in the Prow job configs.