### PR TITLE
Add missing privileged setting to HPA presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -118,3 +118,5 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-autoscaling-hpa-cm
         - --timeout=300m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
+        securityContext:
+          privileged: true


### PR DESCRIPTION
Fixing Docker not starting, [example run](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/118048/pull-kubernetes-e2e-autoscaling-hpa-cm/1660630495890771968).