### PR TITLE
migrate kubernetes/descheduler jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/descheduler:
   - name: pull-descheduler-verify-master
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-master
@@ -18,7 +19,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-descheduler-verify-build-master
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-build-master
@@ -35,7 +44,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-descheduler-unit-test-master-master
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-unit-test-master
@@ -53,7 +70,15 @@ presubmits:
         - make
         args:
         - test-unit
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-27
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.27
@@ -83,7 +108,15 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-26
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.26
@@ -113,7 +146,15 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-25
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.25
@@ -143,3 +184,10 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi


### PR DESCRIPTION
jobs: migrate kubernetes/descheduler jobs to eks cluster

- Add missing resource blocks

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722