### PR TITLE
increase interval for standalone kubelet tests now that they work

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -330,7 +330,7 @@ periodics:
 
 
 - name: ci-kubernetes-node-e2e-containerd-standalone-mode-all-alpha
-  interval: 4h
+  interval: 24h
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
@@ -370,7 +370,7 @@ periodics:
     description: "Runs kubelet in standalone mode with all alpha features enabled"
 
 - name: ci-kubernetes-node-e2e-containerd-standalone-mode
-  interval: 4h
+  interval: 24h
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
The 4h interval was for faster iteration, now that the tests are working fine, we can increase the interval to 24h.