### PR TITLE
migrate kubernetes/node-feature-discovery jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -18,6 +18,7 @@ presubmits:
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-build-image-generic
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -37,7 +38,15 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-image.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-image-cross-generic
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -61,7 +70,15 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-image-cross.sh
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
   - name: pull-node-feature-discovery-build-gh-pages-generic
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     skip_branches:
     - gh-pages
@@ -81,3 +98,10 @@ presubmits:
         - runner.sh
         args:
         - scripts/test-infra/build-gh-pages.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -21,6 +21,7 @@ presubmits:
               name: nfd-creds
               key: codecov-token
   - name: pull-node-feature-discovery-verify-docs-master
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     branches:
     - ^master
@@ -34,7 +35,15 @@ presubmits:
       - image: ruby:slim
         command:
         - scripts/test-infra/mdlint.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-master
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^master
@@ -48,3 +57,10 @@ presubmits:
       - image: golang:1.20
         command:
         - scripts/test-infra/build.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
jobs: migrate kubernetes/node-feature-discovery jobs to eks cluster

- Add missing resource blocks
/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722