### PR TITLE
e2e-node: increase limit of inotify watches

### DIFF
--- a/jobs/e2e_node/arm/init.yaml
+++ b/jobs/e2e_node/arm/init.yaml
@@ -24,5 +24,8 @@ runcmd:
   - echo "Restarting containerd"
   - systemctl restart containerd
 
+  - echo "Increasing the limit of inotify watches"
+  - sysctl -w fs.inotify.max_user_watches=524288
+
   - echo "Configuration complete"
 


### PR DESCRIPTION
Signed-off-by: Ruquan Zhao ruquan.zhao@arm.com

Job: https://testgrid.k8s.io/sig-node-containerd#pull-e2e-arm64-gce&width=90 is keep failing. Let's fix it😀.

Failed testcase: [It] [sig-node] Device Plugin [Feature:DevicePluginProbe][NodeFeature:DevicePluginProbe][Serial] DevicePlugin [Serial] [Disruptive] Keeps device plugin assignments across node reboots (no pod restart, no device plugin re-registration)

It seems that the sample-device-plugin (https://github.com/kubernetes/kubernetes/blob/master/test/images/sample-device-plugin/sampledeviceplugin.go#L153C21-L153C21) often miss inotify events, increase the default limit may fix it.
