### PR TITLE
CAPI: Bump minimum Kubernetes version to v1.24.15

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -188,7 +188,7 @@ periodics:
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       - name: KUBERNETES_VERSION_MANAGEMENT
-        value: "v1.24.13"
+        value: "v1.24.15"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -148,7 +148,7 @@ presubmits:
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
         # docs (look for minimum supported k8s version for management cluster, i.e N-3).
         - name: KUBERNETES_VERSION_MANAGEMENT
-          value: "v1.24.13"
+          value: "v1.24.15"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Bump the minimum Kuberntes version used by CAPI in tests. This should fix test errors related to updating the KIND version here: https://storage.googleapis.com/k8s-triage/index.html?job=.*-cluster-api-.*&xjob=.*-provider-.*#0ff0e564ab6fae778815