### PR TITLE
Increase resources for pull-release-verify

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -146,11 +146,11 @@ presubmits:
         - verify
         resources:
           limits:
-            memory: 4Gi
-            cpu: 2
+            memory: 16Gi
+            cpu: 8
           requests:
-            memory: 4Gi
-            cpu: 2
+            memory: 16Gi
+            cpu: 8
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-verify


### PR DESCRIPTION
I observed that `pull-release-verify` job is taking about 50 minutes in average. Let's give this job some more resources to see if this is going to help at least a little bit.

/assign @saschagrunert @cpanato 
cc @kubernetes/release-engineering 