### PR TITLE
kOps: Fix version for Karpenter upgrade test

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1626,7 +1626,7 @@ def generate_presubmits_e2e():
                 "--master-size=c6g.xlarge",
             ],
             env={
-                'KOPS_VERSION_A': "1.27.0-beta.2",
+                'KOPS_VERSION_A': "1.27",
                 'K8S_VERSION_A': "v1.26.0",
                 'KOPS_VERSION_B': "latest",
                 'K8S_VERSION_B': "v1.27.0",

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2399,7 +2399,7 @@ presubmits:
         - name: GOPATH
           value: /home/prow/go
         - name: KOPS_VERSION_A
-          value: "1.27.0-beta.2"
+          value: "1.27"
         - name: K8S_VERSION_A
           value: "v1.26.0"
         - name: KOPS_VERSION_B


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/15585/pull-kops-e2e-aws-upgrade-k126-ko1270b2-to-k127-kolatest-karpenter/1675815908464922624/build-log.txt

/cc @olemarkus @rifelpet 