### PR TITLE
Add arm64 based node-e2e serial tests on GCE

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2219,3 +2219,57 @@ presubmits:
               requests:
                 cpu: 8
                 memory: 10Gi
+    - name: pull-kubernetes-node-arm64-ubuntu-serial-gce
+      skip_branches:
+      - release-\d+\.\d+  # per-release image
+      always_run: false
+      optional: true
+      decorate: true
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      decoration_config:
+        timeout: 180m
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+        preset-dind-enabled: "true"
+      annotations:
+        fork-per-release: "true"
+        testgrid-create-test-group: "true"
+        testgrid-alert-stale-results-hours: "24"
+        testgrid-num-failures-to-alert: "10"
+      spec:
+        containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-experimental
+          command:
+          - runner.sh
+          args:
+            - kubetest2
+            - noop
+            - --test=node
+            - --
+            - --repo-root=.
+            - --gcp-zone=us-central1-a
+            - --parallelism=1
+            - --focus-regex=\[Serial\]
+            - --use-dockerized-build=true
+            - --target-build-arch=linux/arm64
+            - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:NodeProblemDetector\]|\[NodeFeature:OOMScoreAdj\]|\[NodeFeature:DevicePluginProbe\]|\[NodeConformance\]|\[Feature:DynamicResourceAllocation\]
+            - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+            - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
+          securityContext:
+            privileged: true
+          env:
+            - name: GOPATH
+              value: /go
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -51,6 +51,9 @@ dashboards:
     - name: pull-e2e-arm64-serial-ec2-canary
       test_group_name: pull-kubernetes-node-arm64-e2e-containerd-serial-ec2-canary
       base_options: width=10
+    - name: pull-e2e-arm64-gce
+      test_group_name: pull-kubernetes-node-arm64-ubuntu-serial-gce
+      base_options: width=10
 
 - name: sig-node-ec2
   dashboard_tab:


### PR DESCRIPTION
NOTE for reviewer:  
- I am currently working on enablement of all those serial tests on arm64 (we have skipped a lot in the config).
- I saw there is already a serial presumit job on [aws](https://testgrid.k8s.io/sig-node-ec2#pull-kubernetes-node-arm64-e2e-containerd-serial-ec2), but the it has too many failures compared with the GCE, having this to compare with aws to give us some clue whether this failure is arch related.
- Eventually, we can just keep one CI job and remove the other.

/assign @SergeyKanzhelev @dims 
/cc @ike-ma 

