### PR TITLE
CAPI Operator: Add needs-triage label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -854,6 +854,18 @@ require_matching_label:
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 - missing_label: needs-triage
   org: kubernetes-sigs
+  repo: cluster-api-operator
+  issues: true
+  prs: false
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If CAPI Operator contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-triage
+  org: kubernetes-sigs
   repo: cluster-api-provider-aws
   issues: true
   prs: false
@@ -1382,6 +1394,10 @@ plugins:
     - milestone
     - override
     - require-matching-label
+
+  kubernetes-sigs/cluster-api-operator:
+    plugins:
+    - require-matching-label   
 
   kubernetes-sigs/cluster-api-provider-aws:
     plugins:


### PR DESCRIPTION
Part of: https://github.com/kubernetes-sigs/cluster-api-operator/issues/153