### PR TITLE
CAPC: fix capi-provider-cloudstack-presubmit-e2e-smoke-test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -130,9 +130,10 @@ presubmits:
       - name: build-container
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
         command:
-        - bash
-        - -c
-        - make run-e2e-smoke
+          - runner.sh
+        args:
+          - make
+          - run-e2e-smoke
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This is the followup of #29626 

An example of the error: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-cloudstack/235/capi-provider-cloudstack-presubmit-e2e-smoke-test/1663818948610625536
```
./cluster-api/hack/kind-install-for-capd.sh
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?. See 'docker run --help'.
make[1]: *** [Makefile:237: kind-cluster] Error 125 make[1]: Leaving directory '/home/prow/go/src/github.com/kubernetes-sigs/cluster-api-provider-cloudstack' make: *** [Makefile:295: run-e2e-smoke] Error 2
```