### PR TITLE
Avoid directly using dockerhub - use ECR public mirror

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -95,7 +95,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.12.5
+      - image: public.ecr.aws/docker/library/golang:1.12.5
         command:
         - /bin/bash
         args:

--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.18
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: golang:1.18.3
+          - image: public.ecr.aws/docker/library/golang:1.18.3
             imagePullPolicy: Always
             command:
               - make

--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: golang:1.18.3
+          - image: public.ecr.aws/docker/library/golang:1.18.3
             imagePullPolicy: Always
             command:
               - make

--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.21.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.22.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.23.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: public.ecr.aws/docker/library/golang:1.17.6
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: public.ecr.aws/docker/library/golang:1.17.6
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: public.ecr.aws/docker/library/golang:1.17.6
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.24.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.6
+      - image: public.ecr.aws/docker/library/golang:1.18.6
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.6
+      - image: public.ecr.aws/docker/library/golang:1.18.6
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.6
+      - image: public.ecr.aws/docker/library/golang:1.18.6
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.25.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.26.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in container-object-storage-interface-api repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in container-object-storage-interface-api repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in container-object-storage-interface-controller repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in container-object-storage-interface-controller repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-csi-adapter.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-csi-adapter.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in container-object-storage-interface-csi-adapter repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in container-object-storage-interface-csi-adapter repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-provisioner-sidecar.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-provisioner-sidecar.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in container-object-storage-interface-provisioner-sidecar repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in container-object-storage-interface-provisioner-sidecar repo.
     spec:
       containers:
-      - image: golang:1.18.4
+      - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
@@ -8,7 +8,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: golang:1.20
+    - image: public.ecr.aws/docker/library/golang:1.20
       command:
       - ./hack/ci-check-everything.sh
       resources:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.10.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.10$
     spec:
       containers:
-      - image: golang:1.16
+      - image: public.ecr.aws/docker/library/golang:1.16
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.10$
     spec:
       containers:
-      - image: golang:1.16
+      - image: public.ecr.aws/docker/library/golang:1.16
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.11.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.11$
     spec:
       containers:
-      - image: golang:1.17
+      - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.11$
     spec:
       containers:
-      - image: golang:1.17
+      - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.12.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.12.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.12$
     spec:
       containers:
-      - image: golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.18
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.12$
     spec:
       containers:
-      - image: golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.18
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.13.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.13.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.13$
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.13$
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.14.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.14.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.14$
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.14$
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.15.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.15.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.15$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.15$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.2.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.2.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-0.2$
     spec:
       containers:
-      - image: golang:1.12
+      - image: public.ecr.aws/docker/library/golang:1.12
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^release-0.2$
     spec:
       containers:
-      - image: golang:1.12
+      - image: public.ecr.aws/docker/library/golang:1.12
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.3.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.3.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - image: golang:1.12
+      - image: public.ecr.aws/docker/library/golang:1.12
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - image: golang:1.12
+      - image: public.ecr.aws/docker/library/golang:1.12
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.4.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.4.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.5.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.5.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-0.6$
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^release-0.6$
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.6.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.6.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-0.5$
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^release-0.5$
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.7.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.7$
     spec:
       containers:
-      - image: golang:1.15
+      - image: public.ecr.aws/docker/library/golang:1.15
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.7$
     spec:
       containers:
-      - image: golang:1.15
+      - image: public.ecr.aws/docker/library/golang:1.15
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.8.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.8.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.8$
     spec:
       containers:
-      - image: golang:1.15
+      - image: public.ecr.aws/docker/library/golang:1.15
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.8$
     spec:
       containers:
-      - image: golang:1.15
+      - image: public.ecr.aws/docker/library/golang:1.15
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.9.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.9.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^release-0.9$
     spec:
       containers:
-      - image: golang:1.16
+      - image: public.ecr.aws/docker/library/golang:1.16
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -26,7 +26,7 @@ presubmits:
     - ^release-0.9$
     spec:
       containers:
-      - image: golang:1.16
+      - image: public.ecr.aws/docker/library/golang:1.16
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         - test-all

