### PR TITLE
tune capacity for `k/release` jobs

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -54,11 +54,11 @@ presubmits:
         - test
         resources:
           limits:
-            memory: 4Gi
-            cpu: 2
+            memory: 2500Mi
+            cpu: 4
           requests:
-            memory: 4Gi
-            cpu: 2
+            memory: 2500Mi
+            cpu: 4
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-test
@@ -105,11 +105,11 @@ presubmits:
         - test-go-integration
         resources:
           requests:
-            memory: "16Gi"
-            cpu: "8"
+            memory: "4Gi"
+            cpu: "12"
           limits:
-            memory: "16Gi"
-            cpu: "8"
+            memory: "4Gi"
+            cpu: "12"
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-integration-test
@@ -130,11 +130,11 @@ presubmits:
         - verify
         resources:
           limits:
-            memory: 16Gi
-            cpu: 8
+            memory: 4Gi
+            cpu: 8500m
           requests:
-            memory: 16Gi
-            cpu: 8
+            memory: 4Gi
+            cpu: 8500m
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-verify


### PR DESCRIPTION
This PR aims to right size the `k/release` job resource requests based on grafana metrics

[pull-release-integration-test](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=now-24h&to=now&var-org=kubernetes&var-repo=release&var-job=pull-release-integration-test&var-build=All&refresh=30s)
[pull-release-test](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=1686879713324&to=1686882596757&var-org=kubernetes&var-repo=release&var-job=pull-release-test&var-build=All)
[pull-release-verify](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=1686879713324&to=1686882596757&var-org=kubernetes&var-repo=release&var-job=pull-release-verify&var-build=All)