### PR TITLE
Remove unused bucket for triage images

### DIFF
--- a/triage/Makefile
+++ b/triage/Makefile
@@ -20,9 +20,6 @@ build:
 test:
 	go test ./...
 
-push:
-  ../../../hack/make-rules/go-run/arbitrary.sh run ./images/builder --project=k8s-staging-test-infra --scratch-bucket=gs://k8s-staging-test-infra-scratch triage
-
 STATIC_FILES=index.html interactive.js model.js render.js style.css
 
 # these need to be run by k8s-infra-prow or community members with access to the kubernetes.io GCP org


### PR DESCRIPTION
It seems that is using the one provided by the cloudbuild job in https://github.com/kubernetes/test-infra/blob/25717e53a1aa9dcc7d29257b93968fd35ddfb308/config/jobs/image-pushing/k8s-staging-test-infra.yaml#L252