### PR TITLE
e2e-node: add package nfs-common for testcase

### DIFF
--- a/jobs/e2e_node/arm/init.yaml
+++ b/jobs/e2e_node/arm/init.yaml
@@ -1,5 +1,9 @@
 #cloud-config
 
+package_upgrade: true
+package_update: true
+packages:
+  - nfs-common
 runcmd:
   - echo "Test run from /tmp folder, remounting it"
   - mount /tmp /tmp -o remount,exec,suid


### PR DESCRIPTION
Signed-off-by: Ruquan Zhao ruquan.zhao@arm.com

Job: https://testgrid.k8s.io/sig-node-containerd#pull-e2e-arm64-gce&width=90 is keep failing. Let's fix it😀.

Failed testcase: [It] [sig-node] MirrorPod when recreating a static pod it should launch successfully even if it temporarily failed termination due to volume failing to unmount [NodeConformance] [Serial]

It seems node can't recognize nfs volumes, so let's add nfs-common into `cloud-init` file.
