### PR TITLE
Trigger image-builder job when ensure-packer.sh is updated

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
       testgrid-tab-name: pr-json-sort-check
   - name: pull-packer-validate
     decorate: true
-    run_if_changed: 'images/capi/Makefile|images/capi/packer/.*|images/capi/scripts/ci-packer-validate\.sh'
+    run_if_changed: 'images/capi/Makefile|images/capi/packer/.*|images/capi/scripts/ci-packer-validate\.sh|images/capi/scripts/ensure-packer\.sh'
     decoration_config:
       timeout: 20m
     max_concurrency: 5


### PR DESCRIPTION
Related: https://github.com/kubernetes-sigs/image-builder/issues/1180

The packer validate test needs to also trigger when we change the `ensure-packer.sh` script so we test changes related to Packer version updated.

/assign @mboersma @jsturtevant 