### PR TITLE
Fix the job of `ci-kubernetes-node-arm64-ubuntu-serial`

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -133,6 +133,12 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  decoration_config:
+    timeout: 180m
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -154,8 +160,8 @@ periodics:
           - --parallelism=1
           - --focus-regex=\[Serial\]
           - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:NodeProblemDetector\]|\[NodeFeature:OOMScoreAdj\]|\[NodeFeature:DevicePluginProbe\]|\[NodeConformance\]
-          - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
           - '--test-args=--use-dockerized-build=true --target-build-arch=linux/arm64 --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
- ~remove the extra_ref to the kubernetes, but use the `path_alias: k8s.io/kubernetes` instead.~ periodic job doesn't support the top level path_alias.
- add the extra_ref to the `k8s.io/test-infra` so that the image config file could be found.
- added timeout config based on the [initial pr](https://github.com/kubernetes/test-infra/pull/29192/files#diff-14f46258d64962b171c1662b99c4e01ea48674ca3ef00b1d9dec13acf2ad91f9R152)

link to the log: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-node-arm64-ubuntu-serial/1664144092101087232


/cc @dims 
/cc @pacoxu 
/cc @ike-ma 
