### PR TITLE
capacity tuning for various jobs recently moved to EKS

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -18,10 +18,10 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
@@ -75,10 +75,10 @@ presubmits:
         - ./scripts/ci-apidiff.sh
         resources:
           requests:
-            cpu: "1"
+            cpu: "4"
             memory: "2Gi"
           limits:
-            cpu: "1"
+            cpu: "4"
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
@@ -101,10 +101,10 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
@@ -127,10 +127,10 @@ presubmits:
         - ./scripts/ci-test.sh
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -43,10 +43,10 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-1.25
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -15,10 +15,10 @@ presubmits:
         - "./scripts/ci-test.sh"
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
@@ -38,10 +38,10 @@ presubmits:
         - "./scripts/ci-build.sh"
         resources:
           limits:
-            cpu: 4
+            cpu: 5
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 5
             memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -21,10 +21,10 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-verify-build-master
     cluster: eks-prow-build-cluster
@@ -46,10 +46,10 @@ presubmits:
         - build
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-unit-test-master-master
     cluster: eks-prow-build-cluster
@@ -72,10 +72,10 @@ presubmits:
         - test-unit
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-27
     cluster: eks-prow-build-cluster
@@ -110,10 +110,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-26
     cluster: eks-prow-build-cluster
@@ -148,10 +148,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-25
     cluster: eks-prow-build-cluster
@@ -186,8 +186,8 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi

--- a/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
@@ -26,10 +26,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
   - name: pull-gateway-api-test
     cluster: eks-prow-build-cluster
@@ -57,8 +57,8 @@ presubmits:
             privileged: true
           resources:
             limits:
-              cpu: 1
+              cpu: 6
               memory: 4Gi
             requests:
-              cpu: 1
+              cpu: 6
               memory: 4Gi

--- a/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
@@ -15,10 +15,10 @@ presubmits:
         - ci/prow/build
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-kernel-module-management-check-api-changes
     cluster: eks-prow-build-cluster
@@ -50,10 +50,10 @@ presubmits:
           value: '0'
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-kernel-module-management-check-commits-count
     cluster: eks-prow-build-cluster
@@ -70,10 +70,10 @@ presubmits:
         - ci/prow/check-commits-count
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
   - name: pull-kernel-module-management-lint
     cluster: eks-prow-build-cluster
@@ -90,10 +90,10 @@ presubmits:
         - ci/prow/lint
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-kernel-module-management-unit-tests
     cluster: eks-prow-build-cluster
@@ -110,8 +110,8 @@ presubmits:
         - ci/prow/unit-tests
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi

--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -189,10 +189,10 @@ presubmits:
         # docker-in-docker needs privileged mode
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 6Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 6Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -79,10 +79,10 @@ presubmits:
         resources:
           requests:
             memory: 1Gi
-            cpu: 2
+            cpu: 4
           limits:
             memory: 1Gi
-            cpu: 2
+            cpu: 4
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -62,10 +62,10 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 4
+            cpu: 8
             memory: 6Gi
           requests:
-            cpu: 4
+            cpu: 8
             memory: 6Gi
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits

--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -16,10 +16,10 @@ presubmits:
         - "export PATH=$PATH:$GOPATH/bin && make verify"
         resources:
           limits:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
     annotations:
       testgrid-dashboards: sig-contribex-community

--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -37,10 +37,10 @@ presubmits:
         resources:
           requests:
             memory: "2000Mi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "2000Mi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-minikube-platform-tests
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
+++ b/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
@@ -15,10 +15,10 @@ presubmits:
         - test
         resources:
           limits:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
     annotations:
       testgrid-num-columns-recent: '30'
@@ -39,10 +39,10 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
     annotations:
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2014,10 +2014,10 @@ presubmits:
                 value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             resources:
               limits:
-                cpu: 4
+                cpu: 6
                 memory: 6Gi
               requests:
-                cpu: 4
+                cpu: 6
                 memory: 6Gi
     - name: pull-kubernetes-node-arm64-e2e-containerd-ec2-canary
       # duplicate job of in the k/k repo to test changes in provider-aws-test-infra repo

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -89,10 +89,10 @@ presubmits:
         - --warnings=unknown-fields-all
         resources:
           requests:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "2Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra


### PR DESCRIPTION
This PR tunes the resource quotas for various jobs that were recently moved from the default cluster to the eks-prow-build-cluster. These updates are largely estemated based on the data available from the [Grafana Builds Dashboard](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&refresh=30s&from=now-7d&to=now&var-org=kubernetes&var-repo=community&var-job=pull-community-verify&var-build=All)  and the job runtime that's provided by Prow Job History. Below is the expected duration of each job and the actual runtime of the most recent job that moved to the EKS cluster. 

