### PR TITLE
Cluster API: Consolidate IPv6 and dualstack jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -109,7 +109,7 @@ periodics:
     testgrid-tab-name: capi-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-e2e-dualstack-ipv6-main
+- name: periodic-cluster-api-e2e-dualstack-and-ipv6-main
   interval: 2h
   decorate: true
   decoration_config:
@@ -151,56 +151,7 @@ periodics:
             cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-dualstack-ipv6-main
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-e2e-ipv6-main
-  interval: 2h
-  decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes-sigs
-        slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api
-      base_ref: main
-      path_alias: sigs.k8s.io/cluster-api
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-  spec:
-    serviceAccountName: prowjob-default-sa
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.27
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
-          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-            value: "true"
-          - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
-          - name: GINKGO_FOCUS
-            value: "\\[IPv6\\] \\[PR-Informing\\]"
-          - name: IP_FAMILY
-            value: "IPv6"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 7300m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-ipv6-main
+    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -212,8 +212,6 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[PR-Informing\\]"
-        - name: GINKGO_SKIP
-          value: "\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -223,44 +221,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-informing-main
-  - name: pull-cluster-api-e2e-ipv6-main
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
-    always_run: false
-    branches:
-    # The script this job runs is not in all branches.
-    - ^main$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      serviceAccountName: prowjob-default-sa
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.27
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
-          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-            value: "true"
-          - name: GINKGO_FOCUS
-            value: "\\[IPv6\\] \\[PR-Informing\\]"
-          - name: IP_FAMILY
-            value: "IPv6"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 7300m
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-ipv6-main
-  - name: pull-cluster-api-e2e-full-dualstack-ipv6-main
+  - name: pull-cluster-api-e2e-full-dualstack-and-ipv6-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -297,7 +258,7 @@ presubmits:
               cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-full-dualstack-ipv6-main
+      testgrid-tab-name: capi-pr-e2e-full-dualstack-and-ipv6-main
   - name: pull-cluster-api-e2e-full-main
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Remove the standalone IPv6 Cluster API jobs. These jobs are now run as part of a consolidated dualstack + ipv6 job. The IPv6 tag refers to any jobs that require IPv6 - i.e. both the IPv6 job and the dualstack jobs.