### PR TITLE
Remove unused  cluster-api-vsphere-maintainers owner alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -260,14 +260,6 @@ aliases:
     - justaugustus # subproject owner
     - mrbobbytables # subproject owner
 
-  # copied from sigs.k8s.io/cluster-api-provider-vsphere/OWNERS_ALIASES
-  cluster-api-vsphere-maintainers:
-    - frapposelli
-    - yastij
-    - randomvariable
-    - srm09
-  # end sigs.k8s.io/cluster-api-provider-vsphere/OWNERS_ALIASES
-
   # mostly copied from sigs.k8s.io/kubebuilder/OWNERS_ALIASES
   kubebuilder-admins:
   - camilamacedo86


### PR DESCRIPTION
We don't need this owner alias anymore since https://github.com/kubernetes/test-infra/pull/30190/files

So let's drop it