### PR TITLE
Migrate test-infra jobs to EKS Prow build cluster

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubernetes/test-infra:
   - name: post-test-infra-test-all
+    cluster: eks-prow-build-cluster
     branches:
     - master
     decorate: true

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -27,6 +27,10 @@ postsubmits:
             # This job is very CPU intensive as building prow images in
             # parallel
             cpu: "14"
+            memory: "16Gi"
+          limits:
+            cpu: "14"
+            memory: "16Gi"
       tolerations:
       - key: "highcpu"
         operator: "Equal"

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -3,6 +3,7 @@ presubmits:
   # pull-test-infra-bazel is deprecated, leave it here just in case. Will be
   # completely removed once bazel footprint is removed from test-infra
   - name: pull-test-infra-bazel
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: false
@@ -29,6 +30,7 @@ presubmits:
       testgrid-tab-name: bazel
 
   - name: pull-test-infra-gubernator
+    cluster: eks-prow-build-cluster
     branches:
     - master
     run_if_changed: 'gubernator|config/prow/config.yaml|config/jobs/.+\.yaml'
@@ -49,6 +51,7 @@ presubmits:
 
   # Please keep this in sync with the `ci-test-infra-prow-checkconfig` job
   - name: pull-test-infra-prow-checkconfig
+    cluster: eks-prow-build-cluster
     decorate: true
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
@@ -73,6 +76,7 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-prow-checkconfig-loose
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: true
@@ -100,6 +104,7 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration
+    cluster: eks-prow-build-cluster
     branches:
     - master
     skip_if_only_changed: '(^config/jobs/)|(^images/)|(^scenarios/)|(^jenkins/)|(^kubetest/)'
@@ -135,6 +140,7 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: integration
   - name: pull-test-infra-unit-test
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: true
@@ -157,6 +163,7 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test
   - name: pull-test-infra-prow-image-build-test
+    cluster: eks-prow-build-cluster
     branches:
     - master
     run_if_changed: '^(\.ko\.yaml|hack/(ts-rollup|make-rules|prowimagebuilder)|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
@@ -193,6 +200,7 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: prow-image-build-test
   - name: pull-test-infra-verify-lint
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: true
@@ -215,6 +223,7 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-test
   - name: pull-test-infra-verify-cri-o
+    cluster: eks-prow-build-cluster
     branches:
     - master
     run_if_changed: 'jobs\/e2e_node\/crio\/'

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -25,6 +25,13 @@ presubmits:
         env:
         - name: BAZEL_FETCH_PLEASE
           value: //...
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: bazel
@@ -45,6 +52,13 @@ presubmits:
         env:
         - name: WORKSPACE
           value: "/workspace"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: gubernator
@@ -73,6 +87,13 @@ presubmits:
         - --warnings=unknown-fields
         - --warnings=duplicate-job-refs
         - --warnings=unknown-fields-all
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-prow-checkconfig-loose
@@ -101,6 +122,13 @@ presubmits:
         - --warnings=unknown-fields-all
         - --warnings=non-decorated-jobs
         - --warnings=valid-decoration-config
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-integration
@@ -129,6 +157,10 @@ presubmits:
             # This job is very CPU intensive as building prow images in
             # parallel
             cpu: "14"
+            memory: "16Gi"
+          limits:
+            cpu: "14"
+            memory: "16Gi"
       tolerations:
       - key: "highcpu"
         operator: "Equal"
@@ -159,6 +191,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test
@@ -189,6 +228,10 @@ presubmits:
             # This job is very CPU intensive as building prow images in
             # parallel
             cpu: "14"
+            limits: "16Gi"
+          limits:
+            cpu: "14"
+            memory: "16Gi"
       tolerations:
       - key: "highcpu"
         operator: "Equal"
@@ -219,6 +262,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-test
@@ -244,6 +294,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-cri-o


### PR DESCRIPTION
This is a proposal to migrate k/test-infra jobs to the EKS Prow build cluster. I only touched jobs that I think don't depend on external resources (or resources that don't exist in that cluster).

I don't have an idea if this is going to work, but we can always revert the PR.

Also, jobs that are running in test-infra-trusted cluster are not touched because the EKS Prow build cluster is not a trusted/sensitive one.

/assign @BenTheElder 