### PR TITLE
Increase memory limit for kueue jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -26,10 +26,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
   - name: pull-kueue-test-integration-main
     cluster: eks-prow-build-cluster
     branches:
@@ -54,10 +54,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "2Gi"
+            memory: "16Gi"
           limits:
             cpu: "4"
-            memory: "2Gi"
+            memory: "16Gi"
   - name: pull-kueue-test-e2e-main-1-24
     cluster: eks-prow-build-cluster
     branches:
@@ -90,10 +90,10 @@ presubmits:
         resources:
           requests:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
           limits:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
   - name: pull-kueue-test-e2e-main-1-25
     cluster: eks-prow-build-cluster
     branches:
@@ -126,10 +126,10 @@ presubmits:
         resources:
           requests:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
           limits:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
   - name: pull-kueue-test-e2e-main-1-26
     cluster: eks-prow-build-cluster
     branches:
@@ -162,10 +162,10 @@ presubmits:
         resources:
           requests:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
           limits:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
   - name: pull-kueue-verify-main
     cluster: eks-prow-build-cluster
     branches:
@@ -190,10 +190,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
   - name: pull-kueue-build-image-main
     cluster: eks-prow-build-cluster
     branches:
@@ -223,7 +223,7 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-3.yaml
@@ -26,10 +26,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
   - name: pull-kueue-test-integration-release-0-3
     cluster: eks-prow-build-cluster
     branches:
@@ -54,10 +54,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "2Gi"
+            memory: "8Gi"
           limits:
             cpu: "4"
-            memory: "2Gi"
+            memory: "8Gi"
   - name: pull-kueue-test-e2e-release-0-3-1-24
     cluster: eks-prow-build-cluster
     branches:
@@ -90,10 +90,10 @@ presubmits:
         resources:
           requests:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
           limits:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
   - name: pull-kueue-test-e2e-release-0-3-1-25
     cluster: eks-prow-build-cluster
     branches:
@@ -126,10 +126,10 @@ presubmits:
         resources:
           requests:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
           limits:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
   - name: pull-kueue-test-e2e-release-0-3-1-26
     cluster: eks-prow-build-cluster
     branches:
@@ -162,10 +162,10 @@ presubmits:
         resources:
           requests:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
           limits:
             cpu: "5"
-            memory: "2Gi"
+            memory: "20Gi"
   - name: pull-kueue-verify-release-0-3
     cluster: eks-prow-build-cluster
     branches:
@@ -190,10 +190,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
   - name: pull-kueue-build-image-release-0-3
     cluster: eks-prow-build-cluster
     branches:
@@ -223,7 +223,7 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "1.5Gi"
+            memory: "8Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -33,10 +33,10 @@ periodics:
           resources:
             requests:
               cpu: "2"
-              memory: "400Mi"
+              memory: "8Gi"
             limits:
               cpu: "2"
-              memory: "400Mi"
+              memory: "8Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-main
     cluster: eks-prow-build-cluster
@@ -69,10 +69,10 @@ periodics:
           resources:
             requests:
               cpu: "4"
-              memory: "2Gi"
+              memory: "16Gi"
             limits:
               cpu: "4"
-              memory: "2Gi"
+              memory: "16Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-24
     cluster: eks-prow-build-cluster
@@ -111,10 +111,10 @@ periodics:
           resources:
             requests:
               cpu: "5"
-              memory: "2Gi"
+              memory: "20Gi"
             limits:
               cpu: "5"
-              memory: "2Gi"
+              memory: "20Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-25
     cluster: eks-prow-build-cluster
@@ -152,11 +152,11 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: "5"
+              memory: "20Gi"
             limits:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: "5"
+              memory: "20Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-26
     cluster: eks-prow-build-cluster
@@ -194,8 +194,8 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6"
-              memory: "1.5Gi"
+              cpu: "5"
+              memory: "20Gi"
             limits:
-              cpu: "6"
-              memory: "1.5Gi"
+              cpu: "5"
+              memory: "20Gi"


### PR DESCRIPTION
The memory usage of the jobs can be unpredictable due to go GC.
The test clusters have roughly 8Gi of memory per core, but 4 should be enough for Kueue.