### PR TITLE
Install kubetest2 in kubekins-e2e image

### DIFF
--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -45,7 +45,7 @@ substitutions:
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
   _KIND_VERSION: ''
-  _KUBETEST2_VERSION: ''
+  _KUBETEST2_VERSION: 'latest'
   _YQ_VERSION: v4.23.1
 timeout: 1800s  
 options:


### PR DESCRIPTION
I need to install kubetest2 in the kubekins image to run node tests using kubetest2.

Looks like someone started the migration and didn't finish it yet by deleting the kubetest equivalents and progressing the rollout.

https://github.com/kubernetes/test-infra/pull/23753