### PR TITLE
Move secrets-store-csi-driver jobs to eks-prow-build-cluster (part 2)

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -34,6 +34,7 @@ presubmits:
       description: "Run linting rules for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-unit
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -53,12 +54,20 @@ presubmits:
           - test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-unit
       description: "Run unit tests for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-sanity
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -78,13 +87,20 @@ presubmits:
           - sanity-test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-sanity
       description: "Run sanity tests for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-image-scan
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -112,10 +128,10 @@ presubmits:
           resources:
             requests:
               cpu: "4"
-              memory: "4Gi"
+              memory: "8Gi"
             limits:
               cpu: "4"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-image-scan


### PR DESCRIPTION
The lint job has been moved to `eks-prow-build-cluster` as part of https://github.com/kubernetes/test-infra/pull/29910 and is mostly running fine. Moving few more jobs to the community cluster with same limits as the lint job.

part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1273
part of https://github.com/kubernetes/test-infra/issues/29722