### PR TITLE
Adapt security-profiles-operator tests

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -34,11 +34,11 @@ presubmits:
         - hack/pull-security-profiles-operator-verify
         resources:
           limits:
-            cpu: 1
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 1
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
 
   - name: pull-security-profiles-operator-test-unit
     cluster: eks-prow-build-cluster
@@ -125,4 +125,4 @@ presubmits:
       - name: varlog
         hostPath:
           path: /var/log/audit
-          type: Directory
+          type: DirectoryOrCreate


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/test-infra/pull/29768

We need more resources for the verify job, because golangci-lint is hungry. We now also ensure that `/var/log/audit` exists.