### PR TITLE
Enable pod disruption conditions test on release branches

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1567,8 +1567,6 @@ presubmits:
     always_run: false
     optional: true
     skip_report: false
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
     annotations:
       testgrid-dashboards: sig-node-presubmits
       testgrid-tab-name: pr-kubelet-gce-e2e-pod-disruption-conditions


### PR DESCRIPTION
Need to enable running of the tests before merging cherry-pick onto the release branch, see: https://github.com/kubernetes/kubernetes/pull/118219#issuecomment-1563339512

/assign @SergeyKanzhelev 
/sig node
