### PR TITLE
Increase CPUs for kueue verify and set GOMAXPROCS

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
+        - name: GOMAXPROCS
+          value: "2"
         command:
         - make
         args:
@@ -46,6 +48,9 @@ presubmits:
         - make
         args:
         - test-integration
+        env:
+        - name: GOMAXPROCS
+          value: "4"
         resources:
           requests:
             cpu: "4"
@@ -179,12 +184,15 @@ presubmits:
         - make
         args:
         - verify
+        env:
+        - name: GOMAXPROCS
+          value: "2"
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"
   - name: pull-kueue-build-image-main
     cluster: eks-prow-build-cluster
@@ -209,10 +217,13 @@ presubmits:
         args:
         - make
         - image-local-build
+        env:
+        - name: GOMAXPROCS
+          value: "2"
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-3.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
+        - name: GOMAXPROCS
+          value: "2"
         command:
         - make
         args:
@@ -46,6 +48,9 @@ presubmits:
         - make
         args:
         - test-integration
+        env:
+        - name: GOMAXPROCS
+          value: "4"
         resources:
           requests:
             cpu: "4"
@@ -179,12 +184,15 @@ presubmits:
         - make
         args:
         - verify
+        env:
+        - name: GOMAXPROCS
+          value: "2"
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"
   - name: pull-kueue-build-image-release-0-3
     cluster: eks-prow-build-cluster
@@ -209,10 +217,13 @@ presubmits:
         args:
         - make
         - image-local-build
+        env:
+        - name: GOMAXPROCS
+          value: "2"
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "1.5Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -24,6 +24,8 @@ periodics:
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
+            - name: GOMAXPROCS
+              value: "2"
           command:
             - make
           args:
@@ -31,10 +33,10 @@ periodics:
           resources:
             requests:
               cpu: "2"
-              memory: "1.5Gi"
+              memory: "400Mi"
             limits:
               cpu: "2"
-              memory: "1.5Gi"
+              memory: "400Mi"
   - interval: 12h
     name: periodic-kueue-test-integration-main
     cluster: eks-prow-build-cluster
@@ -61,6 +63,9 @@ periodics:
             - make
           args:
             - test-integration
+          env:
+            - name: GOMAXPROCS
+              value: "4"
           resources:
             requests:
               cpu: "4"


### PR DESCRIPTION
As shown in kubernetes-sigs/kueue#818, verify can go over the default time limit.
Adding one more CPU, and setting GOMAXPROCS for unit, integration, verify and build tests.