### PR TITLE
skip `slow` e2e node test in presubmit CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -212,7 +212,7 @@ presubmits:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
+              value: \[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
             - name: USE_DOCKERIZED_BUILD
               value: "true"
             - name: TARGET_BUILD_ARCH
@@ -271,7 +271,7 @@ presubmits:
           - --focus-regex=\[Serial\]
           - --use-dockerized-build=true
           - --target-build-arch=linux/arm64
-          - --skip-regex=\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]
+          - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]
           - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
         securityContext:


### PR DESCRIPTION
Those slow jobs would properly cause the test aborts when the default timeout reached (45 mins), we might shouldn't define too long timeout setting for presubmit CI jobs.

Instead of the `presubmit` job, those testcases could be covered by the periodic jobs (when it's stable enough).

For what we can see in the [log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/118650/pull-kubernetes-node-arm64-ubuntu-serial-gce/1672445937110224896/artifacts/build-log.txt), 
> [sig-node] Restart [Serial] [Slow] [Disruptive] Container Runtime Network should recover from ip leak
> ...
>   Interrupted by User
  First interrupt received; Ginkgo will run any cleanup and reporting nodes but will skip all remaining specs.  Interrupt again to skip cleanup.
> /bin/bash: line 1:  2134 Killed                  timeout -k 30s 2700.000000s ./ginkgo ...

Verified the slow test locally, the test itself is okay.