### PR TITLE
Update kubekins/krte to Go 1.20.5/1.19.10

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,57 +1,57 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.20.4
+    GO_VERSION: 1.20.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.20.4
+    GO_VERSION: 1.20.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.19.9
+    GO_VERSION: 1.19.10
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
     KIND_VERSION: 0.17.0
   master:
     CONFIG: master
-    GO_VERSION: 1.20.4
+    GO_VERSION: 1.20.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.20.4
+    GO_VERSION: 1.20.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: 1.20.4
+    GO_VERSION: 1.20.5
     K8S_RELEASE: latest-1.27
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: 1.19.9
+    GO_VERSION: 1.19.10
     K8S_RELEASE: stable-1.26
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: 1.19.9
+    GO_VERSION: 1.19.10
     K8S_RELEASE: stable-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: 1.19.9
+    GO_VERSION: 1.19.10
     K8S_RELEASE: stable-1.24
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
* Update kubekins/krte to Go 1.20.5/1.19.10

/assign @saschagrunert @puerco @dims
/cc @kubernetes/release-engineering 