### PR TITLE
pull-kubernetes-integration-eks: fix cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -34,7 +34,7 @@ presubmits:
             cpu: 6
             memory: 15Gi
   - name: pull-kubernetes-integration-eks
-    cluster: eks-infra-prow-build
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true


### PR DESCRIPTION
The right name is "eks-prow-build-cluster", "eks-infra-prow-build" doesn't exist.