### PR TITLE
fix gcb-docker-gcloud buildx paths

### DIFF
--- a/images/gcb-docker-gcloud/buildx-entrypoint.sh
+++ b/images/gcb-docker-gcloud/buildx-entrypoint.sh
@@ -16,5 +16,5 @@
 set -euo pipefail
 
 /register --reset -p yes
-/root/.docker/cli-plugins/docker-buildx create --use
-/root/.docker/cli-plugins/docker-buildx "$@"
+docker buildx create --use
+docker buildx "$@"


### PR DESCRIPTION
docker buildx paths were modified https://github.com/kubernetes/test-infra/pull/29526 but entrypoint.sh is pointing to hardcoded old directories. It will make builds to fail https://storage.googleapis.com/kubernetes-jenkins/logs/cloud-provider-openstack-push-images/1660667996332363776/build-log.txt