### PR TITLE
Add job pull-kubernetes-node-e2e-containerd-serial-ec2 (add it to dashboards as well)

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2097,6 +2097,51 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+  - name: pull-kubernetes-node-e2e-containerd-serial-ec2
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: k8s.io/kubernetes
+    always_run: false # flip after tests are green
+    optional: true # flip after tests are green
+    cluster: eks-prow-build-cluster
+    max_concurrency: 50
+    decorate: true
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: sigs.k8s.io/provider-aws-test-infra
+        workdir: true
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230616-e730b60769-master
+          command:
+            - runner.sh
+          args:
+            - hack/make-rules/test-e2e-node.sh
+          env:
+            - name: FOCUS
+              value: \[Serial\]
+            - name: SKIP
+              value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
+            - name: TEST_ARGS
+              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
   kubernetes-sigs/provider-aws-test-infra:
     - name: pull-kubernetes-node-e2e-containerd-ec2-canary
       # duplicate job of in the k/k repo to test changes in provider-aws-test-infra repo

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -34,6 +34,9 @@ dashboards:
       test_group_name: pull-kubernetes-node-e2e-containerd-ec2
       base_options: width=10
     - name: pull-e2e-serial-ec2
+      test_group_name: pull-kubernetes-node-e2e-containerd-serial-ec2
+      base_options: width=10
+    - name: pull-e2e-arm64-serial-ec2
       test_group_name: pull-kubernetes-node-arm64-e2e-containerd-serial-ec2
       base_options: width=10
     - name: pull-e2e-ec2-canary
@@ -71,6 +74,9 @@ dashboards:
       base_options: width=10
     - name: pull-kubernetes-node-arm64-e2e-containerd-ec2-canary
       test_group_name: pull-kubernetes-node-arm64-e2e-containerd-ec2-canary
+      base_options: width=10
+    - name: pull-kubernetes-node-e2e-containerd-serial-ec2
+      test_group_name: pull-kubernetes-node-e2e-containerd-serial-ec2
       base_options: width=10
     - name: pull-kubernetes-node-e2e-containerd-serial-ec2-canary
       test_group_name: pull-kubernetes-node-e2e-containerd-serial-ec2-canary


### PR DESCRIPTION
We are missing the AWS/EC2 node-e2e serial job that runs on amd64 images with k/k PRs