### PR TITLE
kubernetes-sigs: migrate cluster-api-addon-provider-helm to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-addon-provider-helm:
   - name: pull-cluster-api-addon-provider-helm-build-main
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -16,10 +17,18 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+        resources:
+          limits:
+            cpu: 7300m
+            memory: 4Gi
+          requests:
+            cpu: 7300m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-build-main
   - name: pull-cluster-api-addon-provider-helm-apidiff-main
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -36,10 +45,18 @@ presubmits:
         - runner.sh
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-1.26
+        resources:
+          limits:
+            cpu: 7300m
+            memory: 4Gi
+          requests:
+            cpu: 7300m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-apidiff-main
   - name: pull-cluster-api-addon-provider-helm-verify-main
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -58,14 +75,19 @@ presubmits:
         - "runner.sh"
         - ./scripts/ci-verify.sh
         resources:
+          limits:
+            cpu: 7300m
+            memory: 4Gi
           requests:
             cpu: 7300m
+            memory: 4Gi
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-verify-main
   - name: pull-cluster-api-addon-provider-helm-test-main
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -82,12 +104,17 @@ presubmits:
         - runner.sh
         - ./scripts/ci-test.sh
         resources:
+          limits:
+            cpu: 7300m
+            memory: 4Gi
           requests:
             cpu: 7300m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-test-main
   - name: pull-cluster-api-addon-provider-helm-test-mink8s-main
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -112,8 +139,12 @@ presubmits:
         - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
           value: "1.20.2"
         resources:
+          limits:
+            cpu: 7300m
+            memory: 4Gi
           requests:
             cpu: 7300m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-test-mink8s-main


### PR DESCRIPTION
This PR transitions the  cluster-api-addon-provider-helm job from the default cluster to eks-prow-build-cluster +1

ref: https://github.com/kubernetes/test-infra/issues/29722