### PR TITLE
sig-release: migrate build jobs to community-owned clusters

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -4,6 +4,7 @@ presubmits:
     optional: true
     always_run: false
     run_if_changed: '(^.go-version)|(^build/build-image/)|(^hack/lib/golang.sh)|(^build/common.sh)'
+    cluster: eks-prow-build-cluster
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -120,6 +121,7 @@ periodics:
 
 - interval: 4h
   name: ci-release-build-packages-debs
+  cluster: eks-prow-build-cluster
   decorate: true
   spec:
     containers:
@@ -130,6 +132,9 @@ periodics:
       args:
       - debs
       resources:
+        limits:
+          cpu: 4
+          memory: "8Gi"
         requests:
           cpu: 4
           memory: "8Gi"
@@ -144,6 +149,7 @@ periodics:
 
 - interval: 4h
   name: ci-release-build-packages-rpms
+  cluster: eks-prow-build-cluster
   decorate: true
   spec:
     containers:
@@ -154,6 +160,9 @@ periodics:
       args:
       - rpms
       resources:
+        limits:
+          cpu: 4
+          memory: "8Gi"
         requests:
           cpu: 4
           memory: "8Gi"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -588,6 +588,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.24
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-e2e-kops-aws
     labels:
       preset-aws-credential: "true"
@@ -631,7 +632,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.24
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -1001,6 +1006,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.24
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-node-e2e-containerd-kubetest2
     decorate: true
     decoration_config:
@@ -1721,6 +1727,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.24
+    cluster: eks-prow-build-cluster
     context: pull-perf-tests-clusterloader2
     decorate: true
     decoration_config:
@@ -1787,6 +1794,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.24
+    cluster: eks-prow-build-cluster
     context: pull-perf-tests-clusterloader2-kubemark
     decorate: true
     decoration_config:


### PR DESCRIPTION
This PR will migrate kubernetes/sig-release prowjobs to `eks-prow-build-cluster`.

Ref: #29722