### PR TITLE
CAPI Operator: Setup release-0.3 periodic/presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
@@ -19,3 +19,26 @@ periodics:
     testgrid-tab-name: capi-operator-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-operator-e2e-main
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-operator
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-operator
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+      command:
+      - "./scripts/ci-e2e.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+    testgrid-tab-name: capi-operator-e2e-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
@@ -19,3 +19,26 @@ periodics:
     testgrid-tab-name: capi-operator-test-release-0-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-operator-e2e-release-0-3
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-operator
+    base_ref: release-0.3
+    path_alias: sigs.k8s.io/cluster-api-operator
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+      command:
+      - "./scripts/ci-e2e.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+    testgrid-tab-name: capi-operator-e2e-release-0-3
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
@@ -1,0 +1,21 @@
+periodics:
+- name: periodic-cluster-api-operator-test-release-0-3
+  interval: 24h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-operator
+    base_ref: release-0.3
+    path_alias: sigs.k8s.io/cluster-api-operator
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+      command:
+      - "./scripts/ci-test.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+    testgrid-tab-name: capi-operator-test-release-0-3
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -21,8 +21,7 @@ presubmits:
   - name: pull-cluster-api-operator-make-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
-    always_run: false
-    optional: true
+    always_run: true
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -95,7 +95,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-test-main
-  - name: pull-cluster-api-operator-e2e
+  - name: pull-cluster-api-operator-e2e-main
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
@@ -1,0 +1,128 @@
+presubmits:
+  kubernetes-sigs/cluster-api-operator:
+  - name: pull-cluster-api-operator-build-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+        command:
+        - runner.sh
+        - ./scripts/ci-build.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+      testgrid-tab-name: capi-operator-pr-build-release-0-3
+  - name: pull-cluster-api-operator-make-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-make.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+      testgrid-tab-name: capi-operator-pr-make-release-0-3
+  - name: pull-cluster-api-operator-apidiff-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+      testgrid-tab-name: capi-operator-pr-apidiff-release-0-3
+  - name: pull-cluster-api-operator-verify-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+        command:
+        - "runner.sh"
+        - ./scripts/ci-verify.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+      testgrid-tab-name: capi-operator-pr-verify-release-0-3
+  - name: pull-cluster-api-operator-test-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+        args:
+        - runner.sh
+        - ./scripts/ci-test.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+      testgrid-tab-name: capi-operator-pr-test-release-0-3
+  - name: pull-cluster-api-operator-e2e-release-0-3
+    path_alias: "sigs.k8s.io/cluster-api-operator"
+    optional: false
+    decorate: true
+    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
+    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-e2e.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: cluster-lifecycle-github-token
+              key: cluster-lifecycle-github-token
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
+      testgrid-tab-name: capi-operator-pr-e2e-release-0-3

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -19,6 +19,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-openstack
     - sig-cluster-lifecycle-cluster-api-provider-cloudstack
     - sig-cluster-lifecycle-cluster-api-provider-nested
+    - sig-cluster-lifecycle-cluster-api-operator-0.3
     - sig-cluster-lifecycle-cluster-api-operator
     - sig-cluster-lifecycle-kops
     - sig-cluster-lifecycle-etcdadm
@@ -61,6 +62,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
 - name: sig-cluster-lifecycle-cluster-api-provider-cloudstack
 - name: sig-cluster-lifecycle-cluster-api-provider-nested
+- name: sig-cluster-lifecycle-cluster-api-operator-0.3
 - name: sig-cluster-lifecycle-cluster-api-operator
 - name: sig-cluster-lifecycle-kops
 - name: sig-cluster-lifecycle-etcdadm


### PR DESCRIPTION
Also:
- adds new e2e periodic jobs for main/release-0.3 branches
- makes `pull-cluster-api-operator-make-main` job required to run in every PR, because it is useful to have (essentially it runs `make lint docker-build` which lints the code base and builds an operator controller image) 
- changes `pull-cluster-api-operator-e2e` job name to `pull-cluster-api-operator-e2e-main` to add missing branch name