### PR TITLE
kustomize: migrate presubmits to community clusters

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -20,7 +20,7 @@ presubmits:
             cpu: 4000m
           limits:
             memory: "2000Mi"
-            cpu: 4000m                    
+            cpu: 4000m                 
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: kustomize-presubmit-master

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kustomize:
   - name: kustomize-presubmit-master
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/kustomize

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -16,7 +16,11 @@ presubmits:
         - prow-presubmit-check
         resources:
           requests:
+            memory: "2000Mi"
             cpu: 4000m
+          limits:
+            memory: "2000Mi"
+            cpu: 500m                    
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: kustomize-presubmit-master

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -20,7 +20,7 @@ presubmits:
             cpu: 4000m
           limits:
             memory: "2000Mi"
-            cpu: 500m                    
+            cpu: 4000m                    
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: kustomize-presubmit-master

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -20,7 +20,7 @@ presubmits:
             cpu: 4000m
           limits:
             memory: "2000Mi"
-            cpu: 4000m                 
+            cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: kustomize-presubmit-master


### PR DESCRIPTION
This PR transitions the `kustomize-presubmit-master` job from the default cluster to `eks-prow-build-cluster` :+1: 

ref: https://github.com/kubernetes/test-infra/issues/29722