### PR TITLE
Tune capacity for `minikube` jobs

### DIFF
--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -37,12 +37,13 @@ presubmits:
         resources:
           requests:
             memory: "2000Mi"
-            cpu: 500m
+            cpu: 2
           limits:
             memory: "2000Mi"
-            cpu: 500m
+            cpu: 2
 
   - name: pull-minikube-platform-tests
+    cluster: eks-prow-build-cluster
     labels:
         preset-minikube-e2e-creds: "true"
         preset-k8s-ssh: "true"
@@ -54,3 +55,10 @@ presubmits:
       - image: gcr.io/k8s-minikube/minikube-e2e:v20181022-a850455f-experimental
         command:
         - hack/prow/minkube_build_and_test.sh
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+            cpu: 2


### PR DESCRIPTION
This PR aims to right size thek-sig/cli-utils job resource requests based on grafana metrics

[pull-minikube-build](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&from=now-24h&to=now&var-org=kubernetes&var-repo=minikube&var-job=pull-minikube-build&var-build=All)

**NOTE** This job is currently failing so bumping the cpu limit is critical.  https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-minikube-build

This PR also migrates the `pull-minikube-platform-tests` test