### PR TITLE
reverts GCP reliant jobs in `vsphere-csi-driver`

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -219,7 +219,7 @@ postsubmits:
 
   # Deploys the CSI image after all merges to master
   - name: post-vsphere-csi-driver-deploy
-    cluster: eks-prow-build-cluster
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -253,7 +253,7 @@ postsubmits:
 
   # Deploys the CSI image for tagged releases
   - name: post-vsphere-csi-driver-release
-    cluster: eks-prow-build-cluster
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This job reverts cluster transition for the `post-vsphere-csi-driver-deploy` and `post-vsphere-csi-driver-release` jobs which rely on GCP specific secrets from the default cluster and should not have been migrated to EKS. 

fixes: https://github.com/kubernetes/test-infra/issues/29928

/cc @xmudrii @divyenpatel @SandeepPissay @xing-yang @BaluDontu @deepakkinni