### PR TITLE
Avoid directly using docker.io - use ECR public mirror

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -65,7 +65,7 @@ periodics:
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
   spec:
     containers:
-    - image: golang
+    - image: public.ecr.aws/docker/library/golang:latest
       command:
       - make
       - e2e-test


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/29961 , updating registry for registry.k8s.io AWS canary.

/assign @MadhavJivrajani @xmudrii @ameukam