### PR TITLE
grafana: allow dashboard embedding

### DIFF
--- a/config/prow/cluster/monitoring/grafana_configmaps.yaml
+++ b/config/prow/cluster/monitoring/grafana_configmaps.yaml
@@ -71,6 +71,7 @@ data:
     provisioning = /etc/grafana/provisioning
     [security]
     disable_gravatar = true
+    allow_embedding = true
     [server]
     http_port = 3001
 ---


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/k8s.io/issues/5165#issuecomment-1582630616, I would like to try to propose embedding dashboards from [monitoring](https://monitoring.prow.k8s.io/) into [monitoring-eks](https://monitoring-eks.prow.k8s.io/) to allow having a single pane of glass in the EKS grafana.

I'm curious if it also makes sense to enhance the nginx proxy settings to prevent embedding by anyone else other than [monitoring-eks](https://monitoring-eks.prow.k8s.io/)?

https://grafana.com/docs/grafana/v6.7/installation/configuration/#allow_embedding