### PR TITLE
[WIP] Replace fsck with bespoke lock file

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -320,7 +320,13 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 		return nil, err
 		// we have cloned the repo previously, ensure it is up to date
 	} else if err := cacheClientCacher.RemoteUpdate(); err != nil {
-		return nil, err
+		// If there was an error updating the remote, delete it and reclone
+		if err := os.RemoveAll(cacheDir); err != nil {
+			return nil, err
+		}
+		if err := cloneDir(cacheDir, cacheClientCacher); err != nil {
+			return nil, err
+		}
 	}
 
 	// initialize the new derivative repo from the cache


### PR DESCRIPTION
The gitClientFactory Cache uses bare repositories which do not have a git lock on them. In order to ensure an interrupted clone or fetch did not corrupt the cache we were running fsck but it was taking a long time to run (upwards of 5 minutes). This replaces the fsck with a lock on the cache. This way if we notice on startup there is a lock on the cache we can just re-clone. 

/hold
/assign @listx @cjwagner 