### PR TITLE
Rename image-builder default branch to main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-1.5.yaml
@@ -153,7 +153,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -195,7 +195,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-1.5.yaml
@@ -128,7 +128,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -125,7 +125,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -115,7 +115,7 @@ periodics:
         path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
       - org: kubernetes-sigs
         repo: image-builder
-        base_ref: master
+        base_ref: main
         path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -157,7 +157,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-2.yaml
@@ -91,7 +91,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   - org: kubernetes-sigs
     repo: image-builder
-    base_ref: master
+    base_ref: main
     path_alias: "sigs.k8s.io/image-builder"
   max_concurrency: 1
   spec:
@@ -61,7 +61,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   - org: kubernetes-sigs
     repo: image-builder
-    base_ref: master
+    base_ref: main
     path_alias: "sigs.k8s.io/image-builder"
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     max_concurrency: 1
     spec:
@@ -51,7 +51,7 @@ postsubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
@@ -101,7 +101,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes
@@ -144,7 +144,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: image-builder
-        base_ref: master
+        base_ref: main
         path_alias: "sigs.k8s.io/image-builder"
     spec:
       serviceAccountName: gcb-builder-cluster-api-gcp


### PR DESCRIPTION
The image-builder project is planning to rename the default branch from `master` to `main`. This PR is in preparation for that happening as outlined in https://www.kubernetes.dev/resources/rename/.

Towards: https://github.com/kubernetes-sigs/image-builder/issues/1161

/assign @mboersma @kkeshavamurthy @jsturtevant
/hold