### PR TITLE
[sig-windows] Use a job name that meets azure requirements

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -167,7 +167,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-alpha-features
       testgrid-num-columns-recent: '30'
-  - name: pull-kubernetes-e2e-capz-windows-alpha-feature-vertical-pod-autoscaler
+  - name: pull-kubernetes-e2e-capz-windows-alpha-feature-vpa
     decorate: true
     always_run: false
     optional: true


### PR DESCRIPTION
The job in https://github.com/kubernetes/kubernetes/pull/112599#issuecomment-1604527836 is failing because azure has a limitation on the container size in the storage bucket.  This makes that job name fit with in those requirements.

/sig windows
/assign @marosset @fabi200123 