### PR TITLE
migrate kubernetes/kernel-module-management jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kernel-module-management:
   - name: pull-kernel-module-management-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -12,7 +13,15 @@ presubmits:
       - image: golang:1.20
         command:
         - ci/prow/build
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-kernel-module-management-check-api-changes
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -39,7 +48,15 @@ presubmits:
         env:
         - name: CGO_ENABLED
           value: '0'
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-kernel-module-management-check-commits-count
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -51,7 +68,15 @@ presubmits:
       - image: docker.io/bitnami/git
         command:
         - ci/prow/check-commits-count
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-kernel-module-management-lint
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -63,7 +88,15 @@ presubmits:
       - image: golang:1.20
         command:
         - ci/prow/lint
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-kernel-module-management-unit-tests
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -75,3 +108,10 @@ presubmits:
       - image: golang:1.20
         command:
         - ci/prow/unit-tests
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi


### PR DESCRIPTION
jobs: migrate kubernetes/kernel-module-management jobs to eks cluster

Add missing resource block

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722