### PR TITLE
Add tenzen-y as approver for kueue jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/OWNERS
+++ b/config/jobs/kubernetes-sigs/kueue/OWNERS
@@ -3,6 +3,8 @@
 approvers:
 - ahg-g
 - alculquicondor
+- tenzen-y
 reviewers:
 - ahg-g
 - alculquicondor
+- tenzen-y


### PR DESCRIPTION
@tenzen-y is deeply familiar with the test suite of Kueue.
He is already an [approver in kueue/test](https://github.com/kubernetes-sigs/kueue/blob/main/test/OWNERS)