### PR TITLE
add kind e2e test job for alpha features

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -281,3 +281,51 @@ presubmits:
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-kind
+
+  - name: pull-kubernetes-e2e-kind-alpha-features
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"true"}'
+        - name: FOCUS
+          value: \[Alpha\]
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 7
+            memory: 9000Mi
+          requests:
+            cpu: 7
+            memory: 9000Mi
+    annotations:
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -90,6 +90,9 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
     test_group_name: pull-kubernetes-e2e-kind-ipvs-dual-canary
     base_options: width=10
+  - name: pull-kubernetes-e2e-kind-alpha-features
+    test_group_name: pull-kubernetes-e2e-kind-alpha-features
+    base_options: width=10
   - name: pull-kubernetes-e2e-gce-cos-alpha-features
     test_group_name: pull-kubernetes-e2e-gce-cos-alpha-features
     base_options: width=10


### PR DESCRIPTION
This PR creates a `pull-kubernetes-e2e-kind-alpha-features` that is optional and opted-in to ease development of alpha features.

The criteria of alpha feature tests is the `[Alpha]` label. Usual skips like `[Slow]`, `[Disruptive]` are preserved. Other settings are copied from `pull-kubernetes-e2e-kind` job.

Previously, when developing an alpha feature, we borrow the `pull-kubernetes-e2e-gce-cos-alpha-features` job in `./config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml` (example: #26994) . However, adding new feature gate to the list and remove it back later every time a new  alpha feature starts is suboptimal. The new job this PR creates formalize the list as "alpha features" and run it with `kind` to speed things up.

NOTE: usually beta graduation requires E2E tests to be in place, which is why E2E tests for alpha features are rare.
