### PR TITLE
log cloud provider gcp builds direct to prow logs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
@@ -88,3 +88,6 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - --with-git-dir
               - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"


### PR DESCRIPTION
should make it easier to confirm uploads, debug results, etc.

cc @aojea @ndixita 