### PR TITLE
Add more resources to prometheus-adapter

### DIFF
--- a/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
@@ -14,11 +14,11 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 1
-            memory: 4Gi
+            cpu: "6000m"
+            memory: "6Gi"
           requests:
-            cpu: 1
-            memory: 4Gi
+            cpu: "6000m"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-instrumentation-prometheus-adapter
       testgrid-tab-name: pr-verify
@@ -36,11 +36,11 @@ presubmits:
         - test
         resources:
           limits:
-            cpu: 1
-            memory: 4Gi
+            cpu: "6000m"
+            memory: "6Gi"
           requests:
-            cpu: 1
-            memory: 4Gi
+            cpu: "6000m"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-instrumentation-prometheus-adapter
       testgrid-tab-name: pr-test
@@ -71,11 +71,11 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 1
-            memory: 4Gi
+            cpu: "6000m"
+            memory: "6Gi"
           requests:
-            cpu: 1
-            memory: 4Gi
+            cpu: "6000m"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-instrumentation-prometheus-adapter
       testgrid-tab-name: pr-test-e2e


### PR DESCRIPTION
Prometheus-adapter CI jobs need more resources. For instance the verify job is currently failing because the linter doesn't have enough memory to load the codebase: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_prometheus-adapter/586/pull-prometheus-adapter-verify/1672242947749318656.