### PR TITLE
Add arm64 based node-e2e tests on AWS

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -125,6 +125,50 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+  - name: pull-kubernetes-node-arm64-e2e-containerd-ec2
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-e2e-containerd-ec2: "true"
+    path_alias: k8s.io/kubernetes
+    always_run: false # flip after tests are green
+    optional: true # flip after tests are green
+    cluster: eks-prow-build-cluster
+    max_concurrency: 50
+    decorate: true
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: sigs.k8s.io/provider-aws-test-infra
+        workdir: true
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-master
+          command:
+            - runner.sh
+          args:
+            - hack/make-rules/test-e2e-node.sh
+          env:
+            - name: FOCUS
+              value: NodeConformance
+            - name: IMAGE_CONFIG_FILE
+              value: aws-instance-arm64.yaml
+            - name: TEST_ARGS
+              value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
   - name: pull-kubernetes-node-e2e-containerd-kubetest2
     always_run: false
     optional: true
@@ -1966,6 +2010,46 @@ presubmits:
             env:
               - name: FOCUS
                 value: NodeConformance
+              - name: TEST_ARGS
+                value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+            resources:
+              limits:
+                cpu: 4
+                memory: 6Gi
+              requests:
+                cpu: 4
+                memory: 6Gi
+    - name: pull-kubernetes-node-arm64-e2e-containerd-ec2-canary
+      # duplicate job of in the k/k repo to test changes in provider-aws-test-infra repo
+      annotations:
+        testgrid-alert-stale-results-hours: "24"
+        testgrid-create-test-group: "true"
+        testgrid-num-failures-to-alert: "10"
+      labels:
+        preset-e2e-containerd-ec2: "true"
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+      always_run: true
+      optional: false
+      cluster: eks-prow-build-cluster
+      decorate: true
+      extra_refs:
+        - org: kubernetes
+          repo: kubernetes
+          base_ref: master
+          path_alias: k8s.io/kubernetes
+      spec:
+        serviceAccountName: node-e2e-tests
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-master
+            command:
+              - runner.sh
+            args:
+              - hack/make-rules/test-e2e-node.sh
+            env:
+              - name: FOCUS
+                value: NodeConformance
+              - name: IMAGE_CONFIG_FILE
+                value: aws-instance-arm64.yaml
               - name: TEST_ARGS
                 value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             resources:

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -35,6 +35,12 @@ dashboards:
     - name: pull-e2e-ec2-canary
       test_group_name: pull-kubernetes-node-e2e-containerd-ec2-canary
       base_options: width=10
+    - name: pull-e2e-arm64-ec2
+      test_group_name: pull-kubernetes-node-arm64-e2e-containerd-ec2
+      base_options: width=10
+    - name: pull-e2e-arm64-ec2-canary
+      test_group_name: pull-kubernetes-node-arm64-e2e-containerd-ec2-canary
+      base_options: width=10
 
 - name: sig-node-cri-o
 - name: sig-node-cri-tools


### PR DESCRIPTION
Only difference from the other job it is cloned from is setting `IMAGE_CONFIG_FILE` to `aws-instance-arm64.yaml`