### PR TITLE
Ensure REGISTRY env var is set for sig-windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2019: "true"
       preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -20,7 +20,7 @@ periodics:
     timeout: 4h0m0s
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-124: "true"
@@ -61,7 +61,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common-124: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-6-latest: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2019: "true"
       preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -20,7 +20,7 @@ periodics:
     timeout: 4h0m0s
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-125: "true"
@@ -65,7 +65,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common-125: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-6-latest: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2019: "true"
       preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -32,7 +32,7 @@ periodics:
   interval: 24h
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-126: "true"
@@ -65,6 +65,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-6-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -36,7 +36,7 @@ periodics:
   interval: 24h
   labels:
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-windows-2022: "true"
     preset-capz-windows-common-127: "true"
@@ -70,6 +70,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2019: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
@@ -68,7 +68,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
@@ -124,7 +124,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2022: "true"
       preset-capz-windows-common-pull: "true"
       preset-windows-private-registry-cred: "true"
@@ -182,6 +182,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
@@ -226,6 +227,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
@@ -274,6 +276,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -78,7 +78,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-7-latest: "true"
@@ -131,6 +131,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
@@ -183,6 +184,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-7-latest: "true"
@@ -233,6 +235,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-windows-private-registry-cred: "true"
@@ -281,6 +284,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
@@ -335,6 +339,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-windows-private-registry-cred: "true"
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
@@ -388,7 +393,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-ci-entrypoint-common-main: "true"
     preset-capz-windows-azuredisk: "true"
   extra_refs:
@@ -478,6 +483,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-windows-private-registry-cred: "true"
     preset-capz-windows-common: "true"
   extra_refs:

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -88,7 +88,7 @@ periodics:
       - "perfDashJobType: windows"
     labels:
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     extra_refs:
       - org: kubernetes
         repo: perf-tests
@@ -190,7 +190,7 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -259,7 +259,7 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
       - org: kubernetes

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
@@ -8,6 +8,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
     preset-windows-private-registry-cred: "true"
@@ -57,6 +58,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
     preset-windows-private-registry-cred: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
+      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-master


### PR DESCRIPTION
REGISTRY is needed when building/pushing cloud-provider-azure `cloud-controller-manager` and `cloud-node-manager` images - which are get built as part switching testing clusters built with az capi from using the in-tree to out-of-tree cloud provider.

This needs to merge before https://github.com/kubernetes-sigs/windows-testing/pull/382
/sig windows
/assign @jsturtevant @CecileRobertMichon 