### PR TITLE
Sync image-builder ownership

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/OWNERS
+++ b/config/jobs/kubernetes-sigs/image-builder/OWNERS
@@ -1,11 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - akutz
-  - CecileRobertMichon
-  - codenrhoden
-  - figo
-  - justinsb
-  - luxas
-  - moshloop
-  - timothysc
+  - AverageMarcus
+  - jsturtevant
+  - kkeshavamurthy
+  - mboersma

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/OWNERS
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/OWNERS
@@ -1,11 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - akutz
-  - CecileRobertMichon
-  - codenrhoden
-  - figo
-  - justinsb
-  - luxas
-  - moshloop
-  - timothysc
+  - AverageMarcus
+  - jsturtevant
+  - kkeshavamurthy
+  - mboersma


### PR DESCRIPTION
The list of maintainers for SIG cluster-lifecycle `image-builder` jobs had drifted far from the current set of [owners](https://github.com/kubernetes-sigs/image-builder/blob/master/OWNERS), so this syncs it back up. 