### PR TITLE
tune capacity for `security-profiles-operator` jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -14,10 +14,10 @@ presubmits:
         - hack/pull-security-profiles-operator-build
         resources:
           limits:
-            cpu: 4
+            cpu: 8
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 8
             memory: 4Gi
 
   - name: pull-security-profiles-operator-verify
@@ -34,10 +34,10 @@ presubmits:
         - hack/pull-security-profiles-operator-verify
         resources:
           limits:
-            cpu: 10
+            cpu: 12
             memory: 8Gi
           requests:
-            cpu: 10
+            cpu: 12
             memory: 8Gi
 
   - name: pull-security-profiles-operator-test-unit
@@ -54,10 +54,10 @@ presubmits:
         - hack/pull-security-profiles-operator-test-unit
         resources:
           limits:
-            cpu: 4
+            cpu: 8
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 8
             memory: 4Gi
 
   - name: pull-security-profiles-operator-build-image
@@ -78,10 +78,10 @@ presubmits:
           privileged: true  # for dind
         resources:
           requests:
-            memory: 2Gi
+            memory: 1Gi
             cpu: 2
           limits:
-            memory: 2Gi
+            memory: 1Gi
             cpu: 2
         command:
         - runner.sh
@@ -108,11 +108,11 @@ presubmits:
           privileged: true  # for dind
         resources:
           requests:
-            memory: 4Gi
-            cpu: 6
+            memory: 2Gi
+            cpu: 5
           limits:
-            memory: 4Gi
-            cpu: 6
+            memory: 2Gi
+            cpu: 5
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Tuning for job capacity of `security-profiles-operator` jobs based on [grafana](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?from=now-24h&to=now&orgId=1&var-org=kubernetes-sigs&var-repo=security-profiles-operator&var-job=pull-security-profiles-operator-build&var-build=All) data: 

ref: https://github.com/kubernetes/test-infra/pull/29821
ref: https://github.com/kubernetes/test-infra/pull/29805
ref: https://github.com/kubernetes/test-infra/pull/29785
ref: https://github.com/kubernetes/test-infra/pull/29768

/cc @saschagrunert