### PR TITLE
perf: right size openstack job capacity

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -19,10 +19,10 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
-            cpu: "2"
+            cpu: "4"
           limits:
             memory: "6Gi"
-            cpu: "2"
+            cpu: "4"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-build
@@ -40,10 +40,10 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
-            cpu: "2"
+            cpu: "4"
           limits:
             memory: "6Gi"
-            cpu: "2"
+            cpu: "4"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-test


### PR DESCRIPTION
Updating the cpu resource quotas based on https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=kubernetes-sigs&var-repo=cluster-api-provider-openstack&var-job=pull-cluster-api-provider-openstack-test&var-build=All&from=1686731465908&to=1686733625908&orgId=1.

ref: https://github.com/kubernetes/test-infra/pull/29739/files

/cc @lentzi90 @tobiasgiese 