### PR TITLE
Revert "integration testing: configure for testing with race detection"

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -23,11 +23,6 @@ presubmits:
         - runner.sh
         args:
         - ./hack/jenkins/test-dockerized.sh
-        env:
-        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "6"
-        - name: KUBE_TIMEOUT
-          value: "1200s"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -94,10 +89,6 @@ presubmits:
         env:
         - name: GO_VERSION
           value: ""
-        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "6"
-        - name: KUBE_TIMEOUT
-          value: "1200s"
         args:
         - ./hack/jenkins/test-dockerized.sh
         # docker-in-docker needs privileged mode
@@ -131,11 +122,6 @@ presubmits:
         - runner.sh
         args:
         - ./hack/jenkins/test-dockerized.sh
-        env:
-        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "6"
-        - name: KUBE_TIMEOUT
-          value: "1200s"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -176,10 +162,6 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-        value: "6"
-      - name: KUBE_TIMEOUT
-        value: "1200s"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
This reverts commit 8d032df62e6325b96c617dc8a321260f5b8d7aa7.

Setting KUBE_TIMEOUT via env variable seems to be broken, leading to:

   +++ [0710 23:22:55] Running tests without code coverage
   cannot find package "1200s" in any of:
	/usr/local/go/src/1200s (from $GOROOT)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/1200s (from $GOPATH)
	
Fixes: https://github.com/kubernetes/kubernetes/issues/119216