### PR TITLE
Cluster API: Set ALWAYS_BUILD_KIND_IMAGES for upgrades

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -29,6 +29,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.22"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -80,6 +82,8 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.23"
       - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -131,6 +135,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.24"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -182,6 +188,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.25"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -233,10 +241,12 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.26"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "v1.27.1" # Setting this to a pinned version due to an issue in the image. See: https://github.com/kubernetes-sigs/cluster-api/issues/8764
+        value: "stable-1.27"
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.6-0"
       - name: COREDNS_VERSION_UPGRADE_TO
@@ -284,6 +294,8 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.27"
       - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-2-upgrades.yaml
@@ -29,6 +29,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.18"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -80,6 +82,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.19"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -131,6 +135,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.20"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -182,6 +188,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.21"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -234,6 +242,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.22"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -286,6 +296,8 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.23"
       - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -337,6 +349,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "v1.24.13"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -388,6 +402,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "v1.25.9"
           - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
@@ -29,6 +29,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.18"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -80,6 +82,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.19"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -131,6 +135,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.20"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -182,6 +188,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.21"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -233,6 +241,8 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.22"
         - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -284,6 +294,8 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.23"
       - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -335,6 +347,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.24"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -386,6 +400,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.25"
           - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4-upgrades.yaml
@@ -28,6 +28,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.21"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -79,6 +81,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.22"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -130,6 +134,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.23"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -181,6 +187,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.24"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -232,6 +240,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.25"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -283,10 +293,12 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.26"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "v1.27.1" # Setting this to a pinned version due to an issue in the image. See: https://github.com/kubernetes-sigs/cluster-api/issues/8764
+            value: "stable-1.27"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.6-0"
           - name: COREDNS_VERSION_UPGRADE_TO
@@ -334,6 +346,8 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.27"
           - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -320,6 +320,8 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.27"
           - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -399,6 +401,8 @@ presubmits:
             - runner.sh
             - "./scripts/ci-e2e.sh"
           env:
+            - name: ALWAYS_BUILD_KIND_IMAGES
+              value: "true"
             - name: KUBERNETES_VERSION_UPGRADE_FROM
               value: "stable-1.26"
             - name: KUBERNETES_VERSION_UPGRADE_TO
@@ -444,6 +448,8 @@ presubmits:
             - wrapper.sh
             - "./scripts/ci-e2e.sh"
           env:
+            - name: ALWAYS_BUILD_KIND_IMAGES
+              value: "true"
             - name: KUBERNETES_VERSION_UPGRADE_FROM
               value: "stable-1.26"
             - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-2.yaml
@@ -276,6 +276,8 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.25"
           - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
@@ -270,6 +270,8 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.25"
           - name: KUBERNETES_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
@@ -280,6 +280,8 @@ presubmits:
             - runner.sh
             - "./scripts/ci-e2e.sh"
           env:
+            - name: ALWAYS_BUILD_KIND_IMAGES
+              value: "true"
             - name: KUBERNETES_VERSION_UPGRADE_FROM
               value: "stable-1.27"
             - name: KUBERNETES_VERSION_UPGRADE_TO


### PR DESCRIPTION
Add `ALWAYS_BUILD_KIND_IMAGES` to the upgrade jobs for Cluster API. This will force all upgrade jobs to build kind images and mean that image incompatibility is not an issue as described in https://github.com/kubernetes-sigs/cluster-api/issues/8788

