### PR TITLE
Remove predefined GCP project from HPA custom metrics presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -108,8 +108,8 @@ presubmits:
         - --build=quick
         - --cluster=hpa
         - --extract=local
+        - --check-leaked-resources
         - --gcp-node-image=gci
-        - --gcp-project=k8s-jkns-gci-autoscaling
         - --gcp-zone=us-west1-b
         - --provider=gce
         # Enable HPAContainerMetrics and HPAScaleToZero. Required for container metrics and scale to zero tests.


### PR DESCRIPTION
Running on a shared GCP projects causes runs to interfere with each other and result in flakes, e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/117845/pull-kubernetes-e2e-autoscaling-hpa-cm/1662083349033783296. I see no reason for not using a project from boskos, HPA CPU e2e tests do and work fine. I assume the custom hardcoded GCP project comes from copying from cluster autoscaling config years ago.