```
pull-community-verify                              Expected:0m27s   Received:0m51s   Off by:45%   Please update kubernetes/community
pull-minikube-build                                Expected:2m48s   Received:5m28s   Off by:48%   Please update kubernetes/minikube
pull-org-test-all                                  Expected:0m18s   Received:0m55s   Off by:66%   Please update kubernetes/org
pull-org-verify-all                                Expected:0m11s   Received:0m25s   Off by:56%   Please update kubernetes/org
pull-cluster-api-operator-apidiff-main             Expected:2m27s   Received:6m39s   Off by:63%   Please update kubernetes-sigs/cluster-api-operator
pull-cluster-api-operator-build-main               Expected:6m29s   Received:8m3s    Off by:19%   Please update kubernetes-sigs/cluster-api-operator
pull-cluster-api-operator-test-main                Expected:7m29s   Received:8m53s   Off by:15%   Please update kubernetes-sigs/cluster-api-operator
pull-cluster-api-operator-verify-main              Expected:1m42s   Received:2m0s    Off by:14%   Please update kubernetes-sigs/cluster-api-operator
pull-cluster-api-provider-aws-apidiff-main         Expected:0m43s   Received:2m3s    Off by:65%   Please update kubernetes-sigs/cluster-api-provider-aws
pull-cluster-api-provider-gcp-build                Expected:2m1s    Received:2m22s   Off by:14%   Please update kubernetes-sigs/cluster-api-provider-gcp
pull-cluster-api-provider-gcp-test                 Expected:3m16s   Received:4m35s   Off by:28%   Please update kubernetes-sigs/cluster-api-provider-gcp
pull-descheduler-test-e2e-k8s-master-1-25          Expected:11m4s   Received:19m25s  Off by:42%   Please update kubernetes-sigs/descheduler
pull-descheduler-test-e2e-k8s-master-1-26          Expected:10m44s  Received:19m21s  Off by:44%   Please update kubernetes-sigs/descheduler
pull-descheduler-test-e2e-k8s-master-1-27          Expected:11m27s  Received:19m27s  Off by:41%   Please update kubernetes-sigs/descheduler
pull-descheduler-unit-test-master-master           Expected:1m46s   Received:10m48s  Off by:83%   Please update kubernetes-sigs/descheduler
pull-descheduler-verify-build-master               Expected:1m17s   Received:7m47s   Off by:83%   Please update kubernetes-sigs/descheduler
pull-descheduler-verify-master                     Expected:7m4s    Received:28m44s  Off by:75%   Please update kubernetes-sigs/descheduler
pull-gateway-api-test                              Expected:1m48s   Received:6m15s   Off by:70%   Please update kubernetes-sigs/gateway-api
pull-gateway-api-verify                            Expected:5m35s   Received:10m53s  Off by:48%   Please update kubernetes-sigs/gateway-api
pull-kernel-module-management-build                Expected:0m50s   Received:4m27s   Off by:81%   Please update kubernetes-sigs/kernel-module-management
pull-kernel-module-management-check-api-changes    Expected:1m18s   Received:5m25s   Off by:76%   Please update kubernetes-sigs/kernel-module-management
pull-kernel-module-management-check-commits-count  Expected:0m5s    Received:0m9s    Off by:35%   Please update kubernetes-sigs/kernel-module-management
pull-kernel-module-management-lint                 Expected:2m17s   Received:11m18s  Off by:79%   Please update kubernetes-sigs/kernel-module-management
pull-kernel-module-management-unit-tests           Expected:1m23s   Received:8m9s    Off by:83%   Please update kubernetes-sigs/kernel-module-management
pull-cip-verify-archives                           Expected:1m17s   Received:1m42s   Off by:23%   Please update kubernetes-sigs/promo-tools
pull-kubernetes-node-e2e-containerd-ec2-canary     Expected:23m11s  Received:33m45s  Off by:31%   Please update kubernetes-sigs/provider-aws-test-infra
pull-security-profiles-operator-build-image        Expected:5m39s   Received:6m59s   Off by:18%   Please update kubernetes-sigs/security-profiles-operator
pull-zeitgeist-verify                              Expected:0m30s   Received:1m0s    Off by:50%   Please update kubernetes-sigs/zeitgeist
pull-test-infra-prow-checkconfig                   Expected:0m5s    Received:0m6s    Off by:10%   Please update kubernetes/test-infra
```