### PR TITLE
Add ingress-nginx release branch on image build job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -8,7 +8,7 @@ postsubmits:
       run_if_changed: 'TAG'
       branches:
         - ^main$
-        - ^legacy$
+        - ^release-.*$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -30,7 +30,7 @@ postsubmits:
       run_if_changed: 'images/nginx/.*'
       branches:
         - ^main$
-        - ^legacy$
+        - ^release-.*$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -52,6 +52,7 @@ postsubmits:
       run_if_changed: 'images/opentelemetry/.*'
       branches:
         - ^main$
+        - ^release-.*$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -73,7 +74,7 @@ postsubmits:
       run_if_changed: 'images/test-runner/.*|NGINX_BASE'
       branches:
         - ^main$
-        - ^legacy$
+        - ^release-.*$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
We are going to start doing release based on branches.

This way, we need the release branches to also trigger image builds