### PR TITLE
migrate kubernetes/aws-efs-csi-driver jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/aws-efs-csi-driver:
   - name: pull-aws-efs-csi-driver-verify
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -15,12 +16,20 @@ presubmits:
         args:
         - make
         - verify
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-efs-csi-driver
       testgrid-tab-name: verify
       description: aws efs csi driver basic code verification
       testgrid-num-columns-recent: '30'
   - name: pull-aws-efs-csi-driver-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -35,6 +44,13 @@ presubmits:
         args:
         - make
         - test
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-efs-csi-driver
       testgrid-tab-name: unit-test


### PR DESCRIPTION
jobs: migrate kubernetes/aws-efs-csi-driver jobs to eks cluster

-  Add missing resource blocks

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722