### PR TITLE
Add missing github-token in namespace test-pods

### DIFF
--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -44,6 +44,15 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: test-pods
+  name: github-token
+stringData:
+  cert: <<insert-downloaded-cert-here>>
+  appid: <<insert-the-app-id-here>>
+---
+apiVersion: v1
+kind: Secret
+metadata:
   namespace: prow
   name: hmac-token
 stringData:


### PR DESCRIPTION
When running ProwJow in kind, checking job executing status:
`k -n test-pods describe pods d0bbd170-ebab-42b3-973e-68d3786f93b1`

```
Events:
  Type     Reason       Age                   From               Message
  ----     ------       ----                  ----               -------
  Normal   Scheduled    5m20s                 default-scheduler  Successfully assigned test-pods/d0bbd170-ebab-42b3-973e-68d3786f93b1 to kind-control-plane
  Warning  FailedMount  70s (x10 over 5m20s)  kubelet            MountVolume.SetUp failed for volume "github-token" : secret "github-token" not found
  Warning  FailedMount  62s (x2 over 3m17s)   kubelet            Unable to attach or mount volumes: unmounted volumes=[github-token], unattached volumes=[], failed to process volumes=[]: timed out waiting for the condition
```