### PR TITLE
Bump timeout for serial-ec2-eks node e2e jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -237,6 +237,8 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd
       testgrid-tab-name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
+    decoration_config:
+      timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2317,6 +2317,8 @@ presubmits:
         testgrid-alert-stale-results-hours: "24"
         testgrid-create-test-group: "true"
         testgrid-num-failures-to-alert: "10"
+      decoration_config:
+        timeout: 240m
       labels:
         preset-e2e-containerd-ec2: "true"
       path_alias: sigs.k8s.io/provider-aws-test-infra


### PR DESCRIPTION
things are timing out at 2 hour mark which is the default.