### PR TITLE
Update `k-csi` gen-jobs to enable different clusters to be used

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-on-kubernetes-1-24
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-on-kubernetes-1-26
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-test-on-kubernetes-1-24
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -370,11 +390,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -411,12 +436,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-test-on-kubernetes-1-25
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -461,11 +487,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -502,12 +533,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-test-on-kubernetes-1-26
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -552,15 +584,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -597,12 +630,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-test-on-kubernetes-1-25
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -647,8 +681,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -677,11 +716,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
 periodics:
 - interval: 6h
@@ -726,11 +765,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-on-kubernetes-1-25
   decorate: true
@@ -773,11 +812,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-on-kubernetes-1-26
   decorate: true
@@ -820,11 +859,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-on-kubernetes-master
   decorate: true
@@ -867,7 +906,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-25-on-kubernetes-1-25
   decorate: true
@@ -910,11 +953,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-25-on-kubernetes-1-26
   decorate: true
@@ -957,11 +1000,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-25-on-kubernetes-master
   decorate: true
@@ -1004,7 +1047,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-26-on-kubernetes-1-26
   decorate: true
@@ -1047,11 +1094,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-26-on-kubernetes-master
   decorate: true
@@ -1094,7 +1141,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-1-24
   decorate: true
@@ -1137,11 +1188,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-1-25
   decorate: true
@@ -1184,11 +1235,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-1-26
   decorate: true
@@ -1231,11 +1282,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-master
   decorate: true
@@ -1278,7 +1329,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-25-test-on-kubernetes-1-25
   decorate: true
@@ -1321,11 +1376,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-25-test-on-kubernetes-1-26
   decorate: true
@@ -1368,11 +1423,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-25-test-on-kubernetes-master
   decorate: true
@@ -1415,7 +1470,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-26-test-on-kubernetes-1-26
   decorate: true
@@ -1458,11 +1517,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 2
+        limits:
+          memory: "9Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-1-26-test-on-kubernetes-master
   decorate: true
@@ -1505,7 +1564,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-24
   decorate: true
@@ -1554,7 +1617,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-25
   decorate: true
@@ -1603,7 +1670,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-26
   decorate: true
@@ -1652,7 +1723,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-master
   decorate: true
@@ -1701,7 +1776,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-on-kubernetes-master
   decorate: true
@@ -1750,7 +1829,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-24
   decorate: true
@@ -1799,7 +1882,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-25
   decorate: true
@@ -1848,7 +1935,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-26
   decorate: true
@@ -1897,7 +1988,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-master
   decorate: true
@@ -1946,7 +2041,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-test-on-kubernetes-master
   decorate: true
@@ -1995,4 +2094,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2000m
+          memory: "4Gi"
+          cpu: 2
+        limits:
+          memory: "4Gi"
+          cpu: 2

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-iscsi:
   - name: pull-kubernetes-csi-csi-driver-iscsi
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nfs:
   - name: pull-kubernetes-csi-csi-driver-nfs
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nvmf:
   - name: pull-kubernetes-csi-csi-driver-nvmf
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-lib-utils:
   - name: pull-kubernetes-csi-csi-lib-utils
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-proxy:
   - name: pull-kubernetes-csi-csi-proxy
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-release-tools:
   - name: pull-kubernetes-csi-csi-release-tools
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,8 +29,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-release-tools-csi-test
+    cluster: default
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -61,11 +67,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-test
   - name: pull-kubernetes-csi-release-tools-external-provisioner
+    cluster: default
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -97,7 +108,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
@@ -112,6 +127,7 @@ presubmits:
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
   - name: pull-kubernetes-csi-release-tools-external-snapshotter
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -143,7 +159,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
@@ -158,6 +178,7 @@ presubmits:
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
   - name: pull-kubernetes-csi-release-tools-csi-driver-host-path
+    cluster: default
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -189,7 +210,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-test:
   - name: pull-kubernetes-csi-csi-test
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-attacher:
   - name: pull-kubernetes-csi-external-attacher-1-24-on-kubernetes-1-24
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-1-26-on-kubernetes-1-26
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-alpha-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-attacher-unit
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -354,11 +374,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
   - name: pull-kubernetes-csi-external-attacher-canary
     optional: true
@@ -405,8 +425,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-health-monitor:
   - name: pull-kubernetes-csi-external-health-monitor
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-provisioner:
   - name: pull-kubernetes-csi-external-provisioner-1-24-on-kubernetes-1-24
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-1-26-on-kubernetes-1-26
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-provisioner-unit
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -354,11 +374,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
   - name: pull-kubernetes-csi-external-provisioner-canary
     optional: true
@@ -406,8 +426,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-resizer:
   - name: pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-1-24
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-alpha-1-25-on-kubernetes-1-25
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-resizer-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false
@@ -354,11 +374,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
   - name: pull-kubernetes-csi-external-resizer-canary
     optional: true
