### PR TITLE
sig-scalability/watch-list: increase tests timeout to 60m

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -178,7 +178,7 @@ periodics:
           - --test-cmd-args=--report-dir=$(ARTIFACTS)
           - --test-cmd-args=--testconfig=testing/watch-list/config.yaml
           - --test-cmd-name=ClusterLoaderV2
-          - --timeout=30m
+          - --timeout=60m
           - --use-logexporter
           - --logexporter-gcs-path=gs://sig-scalability-logs/$(JOB_NAME)/$(BUILD_ID)
         resources:
@@ -243,7 +243,7 @@ periodics:
           - --test-cmd-args=--report-dir=$(ARTIFACTS)
           - --test-cmd-args=--testconfig=testing/watch-list/config.yaml
           - --test-cmd-name=ClusterLoaderV2
-          - --timeout=30m
+          - --timeout=60m
           - --use-logexporter
           - --logexporter-gcs-path=gs://sig-scalability-logs/$(JOB_NAME)/$(BUILD_ID)
         resources:


### PR DESCRIPTION
past runs indicate that the tests [take almost](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-watch-list-on/1660197272891166720/build-log.txt) 30m or even more [like in](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-watch-list-on/1660559664519057408).