### PR TITLE
Adding in serial-slow windows jobs for release 1.26 and 1.27 branches

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -56,3 +56,56 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.26-informing, sig-windows-signal,  sig-windows-1.26-release
     testgrid-tab-name: capz-windows-containerd-1.26
+- name: ci-kubernetes-e2e-capz-1-26-windows-serial-slow
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
+    preset-capz-windows-common-126: "true"
+    preset-capz-windows-2019: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.8
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.26
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|RebootHost|\[sig-autoscaling\].\[Feature:HPA\]
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.26-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1-26-serial-slow

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -61,3 +61,56 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.27-informing, sig-windows-signal,  sig-windows-1.27-release
     testgrid-tab-name: capz-windows-containerd-1.27
+- name: ci-kubernetes-e2e-capz-1-27-windows-serial-slow
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-containerd-1-7-latest: "true"
+    preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
+    preset-capz-windows-common-127: "true"
+    preset-capz-windows-2022: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.8
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.27
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|RebootHost|\[sig-autoscaling\].\[Feature:HPA\]
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.27-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1-27-serial-slow


### PR DESCRIPTION
Adding serial-slow windows jobs for 1.26 and 1.27

For the 1.26 branch we'll test on Windows Server 2019 and for 1.27 branch we'll test on Windows Server 2022

/sig windows
/assign @jsturtevant 