### PR TITLE
Update CAPV test alert address

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -30,7 +30,7 @@ postsubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: post-deploy
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Pushes new images and binaries from main
 
   # Deploys images and binaries for tagged releases
@@ -61,5 +61,5 @@ postsubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: release
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: releases new tagged images and binaries

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
@@ -34,7 +34,7 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-e2e-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs all the e2e tests
 
   - name: periodic-cluster-api-provider-vsphere-conformance-release-1-5
@@ -72,5 +72,5 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-conformance-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs conformance tests for CAPV

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -34,7 +34,7 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-e2e-release-1-6
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs all the e2e tests
 
   - name: periodic-cluster-api-provider-vsphere-conformance-release-1-6
@@ -72,5 +72,5 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-conformance-release-1-6
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs conformance tests for CAPV

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
@@ -34,7 +34,7 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-e2e-main
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs all the e2e tests
 
   - name: periodic-cluster-api-provider-vsphere-conformance-main
@@ -72,7 +72,7 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-conformance-main
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs conformance tests for CAPV
 
   - name: periodic-cluster-api-provider-vsphere-upgrade-main
@@ -110,7 +110,7 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-clusterctl-upgrade-main
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs clusterctl upgrade tests for CAPV
 
   - name: periodic-cluster-api-provider-vsphere-coverage
@@ -155,5 +155,5 @@ periodics:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: periodic-test-coverage
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Shows test coverage for CAPV

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
@@ -22,7 +22,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-integration-test-release-1-5
@@ -56,7 +56,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-integration-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-5
@@ -94,7 +94,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-e2e-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-full-e2e-release-1-5
@@ -131,5 +131,5 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-full-e2e-release-1-5
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs all e2e tests

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -22,7 +22,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-release-1-6
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-integration-test-release-1-6
@@ -55,7 +55,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-integration-release-1-6
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-6
@@ -93,7 +93,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-e2e-release-1-6
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-full-e2e-release-1-6
@@ -130,5 +130,5 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-full-e2e-release-1-6
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs all e2e tests

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -94,7 +94,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-markdown
@@ -117,7 +117,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-markdown
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Verifies the markdown has been linted
 
   - name: pull-cluster-api-provider-vsphere-verify-shell
@@ -133,7 +133,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-shell
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Verifies the shell scripts have been linted
 
   - name: pull-cluster-api-provider-vsphere-verify-crds
@@ -150,7 +150,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-crds
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Verifies the CRDs have been updated
 
   - name: pull-cluster-api-provider-vsphere-verify-gen
@@ -170,7 +170,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-gen
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Verifies generated files are up to date
 
   - name: pull-cluster-api-provider-vsphere-test
@@ -195,7 +195,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-integration-test
@@ -228,7 +228,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-integration
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e
@@ -266,7 +266,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-e2e
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-full-e2e
@@ -303,7 +303,7 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-full-e2e
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs all e2e tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-v1alpha
@@ -339,5 +339,5 @@ presubmits:
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-e2e-v1alpha
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
       description: Runs e2e tests for v1alpha3 and v1alpha4 types


### PR DESCRIPTION
Update the alert email address used for Cluster API Provider vSphere to a new kubernetes.io address.
