### PR TITLE
Cluster API: Add temporary fix and experiments for 1.27 upgrade

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4-upgrades.yaml
@@ -286,7 +286,7 @@ periodics:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.26"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "stable-1.27"
+            value: "v1.27.1" # Setting this to a pinned version due to an issue in the image. See: https://github.com/kubernetes-sigs/cluster-api/issues/8764
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.6-0"
           - name: COREDNS_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -412,3 +412,93 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-scale-main-experimental
+  - name: pull-cluster-api-e2e-workload-upgrade-1-26-1-27-kubekins-exp
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    optional: true
+    always_run: false
+    branches:
+      # The script this job runs is not in all branches.
+      - ^main$
+    path_alias: sigs.k8s.io/cluster-api
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.27
+          args:
+            - runner.sh
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: KUBERNETES_VERSION_UPGRADE_FROM
+              value: "stable-1.26"
+            - name: KUBERNETES_VERSION_UPGRADE_TO
+              value: "stable-1.27"
+            - name: ETCD_VERSION_UPGRADE_TO
+              value: "3.5.6-0"
+            - name: COREDNS_VERSION_UPGRADE_TO
+              value: "v1.9.3"
+            - name: GINKGO_FOCUS
+              value: "\\[K8s-Upgrade\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-main-1-26-1-27-kubekins-exp
+  - name: pull-cluster-api-e2e-workload-upgrade-1-26-1-27-krte-exp
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    optional: true
+    always_run: false
+    branches:
+      # The script this job runs is not in all branches.
+      - ^main$
+    path_alias: sigs.k8s.io/cluster-api
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
+          args:
+            - wrapper.sh
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: KUBERNETES_VERSION_UPGRADE_FROM
+              value: "stable-1.26"
+            - name: KUBERNETES_VERSION_UPGRADE_TO
+              value: "stable-1.27"
+            - name: ETCD_VERSION_UPGRADE_TO
+              value: "3.5.6-0"
+            - name: COREDNS_VERSION_UPGRADE_TO
+              value: "v1.9.3"
+            - name: GINKGO_FOCUS
+              value: "\\[K8s-Upgrade\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-main-1-26-1-27-krte-exp


### PR DESCRIPTION
Pin the 1.4 version of 1.26 -> 1.27 upgrade job for CAPI to v1.27.1.

Add two experimental presubmit jobs - one using the kubekins image and one using the kint krte image - to help debug the issues with the current v1.27 conformance test runs.