### PR TITLE
Cluster API: Pin upgrade job to v1.27.1

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -236,7 +236,7 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.26"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "stable-1.27"
+        value: "v1.27.1" # Setting this to a pinned version due to an issue in the image. See: https://github.com/kubernetes-sigs/cluster-api/issues/8764
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.6-0"
       - name: COREDNS_VERSION_UPGRADE_TO


### PR DESCRIPTION
Pin the Cluster API v1.26 -> v1.27 upgrade job to v1.27.1. This change is necessary due to a change in how Kind builds its images. More info on the CAPI issue: https://github.com/kubernetes-sigs/cluster-api/issues/8764