### PR TITLE
Move containerd build job back to the Google Build Cluster.

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -40,7 +40,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-  cluster: k8s-infra-prow-build
+  cluster: default # don't move this job to the community cluster till the gs://cri-containerd-staging is owned by the community
   decorate: true
   extra_refs:
     - org: containerd


### PR DESCRIPTION
/cc @dims @SergeyKanzhelev @BenTheElder @ameukam 

I need to move this back to the default cluster because the job writes to a bucket(`gs://cri-containerd-staging`) in a google owned GCP project. `prow-build@k8s-infra-prow-build.iam.gserviceaccount.com` can't write to that bucket.

The assets in that bucket are used exclusively by Node e2e tests with fresh containerd binaries instead of building containerd on every test run.

We need to move that bucket to a `kubernetes.io` GCP project. https://cloud.google.com/storage/docs/moving-buckets