--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -14,7 +14,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:
@@ -39,7 +39,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:
@@ -65,7 +65,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.13
+      - image: public.ecr.aws/docker/library/golang:1.13
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.19.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.20.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: public.ecr.aws/docker/library/golang:1.15.5
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: public.ecr.aws/docker/library/golang:1.15.5
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: public.ecr.aws/docker/library/golang:1.15.5
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.16.14
+      - image: public.ecr.aws/docker/library/golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.23.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: public.ecr.aws/docker/library/golang:1.17.6
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: public.ecr.aws/docker/library/golang:1.17.6
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: public.ecr.aws/docker/library/golang:1.17.6
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.24.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.2
+      - image: public.ecr.aws/docker/library/golang:1.18.2
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.18.2
+      - image: public.ecr.aws/docker/library/golang:1.18.2
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.18.2
+      - image: public.ecr.aws/docker/library/golang:1.18.2
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.25.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.0
+      - image: public.ecr.aws/docker/library/golang:1.19.0
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.0
+      - image: public.ecr.aws/docker/library/golang:1.19.0
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.19.0
+      - image: public.ecr.aws/docker/library/golang:1.19.0
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.26.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.27.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.20.3
+      - image: public.ecr.aws/docker/library/golang:1.20.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.1.yaml
@@ -78,7 +78,7 @@ presubmits:
       - ^release-0.1
      spec:
        containers:
-       - image: golang:1.17
+       - image: public.ecr.aws/docker/library/golang:1.17
          command:
          - make
          args:
@@ -105,7 +105,7 @@ presubmits:
       - ^release-0.1
      spec:
        containers:
-       - image: golang:1.17
+       - image: public.ecr.aws/docker/library/golang:1.17
          command:
          - make
          args:

--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.2.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.2.yaml
@@ -78,7 +78,7 @@ presubmits:
       - ^release-0.2
      spec:
        containers:
-       - image: golang:1.18
+       - image: public.ecr.aws/docker/library/golang:1.18
          command:
          - make
          args:
@@ -105,7 +105,7 @@ presubmits:
       - ^release-0.2
      spec:
        containers:
-       - image: golang:1.18
+       - image: public.ecr.aws/docker/library/golang:1.18
          command:
          - make
          args:

--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
@@ -78,7 +78,7 @@ presubmits:
       - ^main$
      spec:
        containers:
-       - image: golang:1.19
+       - image: public.ecr.aws/docker/library/golang:1.19
          command:
          - make
          args:
@@ -105,7 +105,7 @@ presubmits:
       - ^main$
      spec:
        containers:
-       - image: golang:1.19
+       - image: public.ecr.aws/docker/library/golang:1.19
          command:
          - make
          args:

--- a/config/jobs/kubernetes-sigs/ibm-vpc-block-csi-driver/ibm-vpc-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-vpc-block-csi-driver/ibm-vpc-block-csi-driver.yaml
@@ -42,7 +42,7 @@ presubmits:
       description: Unit tests in ibm-vpc-block-csi-driver repo.
     spec:
       containers:
-      - image: golang:1.19.6
+      - image: public.ecr.aws/docker/library/golang:1.19.6
         command:
         - make
         args:
@@ -68,7 +68,7 @@ presubmits:
       description: ibm-vpc-block-csi-driver basic code verification.
     spec:
       containers:
-      - image: golang:1.19.6
+      - image: public.ecr.aws/docker/library/golang:1.19.6
         command:
         - make
         args:
@@ -94,7 +94,7 @@ presubmits:
       description: ibm-vpc-block-csi-driver sanity execution.
     spec:
       containers:
-      - image: golang:1.19.6
+      - image: public.ecr.aws/docker/library/golang:1.19.6
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
@@ -41,7 +41,7 @@ presubmits:
       description: "Run jobset integration tests"
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -165,7 +165,7 @@ presubmits:
       description: "Run jobset verify checks"
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kernel-module-management/kernel-module-management-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: "build the kernel-module-management controller binary."
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ci/prow/build
         resources:
@@ -30,7 +30,7 @@ presubmits:
       description: "make sure deployment manifests and bundle are up-to-date."
     spec:
       containers:
-      - image: golang:1.20-alpine
+      - image: public.ecr.aws/docker/library/golang:1.20-alpine
         command: [sh]
         args:
         - -c
@@ -85,7 +85,7 @@ presubmits:
       description: "lint the source code of kernel-module-management."
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ci/prow/lint
         resources:
@@ -105,7 +105,7 @@ presubmits:
       description: "unit-tests the source code of kernel-module-management."
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ci/prow/unit-tests
         resources:

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -12,7 +12,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - /bin/bash
         - -c

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -12,7 +12,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - /bin/bash
         - -c

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./test.sh
         resources:

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery-operator: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-operator-verify-docs

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       testgrid-alert-email: markus.lehtonen@intel.com,feruzjon.muyassarov@intel.com
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/verify.sh
         env:
@@ -34,7 +34,7 @@ postsubmits:
       testgrid-alert-email: markus.lehtonen@intel.com,feruzjon.muyassarov@intel.com
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - bash
         args:

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: "Verify source code of pre golang 1.17 release branches"
     spec:
       containers:
