### PR TITLE
force to be empty - promo-tools canary job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -291,6 +291,7 @@ periodics:
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/promo-tools/canary
       - --confirm
       - --log-level=debug
+      - --certificate-identity=""
       - --certificate-identity-regexp="(keyless@projectsigstore.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)"
       - --certificate-oidc-issuer=https://accounts.google.com
   annotations:


### PR DESCRIPTION
the promo tool flag have a default value for the `certificate-identity` and in this case we don't want that, so forcing to be empty for now in the job and if that works I will refactor the code to remove that.

/assign @puerco @xmudrii 
cc @kubernetes/release-managers 