### PR TITLE
Use non-outdated CI images for deb/rpm verification jobs

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -506,7 +506,7 @@ periodics:
     path_alias: k8s.io/release
   spec:
     containers:
-    - image: quay.io/k8s/release-tools:latest
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
       imagePullPolicy: Always
       command:
       - make
@@ -529,11 +529,12 @@ periodics:
     path_alias: k8s.io/release
   spec:
     containers:
-    - image: quay.io/k8s/release-tools-centos:latest
+    - image: registry.access.redhat.com/ubi9/ubi:9.2
       imagePullPolicy: Always
       command:
-      - make
-      - verify-published-rpms
+      - sh
+      - "-c"
+      - "yum install -y make jq && make verify-published-rpms"
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes


### PR DESCRIPTION
We now use our official test image `gcr.io/k8s-staging-releng/releng-ci` for the `deb` verification as well as `ubi9` for the centos image replacement.

Fixes https://github.com/kubernetes/kubernetes/issues/118449