### PR TITLE
config/prow: add k/utils to trigger_github_workflows trigger

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -27,6 +27,10 @@ triggers:
   join_org_url: "https://github.com/containerd/project/blob/main/MAINTAINERS"
 - repos:
   - bazelbuild
+- repos:
+  - kubernetes/utils
+  join_org_url: "https://git.k8s.io/community/community-membership.md#member"
+  trigger_github_workflows: true
 
 owners:
   mdyamlrepos:


### PR DESCRIPTION
Enable `/retest` trigger for GH workflows for k/utils.
Needed to unblock CI after https://github.com/kubernetes/utils/issues/284
(can retrigger manually but not everyone can)