### PR TITLE
chore: move some capa jobs to eks prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -219,6 +219,7 @@ periodics:
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: release-team@kubernetes.io, sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
 - name: periodic-cluster-api-provider-aws-coverage
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   path_alias: "sigs.k8s.io/cluster-api-provider-aws"
@@ -249,5 +250,12 @@ periodics:
             ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
             ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
             exit $result
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.5.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-aws:
   - name: pull-cluster-api-provider-aws-test-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.5$
@@ -13,10 +14,18 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.24
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-test-release-1-5
   - name: pull-cluster-api-provider-aws-apidiff-release-1-5
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-aws
     always_run: true
@@ -32,10 +41,18 @@ presubmits:
         - runner.sh
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.24
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-apidiff-release-1-5
   - name: pull-cluster-api-provider-aws-build-release-1-5
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -48,10 +65,18 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.24
         command:
         - "./scripts/ci-build.sh"
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-build-release-1-5
   - name: pull-cluster-api-provider-aws-verify-release-1-5
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
     # The script this job runs is not in all branches.
@@ -66,6 +91,13 @@ presubmits:
         - "runner.sh"
         - "make"
         - "verify"
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
         # docker-in-docker needs privileged mode
         securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-aws:
   - name: pull-cluster-api-provider-aws-test
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -13,10 +14,18 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-test
   - name: pull-cluster-api-provider-aws-apidiff-main
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-aws
     always_run: true
@@ -32,10 +41,18 @@ presubmits:
         - runner.sh
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-apidiff-main
   - name: pull-cluster-api-provider-aws-build
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -45,10 +62,18 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
         command:
         - "./scripts/ci-build.sh"
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-build
   - name: pull-cluster-api-provider-aws-verify
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
     # The script this job runs is not in all branches.
@@ -63,6 +88,13 @@ presubmits:
         - "runner.sh"
         - "make"
         - "verify"
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
         # docker-in-docker needs privileged mode
         securityContext:
             privileged: true


### PR DESCRIPTION
This change moves the non-boskos related jobs for CAPA to the EKS Prow cluster

/cc @Skarlso @Ankitasw @dlipovetsky 