### PR TITLE
Set the parameters to build arm64 binaries

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -159,8 +159,10 @@ periodics:
           - --gcp-zone=us-central1-a
           - --parallelism=1
           - --focus-regex=\[Serial\]
+          - --use-dockerized-build=true
+          - --target-build-arch=linux/arm64
           - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:NodeProblemDetector\]|\[NodeFeature:OOMScoreAdj\]|\[NodeFeature:DevicePluginProbe\]|\[NodeConformance\]
-          - '--test-args=--use-dockerized-build=true --target-build-arch=linux/arm64 --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
         securityContext:
           privileged: true


### PR DESCRIPTION
The job ci-kubernetes-node-arm64-ubuntu-serial is failing because the binaries, such as "ginkgo" are copied from the wrong location and was build for linux/amd64 instead.


ref: 
https://github.com/kubernetes/kubernetes/pull/118567
https://github.com/kubernetes-sigs/kubetest2/pull/229

/hold
waiting for https://github.com/kubernetes-sigs/kubetest2/pull/229 get in first