### PR TITLE
trigger github action workflows from prow for containerd

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -25,6 +25,7 @@ triggers:
 - repos:
   - containerd/containerd
   join_org_url: "https://github.com/containerd/project/blob/main/MAINTAINERS"
+  trigger_github_workflows: true
 - repos:
   - bazelbuild
 


### PR DESCRIPTION
currently if a github workflow needs to be retriggered in containerd repo, only the org members can do it. But after having an ok-to-test label on the PR, the author also should be able to retrigger the workflows so that flaky jobs and jobs which have the changes can be easily iterated on.