### PR TITLE
Add Bootstrap image periodic

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -285,8 +285,10 @@ periodics:
       testgrid-num-failures-to-alert: '1'
       description: builds and pushes the bootstrap image
     decorate: true
-    branches:
-    - ^master$
+    extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
     spec:
       serviceAccountName: gcb-builder
       containers:


### PR DESCRIPTION
Update the image push jobs to include a monthly periodic for bootstrap to keep it updated if gcloud CLI udpates