### PR TITLE
PodUtils InCI Function

### DIFF
--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -259,3 +259,11 @@ func shaForRefs(refs prowv1.Refs, cloneRecords []clone.Record) string {
 	}
 	return ""
 }
+
+// InCI returns true if the CI environment variable is not empty
+func InCI() bool {
+	if os.Getenv(CI) == "" {
+		return false
+	}
+	return true
+}

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -262,8 +262,5 @@ func shaForRefs(refs prowv1.Refs, cloneRecords []clone.Record) string {
 
 // InCI returns true if the CI environment variable is not empty
 func InCI() bool {
-	if os.Getenv(CI) == "" {
-		return false
-	}
-	return true
+	return os.Getenv(CI) != ""
 }

--- a/prow/pod-utils/downwardapi/jobspec_test.go
+++ b/prow/pod-utils/downwardapi/jobspec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package downwardapi
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -258,5 +259,12 @@ func TestGetRevisionFromSpec(t *testing.T) {
 		if actual, expected := GetRevisionFromSpec(&test.spec), test.expected; actual != expected {
 			t.Errorf("%s: got revision:%s but expected: %s", test.name, actual, expected)
 		}
+	}
+}
+
+func TestInCI(t *testing.T) {
+	os.Setenv("CI", "true")
+	if !InCI() {
+		t.Error("we expected InCI() to return true, but it returned false")
 	}
 }


### PR DESCRIPTION
A simple function that can be used to determine if we are in a prow environment or not (via the `CI` environment variable).