### PR TITLE
Remove noderesourcetopology-api staging rule

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -428,11 +428,6 @@ branch-protection:
             users: []
             teams:
             - stage-bots
-        noderesourcetopology-api:
-          restrictions:
-            users: []
-            teams:
-            - stage-bots
         org:
           restrictions: # only allow admins
             users: []


### PR DESCRIPTION
The repo has been removed from staging, they are shifting to development in k-sigs
ref: https://github.com/kubernetes/org/issues/4224
ref: https://github.com/kubernetes/kubernetes/pull/96275