### PR TITLE
Migrate `vsphere-csi-driver` to `eks-prow-build-cluster`

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes-sigs/vsphere-csi-driver:
 
   - name: pull-vsphere-csi-driver-verify-fmt
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack\/check-format\.sh'
     decorate: true
@@ -13,6 +14,13 @@ presubmits:
         - make
         args:
         - fmt
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -21,6 +29,7 @@ presubmits:
 
 
   - name: pull-vsphere-csi-driver-verify-vet
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack\/check-vet\.sh'
     decorate: true
@@ -32,6 +41,13 @@ presubmits:
         - make
         args:
         - vet
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -39,6 +55,7 @@ presubmits:
       description: Vets the Golang sources have been vetted
 
   - name: pull-vsphere-csi-driver-verify-golangci-lint
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go'
     decorate: true
@@ -50,6 +67,13 @@ presubmits:
             - make
           args:
             - golangci-lint
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -58,6 +82,7 @@ presubmits:
 
   # Runs 'shellcheck' on appropriate sources
   - name: pull-vsphere-csi-driver-verify-shell
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '.*\.\w*sh$'
     decorate: true
@@ -67,6 +92,13 @@ presubmits:
       - image: gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.7.1
         command:
         - /bin/shellcheck.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-tab-name: pr-verify-shell
@@ -75,6 +107,7 @@ presubmits:
 
   # Runs 'mdlint' on appropriate sources
   - name: pull-vsphere-csi-driver-verify-markdown
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '.*\.md$'
     decorate: true
@@ -87,6 +120,13 @@ presubmits:
         args:
         - /md/lint
         - .
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-tab-name: pr-verify-markdown
@@ -95,6 +135,7 @@ presubmits:
 
   # Runs 'staticcheck' on appropriate sources
   - name: pull-vsphere-csi-driver-verify-staticcheck
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack\/check-staticcheck\.sh'
     decorate: true
@@ -106,6 +147,13 @@ presubmits:
         - make
         args:
         - staticcheck
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-tab-name: pr-verify-staticcheck
@@ -114,6 +162,7 @@ presubmits:
 
   # Builds the CSI binary
   - name: pull-vsphere-csi-driver-build
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(cmd|pkg|go.mod)'
     decorate: true
@@ -127,12 +176,20 @@ presubmits:
         - "make"
         args:
         - "build"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
   # Executes the unit tests.
   - name: pull-vsphere-csi-driver-unit-test
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|go\.mod'
     decorate: true
@@ -146,6 +203,13 @@ presubmits:
         - "make"
         args:
         - "unit-test"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -155,6 +219,7 @@ postsubmits:
 
   # Deploys the CSI image after all merges to master
   - name: post-vsphere-csi-driver-deploy
+    cluster: eks-prow-build-cluster
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -174,6 +239,13 @@ postsubmits:
         - "deploy"
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-postsubmits-vsphere-csi-driver
       testgrid-num-columns-recent: '20'
@@ -181,6 +253,7 @@ postsubmits:
 
   # Deploys the CSI image for tagged releases
   - name: post-vsphere-csi-driver-release
+    cluster: eks-prow-build-cluster
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -199,6 +272,13 @@ postsubmits:
         - "push-images"
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     rerun_auth_config:
       github_users:
       - codenrhoden


### PR DESCRIPTION
This PR transitions the `vsphere-csi-driver` jobs from the `default` cluster to `eks-prow-build-cluster`

ref: https://github.com/kubernetes/test-infra/issues/29722