### PR TITLE
Always skip CAPI Scale e2e tests (experimental)

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -97,7 +97,7 @@ periodics:
           - "./scripts/ci-e2e.sh"
         env:
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -142,7 +142,7 @@ periodics:
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -184,7 +184,7 @@ periodics:
       - "./scripts/ci-e2e.sh"
       env:
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       - name: KUBERNETES_VERSION_MANAGEMENT

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -142,7 +142,7 @@ presubmits:
         - ./scripts/ci-e2e.sh
         env:
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
+          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -249,7 +249,7 @@ presubmits:
             # and the upgrade tests are being run as part of the periodic upgrade jobs.
             # This jobs ends up running all the other tests in the E2E suite
             - name: GINKGO_SKIP
-              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
+              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -284,7 +284,7 @@ presubmits:
           # and the upgrade tests are being run as part of the periodic upgrade jobs.
           # This jobs ends up running all the other tests in the E2E suite
           - name: GINKGO_SKIP
-            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
+            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -360,10 +360,12 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.27
         args:
         - runner.sh
-        - "./scripts/ci-e2e-scale.sh"
+        - "./scripts/ci-e2e.sh"
         env:
         - name: BOSKOS_HOST
           value: "boskos.test-pods.svc.cluster.local"
+        - name: GINKGO_FOCUS
+          value: "\\[Scale\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
@@ -299,37 +299,3 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-e2e-release-1-4-1-27-latest
-  # This job is experimental for now. Please do not duplicate it to release branches.
-  - name: pull-cluster-api-e2e-scale-release-1-4-experimental
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    decorate: true
-    optional: true
-    always_run: false
-    branches:
-      # The script this job runs is not in all branches.
-      - ^release-1.4$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      serviceAccountName: prowjob-default-sa
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.26
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e-scale.sh"
-          env:
-            - name: BOSKOS_HOST
-              value: "boskos.test-pods.svc.cluster.local"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 7300m
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
-      testgrid-tab-name: capi-pr-e2e-scale-release-1-4-experimental


### PR DESCRIPTION
Always skips the experimental CAPI scale e2e tests in the current jobs.

Switch over the experimental job to use the new scale test.