### PR TITLE
image-builder: require explicit approvals

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -79,6 +79,7 @@ approve:
   - kubernetes-sigs/cluster-api-provider-azure
   - kubernetes-sigs/cluster-api-provider-vsphere
   - kubernetes-sigs/descheduler
+  - kubernetes-sigs/image-builder
   require_self_approval: true
   ignore_review_state: true
 - repos:


### PR DESCRIPTION
Sets `require_self_approval` and `ignore_review_state` to `true` for the kubernetes-sigs/image-builder project.

This will change behavior so that PRs opened by maintainers are not born with the `approved` label, and so that GitHub's own "approved" review status is ignored in favor of an explicit `/approved` comment by a maintainer.

We had discussed this in the past and come to a rough consensus, but if you disagree please say so–it's not a crucial change.

/assign @jsturtevant @kkeshavamurthy @AverageMarcus 