### PR TITLE
perf: tune capacity for `security-profiles-operator` jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -14,10 +14,10 @@ presubmits:
         - hack/pull-security-profiles-operator-build
         resources:
           limits:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
 
   - name: pull-security-profiles-operator-verify
@@ -34,10 +34,10 @@ presubmits:
         - hack/pull-security-profiles-operator-verify
         resources:
           limits:
-            cpu: 6
+            cpu: 10
             memory: 8Gi
           requests:
-            cpu: 6
+            cpu: 10
             memory: 8Gi
 
   - name: pull-security-profiles-operator-test-unit
@@ -54,10 +54,10 @@ presubmits:
         - hack/pull-security-profiles-operator-test-unit
         resources:
           limits:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
 
   - name: pull-security-profiles-operator-build-image


### PR DESCRIPTION
Tuning for job capacity of [`pull-security-profiles-operator-build`](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?from=1686787202799&to=1686787931592&orgId=1&var-org=kubernetes-sigs&var-repo=security-profiles-operator&var-job=pull-security-profiles-operator-build&var-build=All), [`pull-security-profiles-operator-verify`](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?from=1686787202799&to=1686787931592&orgId=1&var-org=kubernetes-sigs&var-repo=security-profiles-operator&var-job=pull-security-profiles-operator-verify&var-build=All), [`pull-security-profiles-operator-test-unit`](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?from=1686787202799&to=1686787931592&orgId=1&var-org=kubernetes-sigs&var-repo=security-profiles-operator&var-job=pull-security-profiles-operator-test-unit&var-build=All) based on grafana monitoring of the previous jobs. 

ref: https://github.com/kubernetes/test-infra/pull/29805
ref: https://github.com/kubernetes/test-infra/pull/29785
ref: https://github.com/kubernetes/test-infra/pull/29768

/cc @saschagrunert