### PR TITLE
CAPI Operator: Increase resource quotas for pull-cluster-api-operator-make-* jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -48,11 +48,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "1"
-            memory: "4Gi"
+            cpu: "4"
+            memory: "8Gi"
           limits:
-            cpu: "1"
-            memory: "4Gi"
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-make-main
@@ -165,11 +165,11 @@ presubmits:
               key: cluster-lifecycle-github-token
         resources:
           requests:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "4"
+            memory: "8Gi"
           limits:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-e2e-main

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-3.yaml
@@ -48,11 +48,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "1"
-            memory: "4Gi"
+            cpu: "4"
+            memory: "8Gi"
           limits:
-            cpu: "1"
-            memory: "4Gi"
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-make-release-0-3
@@ -165,11 +165,11 @@ presubmits:
               key: cluster-lifecycle-github-token
         resources:
           requests:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "4"
+            memory: "8Gi"
           limits:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
       testgrid-tab-name: capi-operator-pr-e2e-release-0-3


### PR DESCRIPTION
1. even after the bump to 4Gi memory for the main jobs in https://github.com/kubernetes/test-infra/pull/29804/commits/4c8e4573fd14ff043efb7edcc12378cc40f4dc02 running on EKS they're still [failing](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-operator/143/pull-cluster-api-operator-make-main/1668960250612420608) . This bumps the jobs (make and e2e) resource quotas to 4 CPUs and 8 GB RAM based on the https://kubernetes.slack.com/archives/CCK68P2Q2/p1686748417608999?thread_ts=1686748157.365979&cid=CCK68P2Q2 from @xmudrii
2. ~reverts e2e jobs back fully by removing the resource quotas introduced in https://github.com/kubernetes/test-infra/pull/29743~

Follow-up to: https://github.com/kubernetes/test-infra/pull/29804
 