### PR TITLE
Add support for bumping AR registries

### DIFF
--- a/experiment/image-bumper/bumper/bumper.go
+++ b/experiment/image-bumper/bumper/bumper.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	imageRegexp = regexp.MustCompile(`\b((?:[a-z0-9]+\.)?gcr\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_./-]+):([a-zA-Z0-9_.-]+)\b`)
+	imageRegexp = regexp.MustCompile(`\b((?:[a-z0-9]+\.)?gcr\.io|(?:[a-z0-9]+\-)?docker\.pkg\.dev)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_./-]+):([a-zA-Z0-9_.-]+)\b`)
 	tagRegexp   = regexp.MustCompile(`(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?`)
 )
 
@@ -68,11 +68,11 @@ var commitRegexp = regexp.MustCompile(`^g?([\da-f]+)|(.+?)??(?:-(\d+)-g([\da-f]+
 
 // DeconstructCommit separates a git describe commit into its parts.
 
-//
 // Examples:
-//  v0.0.30-14-gdeadbeef => (v0.0.30 14 deadbeef)
-//  v0.0.30 => (v0.0.30 0 "")
-//  deadbeef => ("", 0, deadbeef)
+//
+//	v0.0.30-14-gdeadbeef => (v0.0.30 14 deadbeef)
+//	v0.0.30 => (v0.0.30 0 "")
+//	deadbeef => ("", 0, deadbeef)
 //
 // See man git describe.
 func DeconstructCommit(commit string) (string, int, string) {

--- a/experiment/image-bumper/bumper/bumper_test.go
+++ b/experiment/image-bumper/bumper/bumper_test.go
@@ -330,6 +330,14 @@ func TestUpdateAllTags(t *testing.T) {
 			},
 		},
 		{
+			name:           "AR subdomains are supported",
+			content:        `{"images": ["us-docker.pkg.dev/k8s-testimages/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["us-docker.pkg.dev/k8s-testimages/some-image:v20190405-123456789"]}`,
+			newTags: map[string]string{
+				"us-docker.pkg.dev/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+		},
+		{
 			name:           "images not matching the filter regex are not updated",
 			content:        `{"images": ["gcr.io/k8s-prow/prow-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
 			expectedResult: `{"images": ["gcr.io/k8s-prow/prow-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,


### PR DESCRIPTION
I need to rewrite this later to use the `github.com/google/go-containerregistry/pkg/name` instead of the regex that limits the number of registries supported by the autobumper.

Knative switched from GCR to AR in preparation for the GCR EoL:
- https://github.com/knative/infra/pull/84
- https://github.com/knative/infra/pull/90

Autobumps are stuck till this is fixed. :( 

/cc @BenTheElder 