### PR TITLE
Run fsck on the cache copy of the repo instead of the repoClient copy

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -319,7 +319,7 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 		// something unexpected happened
 		return nil, err
 		// we have cloned the repo previously, ensure it is valid and refresh it
-	} else if err := c.ensureValidUpdatedCache(cacheDir, repoClient, cacheClientCacher); err != nil {
+	} else if err := c.ensureValidUpdatedCache(cacheDir, cacheClientCacher); err != nil {
 		return nil, err
 	}
 
@@ -332,11 +332,11 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 }
 
 // Ensures that the repos in the cache are valid, clean, and up to date
-func (c *clientFactory) ensureValidUpdatedCache(cacheDir string, repoClient RepoClient, cacheClientCacher cacher) error {
+func (c *clientFactory) ensureValidUpdatedCache(cacheDir string, cacheClientCacher cacher) error {
 	// We only need to verify that the repos are valid once on startup
 	if _, ok := c.verifiedRepos[cacheDir]; !ok {
 		// Ensure it is valid
-		if valid, _ := repoClient.Fsck(); !valid {
+		if valid, _ := cacheClientCacher.Fsck(); !valid {
 			if err := os.RemoveAll(cacheDir); err != nil {
 				return err
 			}
@@ -345,9 +345,6 @@ func (c *clientFactory) ensureValidUpdatedCache(cacheDir string, repoClient Repo
 			}
 			c.verifiedRepos[cacheDir] = true
 			return nil
-		}
-		if err := repoClient.ResetHard("HEAD"); err != nil {
-			return err
 		}
 	}
 	// Ensure it is up to date

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -72,8 +72,6 @@ type Interactor interface {
 	MergeCommitsExistBetween(target, head string) (bool, error)
 	// ShowRef returns the commit for a commitlike. Unlike rev-parse it does not require a checkout.
 	ShowRef(commitlike string) (string, error)
-	// Fsck verifies the connectivity and validity of the repo and returns true if passed
-	Fsck() (bool, error)
 }
 
 // cacher knows how to cache and update repositories in a central cache
@@ -82,6 +80,8 @@ type cacher interface {
 	MirrorClone() error
 	// RemoteUpdate fetches all updates from the remote.
 	RemoteUpdate() error
+	// Fsck verifies the connectivity and validity of the repo and returns true if passed
+	Fsck() (bool, error)
 }
 
 // cloner knows how to clone repositories from a central cache


### PR DESCRIPTION
This was not working because I was calling git fsck on the repoClient. The dir for the repo Client isn't created until after ensureValidUpdatedCache is called. Instead I changed it to run on the cached copy of the repo.

/assign @cjwagner @listx 