### PR TITLE
kubekins-e2e: bump go-canary go version to go1.21rc2

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -8,7 +8,7 @@ variants:
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.20.5
+    GO_VERSION: 1.21rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/118996
Ref: https://github.com/kubernetes/kubernetes/pull/119027

/assign @ameukam @dims 