### PR TITLE
Fix prow-controller-manager starting error

### DIFF
--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -95,22 +95,22 @@ data:
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
         - config:
-          gcs_configuration:
-            bucket: s3://prow-logs
-            path_strategy: explicit
-          github_api_endpoints:
-            - http://ghproxy
-            - https://api.github.com
-          github_app_id: "<<insert-the-app-id-here>>"
-          github_app_private_key_secret:
-            name: github-token
-            key: cert
-          s3_credentials_secret: s3-credentials
-          utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:latest
-            entrypoint: gcr.io/k8s-prow/entrypoint:latest
-            initupload: gcr.io/k8s-prow/initupload:latest
-            sidecar: gcr.io/k8s-prow/sidecar:latest
+            gcs_configuration:
+              bucket: s3://prow-logs
+              path_strategy: explicit
+            github_api_endpoints:
+              - http://ghproxy
+              - https://api.github.com
+            github_app_id: "<<insert-the-app-id-here>>"
+            github_app_private_key_secret:
+              name: github-token
+              key: cert
+            s3_credentials_secret: s3-credentials
+            utility_images:
+              clonerefs: gcr.io/k8s-prow/clonerefs:latest
+              entrypoint: gcr.io/k8s-prow/entrypoint:latest
+              initupload: gcr.io/k8s-prow/initupload:latest
+              sidecar: gcr.io/k8s-prow/sidecar:latest
 
     tide:
       queries:


### PR DESCRIPTION
the config section in `default decoration config_entries` is wrongly indented, cause prow-controller-manager failed to start when deploying in kind, error log:

```
{"component":"prow-controller-manager","error":"[invalid presubmit job presubmit-echo-test: invalid decoration config: utility image config is not specified, invalid periodic job echo-test: invalid decoration config: utility image config is not specified]","file":"k8s.io/test-infra/prow/cmd/prow-controller-manager/main.go:124","func":"main.main","level":"fatal","msg":"Error starting config agent.","severity":"fatal","time":"2023-06-07T04:17:17Z"}
```