### PR TITLE
Drop unnecessary CI job : ci-kubernetes-e2e-gci-gce-single-flake-attempt

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -750,32 +750,6 @@ periodics:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-flaky
 
-- interval: 12h
-  name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=200
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gci-gce-single-flake-attempt
-
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-reboot
   cluster: k8s-infra-prow-build

--- a/config/testgrids/kubernetes/sig-api-machinery/config.yaml
+++ b/config/testgrids/kubernetes/sig-api-machinery/config.yaml
@@ -19,10 +19,6 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gce-flaky
       base_options: include-filter-by-regex=sig-api-machinery
       description: apimachinery gce flaky e2e tests for master branch
-    - name: gce-single-flake-attempt
-      test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
-      base_options: include-filter-by-regex=sig-api-machinery
-      description: apimachinery gce e2e tests for master branch with reduced flake attempt
     - name: gce-containerd
       test_group_name: ci-kubernetes-e2e-gci-gce-containerd
       base_options: include-filter-by-regex=sig-node

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -34,12 +34,6 @@ dashboards:
       description: storage gce flaky e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-    - name: gce-single-flake-attempt
-      test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
-      base_options: include-filter-by-regex=Volume%7Cstorage
-      description: storage gce e2e tests for master branch with reduced flake attempt
-      alert_options:
-        alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
     - name: gce-slow
       test_group_name: ci-kubernetes-e2e-gci-gce-slow
       base_options: include-filter-by-regex=Volume%7Cstorage


### PR DESCRIPTION
7c96a78c2b6cb4372f98cda38c72f5743fb9809f was filed when we were using `flakeAttempts` feature in `ginkgo`

Since we don't use this anymore and have switched to the default (no flake attempts!) we can get rid of this job. 