### PR TITLE
set certificate-identity and certificate-oidc-issuer to check the images signatures in the promotion process

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -21,6 +21,8 @@ presubmits:
         - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
         - --use-prow-manifest-diff
+        - --certificate-identity-regexp=(krel-staging@k8s-releng-prod.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)
+        - --certificate-oidc-issuer=https://accounts.google.com
         resources:
           limits:
             cpu: 2
@@ -51,6 +53,8 @@ presubmits:
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
         - --use-prow-manifest-diff
         - --vuln-severity-threshold=1
+        - --certificate-identity-regexp=(krel-staging@k8s-releng-prod.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)
+        - --certificate-oidc-issuer=https://accounts.google.com
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
     annotations:


### PR DESCRIPTION
- set certificate-identity and certificate-oidc-issuer to check the images signatures in the promotion process

This is required after we upgrade the cosign lib to v2, now `kpromo` need to know what are the `certificate-identity` and `certificate-oidc-issuer` while doing the verification of the images signatures

/assign @Verolop @jeremyrickard @puerco @saschagrunert @xmudrii 
cc @kubernetes/release-managers  