### PR TITLE
jobs: move pull-community-tempelis-check back to GCP

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -25,7 +25,6 @@ presubmits:
       testgrid-dashboards: sig-contribex-community
       testgrid-tab-name: pull-verify
   - name: pull-community-tempelis-check
-    cluster: eks-prow-build-cluster
     decorate: true
     branches:
     - ^master$


### PR DESCRIPTION
Seeing errors like https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/community/7363/pull-community-tempelis-check/1671213614779863040

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>
