### PR TITLE
add gs://arm64-k8s-test to additional_allowed_buckets

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -183,6 +183,7 @@ deck:
     - containerd-integration
     - ppc64le-kubernetes
     - k8s-conform-s390x-k8s
+    - arm64-k8s-test
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
 [Publishing arm64 conformance test results into testgrid](https://github.com/kubernetes/test-infra/pull/29574)  has been merged,  but the [job page](https://prow.k8s.io/view/gs/arm64-k8s-test/logs/conformance-arm64/1687155848) in prow can't show `build.log` and `junit` report correctlly. 

According to help message in https://prow.k8s.io/job-history/gs/arm64-k8s-test/logs/conformance-arm64 and doc form https://docs.prow.k8s.io/docs/announcements/ about `deck.additional_allowed_buckets`, adding gs://`arm64-k8s-test` to `deck.additional_allowed_buckets` could slove this.
