### PR TITLE
Create Initial EC2 sig-node e2e tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -94,7 +94,7 @@ presubmits:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
-    always_run: true
+    always_run: false # flip after tests are green
     optional: true # flip after tests are green
     cluster: eks-prow-build-cluster
     max_concurrency: 12

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -83,6 +83,40 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+  - name: pull-kubernetes-node-e2e-ec2-containerd
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    labels:
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    always_run: true
+    optional: true # flip after tests are green
+    cluster: eks-prow-build-cluster
+    max_concurrency: 12
+    decorate: true
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: "sigs.k8s.io/provider-aws-test-infra"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-master
+          command:
+            - "runner.sh"
+            - "./home/prow/go/src/sigs.k8s.io/provider-aws-test-infra/run.sh"
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
   - name: pull-kubernetes-node-e2e-containerd-kubetest2
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -83,7 +83,7 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
-  - name: pull-kubernetes-node-e2e-ec2-containerd
+  - name: pull-kubernetes-node-e2e-containerd-ec2
     skip_branches:
       - release-\d+\.\d+  # per-release image
     labels:

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -26,11 +26,11 @@ dashboards:
     - name: pull-node-e2e
       test_group_name: pull-kubernetes-node-e2e-containerd
       base_options: width=10
-    - name: pull-e2e-gci
+    - name: pull-e2e-gce
       test_group_name: pull-kubernetes-e2e-containerd-gce
       base_options: width=10
     - name: pull-e2e-ec2
-      test_group_name: pull-kubernetes-e2e-containerd-ec2
+      test_group_name: pull-kubernetes-node-e2e-containerd-ec2
       base_options: width=10
 
 - name: sig-node-cri-o

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -29,6 +29,9 @@ dashboards:
     - name: pull-e2e-gci
       test_group_name: pull-kubernetes-e2e-containerd-gce
       base_options: width=10
+    - name: pull-e2e-ec2
+      test_group_name: pull-kubernetes-e2e-containerd-ec2
+      base_options: width=10
 
 - name: sig-node-cri-o
 - name: sig-node-cri-tools


### PR DESCRIPTION
The EC2 testing logic lives in https://github.com/kubernetes-sigs/provider-aws-test-infra to reduce deps in k/k repo

