### PR TITLE
tune capacity for `k-csi` jobs

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-on-kubernetes-1-25
     cluster: default
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-on-kubernetes-1-26
     cluster: default
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-on-kubernetes-1-25
     cluster: default
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-test-on-kubernetes-1-24
     cluster: default
     always_run: true
@@ -391,10 +391,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -437,10 +437,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-test-on-kubernetes-1-25
     cluster: default
     always_run: true
@@ -488,10 +488,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -534,10 +534,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-test-on-kubernetes-1-26
     cluster: default
     always_run: true
@@ -585,10 +585,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -631,10 +631,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-test-on-kubernetes-1-25
     cluster: default
     always_run: false
@@ -682,10 +682,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
     cluster: default
     always_run: true
@@ -717,10 +717,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
 periodics:
 - interval: 6h
@@ -766,10 +766,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-on-kubernetes-1-25
   decorate: true
@@ -813,10 +813,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-on-kubernetes-1-26
   decorate: true
@@ -860,10 +860,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-on-kubernetes-master
   decorate: true
@@ -907,10 +907,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-25-on-kubernetes-1-25
   decorate: true
@@ -954,10 +954,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-25-on-kubernetes-1-26
   decorate: true
@@ -1001,10 +1001,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-25-on-kubernetes-master
   decorate: true
@@ -1048,10 +1048,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-26-on-kubernetes-1-26
   decorate: true
@@ -1095,10 +1095,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-26-on-kubernetes-master
   decorate: true
@@ -1142,10 +1142,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-1-24
   decorate: true
@@ -1189,10 +1189,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-1-25
   decorate: true
@@ -1236,10 +1236,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-1-26
   decorate: true
@@ -1283,10 +1283,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-24-test-on-kubernetes-master
   decorate: true
@@ -1330,10 +1330,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-25-test-on-kubernetes-1-25
   decorate: true
@@ -1377,10 +1377,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-25-test-on-kubernetes-1-26
   decorate: true
@@ -1424,10 +1424,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-25-test-on-kubernetes-master
   decorate: true
@@ -1471,10 +1471,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-26-test-on-kubernetes-1-26
   decorate: true
@@ -1518,10 +1518,10 @@ periodics:
       resources:
         requests:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "9Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-26-test-on-kubernetes-master
   decorate: true
@@ -1565,10 +1565,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-24
   decorate: true
@@ -1618,10 +1618,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-25
   decorate: true
@@ -1671,10 +1671,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-26
   decorate: true
@@ -1724,10 +1724,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-master
   decorate: true
@@ -1777,10 +1777,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-on-kubernetes-master
   decorate: true
@@ -1830,10 +1830,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-24
   decorate: true
@@ -1883,10 +1883,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-25
   decorate: true
@@ -1936,10 +1936,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-26
   decorate: true
@@ -1989,10 +1989,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-master
   decorate: true
@@ -2042,10 +2042,10 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-test-on-kubernetes-master
   decorate: true
@@ -2095,7 +2095,7 @@ periodics:
       resources:
         requests:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4
         limits:
           memory: "4Gi"
-          cpu: 2
+          cpu: 4

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -30,10 +30,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-release-tools-csi-test
     cluster: default
     always_run: true
@@ -68,10 +68,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-test
@@ -109,10 +109,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
@@ -160,10 +160,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
@@ -211,10 +211,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
         env:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-25-on-kubernetes-1-25
     cluster: default
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-26-on-kubernetes-1-26
     cluster: default
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-alpha-1-25-on-kubernetes-1-25
     cluster: default
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-unit
     cluster: default
     always_run: true
@@ -375,10 +375,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-kubernetes-csi-external-attacher-canary
     optional: true
@@ -426,7 +426,7 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-25-on-kubernetes-1-25
     cluster: default
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-26-on-kubernetes-1-26
     cluster: default
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-25-on-kubernetes-1-25
     cluster: default
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-unit
     cluster: default
     always_run: true
@@ -375,10 +375,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-kubernetes-csi-external-provisioner-canary
     optional: true
@@ -427,7 +427,7 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25
     cluster: eks-prow-build-cluster
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26
     cluster: eks-prow-build-cluster
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-alpha-1-25-on-kubernetes-1-25
     cluster: eks-prow-build-cluster
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-unit
     cluster: eks-prow-build-cluster
     always_run: true
