### PR TITLE
Shuffle Gerrit changes before processing to avoid processing repos sequentially.

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -20,6 +20,7 @@ package adapter
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"strconv"
 	"strings"
@@ -253,6 +254,14 @@ func (c *Controller) Sync() {
 
 		var wg sync.WaitGroup
 		wg.Add(len(changes))
+
+		// Randomly permute the slice of changes to reduce the chance of processing repos sequentially.
+		// We can improve on this by properly parrellelizing repo processing, but this is a less invasive
+		// temporary mitigation.
+		rand.Shuffle(
+			len(changes),
+			func(i, j int) { changes[i], changes[j] = changes[j], changes[i] },
+		)
 
 		changeChan := make(chan Change)
 		for i := 0; i < c.workerPoolSize; i++ {


### PR DESCRIPTION
/assign @airbornepony @listx 
/sig testing

It looks like we're getting a lot of contention between workers processing a single repo and blocking progress on other repos. Shuffling the changes before processing is not as good as properly parallelizing repo processing, but this is a super simple mitigation we can add now that doesn't introduce any tech debt.
