### PR TITLE
fix regex for promo-tools canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -290,7 +290,7 @@ periodics:
       - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/promo-tools/canary
       - --confirm
-      - --certificate-identity-regexp="(keyless@projectsigstore.iam.gserviceaccount.com|krel-trust@k8s-releng-prod.iam.gserviceaccount.com)"
+      - --certificate-identity-regexp="(keyless@projectsigstore.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)"
       - --certificate-oidc-issuer=https://accounts.google.com
   annotations:
     testgrid-dashboards: sig-release-releng-informing

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -290,6 +290,7 @@ periodics:
       - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/promo-tools/canary
       - --confirm
+      - --log-level=debug
       - --certificate-identity-regexp="(keyless@projectsigstore.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)"
       - --certificate-oidc-issuer=https://accounts.google.com
   annotations:


### PR DESCRIPTION
/assign @saschagrunert @xmudrii 
cc @kubernetes/release-managers 


This matches the same that @xmudrii did in the release-sdk repo, lets see if that fixes the job; otherwise will require more debug, also enabling debug for now in case that is needed 