### PR TITLE
increase timeout for periodic-image-builder-gcp-all-nightly job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -1,31 +1,36 @@
 periodics:
-- name: periodic-image-builder-gcp-all-nightly
-  cluster: k8s-infra-prow-build-trusted
-  interval: 24h
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: image-builder
-    base_ref: master
-    path_alias: "sigs.k8s.io/image-builder"
-  spec:
-    serviceAccountName: gcb-builder-cluster-api-gcp
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        args:
-          - runner.sh
-          - "./images/capi/scripts/ci-gce-nightly.sh"
-        env:
-          - name: GCP_PROJECT
-            value: "k8s-staging-cluster-api-gcp"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "4Gi"
-            cpu: 2000m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-image-builder
-    testgrid-tab-name: periodic-image-builder-gcp-all-nightly
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+  - name: periodic-image-builder-gcp-all-nightly
+    cluster: k8s-infra-prow-build-trusted
+    interval: 24h
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: image-builder
+        base_ref: master
+        path_alias: "sigs.k8s.io/image-builder"
+    spec:
+      serviceAccountName: gcb-builder-cluster-api-gcp
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
+          args:
+            - runner.sh
+            - "./images/capi/scripts/ci-gce-nightly.sh"
+          env:
+            - name: GCP_PROJECT
+              value: "k8s-staging-cluster-api-gcp"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: 2000m
+            limits:
+              memory: "4Gi"
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-image-builder
+      testgrid-tab-name: periodic-image-builder-gcp-all-nightly
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: "2"


### PR DESCRIPTION
job is timing out due to now we build more images than before, so extending the timeout to allow the job to complete

Fixes: https://github.com/kubernetes-sigs/image-builder/issues/1190

/assign @ameukam @mboersma 