### PR TITLE
Remove legacy nodeSelectors from test-infra jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -31,13 +31,6 @@ postsubmits:
           limits:
             cpu: "14"
             memory: "16Gi"
-      tolerations:
-      - key: "highcpu"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-      nodeSelector:
-        highcpu: "true"
     annotations:
       testgrid-dashboards: sig-testing-misc
       testgrid-tab-name: post-test-all

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -161,13 +161,6 @@ presubmits:
           limits:
             cpu: "14"
             memory: "16Gi"
-      tolerations:
-      - key: "highcpu"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-      nodeSelector:
-        highcpu: "true"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: integration
@@ -232,13 +225,6 @@ presubmits:
           limits:
             cpu: "14"
             memory: "16Gi"
-      tolerations:
-      - key: "highcpu"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-      nodeSelector:
-        highcpu: "true"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: prow-image-build-test


### PR DESCRIPTION
Since moving to EKS Prow build cluster in #29629, we don't need those `highcpu` tolerations and node selectors. The new build cluster doesn't have a concept of dedicated `highcpu` nodes, instead, all nodes have enough CPU.

/assign @BenTheElder 