### PR TITLE
Revert "dra: lock down KinD to v0.19.0", use standard base image

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -27,9 +27,8 @@ periodics:
         - -xc
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL --output "${PATH%%:*}/kind" https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64 &&
-          chmod u+x "${PATH%%:*}/kind" &&
-          kind build node-image --base-image gcr.io/k8s-staging-kind/base:v20230515-01914134-containerd_v1.7.1@sha256:468fc430a6848884b786c5cd2f1c03e7a0977f04fb129a2cda2a19ec986ddacb --image dra/node:latest &&
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
+          test/e2e/dra/kind-build-image.sh dra/node:latest &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation

--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -28,7 +28,7 @@ periodics:
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          test/e2e/dra/kind-build-image.sh dra/node:latest &&
+          kind build node-image --image=dra/node:latest . &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1219,7 +1219,7 @@ presubmits:
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          test/e2e/dra/kind-build-image.sh dra/node:latest &&
+          kind build node-image --image=dra/node:latest . &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1218,9 +1218,8 @@ presubmits:
         - -xc
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL --output "${PATH%%:*}/kind" https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64 &&
-          chmod u+x "${PATH%%:*}/kind" &&
-          kind build node-image --base-image gcr.io/k8s-staging-kind/base:v20230515-01914134-containerd_v1.7.1@sha256:468fc430a6848884b786c5cd2f1c03e7a0977f04fb129a2cda2a19ec986ddacb --image dra/node:latest &&
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
+          test/e2e/dra/kind-build-image.sh dra/node:latest &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus=DynamicResourceAllocation


### PR DESCRIPTION
This reverts commit a33c35e2186add58b5446785075aa045f4ee323b.

we're on containerd 1.7.1 in kind now, we're going to get DRA working again on mainline without a customized base image

xref: https://github.com/kubernetes/kubernetes/issues/118201