@@ -405,8 +425,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-snapshotter:
   - name: pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-24
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-alpha-1-25-on-kubernetes-1-25
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-external-snapshotter-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false
@@ -354,11 +374,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
   - name: pull-kubernetes-csi-external-snapshotter-canary
     optional: true
@@ -405,8 +425,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -131,20 +131,38 @@ resources_for_kubernetes () {
     case $kubernetes in master|$experimental_k8s_version|release-*) cat <<EOF
 resources:
   requests:
-    # these are both a bit below peak usage during build
-    # this is mostly for building kubernetes
-    memory: "9000Mi"
-    # during the tests more like 3-20m is used
-    cpu: 2000m
+    memory: "9Gi"
+    cpu: 2
+  limits:
+    memory: "9Gi"
+    cpu: 2
 EOF
                             ;;
                             *) cat <<EOF
 resources:
   requests:
-    cpu: 2000m
+    memory: "4Gi"
+    cpu: 2
+  limits:
+    memory: "4Gi"
+    cpu: 2
 EOF
                             ;;
     esac | sed -e "s/^/${indentation}/"
+}
+
+job_cluster() {
+  local repo=$1
+
+  case "$repo" in
+   external-snapshotter|external-resizer)
+     echo "eks-prow-build-cluster"
+     ;;
+   *)
+     echo "default"
+     ;;
+  esac
+
 }
 
 # Combines deployment and Kubernetes version in a job suffix like "1-14-on-kubernetes-1-13".
@@ -362,6 +380,7 @@ EOF
                             # older, stable hostpath driver deployments and Kubernetes versions
                             cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "$tests" "$deployment$deployment_suffix" "$kubernetes")
+    cluster: $(job_cluster "$repo")
     always_run: $(pull_alwaysrun "$tests")
     optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix")
     decorate: true
@@ -416,6 +435,7 @@ EOF
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: $(job_cluster "$repo")
     always_run: false
     optional: true
     decorate: true
@@ -456,6 +476,7 @@ EOF
 
     cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "unit")
+    cluster: $(job_cluster "$repo")
     always_run: true
     decorate: true
     skip_report: false
@@ -547,6 +568,7 @@ EOF
     for tests in non-alpha unit alpha; do
         cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "$tests")
+    cluster: $(job_cluster "$repo")
     always_run: true
     optional: $(pull_optional "$tests")
     decorate: true
@@ -588,6 +610,7 @@ EOF
 
     cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: pull-kubernetes-csi-$repo
+    cluster: $(job_cluster "$repo")
     always_run: true
     decorate: true
     skip_report: false
@@ -765,6 +788,7 @@ done
 for repo in $csi_release_tools_repos; do
     cat >>"$base/csi-release-tools/csi-release-tools-config.yaml" <<EOF
   - name: $(job_name "pull" "release-tools" "$repo" "" "")
+    cluster: $(job_cluster "$repo")
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true

--- a/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
+++ b/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/lib-volume-populator:
   - name: pull-kubernetes-csi-lib-volume-populator
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/livenessprobe:
   - name: pull-kubernetes-csi-livenessprobe-1-24-on-kubernetes-1-24
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-1-26-on-kubernetes-1-26
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-alpha-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-livenessprobe-unit
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -354,11 +374,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
   - name: pull-kubernetes-csi-livenessprobe-canary
     optional: true
@@ -405,8 +425,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/node-driver-registrar:
   - name: pull-kubernetes-csi-node-driver-registrar-1-24-on-kubernetes-1-24
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -47,11 +48,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -88,12 +94,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -138,11 +145,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -179,12 +191,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-1-26-on-kubernetes-1-26
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -229,15 +242,16 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -274,12 +288,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-25-on-kubernetes-1-25
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -324,8 +339,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2
   - name: pull-kubernetes-csi-node-driver-registrar-unit
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -354,11 +374,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2
 
   - name: pull-kubernetes-csi-node-driver-registrar-canary
     optional: true
@@ -405,8 +425,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
+          limits:
+            memory: "9Gi"
+            cpu: 2

--- a/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
+++ b/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/volume-data-source-validator:
   - name: pull-kubernetes-csi-volume-data-source-validator
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false
@@ -28,4 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2000m
+            memory: "4Gi"
+            cpu: 2
+          limits:
+            memory: "4Gi"
+            cpu: 2


### PR DESCRIPTION
There are three parts to this PR:

1. Provide the ability to define components on a cluster by cluster basis. This change also transition 
2. Increase and standardize the resource quotas. They are likely over tuned right now but can be lowered in the future.
3. Moves both the `external-snapshotter` and `external-resizer` jobs to the EKS cluster. 

ref: https://github.com/kubernetes/test-infra/issues/29722
ref: https://github.com/kubernetes/test-infra/pull/29763

/cc @msau42 @saad-ali @xing-yang @jsafrane @pohly