### PR TITLE
Add pull-release-integration-test-eks-canary job

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -108,6 +108,30 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
+  - name: pull-release-integration-test-eks-canary
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: k8s.io/release
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+        imagePullPolicy: Always
+        command:
+        - make
+        - test-go-integration
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "8"
+          limits:
+            memory: "16Gi"
+            cpu: "8"
+    annotations:
+      testgrid-dashboards: sig-k8s-infra-canaries
+      testgrid-tab-name: release-integration-test-eks-canary
+      testgrid-num-columns-recent: '30'
   - name: pull-release-verify
     always_run: true
     decorate: true


### PR DESCRIPTION
This PR adds `pull-release-integration-test-eks-canary` job that's running on the EKS Prow build cluster. It's a canary job based on `pull-release-integration-test`. Let's see if this is going to work, and if it isn't, can we make it work.

/assign @cpanato @saschagrunert @puerco 
cc @kubernetes/release-engineering 