### PR TITLE
Migrate NPD jobs to cluster k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: ci-npd-build
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-node
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -212,7 +212,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true


### PR DESCRIPTION
### What does this PR do?
Migrate jobs `ci-npd-build`, `pull-npd-e2e-node`, and `pull-npd-e2e-test` to cluster `k8s-infra-prow-build`.

These jobs are failing due to https://github.com/kubernetes/kubernetes/issues/119211. We need to migrate them outside EKS, since they are not compatible (they push images to gcr.io).

/sig node
/area testing
/cc @BenTheElder @pacoxu 