### PR TITLE
testing: always run pull-kubernetes-verify-strict-lint, add linter hints

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -50,7 +50,7 @@ presubmits:
     # This entire job is currently experimental. If it turns out to be useful,
     # the job can be removed and the same check can run as part of pull-kubernetes-verify
     # by removing the exclusion of verify-golangci-lint-pr.sh in hack/make-rules/verify.sh.
-    always_run: false
+    always_run: true
     optional: true
     skip_branches:
     - release-\d+.\d+ # per-release job
@@ -73,7 +73,46 @@ presubmits:
         args:
         - /bin/sh
         - "-c"
-        - "if [ -x hack/verify-golangci-lint-pr.sh ]; then hack/verify-golangci-lint-pr.sh; fi"
+        - "hack/verify-golangci-lint.sh -r ${PULL_BASE_SHA} -s"
+        resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
+          limits:
+            cpu: 7
+            memory: 12Gi
+          requests:
+            cpu: 7
+            memory: 12Gi
+  - name: pull-kubernetes-linter-hints
+    cluster: k8s-infra-prow-build
+    decorate: true
+    always_run: true
+    # This job will always remain optional because linting may fail because of issues that do not
+    # need to be addressed. The job has to fail nonetheless to make it visible in GitHub that there
+    # were such issues.
+    optional: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: sig-testing-misc
+      description: Runs golangci-lint with a configuration for new code that reports also issues which do not need to be fixed.
+      testgrid-alert-email: patrick.ohly@intel.com
+      testgrid-num-failures-to-alert: "15"
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - /bin/sh
+        - "-c"
+        - "hack/verify-golangci-lint.sh -r ${PULL_BASE_SHA} -n"
         resources:
           # Consider reducing memory limits after govet memory usage issue is
           # addressed in https://github.com/kubernetes/kubernetes/issues/93822

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -32,10 +32,12 @@ jobs:
   - pull-kubernetes-e2e-kind-ipv6
   - pull-kubernetes-integration
   - pull-kubernetes-integration-go-compatibility
+  - pull-kubernetes-linter-hints
   - pull-kubernetes-node-e2e-containerd
   - pull-kubernetes-typecheck
   - pull-kubernetes-unit
   - pull-kubernetes-unit-go-compatibility
   - pull-kubernetes-verify
   - pull-kubernetes-verify-govet-levee
+  - pull-kubernetes-verify-strict-lint
 recursive_artifacts: false


### PR DESCRIPTION
We have consensus on how the different known issues should be handled. https://github.com/kubernetes/kubernetes/pull/118502 implements that. Before go towards the final goal of making strict linting merge blocking by moving it into pull-kubernetes-verify, let's expose more developers to this new check by running it for all PRs.

Hints are issues that may or may not need fixing. To make those visible to developers and reviewers, another, permanently non-blocking job is needed which runs checks for those -> pull-kubernetes-linter-hints.

/hold 
https://github.com/kubernetes/kubernetes/pull/118502  needs to be merged first.
