### PR TITLE
update the default working dir for pod-utils

### DIFF
--- a/jobs/e2e_node/arm/image-config-serial.yaml
+++ b/jobs/e2e_node/arm/image-config-serial.yaml
@@ -5,6 +5,6 @@ images:
   ubuntu:
     image_family: pipeline-1-25-arm64
     machine: t2a-standard-2 # These tests need a lot of memory
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"
     project: ubuntu-os-gke-cloud
 


### PR DESCRIPTION
This change intends to fix the path of metadata.

ref: https://github.com/kubernetes/test-infra/issues/29693


/cc @chaodaiG 
/cc @ike-ma 
/cc @pacoxu 