### PR TITLE
integration testing: configure for testing with race detection

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -23,6 +23,11 @@ presubmits:
         - runner.sh
         args:
         - ./hack/jenkins/test-dockerized.sh
+        env:
+        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+          value: "6"
+        - name: KUBE_TIMEOUT
+          value: "1200s"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -57,6 +62,10 @@ presubmits:
         env:
         - name: GO_VERSION
           value: ""
+        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+          value: "6"
+        - name: KUBE_TIMEOUT
+          value: "1200s"
         args:
         - ./hack/jenkins/test-dockerized.sh
         # docker-in-docker needs privileged mode
@@ -90,6 +99,11 @@ presubmits:
         - runner.sh
         args:
         - ./hack/jenkins/test-dockerized.sh
+        env:
+        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+          value: "6"
+        - name: KUBE_TIMEOUT
+          value: "1200s"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -130,6 +144,10 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
+      - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+        value: "6"
+      - name: KUBE_TIMEOUT
+        value: "1200s"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
When reducing parallelism (KUBE_INTEGRATION_TEST_MAX_CONCURRENCY) and extending the allowed runtime (KUBE_TIMEOUT), integration testing works with race detection enabled.

This was tested in https://github.com/kubernetes/kubernetes/pull/116980 with locally modified settings. The job definitions are the right place for settings which depend on the capability of the test environment.