### PR TITLE
[jobs/kueue] Run all e2e in a single job

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -58,7 +58,7 @@ presubmits:
           limits:
             cpu: "4"
             memory: "16Gi"
-  - name: pull-kueue-test-e2e-main-1-24
+  - name: pull-kueue-test-e2e-main
     cluster: eks-prow-build-cluster
     branches:
     - ^main
@@ -67,131 +67,20 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-24
-      description: "Run kueue end to end tests for Kubernetes 1.24"
+      testgrid-tab-name: pull-kueue-test-e2e-main
+      description: "Run kueue end to end tests"
     labels:
       preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.24.15
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
         args:
         - make
         - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
-  - name: pull-kueue-test-e2e-main-1-25
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-25
-      description: "Run kueue end to end tests for Kubernetes 1.25"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.25.11
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
-  - name: pull-kueue-test-e2e-main-1-26
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-26
-      description: "Run kueue end to end tests for Kubernetes 1.26"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.26.6
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
-  - name: pull-kueue-test-e2e-main-1-27
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-27
-      description: "Run kueue end to end tests for Kubernetes 1.27"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.27.3
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
+        - test-e2e-all
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-3.yaml
@@ -58,7 +58,7 @@ presubmits:
           limits:
             cpu: "4"
             memory: "8Gi"
-  - name: pull-kueue-test-e2e-release-0-3-1-24
+  - name: pull-kueue-test-e2e-release-0-3
     cluster: eks-prow-build-cluster
     branches:
     - ^release-0.3
@@ -67,131 +67,20 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-3-1-24
-      description: "Run kueue-release-0-3 end to end tests for Kubernetes 1.24"
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-3
+      description: "Run kueue-release-0-3 end to end tests"
     labels:
       preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.24.15
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
         args:
         - make
         - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
-  - name: pull-kueue-test-e2e-release-0-3-1-25
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.3
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-3-1-25
-      description: "Run kueue-release-0-3 end to end tests for Kubernetes 1.25"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.25.11
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
-  - name: pull-kueue-test-e2e-release-0-3-1-26
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.3
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-3-1-26
-      description: "Run kueue-release-0-3 end to end tests for Kubernetes 1.26"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.26.6
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
-  - name: pull-kueue-test-e2e-release-0-3-1-27
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.3
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-3-1-27
-      description: "Run kueue-release-0-3 end to end tests for Kubernetes 1.27"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.27.3
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
+        - test-e2e-all
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -74,12 +74,12 @@ periodics:
               cpu: "4"
               memory: "16Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-24
+    name: periodic-kueue-test-e2e-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-24
-      description: "Run periodic kueue end to end tests for Kubernetes 1.24"
+      testgrid-tab-name: periodic-kueue-test-e2e-main
+      description: "Run periodic kueue end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -95,142 +95,13 @@ periodics:
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.24.15
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
           args:
             - make
             - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "40Gi"
-            limits:
-              cpu: "10"
-              memory: "40Gi"
-  - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-25
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-25
-      description: "Run periodic kueue end to end tests for Kubernetes 1.25"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.25.11
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "40Gi"
-            limits:
-              cpu: "10"
-              memory: "40Gi"
-  - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-26
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-26
-      description: "Run periodic kueue end to end tests for Kubernetes 1.26"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.26.6
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "40Gi"
-            limits:
-              cpu: "10"
-              memory: "40Gi"
-  - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-27
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-27
-      description: "Run periodic kueue end to end tests for Kubernetes 1.27"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.27.3
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
+            - test-e2e-all
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Run the e2e tests for all k8s version in a single job. This way we can reuse the built image and try to avoid golang image pull rate limit errors. 