### PR TITLE
Fix prow-controller-manager lack of permission

### DIFF
--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -255,8 +255,7 @@ spec:
   selector:
     app: hook
   ports:
-    -
-      name: hook-1
+    - name: hook-1
       port: 8888
       targetPort: 8888
       nodePort: 30001
@@ -408,8 +407,7 @@ spec:
   selector:
     app: deck
   ports:
-    -
-      name: deck-1
+    - name: deck-1
       port: 80
       targetPort: 8080
       nodePort: 30002
@@ -1122,6 +1120,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1405,12 +1404,10 @@ spec:
   selector:
     app: minio
   ports:
-    -
-      name: minio-1
+    - name: minio-1
       port: 9001
       targetPort: 9001
       nodePort: 30003
-    -
-      name: minio-2
+    - name: minio-2
       port: 9000
       targetPort: 9000


### PR DESCRIPTION
Running ProwJob on kind
when prow-controller-manager starts, printing logs below:   
```
{"component":"prow-controller-manager","file":"k8s.io/test-infra/prow/kube/config.go:76","func":"k8s.io/test-infra/prow/kube.LoadClusterConfigs","level":"info","msg":"Loading cluster contexts...","severity":"info","time":"2023-06-07T02:20:00Z"}
{"component":"prow-controller-manager","error":"failed pod resource authorization check: unable to \"get\" pods","file":"k8s.io/test-infra/prow/cmd/prow-controller-manager/main.go:189","func":"main.main","level":"error","msg":"Failed to construct build cluster managers. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.","severity":"error","time":"2023-06-07T02:20:00Z"}
I0607 02:20:01.140367       1 leaderelection.go:248] attempting to acquire leader lease prow/prow-controller-manager-leader-lock...
I0607 02:20:16.739464       1 leaderelection.go:258] successfully acquired lease prow/prow-controller-manager-leader-lock
{"level":"info","ts":1686104416.7507408,"msg":"Starting EventSource","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","source":"kind source: *v1.ProwJob"}
{"level":"info","ts":1686104416.754289,"msg":"Starting Controller","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob"}
{"level":"info","ts":1686104416.757889,"msg":"Starting workers","controller":"plank","controllerGroup":"prow.k8s.io","controllerKind":"ProwJob","worker count":10}
{"component":"prow-controller-manager","controller":"plank","error":"nonretryable error: no build client found for cluster \"default\"","file":"k8s.io/test-infra/prow/plank/reconciler.go:279","func":"k8s.io/test-infra/prow/plank.(*reconciler).defaultReconcile","job":"echo-test","level":"error","msg":"Reconciliation failed with terminal error and will not be requeued","name":"79eeb2d9-c566-49f8-bd6c-2ba49d0d10da","severity":"error","state":"triggered","time":"2023-06-07T02:20:16Z","type":"periodic"}
```