### PR TITLE
migrate kubernetes/kubetest2 jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kubetest2:
   - name: pull-kubetest2-verify
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     labels:
@@ -13,9 +14,17 @@ presubmits:
         args:
         - make
         - verify
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         securityContext:
           privileged: true
   - name: pull-kubetest2-build
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     labels:
@@ -28,5 +37,12 @@ presubmits:
         args:
         - make
         - build-all
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
         securityContext:
           privileged: true


### PR DESCRIPTION
jobs: migrate kubernetes/kubetest2 jobs to eks cluster

- Add missing resource blocks
/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722