### PR TITLE
Migrate `cloud-provider-openstack` to `eks-prow-build-cluster`

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: pull-cloud-provider-openstack-check
+    cluster: eks-prow-build-cluster
     always_run: true
     skip_branches:
     - gh-pages
@@ -17,8 +18,16 @@ presubmits:
         - --
         - make
         - check
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
   - name: pull-cloud-provider-openstack-test
+    cluster: eks-prow-build-cluster
     always_run: true
     skip_branches:
     - gh-pages
@@ -35,3 +44,10 @@ presubmits:
         - --
         - make
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-controller-manager-e2e-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -26,9 +27,12 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test
@@ -67,6 +71,7 @@ presubmits:
   #     testgrid-tab-name: presubmit-e2e-conformance-test
 
   - name: openstack-cloud-csi-cinder-e2e-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -92,14 +97,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test
 
   - name: openstack-cloud-csi-manila-e2e-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -125,14 +134,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test
 
   - name: openstack-cloud-csi-cinder-sanity-test
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile)'
     decorate: true
@@ -146,12 +159,20 @@ presubmits:
         - make
         args:
         - test-cinder-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-csi-manila-sanity-test
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile)'
     decorate: true
@@ -165,12 +186,20 @@ presubmits:
         - make
         args:
         - test-manila-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test
       description: Run cloud-provider-openstack csi sanity tests for manila-csi-plugin
 
   - name: openstack-cloud-keystone-authentication-authorization-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -196,9 +225,12 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.24-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.24-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-csi-cinder-sanity-test-release-124
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
     decorate: true
@@ -14,12 +15,20 @@ presubmits:
         - make
         args:
         - test-cinder-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.24
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-controller-manager-e2e-test-release-124
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -45,14 +54,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.24
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-124
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -78,14 +91,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.24
 
   - name: openstack-cloud-csi-manila-e2e-test-release-124
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -111,14 +128,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.24
 
   - name: openstack-cloud-csi-manila-sanity-test-release-124
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
     decorate: true
@@ -132,6 +153,13 @@ presubmits:
         - make
         args:
         - test-manila-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.24

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-csi-cinder-sanity-test-release-125
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
     decorate: true
@@ -14,12 +15,20 @@ presubmits:
         - make
         args:
         - test-cinder-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.25
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-controller-manager-e2e-test-release-125
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -45,14 +54,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.25
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-125
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -78,14 +91,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.25
 
   - name: openstack-cloud-csi-manila-e2e-test-release-125
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -111,14 +128,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.25
 
   - name: openstack-cloud-csi-manila-sanity-test-release-125
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
     decorate: true
@@ -132,6 +153,13 @@ presubmits:
         - make
         args:
         - test-manila-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.25

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-controller-manager-e2e-test-release-126
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -26,14 +27,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.26
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-126
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -59,14 +64,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.26
 
   - name: openstack-cloud-csi-manila-e2e-test-release-126
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -92,14 +101,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.26
 
   - name: openstack-cloud-csi-cinder-sanity-test-release-126
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
     decorate: true
@@ -113,12 +126,20 @@ presubmits:
         - make
         args:
         - test-cinder-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.26
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-csi-manila-sanity-test-release-126
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
     decorate: true
@@ -132,6 +153,13 @@ presubmits:
         - make
         args:
         - test-manila-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.26

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-controller-manager-e2e-test-release-127
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -26,14 +27,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.27
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-127
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -59,14 +64,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.27
 
   - name: openstack-cloud-csi-manila-e2e-test-release-127
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -92,14 +101,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              memory: "1Gi"
-              cpu: 1
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.27
 
   - name: openstack-cloud-csi-cinder-sanity-test-release-127
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
     decorate: true
@@ -113,12 +126,20 @@ presubmits:
         - make
         args:
         - test-cinder-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.27
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-csi-manila-sanity-test-release-127
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
     decorate: true
@@ -132,6 +153,13 @@ presubmits:
         - make
         args:
         - test-manila-csi-sanity
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.27


### PR DESCRIPTION
This PR transitions the `cloud-provider-openstack` jobs from the `default` cluster to `eks-prow-build-cluster`

ref: https://github.com/kubernetes/test-infra/issues/29722