### PR TITLE
Use ECR mirror for pulling node:14 in release-notes-presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: node:14
+      - image: public.ecr.aws/docker/library/node:14
         command:
         - /bin/bash
         - -c
@@ -30,7 +30,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: node:14
+      - image: public.ecr.aws/docker/library/node:14
         command:
         - /bin/bash
         - -c
@@ -54,7 +54,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: node:14
+      - image: public.ecr.aws/docker/library/node:14
         command:
         - /bin/bash
         - -c
@@ -78,7 +78,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: node:14
+      - image: public.ecr.aws/docker/library/node:14
         command:
         - /bin/bash
         - -c
@@ -126,7 +126,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: node:14
+      - image: public.ecr.aws/docker/library/node:14
         command:
         - /bin/bash
         - -c
@@ -150,7 +150,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: node:14
+      - image: public.ecr.aws/docker/library/node:14
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Fixing: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_release-notes/552/pull-release-notes-build-prod/1674112852811583488

Follow up to: https://github.com/kubernetes/test-infra/pull/29961

/assign @ameukam @dims 