### PR TITLE
CAPI Operator: use 'run_if_changed' consistently in presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -43,13 +43,13 @@ presubmits:
   - name: pull-cluster-api-operator-apidiff-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
-    always_run: true
     optional: true
     labels:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
     - ^main$
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
       - command:
@@ -80,12 +80,12 @@ presubmits:
   - name: pull-cluster-api-operator-test-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
-    always_run: true
     labels:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
     - ^main$
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
@@ -99,8 +99,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true
-    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
-    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
@@ -43,13 +43,13 @@ presubmits:
   - name: pull-cluster-api-operator-apidiff-release-0-3
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
-    always_run: true
     optional: true
     labels:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
     - ^release-0.3$
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
       - command:
@@ -80,12 +80,12 @@ presubmits:
   - name: pull-cluster-api-operator-test-release-0-3
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
-    always_run: true
     labels:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
     - ^release-0.3$
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
@@ -99,8 +99,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true
-    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
-    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Part of: https://github.com/kubernetes-sigs/cluster-api-operator/issues/153

we use `run_If_changed` only in one presubmit job to ensure it is not run if only e.g. documentation is changed.
This PR makes sure that `run_if_changed` is used consistently in all presubmit jobs that should only be run if our code changes.

Changes ensure the following jobs also use `run_if_changed`:


- pull-cluster-api-operator-apidiff-main/pull-cluster-api-operator-apidiff-release-0-3
- pull-cluster-api-operator-test-main/pull-cluster-api-operator-test-release-0-3
- pull-cluster-api-operator-e2e-main/pull-cluster-api-operator-e2e-release-0-3 (run_if_changed was already in use, regexp was changed to more an explicit one)


Pros of using `run_if_changed`:

- less resource usage as we run a lot less jobs
- less waiting around and re-triggering for test jobs that are not relevant to doc PRs
