### PR TITLE
test: change the eks gc e2e to use the eks prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -316,6 +316,7 @@ presubmits:
       testgrid-tab-name: pr-e2e-eks-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks-gc
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -346,6 +347,9 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: "9Gi"
             requests:
               cpu: 2
               memory: "9Gi"


### PR DESCRIPTION
Change one of the EKE e2e jobs to run on the Prow EKS cluster....for testing before moving them all.

Using the same resource request/limits as @xmudrii  used in the canary test

/cc @Ankitasw @Skarlso @dlipovetsky 