### PR TITLE
tune capacity for `cluster-api-provider-azure` test job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -36,10 +36,10 @@ presubmits:
         resources:
           limits:
             cpu: 6
-            memory: 8Gi
+            memory: 16Gi
           requests:
             cpu: 6
-            memory: 8Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-test-main


### PR DESCRIPTION
Bumping memory for `pull-cluster-api-provider-azure-test` to 16GB since it's still failing. https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-azure&var-job=pull-cluster-api-provider-azure-test&var-build=All&from=1687922728132&to=1687926066022

/cc @marosset @jackfrancis @mboersma