### PR TITLE
migrate kubernetes/kubetest2 jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kubetest2:
   - name: pull-kubetest2-verify
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     labels:
@@ -13,9 +14,17 @@ presubmits:
         args:
         - make
         - verify
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         securityContext:
           privileged: true
   - name: pull-kubetest2-build
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     labels:
@@ -28,5 +37,12 @@ presubmits:
         args:
         - make
         - build-all
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: postsubmit-node-feature-discovery-verify-master
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     - ^master
@@ -15,6 +16,13 @@ postsubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         env:
         - name: CODECOV_TOKEN
           valueFrom:
@@ -22,6 +30,7 @@ postsubmits:
               name: nfd-creds
               key: codecov-token
   - name: postsubmit-node-feature-discovery-e2e-test
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     - ^master$
@@ -40,6 +49,13 @@ postsubmits:
         args:
         - -c
         - apt update && apt install -y jq && scripts/test-infra/test-e2e.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -18,6 +18,7 @@ presubmits:
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-build-image-generic
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -37,7 +38,15 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-image.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-image-cross-generic
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -61,7 +70,15 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-image-cross.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-gh-pages-generic
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     skip_branches:
     - gh-pages
@@ -81,3 +98,10 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-gh-pages.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-master
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^master
@@ -14,6 +15,13 @@ presubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         env:
         - name: CODECOV_TOKEN
           valueFrom:
@@ -21,6 +29,7 @@ presubmits:
               name: nfd-creds
               key: codecov-token
   - name: pull-node-feature-discovery-verify-docs-master
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     branches:
     - ^master
@@ -34,7 +43,15 @@ presubmits:
       - image: ruby:slim
         command:
         - scripts/test-infra/mdlint.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-master
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^master
@@ -48,3 +65,10 @@ presubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/build.sh
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi


### PR DESCRIPTION
jobs: migrate kubernetes/kubetest2 jobs to eks cluster

- Add missing resource blocks
/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722