### PR TITLE
Change alpine registry for create-loop-devs and tune-sysctl ds

### DIFF
--- a/config/prow/cluster/build/create-loop-devs_daemonset.yaml
+++ b/config/prow/cluster/build/create-loop-devs_daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             done
             sleep 100000000
           done
-        image: alpine:3.6
+        image: gcr.io/k8s-prow/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:

--- a/config/prow/cluster/build/tune-sysctls_daemonset.yaml
+++ b/config/prow/cluster/build/tune-sysctls_daemonset.yaml
@@ -32,7 +32,7 @@ spec:
             sysctl -w fs.inotify.max_user_watches=524288
             sleep 10
           done
-        image: alpine:3.6
+        image: gcr.io/k8s-prow/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:


### PR DESCRIPTION
Switching alpine registry to gcr.io in order to avoid docker.io rate limiting.

ref: https://github.com/kubernetes/k8s.io/pull/5488

/assign @ameukam @dims 