### PR TITLE
move ci-kubernetes-kind-e2e-parallel to GKE

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 1h
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   name: ci-kubernetes-kind-e2e-parallel
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-testing-kind


### PR DESCRIPTION
Currently the EKS is faulty. Moving to GKE to get signal before 1.28.0-alpha.4