### PR TITLE
fix unit test issues

### DIFF
--- a/hack/make-rules/go-test/unit.sh
+++ b/hack/make-rules/go-test/unit.sh
@@ -61,6 +61,7 @@ fi
 # run unit tests with junit output
 (
   set -x;
+  umask 0022
   mkdir -p "${JUNIT_RESULT_DIR}"
   "${REPO_ROOT}/_bin/gotestsum" --junitfile="${JUNIT_RESULT_DIR}/junit-unit.xml" \
     -- "./${folder_to_test}"

--- a/hack/make-rules/go-test/unit.sh
+++ b/hack/make-rules/go-test/unit.sh
@@ -64,5 +64,7 @@ fi
   umask 0022
   mkdir -p "${JUNIT_RESULT_DIR}"
   "${REPO_ROOT}/_bin/gotestsum" --junitfile="${JUNIT_RESULT_DIR}/junit-unit.xml" \
-    -- "./${folder_to_test}"
+    -- \
+    -race \
+    "./${folder_to_test}"
 )

--- a/prow/cache/cache_test.go
+++ b/prow/cache/cache_test.go
@@ -341,8 +341,13 @@ func TestCallbacks(t *testing.T) {
 	forcedEvictionsCounter := 0
 	manualEvictionsCounter := 0
 
+	counterLock := &sync.Mutex{}
 	mkCallback := func(counter *int) EventCallback {
-		callback := func(key interface{}) { (*counter)++ }
+		callback := func(key interface{}) {
+			counterLock.Lock()
+			(*counter)++
+			counterLock.Unlock()
+		}
 		return callback
 	}
 

--- a/prow/cache/cache_test.go
+++ b/prow/cache/cache_test.go
@@ -465,15 +465,16 @@ func TestCallbacks(t *testing.T) {
 			cacheCallbacks:    defaultCallbacks,
 			lookups: []lookup{
 				lookup{"(key)1", goodValConstructor},
-				lookup{"(key)1", goodValConstructor},
-				lookup{"(key)1", goodValConstructor},
+				lookup{"(key)2", goodValConstructor},
+				lookup{"(key)3", goodValConstructor},
 				lookup{"(key)1", badValConstructor},
-				lookup{"(key)1", badValConstructor},
+				lookup{"(key)2", badValConstructor},
+				lookup{"(key)3", badValConstructor},
 			},
 			expected: expected{
-				lookups:         5,
+				lookups:         6,
 				hits:            0,
-				misses:          5,
+				misses:          0,
 				forcedEvictions: 0,
 				manualEvictions: 0,
 				// If racyEvictions is true, then we expect some positive number of evictions to occur.

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -43,6 +43,7 @@ const (
 	dependabotUser          = "dependabot[bot]"
 )
 
+var sleepLock sync.Mutex
 var sleep = time.Sleep
 
 type githubClient interface {

--- a/prow/external-plugins/needs-rebase/plugin/plugin_test.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin_test.go
@@ -162,8 +162,10 @@ func TestHandleIssueCommentEvent(t *testing.T) {
 		return &pr
 	}
 
+	sleepLock.Lock()
 	oldSleep := sleep
 	sleep = func(time.Duration) {}
+	sleepLock.Unlock()
 	defer func() { sleep = oldSleep }()
 
 	testCases := []struct {
@@ -252,8 +254,10 @@ func TestHandleIssueCommentEvent(t *testing.T) {
 
 func TestHandlePullRequestEvent(t *testing.T) {
 	t.Parallel()
+	sleepLock.Lock()
 	oldSleep := sleep
 	sleep = func(time.Duration) {}
+	sleepLock.Unlock()
 	defer func() { sleep = oldSleep }()
 
 	testCases := []struct {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -300,6 +300,7 @@ type client struct {
 	identifier string
 	gqlc       gqlClient
 	used       bool
+	mutUsed    sync.Mutex // protects used
 	*delegate
 }
 
@@ -907,7 +908,10 @@ func NewFakeClient() Client {
 }
 
 func (c *client) log(methodName string, args ...interface{}) (logDuration func()) {
+	c.mutUsed.Lock()
 	c.used = true
+	c.mutUsed.Unlock()
+
 	if c.logger == nil {
 		return func() {}
 	}


### PR DESCRIPTION
This fixes some slightly-annoying things in the unit tests to reduce local unit-testing friction. It fixes some long-standing race conditions (including a real race in the GitHub client) as well as fixing a umask issue with file permissions which made one of the tests fail locally (but pass CI, because it is system-dependent).

We also enable the race detector with the `-race` flag by default.

/cc @cjwagner 