### PR TITLE
CAPI Operator: move jobs to EKS prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-operator-test-main
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   labels:
@@ -14,12 +15,20 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
       command:
       - "./scripts/ci-test.sh"
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
     testgrid-tab-name: capi-operator-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-operator-e2e-main
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -41,6 +50,13 @@ periodics:
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
     testgrid-tab-name: capi-operator-e2e-main

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-3.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-operator-test-release-0-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   labels:
@@ -14,12 +15,20 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
       command:
       - "./scripts/ci-test.sh"
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
     testgrid-tab-name: capi-operator-test-release-0-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-operator-e2e-release-0-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -41,6 +50,13 @@ periodics:
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
     testgrid-tab-name: capi-operator-e2e-release-0-3

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-operator:
   - name: pull-cluster-api-operator-build-main
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -15,10 +16,18 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-build-main
   - name: pull-cluster-api-operator-make-main
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -30,17 +39,25 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - command:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        command:
         - runner.sh
         - ./scripts/ci-make.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-make-main
   - name: pull-cluster-api-operator-apidiff-main
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -52,14 +69,22 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - command:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-apidiff-main
   - name: pull-cluster-api-operator-verify-main
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -74,10 +99,18 @@ presubmits:
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-verify-main
   - name: pull-cluster-api-operator-test-main
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -92,10 +125,18 @@ presubmits:
         args:
         - runner.sh
         - ./scripts/ci-test.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-test-main
   - name: pull-cluster-api-operator-e2e-main
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true
@@ -123,6 +164,13 @@ presubmits:
             secretKeyRef:
               name: cluster-lifecycle-github-token
               key: cluster-lifecycle-github-token
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-e2e-main

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-operator:
   - name: pull-cluster-api-operator-build-release-0-3
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -15,10 +16,18 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-build-release-0-3
   - name: pull-cluster-api-operator-make-release-0-3
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -30,17 +39,25 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - command:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        command:
         - runner.sh
         - ./scripts/ci-make.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-make-release-0-3
   - name: pull-cluster-api-operator-apidiff-release-0-3
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -52,14 +69,22 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - command:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-apidiff-release-0-3
   - name: pull-cluster-api-operator-verify-release-0-3
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -74,10 +99,18 @@ presubmits:
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-verify-release-0-3
   - name: pull-cluster-api-operator-test-release-0-3
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
     always_run: true
@@ -92,10 +125,18 @@ presubmits:
         args:
         - runner.sh
         - ./scripts/ci-test.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-test-release-0-3
   - name: pull-cluster-api-operator-e2e-release-0-3
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true
@@ -123,6 +164,13 @@ presubmits:
             secretKeyRef:
               name: cluster-lifecycle-github-token
               key: cluster-lifecycle-github-token
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-e2e-release-0-3


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/cluster-api-operator/issues/152
Part of: https://github.com/kubernetes-sigs/cluster-api-operator/issues/153
Related to: https://github.com/kubernetes/test-infra/issues/29722

/hold