### PR TITLE
Reduce scheduler throughput for CL2 test on kops

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1076,6 +1076,7 @@ def generate_presubmits_scale():
             artifacts='$(ARTIFACTS)',
             env={
                 'RUN_CL2_TEST': "true",
+                'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "25",
             }
         )
     ]

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -107,6 +107,8 @@ presubmits:
           value: $(ARTIFACTS)
         - name: RUN_CL2_TEST
           value: "true"
+        - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
+          value: "25"
         - name: CLOUD_PROVIDER
           value: "aws"
         - name: CLUSTER_NAME


### PR DESCRIPTION
Making this change to get this initial job to pass https://github.com/kubernetes/kops/pull/15538