### PR TITLE
Migrate to a community owned bucket for installing containerd

### DIFF
--- a/config/jobs/containerd/containerd/containerd-periodic-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-periodic-jobs.yaml
@@ -1,0 +1,38 @@
+# These CI/post-submit jobs are used by Kubernetes tests to fetch a recent build of containerd instead of building containerd on every run.
+periodics:
+- name: ci-containerd-build-canary
+  interval: 30m
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+    - org: containerd
+      repo: containerd
+      base_ref: main
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
+      command:
+      - runner.sh
+      args:
+      - test/build.sh
+      env:
+      - name: DEPLOY_DIR
+        value: main
+      - name: DEPLOY_BUCKET
+        value: k8s-staging-cri-tools
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
+    testgrid-tab-name: containerd-build-canary
+    description: "builds development in progress branch of upstream containerd"

--- a/jobs/e2e_node/containerd/containerd-main/systemd/env
+++ b/jobs/e2e_node/containerd/containerd-main/systemd/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/main'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'


### PR DESCRIPTION
/cc @SergeyKanzhelev @dims 

My previous attempt to move this job to the community owned GKE cluster failed because the previous bucket doesn't belong to us(old bucket is somewhere in `google.com` GCP org). This creates a new canary job that will replace the old job once the bucket has been populated.

Also, we should probably run this as a post-submit on containerd/containerd repo instead of running it every 30 minutes as it is quite wasteful.

Part of https://github.com/kubernetes/k8s.io/issues/1469
Part of #29995 

~/hold 
I need to merge this PR https://github.com/kubernetes/k8s.io/pull/5500 in k/k8s.io to allow prow build service account to write to this bucket~