### PR TITLE
migrate external-snapshotter to community cluster

### DIFF
--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-snapshotter:
   - name: pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-24
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -47,7 +48,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "16000Mi"
+            cpu: 10000m
+          limits:
+            memory: "16000Mi"
+            cpu: 10000m
   - name: pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -94,6 +99,7 @@ presubmits:
             # during the tests more like 3-20m is used
             cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -138,7 +144,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "16000Mi"
+            cpu: 10000m
+          limits:
+            memory: "16000Mi"
+            cpu: 10000m
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -185,6 +195,7 @@ presubmits:
             # during the tests more like 3-20m is used
             cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -229,11 +240,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "16000Mi"
+            cpu: 10000m
+          limits:
+            memory: "16000Mi"
+            cpu: 10000m
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -326,6 +337,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false
@@ -356,9 +368,12 @@ presubmits:
           requests:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
-            memory: "9000Mi"
+            memory: "16000Mi"
             # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 10000m
+          limits:
+            memory: "16000Mi"
+            cpu: 10000m
 
   - name: pull-kubernetes-csi-external-snapshotter-canary
     optional: true


### PR DESCRIPTION
migrate `kubernetes-csi/external-snapshotter` jobs from `default` cluster to `eks-prow-build-cluster`

Ref: https://github.com/kubernetes/test-infra/issues/29722