### PR TITLE
Adjust configuration for pod disruption conditions test suite (to fix the eviction test)

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1737,7 +1737,7 @@ presubmits:
             - --
             - --deployment=node
             - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
             - '--node-test-args=--feature-gates=PodDisruptionConditions=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce


### PR DESCRIPTION
/sig-node

I propose to reuse the eviction configuration for the pod disruption conditions tests. 

**Context**: the configuration for pod-disruption-conditions fails currently on the PIDPressure test: https://testgrid.k8s.io/sig-node-presubmits#pr-kubelet-gce-e2e-pod-disruption-conditions. However, this test passes (except for rare flakes) on the generic eviction tests: https://testgrid.k8s.io/sig-node-containerd#node-kubelet-containerd-eviction, because they use custom configuration.

The other scenarios (kubelet preemption for a critical pod & eviction due to graceful node shutdown) are unlikely to be affected - I've already run them twice using the new eviction config, and they passed.

Note that, this is just a handy configuration to run the tests quickly, but they are also run as part of other suites.

/cc @bobbypage @SergeyKanzhelev 