### PR TITLE
Add race detector nonblocking job and fix one race condition

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -164,6 +164,41 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: integration
+  - name: pull-test-infra-unit-test-race-detector-nonblocking
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    optional: true
+    skip_report: true
+    labels:
+      # Python unit tests run in docker.
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - unit
+        env:
+        - name: PROW_UNIT_TEST_EXTRA_FLAGS
+          value: "-race"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: unit-test-race-detector-nonblocking
   - name: pull-test-infra-unit-test
     cluster: eks-prow-build-cluster
     branches:

--- a/hack/make-rules/go-test/unit.sh
+++ b/hack/make-rules/go-test/unit.sh
@@ -64,5 +64,7 @@ fi
   umask 0022
   mkdir -p "${JUNIT_RESULT_DIR}"
   "${REPO_ROOT}/_bin/gotestsum" --junitfile="${JUNIT_RESULT_DIR}/junit-unit.xml" \
-    -- "./${folder_to_test}"
+    -- \
+    ${PROW_UNIT_TEST_EXTRA_FLAGS[@]+${PROW_UNIT_TEST_EXTRA_FLAGS[@]}} \
+    "./${folder_to_test}"
 )

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -43,7 +43,6 @@ const (
 	dependabotUser          = "dependabot[bot]"
 )
 
-var sleepLock sync.Mutex
 var sleep = time.Sleep
 
 type githubClient interface {

--- a/prow/external-plugins/needs-rebase/plugin/plugin_test.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -147,6 +148,12 @@ func (f *fghc) compareExpected(t *testing.T, org, repo string, num int, expected
 	}
 }
 
+func TestMain(m *testing.M) {
+	sleep = func(time.Duration) {}
+	code := m.Run()
+	os.Exit(code)
+}
+
 func TestHandleIssueCommentEvent(t *testing.T) {
 	t.Parallel()
 	pr := func() *github.PullRequest {
@@ -161,12 +168,6 @@ func TestHandleIssueCommentEvent(t *testing.T) {
 		}
 		return &pr
 	}
-
-	sleepLock.Lock()
-	oldSleep := sleep
-	sleep = func(time.Duration) {}
-	sleepLock.Unlock()
-	defer func() { sleep = oldSleep }()
 
 	testCases := []struct {
 		name string
@@ -254,11 +255,6 @@ func TestHandleIssueCommentEvent(t *testing.T) {
 
 func TestHandlePullRequestEvent(t *testing.T) {
 	t.Parallel()
-	sleepLock.Lock()
-	oldSleep := sleep
-	sleep = func(time.Duration) {}
-	sleepLock.Unlock()
-	defer func() { sleep = oldSleep }()
 
 	testCases := []struct {
 		name string


### PR DESCRIPTION
This creates a newly-observed environment variable for accepting `go test` flags, and adds a new unit test job that uses it to turn on the race detector. The new job is optional and skips reporting.

We can use this new job as a reference to see exactly which tests are failing for the race detector. This way we can have pretty high confidence that we've fixed each individual case when we do make those fixes.

This PR also includes a simpler fix for the race in the needs-rebase plugin which was the source of the majority of the race detector failures we saw previously.

/cc @airbornepony @cjwagner 