### PR TITLE
update kube-cross job timeout to 4 hours

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -134,6 +134,8 @@ postsubmits:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
+      decoration_config:
+        timeout: 4h
       run_if_changed: '^images\/build\/cross\/'
       branches:
         - ^main$

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -144,6 +144,8 @@ presubmits:
   - name: pull-release-image-kube-cross
     cluster: k8s-infra-prow-build
     decorate: true
+    decoration_config:
+      timeout: 4h
     run_if_changed: '^images\/build\/cross\/'
     path_alias: k8s.io/release
     spec:


### PR DESCRIPTION
job is failing due to timeout, see https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/release/3132/pull-release-image-kube-cross/1674101237676511232

we need to build new images here: https://github.com/kubernetes/release/pull/3132


/assign @ameukam @saschagrunert 
cc @kubernetes/release-managers 