### PR TITLE
migrate kubernetes/gateway-api jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/gateway-api:
   - name: pull-gateway-api-verify
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-network-gateway-api
       testgrid-tab-name: verify
@@ -23,7 +24,15 @@ presubmits:
         # docker-in-docker needs privileged mode.
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-gateway-api-test
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-network-gateway-api
       testgrid-tab-name: test
@@ -46,3 +55,10 @@ presubmits:
           # docker-in-docker needs privileged mode.
           securityContext:
             privileged: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 4Gi
+            requests:
+              cpu: 1
+              memory: 4Gi


### PR DESCRIPTION
jobs: migrate kubernetes/gateway-api jobs to eks cluster

- Add missing resource blocks

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722