### PR TITLE
migrate kubernetes/image-builder jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/image-builder:
     - name: pull-ova-all
+      cluster: eks-prow-build-cluster
       labels:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
@@ -20,6 +21,10 @@ presubmits:
             resources:
               requests:
                 cpu: "1000m"
+                memory: "4Gi"
+              limits:
+                cpu: "1000m"
+                memory: "4Gi"
             securityContext:
               privileged: true
               capabilities:

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -47,6 +47,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-azure-sigs
   - name: json-sort-check
+    cluster: eks-prow-build-cluster
     decorate: true
     run_if_changed: 'images/capi/.*\.json$'
     decoration_config:
@@ -62,10 +63,15 @@ presubmits:
           resources:
             requests:
               cpu: 1000m
+              memory: 4Gi
+            limits:
+              cpu: 1000m
+              memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-json-sort-check
   - name: pull-packer-validate
+    cluster: eks-prow-build-cluster
     decorate: true
     run_if_changed: 'images/capi/Makefile|images/capi/packer/.*|images/capi/scripts/ci-packer-validate\.sh|images/capi/scripts/ensure-packer\.sh'
     decoration_config:
@@ -78,6 +84,13 @@ presubmits:
           args:
           - runner.sh
           - "./images/capi/scripts/ci-packer-validate.sh"
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 4Gi
+            limits:
+              cpu: 1000m
+              memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-packer-validate
@@ -110,6 +123,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-pull-image-builder-gcp-all
   - name: pull-goss-populate
+    cluster: eks-prow-build-cluster
     path_alias: sigs.k8s.io/image-builder
     run_if_changed: 'images/capi/packer/config/.*|images/capi/packer/goss/.*|images/capi/scripts/ci-goss-populate\.sh|images/capi/hack/generate-goss-specs\.py'
     decorate: true
@@ -122,6 +136,13 @@ presubmits:
           args:
             - runner.sh
             - "./images/capi/scripts/ci-goss-populate.sh"
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 4Gi
+            limits:
+              cpu: 1000m
+              memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-goss-populate


### PR DESCRIPTION
jobs: migrate kubernetes/image-builder jobs to eks cluster

- Add missing resource blocks

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722