### PR TITLE
capz: 6 CPU cores for build jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -59,10 +59,10 @@ presubmits:
         - "./scripts/ci-build.sh"
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -39,10 +39,10 @@ presubmits:
         - "./scripts/ci-build.sh"
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure


### PR DESCRIPTION
This PR increases the CPU limits to 6 for CAPZ build jobs after observing a test failure w/ 4 cores. Ref:

- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/3425/pull-cluster-api-provider-azure-build/1673816502014316544