### PR TITLE
[WIP]sig-release: migrate release jobs to community-owned clusters

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -548,6 +548,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-kubernetes-e2e-kops-aws
+    cluster: eks-prow-build-cluster
     optional: true
     spec:
       containers:
@@ -582,7 +583,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -852,6 +857,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 5
     name: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: eks-prow-build-cluster
     optional: true
     spec:
       containers:
@@ -880,7 +886,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -937,6 +947,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
+    cluster: eks-prow-build-cluster
     optional: true
     spec:
       containers:
@@ -962,7 +973,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.25
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -1020,6 +1035,7 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     name: pull-kubernetes-node-e2e-containerd-kubetest2
+    cluster: eks-prow-build-cluster
     optional: true
     path_alias: k8s.io/kubernetes
     spec:
@@ -1734,6 +1750,7 @@ presubmits:
     branches:
     - release-1.25
     context: pull-perf-tests-clusterloader2
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 2h0m0s
@@ -1801,6 +1818,7 @@ presubmits:
     branches:
     - release-1.25
     context: pull-perf-tests-clusterloader2-kubemark
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 2h0m0s

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -537,6 +537,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-kubernetes-e2e-kops-aws
+    cluster: eks-prow-build-cluster
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
@@ -579,7 +580,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.26
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -905,6 +910,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -941,7 +947,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.26
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -991,6 +1001,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-kubernetes-e2e-containerd-gce
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -1023,7 +1034,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.26
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -1069,6 +1084,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-kubernetes-node-e2e-containerd-kubetest2
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 1h5m0s
@@ -1755,6 +1771,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-perf-tests-clusterloader2
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 2h0m0s
@@ -1821,6 +1838,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-perf-tests-clusterloader2-kubemark
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 2h0m0s

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -547,6 +547,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-kubernetes-e2e-kops-aws
+    cluster: eks-prow-build-cluster
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
@@ -589,7 +590,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.27
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -900,6 +905,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -936,7 +942,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.27
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -944,6 +954,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-kubernetes-e2e-containerd-gce
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -976,7 +987,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230513-7e1db2f1bb-1.27
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -1022,6 +1037,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-kubernetes-node-e2e-containerd-kubetest2
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 1h5m0s
@@ -1744,6 +1760,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-perf-tests-clusterloader2
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 2h0m0s
@@ -1810,6 +1827,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-perf-tests-clusterloader2-kubemark
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 2h0m0s


### PR DESCRIPTION
 This PR will migrate kubernetes/sig-release prowjobs(1.25, 1.26, 1.27) to eks-prow-build-cluster.

Ref: https://github.com/kubernetes/test-infra/issues/29722