### PR TITLE
make nonblocking race detector job report results

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -171,7 +171,7 @@ presubmits:
     always_run: true
     decorate: true
     optional: true
-    skip_report: true
+    skip_report: false
     labels:
       # Python unit tests run in docker.
       preset-dind-enabled: "true"


### PR DESCRIPTION
It appears that this job has mostly settled down (low flakiness [1]). Before turning the race detector back on in the main job, make this job start reporting as an interim step. If we observe for some period of time that this job is pretty stable, we can retire it and restore the race detector flag for the normal unit test
job (https://github.com/kubernetes/test-infra/pull/29917).

[1] https://testgrid.k8s.io/presubmits-test-infra#unit-test-race-detector-nonblocking&width=20

/cc @cjwagner @aojea 