### PR TITLE
Run all iscsi tests as serial

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -193,41 +193,6 @@ presubmits:
       testgrid-create-test-group: 'true'
 periodics:
 - interval: 24h
-  name: ci-kubernetes-e2e-gce-iscsi
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=150
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.1
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.7
-      - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-      - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-      - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-      - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
-      - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-      - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-      - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
-      - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-      - --extract=ci/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
-      - --gcp-master-image=ubuntu
-      - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --ginkgo-parallel=30
-      - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-  annotations:
-    testgrid-num-columns-recent: '20'
-- interval: 24h
   name: ci-kubernetes-e2e-gce-iscsi-serial
   labels:
     preset-service-account: "true"
@@ -256,7 +221,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
   annotations:

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -58,12 +58,6 @@ dashboards:
       description: storage gci gce alpha enabled default features e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-    - name: gce-iscsi
-      test_group_name: ci-kubernetes-e2e-gce-iscsi
-      base_options: include-filter-by-regex=Volume%7Cstorage
-      description: storage iSCSI e2e tests for master branch
-      alert_options:
-        alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
     - name: gce-iscsi-serial
       test_group_name: ci-kubernetes-e2e-gce-iscsi-serial
       base_options: include-filter-by-regex=Volume%7Cstorage


### PR DESCRIPTION
My iscsi target configurator pod* is not as stable on Ubuntu as on Fedora. Run all iSCSI tests serially, there is just 75 parallel tests + 38 serial / disruptive ones.

Fixes: https://github.com/kubernetes/kubernetes/issues/118446
*) https://github.com/kubernetes/kubernetes/tree/master/test/images/volume/iscsi