### PR TITLE
chore: move remaining capa jobs to the EKS prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-aws-e2e-clusterclass
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -35,6 +36,9 @@ periodics:
         privileged: true
       resources:
         requests:
+          cpu: 2
+          memory: "9Gi"
+        limits:
           cpu: 2
           memory: "9Gi"
   annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.5.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-aws-e2e-release-1-5
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -35,12 +36,16 @@ periodics:
         requests:
           cpu: 2
           memory: "9Gi"
+        limits:
+          cpu: 2
+          memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
     testgrid-tab-name: periodic-e2e-release-1-5
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-eks-e2e-release-1-5
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -73,12 +78,16 @@ periodics:
         requests:
           cpu: 2
           memory: "9Gi"
+        limits:
+          cpu: 2
+          memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
     testgrid-tab-name: periodic-eks-e2e-release-1-5
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-release-1-5
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -116,12 +125,16 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
     testgrid-tab-name: periodic-conformance-release-1-5
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts-release-1-5
+  cluster: eks-prow-build-cluster
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -171,6 +184,9 @@ periodics:
             # this is mostly for building kubernetes
             memory: "9Gi"
             cpu: 2
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
     testgrid-tab-name: periodic-conformance-release-1-5-k8s-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-aws-e2e
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -33,6 +34,9 @@ periodics:
         privileged: true
       resources:
         requests:
+          cpu: 2
+          memory: "9Gi"
+        limits:
           cpu: 2
           memory: "9Gi"
   annotations:
@@ -85,6 +89,7 @@ periodics:
     testgrid-tab-name: periodic-aws-e2e-main-canary
     testgrid-num-columns-recent: "6"
 - name: periodic-cluster-api-provider-aws-eks-e2e
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -117,12 +122,16 @@ periodics:
         requests:
           cpu: 2
           memory: "9Gi"
+        limits:
+          cpu: 2
+          memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-eks-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5h
@@ -158,12 +167,16 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-conformance-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts
+  cluster: eks-prow-build-cluster
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -213,6 +226,9 @@ periodics:
             # this is mostly for building kubernetes
             memory: "9Gi"
             cpu: 2
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
     testgrid-tab-name: periodic-conformance-main-k8s-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubernetes-sigs/cluster-api-provider-aws:
     - name: ci-cluster-api-provider-aws-e2e
+      cluster: eks-prow-build-cluster
       branches:
       # The script this job runs is not in all branches.
       - ^main
@@ -35,12 +36,16 @@ postsubmits:
               requests:
                 cpu: 2
                 memory: "9Gi"
+              limits:
+                cpu: 2
+                memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
         testgrid-tab-name: postsubmit-e2e-main
         testgrid-num-columns-recent: '20'
         testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     - name: ci-cluster-api-provider-aws-eks-e2e
+      cluster: eks-prow-build-cluster
       branches:
       # The script this job runs is not in all branches.
       - ^main
@@ -72,6 +77,9 @@ postsubmits:
               requests:
                 cpu: 2
                 memory: "9Gi"
+              limits:
+                cpu: 2
+                memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
         testgrid-tab-name: postsubmit-eks-e2e-main
@@ -79,6 +87,7 @@ postsubmits:
         testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
         testgrid-num-failures-to-alert: "2"
     - name: ci-cluster-api-provider-aws-e2e-conformance
+      cluster: eks-prow-build-cluster
       branches:
       # The script this job runs is not in all branches.
       - ^main
@@ -108,6 +117,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
+                cpu: 2
+                memory: "9Gi"
+              limits:
                 cpu: 2
                 memory: "9Gi"
       annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-aws:
     - name: pull-cluster-api-provider-aws-e2e-clusterclass
+      cluster: eks-prow-build-cluster
       branches:
         # The script this job runs is not in all branches.
         - ^main$
@@ -37,6 +38,9 @@ presubmits:
               privileged: true
             resources:
               requests:
+                cpu: 2
+                memory: "9Gi"
+              limits:
                 cpu: 2
                 memory: "9Gi"
       annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.5.yaml
@@ -108,6 +108,7 @@ presubmits:
       preset-dind-enabled: "true"
   # conformance test
   - name: pull-cluster-api-provider-aws-e2e-conformance-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.5$
@@ -153,12 +154,16 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9Gi"
               cpu: 2
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-conformance-release-1-5
       testgrid-num-columns-recent: '20'
   # conformance test against kubernetes main branch with `kind` + cluster-api-provider-aws
   - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.5$
@@ -194,11 +199,15 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-conformance-release-1-5-k8s-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-blocking-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
       # The script this job runs is not in all branches.
       - ^release-1.5$
@@ -238,11 +247,15 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-quick-e2e-release-1-5
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.5$
@@ -276,11 +289,15 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
       testgrid-tab-name: pr-e2e-release-1-5
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.5$
@@ -312,6 +329,9 @@ presubmits:
             privileged: true
           resources:
             requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
               cpu: 2
               memory: "9Gi"
     annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -105,6 +105,7 @@ presubmits:
       preset-dind-enabled: "true"
   # conformance test
   - name: pull-cluster-api-provider-aws-e2e-conformance
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -150,12 +151,16 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9Gi"
               cpu: 2
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance
       testgrid-num-columns-recent: '20'
   # conformance test against kubernetes main branch with `kind` + cluster-api-provider-aws
   - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -191,11 +196,15 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance-main-k8s-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-blocking
+    cluster: eks-prow-build-cluster
     branches:
       # The script this job runs is not in all branches.
       - ^main$
@@ -235,11 +244,15 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-quick-e2e-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -273,11 +286,15 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -309,6 +326,9 @@ presubmits:
             privileged: true
           resources:
             requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
               cpu: 2
               memory: "9Gi"
     annotations:
@@ -358,6 +378,7 @@ presubmits:
       testgrid-tab-name: pr-e2e-eks-gc-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks-testing
+    cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -391,6 +412,9 @@ presubmits:
             privileged: true
           resources:
             requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
               cpu: 2
               memory: "9Gi"
     annotations:


### PR DESCRIPTION
This change removed the remaining CAPA jobs to the EKS Prow cluster.

/cc @Skarlso @Ankitasw @dlipovetsky @xmudrii 