### PR TITLE
Move secrets-store-csi-driver lint job to eks-prow-build-cluster (part 1)

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/secrets-store-csi-driver:
   - name: pull-secrets-store-csi-driver-lint
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -20,6 +21,13 @@ presubmits:
           - test-style
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-lint


### PR DESCRIPTION
Reattempting this with higher limits as per https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1273#issuecomment-1591190536

part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1273
part of https://github.com/kubernetes/test-infra/issues/29722