### PR TITLE
tune capacity for more cluster-api-provider-azure jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -15,11 +15,11 @@ presubmits:
         - "./scripts/ci-test.sh"
         resources:
           limits:
-            cpu: 4
-            memory: 4Gi
+            cpu: 6
+            memory: 16Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 6
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-test-v1beta1
@@ -40,10 +40,10 @@ presubmits:
         resources:
           limits:
             cpu: 6
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 6
-            memory: 4Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-build-v1beta1


### PR DESCRIPTION
Bumping CPU and memory resources for `pull-cluster-api-provider-azure-test-v1beta1` and `pull-cluster-api-provider-azure-build-v1beta1`.

We've been seeing failures in these release branch-based jobs, so this brings their configuration to parity with changes in #29952.

/cc @marosset @rjsadow @willie-yao 