### PR TITLE
support retrigger pull request target workflows

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2169,21 +2169,20 @@ func (c *client) GetFailedActionRunsByHeadBranch(org, repo, branchName, headSHA 
 
 	var runs WorkflowRuns
 
-	url := url.URL{
+	u := url.URL{
 		Path: fmt.Sprintf("/repos/%s/%s/actions/runs", org, repo),
 	}
-	query := url.Query()
-
+	query := u.Query()
 	query.Add("status", "failure")
-	query.Add("event", "pull_request")
+	// setting the OR condition to get both PR and PR target workflows
+	query.Add("event", "pull_request OR pull_request_target")
 	query.Add("branch", branchName)
-
-	url.RawQuery = query.Encode()
+	u.RawQuery = query.Encode()
 
 	_, err := c.request(&request{
 		accept:    "application/vnd.github.v3+json",
 		method:    http.MethodGet,
-		path:      url.String(),
+		path:      u.String(),
 		org:       org,
 		exitCodes: []int{200},
 	}, &runs)


### PR DESCRIPTION
Hi test-infra team,

currently I'm facing the issue that in my environment (GitHub Enterprise) failed GitHub Actions runs are not retriggered using `/retest` even `trigger_github_workflows: true` [config entry](https://github.com/kubernetes/test-infra/blob/3380f527d194ff2c403b57f69d0021a7e907c2e4/prow/plugins/plugin-config-documented.yaml#LL601C7-L601C31 ) is set. The main reason behind this problem is, we are using [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) and in the changed code it was set to `pull_request` only. 

I used `gh` cli to test the actual needed query parameters:
```
$ gh api "repos/org/repo/actions/runs?branch=branchName&event=pull_request_target+OR+pull_request&status=failure

{
  "total_count": 1,
  "workflow_runs": [
    {
      "id": 577122,
      "name": "CI",
      "node_id": "MDExOldvcmtmbG93UnVuNTc3MTIy",
      "head_branch": "branchName",
      "head_sha": "96e61cfbce4b1d9024f67e516f6e67723376b6cd",
      "path": ".github/workflows/ci.yaml",
      "run_number": 136,
      "event": "pull_request_target",
      "status": "completed",
      "conclusion": "failure",
      "workflow_id": 4151,
      "check_suite_id": 2423096,
...
```

This PR supports `pull_request` and `pull_request_target` workflows (oh so many pull-requests in this sentence :-) )

