### PR TITLE
CAPI operator: enable cherry-picker plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1658,6 +1658,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/cluster-api-operator:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Signed-off by: Furkat Gofurov <furkat.gofurov@suse.com>

Fixes: https://github.com/kubernetes-sigs/cluster-api-operator/issues/123