### PR TITLE
Migrate `cloud-provider-vsphere` to `eks-prow-build-cluster`

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes/cloud-provider-vsphere:
 
   - name: pull-cloud-provider-vsphere-verify-fmt-1-26-minus
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-format\.sh'
     decorate: true
@@ -15,6 +16,13 @@ presubmits:
         - make
         args:
         - fmt
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -22,6 +30,7 @@ presubmits:
       description: Verifies the Golang sources have been formatted
 
   - name: pull-cloud-provider-vsphere-verify-lint-1-26-minus
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-lint\.sh'
     decorate: true
@@ -35,6 +44,13 @@ presubmits:
         - make
         args:
         - lint
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -42,6 +58,7 @@ presubmits:
       description: Verifies the Golang sources are linted
 
   - name: pull-cloud-provider-vsphere-verify-vet-1-26-minus
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-vet\.sh'
     decorate: true
@@ -55,6 +72,13 @@ presubmits:
         - make
         args:
         - vet
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -62,6 +86,7 @@ presubmits:
       description: Vets the Golang sources have been vetted
 
   - name: pull-cloud-provider-vsphere-verify-staticcheck-1-26-minus
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-staticcheck\.sh$|go.mod'
     decorate: true
@@ -75,6 +100,13 @@ presubmits:
         - make
         args:
         - staticcheck
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -83,6 +115,7 @@ presubmits:
 
   # Builds the CCM and CSI binaries.
   - name: pull-cloud-provider-vsphere-build-1-26-minus
+    cluster: eks-prow-build-cluster
     decorate: true
     branches:
     - ^release-1.2[4-6]$
@@ -98,12 +131,20 @@ presubmits:
         - "make"
         args:
         - "build"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
   # Executes the unit tests.
   - name: pull-cloud-provider-vsphere-unit-test-1-26-minus
+    cluster: eks-prow-build-cluster
     decorate: true
     branches:
     - ^release-1.2[4-6]$
@@ -119,12 +160,20 @@ presubmits:
         - "make"
         args:
         - "unit-test"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
   # Executes the integration tests.
   - name: pull-cloud-provider-vsphere-integration-test-1-26-minus
+    cluster: eks-prow-build-cluster
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -143,6 +192,13 @@ presubmits:
         - "make"
         args:
         - "integration-test"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
         securityContext:
           privileged: true
     annotations:
@@ -151,6 +207,7 @@ presubmits:
 
   # Executes the test coverage.
   - name: pull-cloud-provider-vsphere-coverage-1-26-minus
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
@@ -179,6 +236,13 @@ presubmits:
           ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
           ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
           exit $result
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -28,6 +28,7 @@ presubmits:
   kubernetes/cloud-provider-vsphere:
 
   - name: pull-cloud-provider-vsphere-verify-fmt
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-format\.sh'
     decorate: true
@@ -43,6 +44,13 @@ presubmits:
         - make
         args:
         - fmt
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -50,6 +58,7 @@ presubmits:
       description: Verifies the Golang sources have been formatted
 
   - name: pull-cloud-provider-vsphere-verify-lint
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-lint\.sh'
     decorate: true
@@ -65,6 +74,13 @@ presubmits:
         - make
         args:
         - lint
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -72,6 +88,7 @@ presubmits:
       description: Verifies the Golang sources are linted
 
   - name: pull-cloud-provider-vsphere-verify-vet
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-vet\.sh'
     decorate: true
@@ -87,6 +104,13 @@ presubmits:
         - make
         args:
         - vet
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -94,6 +118,7 @@ presubmits:
       description: Vets the Golang sources have been vetted
 
   - name: pull-cloud-provider-vsphere-verify-markdown
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '.*\.md$'
     decorate: true
@@ -110,6 +135,13 @@ presubmits:
         - -i
         - docs/book/node_modules
         - .
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-tab-name: pr-verify-markdown
@@ -117,6 +149,7 @@ presubmits:
       description: Verifies the markdown has been linted
 
   - name: pull-cloud-provider-vsphere-verify-shell
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '.*\.\w*sh$'
     decorate: true
@@ -126,6 +159,13 @@ presubmits:
       - image: gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.6.0
         command:
         - /bin/shellcheck.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-tab-name: pr-verify-shell
@@ -133,6 +173,7 @@ presubmits:
       description: Verifies the shell scripts have been linted
 
   - name: pull-cloud-provider-vsphere-verify-staticcheck
+    cluster: eks-prow-build-cluster
     always_run: false
     run_if_changed: '\.go$|hack/check-staticcheck\.sh$|go.mod'
     decorate: true
@@ -148,6 +189,13 @@ presubmits:
         - make
         args:
         - staticcheck
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
@@ -156,6 +204,7 @@ presubmits:
 
   # Builds the CCM and CSI binaries.
   - name: pull-cloud-provider-vsphere-build
+    cluster: eks-prow-build-cluster
     decorate: true
     branches:
     - ^master$
@@ -173,12 +222,20 @@ presubmits:
         - "make"
         args:
         - "build"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
   # Executes the unit tests.
   - name: pull-cloud-provider-vsphere-unit-test
+    cluster: eks-prow-build-cluster
     decorate: true
     branches:
     - ^master$
@@ -196,12 +253,20 @@ presubmits:
         - "make"
         args:
         - "unit-test"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
   # Executes the integration tests.
   - name: pull-cloud-provider-vsphere-integration-test
+    cluster: eks-prow-build-cluster
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -224,12 +289,20 @@ presubmits:
         - "integration-test"
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
   # Executes the test coverage.
   - name: pull-cloud-provider-vsphere-coverage
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
@@ -262,6 +335,13 @@ presubmits:
           exit $result
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com


### PR DESCRIPTION
This PR transitions the `cloud-provider-vsphere` jobs from the `default` cluster to `eks-prow-build-cluster`. This PR ignores the jobs with `preset-cloud-provider-vsphere-e2e-config`. 

ref: https://github.com/kubernetes/test-infra/issues/29722