### PR TITLE
tune capacity for `k-sig/cli-utils` jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -17,11 +17,11 @@ presubmits:
         - prow-presubmit-check
         resources:
           requests:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: "4Gi"
+            cpu: 6
           limits:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: "4Gi"
+            cpu: 6
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master
@@ -49,11 +49,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: 750Mi
+            cpu: 2500m
           limits:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: 750Mi
+            cpu: 2500m
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master-e2e
@@ -81,11 +81,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: 1Gi
+            cpu: 2500m
           limits:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: 1Gi
+            cpu: 2500m
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master-stress


### PR DESCRIPTION
This PR aims to right size the`k-sig/cli-utils` job resource requests based on grafana metrics

[cli-utils-presubmit-master](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=1686926591286&to=1686927949448&var-org=kubernetes-sigs&var-repo=cli-utils&var-job=cli-utils-presubmit-master&var-build=All)
[cli-utils-presubmit-master-e2e](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=1686926591286&to=1686927949448&var-org=kubernetes-sigs&var-repo=cli-utils&var-job=cli-utils-presubmit-master-e2e&var-build=All)
[cli-utils-presubmit-master-stress](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=1686926591286&to=1686927949448&var-org=kubernetes-sigs&var-repo=cli-utils&var-job=cli-utils-presubmit-master-stress&var-build=All)