### PR TITLE
Enable review_acts_as_lgtm for external-dns

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -220,6 +220,7 @@ lgtm:
   - kubernetes-sigs/downloadkubernetes
   - kubernetes-sigs/e2e-framework
   - kubernetes-sigs/etcdadm
+  - kubernetes-sigs/external-dns
   - kubernetes-sigs/promo-tools
   - kubernetes-sigs/k8s-gsm-tools
   - kubernetes-sigs/kind


### PR DESCRIPTION
This configures Prow to consider GitHub-level review approvals as an LGTM for the external-dns project.

/cc @szuecs @Raffo @njuettner 