### PR TITLE
Increase job timeout duration

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1080,6 +1080,7 @@ def generate_presubmits_scale():
             networking='amazonvpc',
             always_run=False,
             artifacts='$(ARTIFACTS)',
+            test_timeout_minutes=450,
             env={
                 'CNI_PLUGIN': "amazonvpc",
                 'KUBE_NODE_COUNT': "500",

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -81,7 +81,7 @@ presubmits:
     max_concurrency: 1
     decorate: true
     decoration_config:
-      timeout: 90m
+      timeout: 480m
     path_alias: k8s.io/kops
     extra_refs:
     - org: kubernetes


### PR DESCRIPTION
Reference job thats timing out - https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/presubmit-kops-aws-scale-amazonvpc-using-cl2