### PR TITLE
update promo-tools canary job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -290,6 +290,8 @@ periodics:
       - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/promo-tools/canary
       - --confirm
+      - --certificate-identity=keyless@projectsigstore.iam.gserviceaccount.com
+      - --certificate-oidc-issuer=https://accounts.google.com"
   annotations:
     testgrid-dashboards: sig-release-releng-informing
     testgrid-alert-email: release-managers+alerts@kubernetes.io


### PR DESCRIPTION
need to update due to upgrade of cosign to v2

ref: https://github.com/kubernetes-sigs/promo-tools/pull/889

/assign @saschagrunert @xmudrii 
cc @kubernetes/release-managers 