### PR TITLE
Cluster API: Pin minimum K8s version

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -237,7 +237,7 @@ periodics:
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       - name: KUBERNETES_VERSION_MANAGEMENT
-        value: "stable-1.24"
+        value: "v1.24.13"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
@@ -143,7 +143,7 @@ periodics:
       # Note: We need ClusterClass for the clusterctl upgrade tests, so we're able to
       # create clusterctl with old versions with the right cgroupDriver configuration.
       - name: KUBERNETES_VERSION_MANAGEMENT
-        value: "stable-1.22"
+        value: "v1.22.17"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4.yaml
@@ -141,7 +141,7 @@ periodics:
           # This value determines the minimum Kubernetes
           # supported version for Cluster API management cluster.
           - name: KUBERNETES_VERSION_MANAGEMENT
-            value: "stable-1.23"
+            value: "v1.23.17"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -148,7 +148,7 @@ presubmits:
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
         # docs (look for minimum supported k8s version for management cluster, i.e N-3).
         - name: KUBERNETES_VERSION_MANAGEMENT
-          value: "stable-1.24"
+          value: "v1.24.13"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Pin the minimum version of Kubernetes used for end-to-end testing in Cluster API.

This version is pinned as these tests use nodes images built for kind which aren't always available for all versions of Kubernetes.