### PR TITLE
CAPI Operator: Revert e2e main/release-0-3 jobs moving to EKS cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -136,7 +136,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-test-main
   - name: pull-cluster-api-operator-e2e-main
-    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             cpu: "1"
-            memory: "2Gi"
+            memory: "4Gi"
           limits:
             cpu: "1"
-            memory: "2Gi"
+            memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-make-main

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
@@ -136,7 +136,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-test-release-0-3
   - name: pull-cluster-api-operator-e2e-release-0-3
-    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             cpu: "1"
-            memory: "2Gi"
+            memory: "4Gi"
           limits:
             cpu: "1"
-            memory: "2Gi"
+            memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-make-release-0-3


### PR DESCRIPTION
After merging https://github.com/kubernetes/test-infra/pull/29743 pull-cluster-api-operator-e2e-main/release-0-3 jobs started failing, this revert the job back to use default cluster. Also, bumps resource requests for pull-cluster-api-operator-make-main/release-0-3 jobs to fix the pod timeout issues seen in https://github.com/kubernetes-sigs/cluster-api-operator/pull/143

xref slack thread: https://kubernetes.slack.com/archives/CCK68P2Q2/p1686743778996879
