### PR TITLE
tune capacity for `cluster-api-provider-azure` jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -35,11 +35,11 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 4
-            memory: 4Gi
+            cpu: 6
+            memory: 8Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 6
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-test-main
@@ -60,10 +60,10 @@ presubmits:
         resources:
           limits:
             cpu: 6
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 6
-            memory: 4Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-build-main


### PR DESCRIPTION
Bumping memory resources for `pull-cluster-api-provider-azure-test` and `pull-cluster-api-provider-azure-build`.

/cc @marosset @jackfrancis @mboersma 