### PR TITLE
bump cpu req/lim for descheduler presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -21,10 +21,10 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-verify-build-master
     cluster: eks-prow-build-cluster
@@ -46,10 +46,10 @@ presubmits:
         - build
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-unit-test-master-master
     cluster: eks-prow-build-cluster
@@ -72,10 +72,10 @@ presubmits:
         - test-unit
         resources:
           limits:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-27
     cluster: eks-prow-build-cluster
@@ -110,10 +110,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-26
     cluster: eks-prow-build-cluster
@@ -148,10 +148,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-25
     cluster: eks-prow-build-cluster
@@ -186,8 +186,8 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi


### PR DESCRIPTION
[Dashboard](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?from=1687171877517&to=1687179382602&orgId=1&var-org=kubernetes-sigs&var-repo=descheduler&var-job=pull-descheduler-verify-master&var-build=All)

![Screenshot 2023-06-20 at 11 29 32 AM](https://github.com/kubernetes/test-infra/assets/9448877/dbdf502d-d95b-4e19-81f9-6d78bd31a16a)


https://github.com/kubernetes/test-infra/pull/29754

cc: @ingvagabund @damemi @iftachk @ameukam