### PR TITLE
🐛 Cluster API Operator: use runner for periodic tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
@@ -36,7 +36,11 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
       command:
-      - "./scripts/ci-e2e.sh"
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
     testgrid-tab-name: capi-operator-e2e-main

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
@@ -36,7 +36,11 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
       command:
-      - "./scripts/ci-e2e.sh"
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
     testgrid-tab-name: capi-operator-e2e-release-0-3


### PR DESCRIPTION
newly introduced [`periodic-cluster-api-operator-e2e-main`](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-operator-e2e-main/1666813034053505024)/[`periodic-cluster-api-operator-e2e-release-0-3`](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-operator-e2e-release-0-3/1666813034175139840) jobs are failing:

```
kind not found, installing
/home/prow/go/src/sigs.k8s.io/cluster-api-operator/hack/ensure-kind.sh: line 45: kind: command not found
/home/prow/go/src/sigs.k8s.io/cluster-api-operator/hack/ensure-kind.sh: line 46: kind_version[1]: unbound variable
/home/prow/go/src/sigs.k8s.io/cluster-api-operator/hack/ensure-kind.sh: line [4](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-operator-e2e-release-0-3/1666813034175139840#1:build-log.txt%3A4)7: kind_version[0]: unbound variable
```

this should fix it by adding runner scripts to sync periodic e2e jobs with presubmit e2e jobs