### PR TITLE
Migrate `kube-storage-version-migrator` to `eks-prow-build-cluster`

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-storage-version-migrator:
   - name: pull-kube-storage-version-migrator-disruptive
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     labels:
@@ -27,6 +28,13 @@ presubmits:
         - --timeout=50m
         - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
         - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-storage-version-migrator:
   - name: pull-kube-storage-version-migrator-test
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     spec:
@@ -9,11 +10,19 @@ presubmits:
         command:
         - make
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-test
   - name: pull-kube-storage-version-migrator-manually-launched-e2e
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     labels:
@@ -42,10 +51,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-manually-launched
   - name: pull-kube-storage-version-migrator-fully-automated-e2e
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     labels:
@@ -75,10 +92,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-fully-automated
   - name: pull-kube-storage-version-migrator-ha-master
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/kube-storage-version-migrator"
     decorate: true
     decoration_config:
@@ -110,6 +135,9 @@ presubmits:
           privileged: true
         resources:
           requests:
+            memory: "9000Mi"
+            cpu: 2000m
+          limits:
             memory: "9000Mi"
             cpu: 2000m
     annotations:


### PR DESCRIPTION
This PR transitions the `kube-storage-version-migrator` from the `default` cluster to `eks-prow-build-cluster`

ref: https://github.com/kubernetes/test-infra/issues/29722