### PR TITLE
Migrate `k-csi` jobs to EKS cluster

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-test-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -399,7 +399,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -442,7 +442,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-test-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -496,7 +496,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -539,7 +539,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-test-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -593,7 +593,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -636,7 +636,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-test-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -687,7 +687,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-iscsi:
   - name: pull-kubernetes-csi-csi-driver-iscsi
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nfs:
   - name: pull-kubernetes-csi-csi-driver-nfs
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nvmf:
   - name: pull-kubernetes-csi-csi-driver-nvmf
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-lib-utils:
   - name: pull-kubernetes-csi-csi-lib-utils
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-proxy:
   - name: pull-kubernetes-csi-csi-proxy
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-release-tools:
   - name: pull-kubernetes-csi-csi-release-tools
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false
@@ -35,7 +35,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-release-tools-csi-test
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -76,7 +76,7 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-test
   - name: pull-kubernetes-csi-release-tools-external-provisioner
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -127,7 +127,7 @@ presubmits:
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
   - name: pull-kubernetes-csi-release-tools-external-snapshotter
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -178,7 +178,7 @@ presubmits:
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
   - name: pull-kubernetes-csi-release-tools-csi-driver-host-path
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-test:
   - name: pull-kubernetes-csi-csi-test
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-attacher:
   - name: pull-kubernetes-csi-external-attacher-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-health-monitor:
   - name: pull-kubernetes-csi-external-health-monitor
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-provisioner:
   - name: pull-kubernetes-csi-external-provisioner-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-resizer:
   - name: pull-kubernetes-csi-external-resizer-1-24-on-kubernetes-1-24
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-25-on-kubernetes-1-25
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-26-on-kubernetes-1-26
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-resizer-alpha-1-25-on-kubernetes-1-25
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-resizer-unit
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-snapshotter:
   - name: pull-kubernetes-csi-external-snapshotter-1-24-on-kubernetes-1-24
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-25-on-kubernetes-1-25
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-26-on-kubernetes-1-26
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-alpha-1-25-on-kubernetes-1-25
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-unit
-    cluster: eks-prow-build-cluster
+    cluster: default
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -155,7 +155,7 @@ job_cluster() {
   local repo=$1
 
   case "$repo" in
-   external-snapshotter|external-resizer)
+   external-provisioner|csi-driver-smb|csi-test|external-attacher|csi-driver-windows-poc|csi-driver-host-path|node-driver-registrar|volume-data-source-validator|csi-lib-utils|csi-driver-nvmf|csi-driver-nfs|csi-driver-iscsi|csi-proxy|external-health-monitor|csi-release-tools|lib-volume-populator|livenessprobe)
      echo "eks-prow-build-cluster"
      ;;
    *)

--- a/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
+++ b/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/lib-volume-populator:
   - name: pull-kubernetes-csi-lib-volume-populator
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/livenessprobe:
   - name: pull-kubernetes-csi-livenessprobe-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/node-driver-registrar:
   - name: pull-kubernetes-csi-node-driver-registrar-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "4Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
+++ b/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/volume-data-source-validator:
   - name: pull-kubernetes-csi-volume-data-source-validator
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false


### PR DESCRIPTION
Migrate the remaining csi jobs to the EKS cluster.

ref: https://github.com/kubernetes/test-infra/pull/29812

/cc @pohly 
/hold for review and discussion