### PR TITLE
Add kmod to bootstrap docker image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     iputils-ping \
     jq \
+    kmod \
     mercurial \
     openssh-client \
     pkg-config \


### PR DESCRIPTION
Add kmod to the api-get in the bootstrap Dockerfile.

When running CAPI e2e ipv6 jobs there's an error where the `modprobe` command fails:
```
Enabling IPV6 for Docker.
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
/usr/local/bin/runner.sh: line 59: modprobe: command not found
Docker in Docker enabled, initializing...
```
This can be seen for example in https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-e2e-dualstack-ipv6-main/1661249935539965952/build-log.txt

Installing kmod should fix this - similar to what was done in the krte image: https://github.com/kubernetes/test-infra/pull/14859