### PR TITLE
migrate kubernetes/security-profiles-operator jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -81,7 +81,7 @@ presubmits:
             memory: 9000Mi
             cpu: 7500m
           limits:
-            memory: 10000Mi
+            memory: 9000Mi
             cpu: 7500m
         command:
         - runner.sh
@@ -111,7 +111,7 @@ presubmits:
             memory: 9000Mi
             cpu: 7500m
           limits:
-            memory: 10000Mi
+            memory: 9000Mi
             cpu: 7500m
         command:
         - runner.sh

--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/security-profiles-operator:
   - name: pull-security-profiles-operator-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -11,8 +12,16 @@ presubmits:
       - image: golang:1.20
         command:
         - hack/pull-security-profiles-operator-build
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
 
   - name: pull-security-profiles-operator-verify
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -23,8 +32,16 @@ presubmits:
       - image: golang:1.20
         command:
         - hack/pull-security-profiles-operator-verify
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
 
   - name: pull-security-profiles-operator-test-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -35,8 +52,16 @@ presubmits:
       - image: golang:1.20
         command:
         - hack/pull-security-profiles-operator-test-unit
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
 
   - name: pull-security-profiles-operator-build-image
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:
@@ -55,12 +80,16 @@ presubmits:
           requests:
             memory: 9000Mi
             cpu: 7500m
+          limits:
+            memory: 10000Mi
+            cpu: 7500m
         command:
         - runner.sh
         args:
         - hack/pull-security-profiles-operator-build-image
 
   - name: pull-security-profiles-operator-test-e2e
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     annotations:


### PR DESCRIPTION
jobs: migrate kubernetes/security-profiles-operator jobs to eks cluster

- Add missing resource blocks

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722