### PR TITLE
CAPI Operator: Retain LGTM through squash

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -246,6 +246,7 @@ lgtm:
   - kubernetes/website
   - kubernetes-sigs/node-feature-discovery
   - kubernetes-sigs/cluster-api
+  - kubernetes-sigs/cluster-api-operator
   - kubernetes-sigs/cluster-api-provider-azure
   store_tree_hash: true
 


### PR DESCRIPTION
Add retaining `lgtm` through squash to the Cluster API Operator repo.