### PR TITLE
remove project from standalone kubelet tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -287,7 +287,7 @@ periodics:
 
 
 - name: ci-kubernetes-node-e2e-containerd-standalone-mode-all-alpha
-  interval: 24h
+  interval: 4h
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
@@ -305,7 +305,6 @@ periodics:
       - --
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--standalone-mode=true --feature-gates=AllAlpha=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true
@@ -328,7 +327,7 @@ periodics:
     description: "Runs kubelet in standalone mode with all alpha features enabled"
 
 - name: ci-kubernetes-node-e2e-containerd-standalone-mode
-  interval: 24h
+  interval: 4h
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
@@ -346,7 +345,6 @@ periodics:
       - --
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--standalone-mode=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true


### PR DESCRIPTION
This was the recommendation from #sig-k8s-infra, lowering the periodic time temporarily to allow for faster iteration.