-      - image: golang:1.16
+      - image: public.ecr.aws/docker/library/golang:1.16
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-build-image-generic

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/verify.sh
         env:
@@ -45,6 +45,6 @@ presubmits:
       description: "Build node-feature-discovery binaries"
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-10.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.17
+      - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-verify-docs-release-0-10
@@ -39,6 +39,6 @@ presubmits:
       description: "Build node-feature-discovery binaries"
     spec:
       containers:
-      - image: golang:1.17
+      - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-11.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.17
+      - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-verify-docs-release-0-11
@@ -39,6 +39,6 @@ presubmits:
       description: "Build node-feature-discovery binaries"
     spec:
       containers:
-      - image: golang:1.17
+      - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-12.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-verify-docs-release-0-12
@@ -39,6 +39,6 @@ presubmits:
       description: "Build node-feature-discovery binaries"
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-13.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-13.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-verify-docs-release-0-13
@@ -39,6 +39,6 @@ presubmits:
       description: "Build node-feature-discovery binaries"
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/build.sh

--- a/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/prometheus-adapter
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -29,7 +29,7 @@ presubmits:
     path_alias: sigs.k8s.io/prometheus-adapter
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: public.ecr.aws/docker/library/golang:1.15.0
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.8
+      - image: public.ecr.aws/docker/library/golang:1.15.8
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.8
+      - image: public.ecr.aws/docker/library/golang:1.15.8
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.8
+      - image: public.ecr.aws/docker/library/golang:1.15.8
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.8
+      - image: public.ecr.aws/docker/library/golang:1.15.8
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.20.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.21.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.22.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: public.ecr.aws/docker/library/golang:1.16.7
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.23.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.24.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.11
+      - image: public.ecr.aws/docker/library/golang:1.17.11
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.25.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.19.3
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - hack/pull-security-profiles-operator-build
         resources:
@@ -29,7 +29,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - hack/pull-security-profiles-operator-verify
         resources:
@@ -49,7 +49,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - hack/pull-security-profiles-operator-test-unit
         resources:

--- a/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/slack-infra/slack-infra-config.yaml
+++ b/config/jobs/kubernetes-sigs/slack-infra/slack-infra-config.yaml
@@ -6,7 +6,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.11.5
+        - image: public.ecr.aws/docker/library/golang:1.11.5
           command:
             - "./hack/verify-all.sh"
   - name: pull-slack-infra-build
@@ -15,7 +15,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.11.5
+        - image: public.ecr.aws/docker/library/golang:1.11.5
           command:
             - "./hack/verify-build.sh"
   - name: pull-slack-infra-test
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.11.5
+        - image: public.ecr.aws/docker/library/golang:1.11.5
           command:
             - "go"
           args:

--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-presubmit.yaml
@@ -9,6 +9,6 @@ presubmits:
     run_if_changed: ".*"
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/ci-test.sh

--- a/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
+++ b/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: k8s.io/client-go
     spec:
       containers:
-      - image: golang:1.15.8
+      - image: public.ecr.aws/docker/library/golang:1.15.8
         env:
         - name: GO111MODULE
           value: "on"

--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -8,7 +8,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: golang:1.18.2
+      - image: public.ecr.aws/docker/library/golang:1.18.2
         command:
         - sh
         - "-c"

--- a/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
+++ b/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
@@ -6,7 +6,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: golang:1.17
+          - image: public.ecr.aws/docker/library/golang:1.17
             command:
               - sh
               - "-c"
@@ -24,7 +24,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: golang:1.17
+          - image: public.ecr.aws/docker/library/golang:1.17
             command:
               - make
               - test

--- a/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
+++ b/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.18
         command:
         - make
         args:
@@ -32,7 +32,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.18
         command:
         - make
         args:

--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
     annotations:
@@ -18,7 +18,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         - test
@@ -36,7 +36,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - go
         args:
@@ -127,7 +127,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - go
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-gcr-to-ar-sync.yaml
@@ -19,7 +19,7 @@ periodics:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-        - image: golang:1.19
+        - image: public.ecr.aws/docker/library/golang:1.19
           imagePullPolicy: Always
           command:
             - /bin/bash

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -817,7 +817,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-verify-all
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -865,7 +865,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-verify-test
     spec:
       containers:
-      - image: golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - verify/test.sh
         resources:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -8,7 +8,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.18
         command:
         - ./admin/update.sh
         args:
@@ -555,7 +555,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: golang:1.18
+    - image: public.ecr.aws/docker/library/golang:1.18
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
A bunch of failures in CI jobs that pull from dockerhub, for example:
https://prow.k8s.io/?job=pull-org-test-all

Fixes https://github.com/kubernetes/k8s.io/issues/5451