### PR TITLE
prow/plugins: prioritise repo level triggers over org level ones

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -882,14 +882,22 @@ func (c *Configuration) LgtmFor(org, repo string) *Lgtm {
 // a trigger can be listed for the repo itself or for the
 // owning organization
 func (c *Configuration) TriggerFor(org, repo string) Trigger {
-	orgRepo := fmt.Sprintf("%s/%s", org, repo)
-	for _, tr := range c.Triggers {
-		for _, r := range tr.Repos {
-			if r == org || r == orgRepo {
-				return tr
-			}
+	fullName := fmt.Sprintf("%s/%s", org, repo)
+	// Prioritize repo level triggers over org level triggers.
+	for _, trigger := range c.Triggers {
+		if !sets.NewString(trigger.Repos...).Has(fullName) {
+			continue
 		}
+		return trigger
 	}
+	// If you don't find anything, loop again looking for an org config
+	for _, trigger := range c.Triggers {
+		if !sets.NewString(trigger.Repos...).Has(org) {
+			continue
+		}
+		return trigger
+	}
+
 	var tr Trigger
 	tr.SetDefaults()
 	return tr

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -226,6 +226,10 @@ func TestTriggerFor(t *testing.T) {
 				Repos:      []string{"k8s/t-i"},
 				TrustedOrg: "org3",
 			},
+			{
+				Repos:      []string{"kuber/utils"},
+				TrustedOrg: "org4",
+			},
 		},
 	}
 	config.setDefaults()
@@ -247,6 +251,12 @@ func TestTriggerFor(t *testing.T) {
 			org:             "k8s",
 			repo:            "t-i",
 			expectedTrusted: "org3",
+		},
+		{
+			name:            "repo trigger",
+			org:             "kuber",
+			repo:            "utils",
+			expectedTrusted: "org4",
 		},
 		{
 			name: "default trigger",


### PR DESCRIPTION
After https://github.com/kubernetes/test-infra/pull/30048 was merged, I wasn't sure why `/retest` triggers were not working, I think this is why.

So far, `TriggerFor` prioristised returning org level trigger configs. There might be cases where in a trigger would need to be configured specifically for a repo (ex: allowing `/retest` to trigger GH workflows). In cases like this, we should return the trigger that is defined at the repo level, rather than its corresponding org level trigger.

We could "work around" the above constraint by simply defining the repo level trigger higher up in the config, but then this trigger config would shadow the org level trigger, which is not desirable.

This change returns a repo level trigger if it finds one, if not, it returns the first org level trigger it sees (keeping in sync with the previous behaviour).

Fwiw - I'm not sure why multiple org level or multiple repo level triggers for the same org or repo would be specified.

/sig contributor-experience
/sig testing
/assign @stevekuznetsov 