### PR TITLE
Move boskos `cloud-provider-openstack` jobs to `k8s-infra-prow-build`

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-controller-manager-e2e-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -71,7 +71,7 @@ presubmits:
   #     testgrid-tab-name: presubmit-e2e-conformance-test
 
   - name: openstack-cloud-csi-cinder-e2e-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -108,7 +108,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test
 
   - name: openstack-cloud-csi-manila-e2e-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -199,7 +199,7 @@ presubmits:
       description: Run cloud-provider-openstack csi sanity tests for manila-csi-plugin
 
   - name: openstack-cloud-keystone-authentication-authorization-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.24-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.24-config.yaml
@@ -28,7 +28,7 @@ presubmits:
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-controller-manager-e2e-test-release-124
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -65,7 +65,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.24
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-124
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -102,7 +102,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.24
 
   - name: openstack-cloud-csi-manila-e2e-test-release-124
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
@@ -28,7 +28,7 @@ presubmits:
       description: Run cloud-provider-openstack csi sanity tests for cinder-csi-plugin
 
   - name: openstack-cloud-controller-manager-e2e-test-release-125
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -65,7 +65,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.25
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-125
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -102,7 +102,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.25
 
   - name: openstack-cloud-csi-manila-e2e-test-release-125
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-controller-manager-e2e-test-release-126
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -38,7 +38,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.26
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-126
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -75,7 +75,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.26
 
   - name: openstack-cloud-csi-manila-e2e-test-release-126
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-openstack:
   - name: openstack-cloud-controller-manager-e2e-test-release-127
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -38,7 +38,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.27
 
   - name: openstack-cloud-csi-cinder-e2e-test-release-127
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -75,7 +75,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test-release-1.27
 
   - name: openstack-cloud-csi-manila-e2e-test-release-127
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Move the jobs that are reliant on boskos to another cluster as jobs are currently failing. 