### PR TITLE
fix regex for ingress-gce push images job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-gce.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-gce.yaml
@@ -8,7 +8,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-        - ^v[0-9].*
+        - ^release.*
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
The branches for releases in ingress-gce repo start with `release-`