### PR TITLE
migrate kubernetes/cluster-api-provider-ibmcloud jobs to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ccm-image
+    cluster: eks-prow-build-cluster
     run_if_changed: '^hack/ccm/'
     branches:
       - ^main$
@@ -27,7 +28,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.26
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.1.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ibmcloud-make-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -21,12 +22,17 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
         imagePullPolicy: Always
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make-release-0-1
   - name: pull-cluster-api-provider-ibmcloud-test-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -41,10 +47,18 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-test-release-0-1
   - name: pull-cluster-api-provider-ibmcloud-build-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -58,6 +72,9 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            memory: "6Gi"
+            cpu: "2"
           requests:
             memory: "6Gi"
             cpu: "2"
@@ -65,6 +82,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-build-release-0-1
   - name: pull-cluster-api-provider-ibmcloud-verify-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -78,6 +96,13 @@ presubmits:
           command:
             - "make"
             - "verify"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify-release-0-1

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.2.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ibmcloud-make-release-0-2
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -21,12 +22,17 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230321-36677f7c05-1.23
         imagePullPolicy: Always
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make-release-0-2
   - name: pull-cluster-api-provider-ibmcloud-test-release-0-2
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -41,10 +47,18 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-test-release-0-2
   - name: pull-cluster-api-provider-ibmcloud-smoke-test-release-0-2
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -68,10 +82,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-smoke-test-release-0-2
   - name: pull-cluster-api-provider-ibmcloud-build-release-0-2
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -85,6 +107,9 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            memory: "6Gi"
+            cpu: "2"
           requests:
             memory: "6Gi"
             cpu: "2"
@@ -92,6 +117,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-build-release-0-2
   - name: pull-cluster-api-provider-ibmcloud-verify-release-0-2
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -105,6 +131,13 @@ presubmits:
           command:
             - "make"
             - "verify"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify-release-0-2

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ibmcloud-make-release-0-3
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -21,12 +22,17 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.24
         imagePullPolicy: Always
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make-release-0-3
   - name: pull-cluster-api-provider-ibmcloud-test-release-0-3
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -41,10 +47,18 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-test-release-0-3
   - name: pull-cluster-api-provider-ibmcloud-smoke-test-release-0-3
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -68,10 +82,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-smoke-test-release-0-3
   - name: pull-cluster-api-provider-ibmcloud-build-release-0-3
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -85,6 +107,9 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            memory: "6Gi"
+            cpu: "2"
           requests:
             memory: "6Gi"
             cpu: "2"
@@ -92,6 +117,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-build-release-0-3
   - name: pull-cluster-api-provider-ibmcloud-verify-release-0-3
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -105,10 +131,18 @@ presubmits:
           command:
             - "make"
             - "verify"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify-release-0-3
   - name: pull-cluster-api-provider-ibmcloud-apidiff-release-0-3
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
     always_run: true
@@ -125,6 +159,13 @@ presubmits:
             - runner.sh
           args:
             - ./scripts/ci-apidiff.sh
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-apidiff-release-0-3

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.4.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ibmcloud-make-release-0-4
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -21,12 +22,17 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.25
         imagePullPolicy: Always
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make-release-0-4
   - name: pull-cluster-api-provider-ibmcloud-test-release-0-4
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -41,10 +47,18 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-test-release-0-4
   - name: pull-cluster-api-provider-ibmcloud-smoke-test-release-0-4
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -68,10 +82,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-smoke-test-release-0-4
   - name: pull-cluster-api-provider-ibmcloud-build-release-0-4
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -85,6 +107,9 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            memory: "6Gi"
+            cpu: "2"
           requests:
             memory: "6Gi"
             cpu: "2"
@@ -92,6 +117,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-build-release-0-4
   - name: pull-cluster-api-provider-ibmcloud-verify-release-0-4
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -105,10 +131,18 @@ presubmits:
           command:
             - "make"
             - "verify"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify-release-0-4
   - name: pull-cluster-api-provider-ibmcloud-apidiff-release-0-4
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
     always_run: true
@@ -124,6 +158,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-apidiff-release-0-4

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.5.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ibmcloud-make-release-0-5
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -21,12 +22,17 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.26
         imagePullPolicy: Always
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make-release-0-5
   - name: pull-cluster-api-provider-ibmcloud-test-release-0-5
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -41,10 +47,18 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-test-release-0-5
   - name: pull-cluster-api-provider-ibmcloud-smoke-test-release-0-5
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -68,10 +82,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-smoke-test-release-0-5
   - name: pull-cluster-api-provider-ibmcloud-build-release-0-5
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -85,6 +107,9 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            memory: "6Gi"
+            cpu: "2"
           requests:
             memory: "6Gi"
             cpu: "2"
@@ -92,6 +117,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-build-release-0-5
   - name: pull-cluster-api-provider-ibmcloud-verify-release-0-5
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -105,10 +131,18 @@ presubmits:
           command:
             - "make"
             - "verify"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify-release-0-5
   - name: pull-cluster-api-provider-ibmcloud-apidiff-release-0-5
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
     always_run: true
@@ -124,6 +158,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-apidiff-release-0-5

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ibmcloud-make
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -21,12 +22,17 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.26
         imagePullPolicy: Always
         resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
           requests:
+            cpu: "2"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make
   - name: pull-cluster-api-provider-ibmcloud-test
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -41,10 +47,18 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-test
   - name: pull-cluster-api-provider-ibmcloud-smoke-test
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -68,10 +82,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-smoke-test
   - name: pull-cluster-api-provider-ibmcloud-build
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -85,6 +107,9 @@ presubmits:
         command:
         - "./scripts/ci-build.sh"
         resources:
+          limits:
+            memory: "6Gi"
+            cpu: "2"
           requests:
             memory: "6Gi"
             cpu: "2"
@@ -92,6 +117,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-build
   - name: pull-cluster-api-provider-ibmcloud-verify
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
       # The script this job runs is not in all branches.
@@ -105,10 +131,18 @@ presubmits:
           command:
             - "make"
             - "verify"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "6Gi"
+            requests:
+              cpu: "2"
+              memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-verify
   - name: pull-cluster-api-provider-ibmcloud-coverage
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -137,7 +171,15 @@ presubmits:
             ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
             ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
             exit $result
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
   - name: pull-cluster-api-provider-ibmcloud-apidiff
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
     always_run: true
@@ -153,6 +195,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+          requests:
+            cpu: "2"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-apidiff-main


### PR DESCRIPTION
jobs: migrate kubernetes/cluster-api-provider-ibmcloud jobs to eks cluster

- Add missing resource blocks

/priority important-longterm
/area jobs

Part of https://github.com/kubernetes/test-infra/issues/29722