### PR TITLE
Allow image-builder maintainers to re-run their periodics

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -5,6 +5,10 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 4h
+    rerun_auth_config:
+      github_team_slugs:
+      - org: kubernetes-sigs
+        slug: image-builder-maintainers
     extra_refs:
       - org: kubernetes-sigs
         repo: image-builder


### PR DESCRIPTION
Enables those in the `image-builder-maintainers` GitHub group to be able to re-run the image-builder periodic job via the Prow UI.