### PR TITLE
capc: add job capi-provider-cloudstack-presubmit-e2e-smoke-test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -108,3 +108,38 @@ presubmits:
           limits:
             memory: "8Gi"
             cpu: "1024m"
+  - name: capi-provider-cloudstack-presubmit-e2e-smoke-test
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    run_if_changed: ".*"
+    max_concurrency: 10
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    skip_report: false
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-cloudstack
+      testgrid-tab-name: pr-e2e-smoke-test
+    spec:
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: build-container
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+        command:
+        - bash
+        - -c
+        - make run-e2e-smoke
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+            cpu: "1024m"
+          limits:
+            memory: "8Gi"
+            cpu: "1024m"


### PR DESCRIPTION
This PR relies on https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/pull/259

Verified by
```
    $ docker run -d -it --privileged \
        --entrypoint /bin/bash \
        --network="host" \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v /usr/bin/kind:/usr/bin/kind \
        -v $(readlink -f .):/workspace \
        --name build-container \
        gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25

    $ docker exec -it build-container /bin/bash -c 'make run-e2e-smoke'
```
