### PR TITLE
Revert "go-test: enable race detector"

### DIFF
--- a/hack/make-rules/go-test/unit.sh
+++ b/hack/make-rules/go-test/unit.sh
@@ -64,7 +64,5 @@ fi
   umask 0022
   mkdir -p "${JUNIT_RESULT_DIR}"
   "${REPO_ROOT}/_bin/gotestsum" --junitfile="${JUNIT_RESULT_DIR}/junit-unit.xml" \
-    -- \
-    -race \
-    "./${folder_to_test}"
+    -- "./${folder_to_test}"
 )


### PR DESCRIPTION
This reverts commit 04c80a77693d6ec68bfb915a6bc934a76f40b979.

https://github.com/kubernetes/test-infra/pull/29797 enabled the race detector after fixing one long standing racy test, the problem is that it seems to be much more races in the code base, and enabling the race detector now blocks merging

https://testgrid.k8s.io/presubmits-test-infra#unit-test&width=5

We should run with the race detector, but it seems we have some work to do before being able to do it :)