### PR TITLE
Use envsubst-able placeholders in starter manifest

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   plugins.yaml: |
     plugins:
-      << your_github_org >>:
+      $GITHUB_ORG:
         plugins:
         - approve
         - assign
@@ -38,8 +38,8 @@ metadata:
   namespace: prow
   name: github-token
 stringData:
-  cert: <<insert-downloaded-cert-here>>
-  appid: <<insert-the-app-id-here>>
+  cert: $GITHUB_TOKEN
+  appid: $GITHUB_APP_ID
 ---
 apiVersion: v1
 kind: Secret
@@ -48,7 +48,7 @@ metadata:
   name: hmac-token
 stringData:
   # Generate via `openssl rand -hex 20`. This is the secret used in the GitHub webhook configuration
-  hmac: << insert-hmac-token-here >>
+  hmac: $HMAC_TOKEN
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -89,11 +89,11 @@ data:
 
     plank:
       job_url_prefix_config:
-        "*": https://prow.<< your-domain.com >>/view/
+        "*": https://$PROW_HOST/view/
       report_templates:
         '*': >-
-            [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
-            [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
+            [Full PR test history](https://$PROW_HOST/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+            [Your PR dashboard](https://$PROW_HOST/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
         - config:
@@ -103,7 +103,7 @@ data:
           github_api_endpoints:
             - http://ghproxy
             - https://api.github.com
-          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_id: "$GITHUB_APP_ID"
           github_app_private_key_secret:
             name: github-token
             key: cert
@@ -125,7 +125,7 @@ data:
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
         orgs:
-        - << your_github_org >>
+        - $GITHUB_ORG
 
     decorate_all_jobs: true
     periodics:
@@ -494,7 +494,7 @@ spec:
       port:
         number: 80
   rules:
-  - host: prow.<< your-domain.com >>
+  - host: $PROW_HOST
     http:
       paths:
       - path: /
@@ -1247,11 +1247,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_AZURE_STORAGE_ACCOUNT_USER>>",
+      "access_key": "$AZURE_STORAGE_ACCOUNT_USER",
       "endpoint": "minio.prow.svc.cluster.local",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_AZURE_STORAGE_ACCOUNT_PASSWORD>>"
+      "secret_key": "$AZURE_STORAGE_ACCOUNT_PASSWORD"
     }
 ---
 apiVersion: v1
@@ -1263,11 +1263,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_AZURE_STORAGE_ACCOUNT_USER>>",
+      "access_key": "$AZURE_STORAGE_ACCOUNT_USER",
       "endpoint": "minio.prow.svc.cluster.local",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_AZURE_STORAGE_ACCOUNT_PASSWORD>>"
+      "secret_key": "$AZURE_STORAGE_ACCOUNT_PASSWORD"
     }
 ---
 apiVersion: apps/v1
@@ -1292,12 +1292,12 @@ spec:
         args:
         - gateway
         - azure
-        - --console-address=:"<<CHANGE_ME_MINIO_CONSOLE_PORT>>"
+        - --console-address=:"$MINIO_CONSOLE_PORT"
         env:
         - name: MINIO_ROOT_USER
-          value: "<<CHANGE_ME_AZURE_STORAGE_ACCOUNT_USER>>"
+          value: "$AZURE_STORAGE_ACCOUNT_USER"
         - name: MINIO_ROOT_PASSWORD
-          value: "<<CHANGE_ME_AZURE_STORAGE_ACCOUNT_PASSWORD>>"
+          value: "$AZURE_STORAGE_ACCOUNT_PASSWORD"
         - name: MINIO_REGION_NAME
           value: minio
         ports:
@@ -1335,7 +1335,7 @@ spec:
   type: NodePort
   ports:
   - port: 8003
-    targetPort: "<<CHANGE_ME_MINIO_CONSOLE_PORT>>"
+    targetPort: "$CHANGE_ME_MINIO_CONSOLE_PORT"
     protocol: TCP
   selector:
     app: minio

--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -1335,7 +1335,7 @@ spec:
   type: NodePort
   ports:
   - port: 8003
-    targetPort: "$CHANGE_ME_MINIO_CONSOLE_PORT"
+    targetPort: "$MINIO_CONSOLE_PORT"
     protocol: TCP
   selector:
     app: minio

--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -39,7 +39,7 @@ metadata:
   name: github-token
 stringData:
   cert: $GITHUB_TOKEN
-  appid: $GITHUB_APP_ID
+  appid: "$GITHUB_APP_ID"
 ---
 apiVersion: v1
 kind: Secret
@@ -1292,7 +1292,7 @@ spec:
         args:
         - gateway
         - azure
-        - --console-address=:"$MINIO_CONSOLE_PORT"
+        - --console-address=:0.0.0.0:$MINIO_CONSOLE_PORT
         env:
         - name: MINIO_ROOT_USER
           value: "$AZURE_STORAGE_ACCOUNT_USER"
@@ -1335,7 +1335,7 @@ spec:
   type: NodePort
   ports:
   - port: 8003
-    targetPort: "$MINIO_CONSOLE_PORT"
+    targetPort: $MINIO_CONSOLE_PORT
     protocol: TCP
   selector:
     app: minio

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   plugins.yaml: |
     plugins:
-      << your_github_org >>:
+      $GITHUB_ORG:
         plugins:
         - approve
         - assign
@@ -38,8 +38,8 @@ metadata:
   namespace: prow
   name: github-token
 stringData:
-  cert: <<insert-downloaded-cert-here>>
-  appid: <<insert-the-app-id-here>>
+  cert: $GITHUB_TOKEN
+  appid: $GITHUB_APP_ID
 ---
 apiVersion: v1
 kind: Secret
@@ -48,7 +48,7 @@ metadata:
   name: hmac-token
 stringData:
   # Generate via `openssl rand -hex 20`. This is the secret used in the GitHub webhook configuration
-  hmac: << insert-hmac-token-here >>
+  hmac: $HMAC_TOKEN
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -89,11 +89,11 @@ data:
 
     plank:
       job_url_prefix_config:
-        "*": https://prow.<< your-domain.com >>/view/
+        "*": https://$PROW_HOST/view/
       report_templates:
         '*': >-
-            [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
-            [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
+            [Full PR test history](https://$PROW_HOST/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+            [Your PR dashboard](https://$PROW_HOST/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
         - config:
@@ -104,7 +104,7 @@ data:
           github_api_endpoints:
             - http://ghproxy
             - https://api.github.com
-          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_id: "$GITHUB_APP_ID"
           github_app_private_key_secret:
             name: github-token
             key: cert
@@ -125,7 +125,7 @@ data:
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
         orgs:
-        - << your_github_org >>
+        - $GITHUB_ORG
 
     decorate_all_jobs: true
     periodics:
@@ -496,7 +496,7 @@ spec:
       port:
         number: 80
   rules:
-  - host: prow.<< your-domain.com >>
+  - host: $PROW_HOST
     http:
       paths:
       - path: /

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -39,7 +39,7 @@ metadata:
   name: github-token
 stringData:
   cert: $GITHUB_TOKEN
-  appid: $GITHUB_APP_ID
+  appid: "$GITHUB_APP_ID"
 ---
 apiVersion: v1
 kind: Secret

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   plugins.yaml: |
     plugins:
-      << your_github_repo >>:
+      $GITHUB_REPO:
         plugins:
         - approve
         - assign
@@ -38,8 +38,8 @@ metadata:
   namespace: prow
   name: github-token
 stringData:
-  cert: <<insert-downloaded-cert-here>>
-  appid: <<insert-the-app-id-here>>
+  cert: $GITHUB_TOKEN
+  appid: $GITHUB_APP_ID
 ---
 apiVersion: v1
 kind: Secret
@@ -48,7 +48,7 @@ metadata:
   name: hmac-token
 stringData:
   # Generate via `openssl rand -hex 20`. This is the secret used in the GitHub webhook configuration
-  hmac: << insert-hmac-token-here >>
+  hmac: $HMAC_TOKEN
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -87,11 +87,11 @@ data:
 
     plank:
       job_url_prefix_config:
-        "*": http://<< your-minikube/kind IP >>:30002/view/
+        "*": http://$LOCAL_IP:30002/view/
       report_templates:
         '*': >-
-            [Full PR test history](http://<< your-minikube/kind IP >>:30002/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
-            [Your PR dashboard](http://<< your-minikube/kind IP >>:30002/pr?query=is:pr+state:open+author:{{with
+            [Full PR test history](http://$LOCAL_IP:30002/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+            [Your PR dashboard](http://$LOCAL_IP:30002/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
         - config:
@@ -101,7 +101,7 @@ data:
           github_api_endpoints:
             - http://ghproxy
             - https://api.github.com
-          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_id: "$GITHUB_APP_ID"
           github_app_private_key_secret:
             name: github-token
             key: cert
@@ -123,7 +123,7 @@ data:
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
         repos:
-        - << your_github_repo >>
+        - $GITHUB_REPO
 
     decorate_all_jobs: true
     periodics:
@@ -143,7 +143,7 @@ metadata:
 data:
   job-config.yaml: |
     presubmits:
-      << your_github_repo >>:
+      $GITHUB_REPO:
       - name: presubmit-echo-test
         decorate: true
         always_run: true
@@ -1307,11 +1307,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_MINIO_ROOT_USER>>",
+      "access_key": "$MINIO_ROOT_USER",
       "endpoint": "minio.prow.svc.cluster.local:9000",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
+      "secret_key": "$MINIO_ROOT_PASSWORD"
     }
 ---
 apiVersion: v1
@@ -1323,11 +1323,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_MINIO_ROOT_USER>>",
+      "access_key": "$MINIO_ROOT_USER",
       "endpoint": "minio.prow.svc.cluster.local:9000",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
+      "secret_key": "$MINIO_ROOT_PASSWORD"
     }
 ---
 apiVersion: apps/v1
@@ -1373,9 +1373,9 @@ spec:
         - /data
         env:
         - name: MINIO_ROOT_USER
-          value: "<<CHANGE_ME_MINIO_ROOT_USER>>"
+          value: "$MINIO_ROOT_USER"
         - name: MINIO_ROOT_PASSWORD
-          value: "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
+          value: "$MINIO_ROOT_PASSWORD"
         - name: MINIO_REGION_NAME
           value: minio
         - name: MINIO_CONSOLE_ADDRESS

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -39,7 +39,7 @@ metadata:
   name: github-token
 stringData:
   cert: $GITHUB_TOKEN
-  appid: $GITHUB_APP_ID
+  appid: "$GITHUB_APP_ID"
 ---
 apiVersion: v1
 kind: Secret

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   plugins.yaml: |
     plugins:
-      << your_github_org >>:
+      $GITHUB_ORG:
         plugins:
         - approve
         - assign
@@ -38,8 +38,8 @@ metadata:
   namespace: prow
   name: github-token
 stringData:
-  cert: <<insert-downloaded-cert-here>>
-  appid: <<insert-the-app-id-here>>
+  cert: $GITHUB_TOKEN
+  appid: $GITHUB_APP_ID
 ---
 apiVersion: v1
 kind: Secret
@@ -48,7 +48,7 @@ metadata:
   name: hmac-token
 stringData:
   # Generate via `openssl rand -hex 20`. This is the secret used in the GitHub webhook configuration
-  hmac: << insert-hmac-token-here >>
+  hmac: $HMAC_TOKEN
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -89,11 +89,11 @@ data:
 
     plank:
       job_url_prefix_config:
-        "*": https://prow.<< your-domain.com >>/view/
+        "*": https://$PROW_HOST/view/
       report_templates:
         '*': >-
-            [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
-            [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
+            [Full PR test history](https://$PROW_HOST/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+            [Your PR dashboard](https://$PROW_HOST/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
         - config:
@@ -103,7 +103,7 @@ data:
           github_api_endpoints:
             - http://ghproxy
             - https://api.github.com
-          github_app_id: "<<insert-the-app-id-here>>"
+          github_app_id: "$GITHUB_APP_ID"
           github_app_private_key_secret:
             name: github-token
             key: cert
@@ -125,7 +125,7 @@ data:
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
         orgs:
-        - << your_github_org >>
+        - $GITHUB_ORG
 
     decorate_all_jobs: true
     periodics:
@@ -494,7 +494,7 @@ spec:
       port:
         number: 80
   rules:
-  - host: prow.<< your-domain.com >>
+  - host: $PROW_HOST
     http:
       paths:
       - path: /
@@ -1259,11 +1259,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_MINIO_ROOT_USER>>",
+      "access_key": "$MINIO_ROOT_USER",
       "endpoint": "minio.prow.svc.cluster.local",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
+      "secret_key": "$MINIO_ROOT_PASSWORD"
     }
 ---
 apiVersion: v1
@@ -1275,11 +1275,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_MINIO_ROOT_USER>>",
+      "access_key": "$MINIO_ROOT_USER",
       "endpoint": "minio.prow.svc.cluster.local",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
+      "secret_key": "$MINIO_ROOT_PASSWORD"
     }
 ---
 apiVersion: apps/v1
@@ -1325,9 +1325,9 @@ spec:
         - /data
         env:
         - name: MINIO_ROOT_USER
-          value: "<<CHANGE_ME_MINIO_ROOT_USER>>"
+          value: "$MINIO_ROOT_USER"
         - name: MINIO_ROOT_PASSWORD
-          value: "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
+          value: "$MINIO_ROOT_PASSWORD"
         - name: MINIO_REGION_NAME
           value: minio
         ports:

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -39,7 +39,7 @@ metadata:
   name: github-token
 stringData:
   cert: $GITHUB_TOKEN
-  appid: $GITHUB_APP_ID
+  appid: "$GITHUB_APP_ID"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Fixes #29936 

[Prow sample manifests](https://docs.prow.k8s.io/docs/getting-started-deploy/#update-the-sample-manifest) use placeholders like `<<insert-the-app-id-here>>` which need to be edited manually, which kinda also encourages the bad practice of putting secret values right there and storing them in version control.

My proposed change is to use envsubt-able placeholder such as `$GITHUB_APP_ID` instead, so the manifest can be applied directly by setting env variables (e.g. in a pipeline) and running one of the following:

```
envsubst < starter-azure.yaml | kubectl apply -f -
envsubst < starter-gcs.yaml | kubectl apply -f -
envsubst < starter-s3-kind.yaml | kubectl apply -f -
envsubst < starter-s3.yaml | kubectl apply -f -
```

Corresponding docs update: https://github.com/kubernetes-sigs/prow/pull/58
