### PR TITLE
Fix: Ensure the channel in WaitForGracefulShutdown closes

### DIFF
--- a/prow/interrupts/interrupts_test.go
+++ b/prow/interrupts/interrupts_test.go
@@ -182,6 +182,7 @@ func TestInterrupts(t *testing.T) {
 	done.Add(1)
 	go func() {
 		WaitForGracefulShutdown()
+		time.Sleep(1 * time.Millisecond) // Ensure graceful shutdown channel closes  
 		done.Done()
 	}()
 


### PR DESCRIPTION
Since https://github.com/kubernetes/test-infra/pull/29934, the interrupts_test is flaky, often resulting in serverCancelled or tlsServerCancelled errors being raised. I believe this caused when the channel in WaitForGracefulShutdown does not finish closing. This PR adds a brief pause after the function is called before the closing the Done waitgroup. 

After this PR, running the test 100 times results in no flaky results( `for ((i=1; i<=100; i++)); do go test -timeout 30s -run ^TestInterrupts$ k8s.io/test-infra/prow/interrupts --count 1; done`). Without this change ~15% of runs fail. 