@@ -375,10 +375,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-kubernetes-csi-external-resizer-canary
     optional: true
@@ -426,7 +426,7 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25
     cluster: eks-prow-build-cluster
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26
     cluster: eks-prow-build-cluster
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-alpha-1-25-on-kubernetes-1-25
     cluster: eks-prow-build-cluster
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-unit
     cluster: eks-prow-build-cluster
     always_run: true
@@ -375,10 +375,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-kubernetes-csi-external-snapshotter-canary
     optional: true
@@ -426,7 +426,7 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -132,20 +132,20 @@ resources_for_kubernetes () {
 resources:
   requests:
     memory: "9Gi"
-    cpu: 2
+    cpu: 4
   limits:
     memory: "9Gi"
-    cpu: 2
+    cpu: 4
 EOF
                             ;;
                             *) cat <<EOF
 resources:
   requests:
     memory: "4Gi"
-    cpu: 2
+    cpu: 4
   limits:
     memory: "4Gi"
-    cpu: 2
+    cpu: 4
 EOF
                             ;;
     esac | sed -e "s/^/${indentation}/"

--- a/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
+++ b/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-25-on-kubernetes-1-25
     cluster: default
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-26-on-kubernetes-1-26
     cluster: default
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-alpha-1-25-on-kubernetes-1-25
     cluster: default
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-unit
     cluster: default
     always_run: true
@@ -375,10 +375,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-kubernetes-csi-livenessprobe-canary
     optional: true
@@ -426,7 +426,7 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -49,10 +49,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-24-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-25-on-kubernetes-1-25
     cluster: default
     always_run: true
@@ -146,10 +146,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-25-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -192,10 +192,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-26-on-kubernetes-1-26
     cluster: default
     always_run: true
@@ -243,10 +243,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-26-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -289,10 +289,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-25-on-kubernetes-1-25
     cluster: default
     always_run: false
@@ -340,10 +340,10 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-unit
     cluster: default
     always_run: true
@@ -375,10 +375,10 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
 
   - name: pull-kubernetes-csi-node-driver-registrar-canary
     optional: true
@@ -426,7 +426,7 @@ presubmits:
         resources:
           requests:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "9Gi"
-            cpu: 2
+            cpu: 4

--- a/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
+++ b/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
@@ -30,7 +30,7 @@ presubmits:
         resources:
           requests:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4
           limits:
             memory: "4Gi"
-            cpu: 2
+            cpu: 4


### PR DESCRIPTION
Increase the cpu requests and limits on csi jobs from 2 to 4 to reduce job throttling. Jobs for external-resizer and external-snapshotter are taking significantly longer or are failing since moving to the eks cluster. 

## Grafana Ref:
[pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-1-24](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-resizer&var-job=pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-1-24&var-build=All&from=1687416078654&to=1687429812104)
[pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-resizer&var-job=pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25&var-build=All&from=1687416078654&to=1687429812104)
[pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-resizer&var-job=pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26&var-build=All&from=1687416078654&to=1687429812104)
[pull-kubernetes-csi-external-resizer-unit](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-resizer&var-job=pull-kubernetes-csi-external-resizer-unit&var-build=All&from=1687416078654&to=1687429812104)
[pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-24](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-snapshotter&var-job=pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-2&var-build=All&from=1687433353739&to=1687447578129)
[pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-snapshotter&var-job=pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-2&var-build=All&from=1687433353739&to=1687447578129)
[pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-snapshotter&var-job=pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-2&var-build=All&from=1687433353739&to=1687447578129)
[pull-kubernetes-csi-external-snapshotter-unit](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-csi&var-repo=external-snapshotter&var-job=pull-kubernetes-csi-external-snapshotter-unit&var-build=All&from=1687433353739&to=1687447578129)

## Prow Job History (notice recent durations):
[pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-1-24](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-1-24)
[pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25)
[pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26)
[pull-kubernetes-csi-external-resizer-unit](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-resizer-unit)
[pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-24](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-24) **FAILING**
[pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25)
[pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26) **FAILING**
[pull-kubernetes-csi-external-snapshotter-unit](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-csi-external-snapshotter-unit)

/cc @pohly 