### PR TITLE
sig-testing:Migrate prow jobs to community clusters

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes/kubernetes:
   # The presubmit version of the ci-kubernetes-coverage-unit job.
   - name: pull-kubernetes-coverage-unit
+    cluster: eks-prow-build-cluster
     always_run: false
     skip_report: false
     max_concurrency: 12
@@ -36,6 +37,13 @@ presubmits:
           ./gopherage junit --threshold 0.05 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
           # For now let's swallow the error - we can reenable returning $result once we're in better shape.
           exit 0
+        resources:
+          limits:
+            cpu: 4
+            memory: 16Gi
+          requests:
+            cpu: 4
+            memory: 16Gi
         securityContext:
           privileged: true
 

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -177,6 +177,7 @@ periodics:
           memory: 24Gi
 - interval: 6h
   name: kubernetes-verify-go-licenses-periodical
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 5m
@@ -206,6 +207,13 @@ periodics:
         value: master
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
This PR will migrate kubernetes/sig-testing prowjobs to eks-prow-build-cluster.

Ref: https://github.com/kubernetes/test-infra/issues/29722