### PR TITLE
Add periodic node-e2e ci job for arm64 on ec2

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -50,6 +50,55 @@ periodics:
             requests:
               cpu: 8
               memory: 10Gi
+  - name: ci-kubernetes-node-arm64-e2e-containerd-ec2
+    interval: 12h
+    annotations:
+      testgrid-dashboards: sig-node-containerd
+      testgrid-tab-name: ci-kubernetes-node-arm64-e2e-containerd-ec2
+      testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    cluster: eks-prow-build-cluster
+    decorate: true
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: sigs.k8s.io/provider-aws-test-infra
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230613-63d85f5ed2-master
+          command:
+            - runner.sh
+          args:
+            - hack/make-rules/test-e2e-node.sh
+          env:
+            - name: FOCUS
+              value: NodeConformance
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+            - name: TARGET_BUILD_ARCH
+              value: "linux/arm64"
+            - name: IMAGE_CONFIG_FILE
+              value: aws-instance-arm64.yaml
+            - name: TEST_ARGS
+              value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
   - name: ci-cgroupv1-containerd-node-e2e-serial-ec2
     interval: 12h
     annotations:


### PR DESCRIPTION
periodic counterpart for `pull-kubernetes-node-arm64-e2e-containerd-ec2` CI job.