### PR TITLE
Stop setting KubeletPodResources=false featuregate for Windows GCE tests

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -6,8 +6,6 @@ presets:
     value: "true"
   - name: KUBERNETES_NODE_PLATFORM
     value: "windows"
-  - name: KUBELET_TEST_ARGS
-    value: "--feature-gates=KubeletPodResources=false"
   - name: USE_TEST_INFRA_LOG_DUMPING
     value: "true"
 - labels:


### PR DESCRIPTION
/sig windows
partial fix for https://github.com/kubernetes/kubernetes/issues/118445

Windows GCE jobs on master are failing with

> E0607 19:31:12.334712    4608 run.go:74] "command failed" err="failed to set feature gates from initial flags-based config: cannot set feature gate KubeletPodResources to false, feature is locked to true"

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-containerd-gce-master/1666524882143285248/artifacts/e2e-0021ce8b3e-734c0-windows-node-group-bg47/kubelet.log

/assign @jsturtevant @claudiubelu @dims 