### PR TITLE
migrate kubernetes/kubespray jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kubespray:
   - name: pull-kubespray-yamllint
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kubespray
       testgrid-tab-name: yamllint
@@ -14,3 +15,10 @@ presubmits:
         - yamllint
         - "--strict"
         - .
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi


### PR DESCRIPTION
jobs: migrate kubernetes/kubespray jobs to eks cluster

- Add missing resource blocks
/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722