### PR TITLE
[sig-windows] Use sig-windows testing script for the alpha feature job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -126,25 +126,32 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
       preset-capz-windows-2022: "true"
-      preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
+      preset-windows-private-registry-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
         base_ref: release-1.9
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
+        workdir: false
       - org: kubernetes-sigs
         repo: cloud-provider-azure
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: k8s.io/windows-testing
+        workdir: true
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
           command:
-            - runner.sh
-            - ./scripts/ci-conformance.sh
+            - "runner.sh"
+            - "env"
+            - "KUBERNETES_VERSION=latest"
+            - "./capz/run-capz-e2e.sh"
           securityContext:
             privileged: true
           resources:
@@ -154,6 +161,8 @@ presubmits:
           env:
             - name: NODE_FEATURE_GATES
               value: "PodAndContainerStatsFromCRI=true"
+            - name: WINDOWS_CONTAINERD_URL
+              value: "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz"
     annotations:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-alpha-features


### PR DESCRIPTION
This uses changes in https://github.com/kubernetes-sigs/windows-testing/pull/381 to enable turning on alpha features in PR's.

It also switches to using the nightly containerd package since there were a couple bugs in containerd ((https://github.com/containerd/containerd/pull/8633 and https://github.com/containerd/containerd/pull/8626)) we need to validate https://github.com/kubernetes/kubernetes/pull/116968

partially fixes https://github.com/kubernetes/kubernetes/issues/118445

/sig windows
/assign @marosset @mansikulkarni96 