### PR TITLE
Pin windows 2019 nodes to a April 2023 patches

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -113,6 +113,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+        env:
+          - name: IMAGE_VERSION
+            value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "KUBERNETES_VERSION=latest -> KUBERNETES_VERSION=latest-{{.Version}}"


### PR DESCRIPTION
We noticed some issues with upgrading contaiener on the Windows nodes after updating to the latest set of OS patches so we're going to pin the nodes to a specific Windows image while we do some investigations.

/sig windows
/assign @jsturtevant 