### PR TITLE
Revert "Move secrets-store-csi-driver lint job to eks-prow-build-cluster"

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -1,7 +1,6 @@
 presubmits:
   kubernetes-sigs/secrets-store-csi-driver:
   - name: pull-secrets-store-csi-driver-lint
-    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -21,13 +20,6 @@ presubmits:
           - test-style
         securityContext:
           privileged: true
-        resources:
-          limits:
-            cpu: 2
-            memory: 2Gi
-          requests:
-            cpu: 2
-            memory: 2Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-lint


### PR DESCRIPTION
Reverts kubernetes/test-infra#29473

The lint job fails due to timeout (10m) even though `make lint` actually completes in 5m (xref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_secrets-store-csi-driver/1271/pull-secrets-store-csi-driver-lint/1668250726058430464). I'm reverting this change, so we can unblock the regular patch release today. I've opened https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1273 to track the work. 