### PR TITLE
spyglass: use correct ID for tr row

### DIFF
--- a/prow/spyglass/lenses/html/template.html
+++ b/prow/spyglass/lenses/html/template.html
@@ -11,7 +11,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok, so we hide on first resize request */}}
-    <tr class="initial" id="{{.Filename}}-tr">
+    <tr class="initial" id="{{.ID}}-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="{{.Content}}" title="{{.Filename}}" sandbox="allow-scripts allow-popups allow-same-origin" id="{{.ID}}" width="100%" scrolling="no"></iframe>
       </td>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><head><meta name=&quot;description&quot; content=&quot;Loki is a log aggregation system&quot;></head><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><head><meta name=&quot;description&quot; content=&quot;Loki is a log aggregation system&quot;><title>Custom tools</title><body></body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>File 1</title><body></body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>File 2</title><body></body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><body>&quot;Hello world!&quot;</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="initial" id="file.html-tr">
+    <tr class="initial" id="file.html-0-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>Custom Title</title><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){


### PR DESCRIPTION
Currently the panels remain open because there's some typescript magic that removes the "initial" class after the first resize:

https://github.com/kubernetes/test-infra/blob/76032326e1e867159f36c5297aaa9e270a24d2df/prow/spyglass/lenses/html/html.ts#L47-L53

This updates the tr tag to use the right ID.