### PR TITLE
Add jobs for Cluster API v1.5

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5-upgrades.yaml
@@ -1,0 +1,319 @@
+periodics:
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-5
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: ALWAYS_BUILD_KIND_IMAGES
+          value: "true"
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.22"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.23"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.3-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.8.6"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5-1-22-1-23
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-5
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.23"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "stable-1.24"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.3-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.8.6"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5-1-23-1-24
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-5
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api
+      base_ref: release-1.5
+      path_alias: sigs.k8s.io/cluster-api
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "stable-1.24"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "stable-1.25"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.5.4-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "v1.9.3"
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5-1-24-1-25
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-5
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api
+      base_ref: release-1.5
+      path_alias: sigs.k8s.io/cluster-api
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "stable-1.25"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "stable-1.26"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.5.6-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "v1.9.3"
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5-1-25-1-26
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-release-1-5
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.26"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "stable-1.27"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.6-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.9.3"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5-1-26-1-27
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-27-latest-release-1-5
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.27"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.28"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.7-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.10.1"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5-1-27-latest
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5.yaml
@@ -1,0 +1,202 @@
+periodics:
+- name: periodic-cluster-api-test-release-1-5
+  interval: 4h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      command:
+      - runner.sh
+      - ./scripts/ci-test.sh
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-test-release-1-5
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+- name: periodic-cluster-api-test-mink8s-release-1-5
+  interval: 4h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      command:
+      - runner.sh
+      - ./scripts/ci-test.sh
+      env:
+      # This value determines the minimum Kubernetes
+      # supported version for Cluster API management cluster
+      # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
+      # docs (look for minimum supported k8s version for management cluster, i.e N-3).
+      #
+      # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
+      # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
+      - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
+        value: "1.24.2"
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-test-mink8s-release-1-5
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+- name: periodic-cluster-api-e2e-release-1-5
+  interval: 4h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_SKIP
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-release-1-5
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+- name: periodic-cluster-api-e2e-dualstack-and-ipv6-release-1-5
+  interval: 4h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api
+      base_ref: release-1.5
+      path_alias: sigs.k8s.io/cluster-api
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
+          - name: GINKGO_SKIP
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-5
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+- name: periodic-cluster-api-e2e-mink8s-release-1-5
+  interval: 4h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.5
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: GINKGO_SKIP
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+      # This value determines the minimum Kubernetes
+      # supported version for Cluster API management cluster.
+      - name: KUBERNETES_VERSION_MANAGEMENT
+        value: "v1.24.15"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+    testgrid-tab-name: capi-e2e-mink8s-release-1-5
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
@@ -1,0 +1,379 @@
+presubmits:
+  kubernetes-sigs/cluster-api:
+  - name: pull-cluster-api-build-release-1-5
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        command:
+        - runner.sh
+        - ./scripts/ci-build.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-build-release-1-5
+  - name: pull-cluster-api-apidiff-release-1-5
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    path_alias: sigs.k8s.io/cluster-api
+    optional: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-apidiff-release-1-5
+  - name: pull-cluster-api-verify-release-1-5
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        command:
+        - "runner.sh"
+        - ./scripts/ci-verify.sh
+        resources:
+          requests:
+            cpu: 7300m
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-verify-release-1-5
+  - name: pull-cluster-api-test-release-1-5
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    path_alias: sigs.k8s.io/cluster-api
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+        - runner.sh
+        - ./scripts/ci-test.sh
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-test-release-1-5
+  - name: pull-cluster-api-test-mink8s-release-1-5
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    path_alias: sigs.k8s.io/cluster-api
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+        - runner.sh
+        - ./scripts/ci-test.sh
+        env:
+        # This value determines the minimum Kubernetes
+        # supported version for Cluster API management cluster
+        # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
+        # docs (look for minimum supported k8s version for management cluster, i.e N-3).
+        #
+        # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
+        # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
+        - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
+          value: "1.24.2"
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-test-mink8s-release-1-5
+  - name: pull-cluster-api-e2e-mink8s-release-1-5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    path_alias: sigs.k8s.io/cluster-api
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+        - runner.sh
+        - ./scripts/ci-e2e.sh
+        env:
+        - name: GINKGO_SKIP
+          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+        # This value determines the minimum Kubernetes
+        # supported version for Cluster API management cluster
+        # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
+        # docs (look for minimum supported k8s version for management cluster, i.e N-3).
+        - name: KUBERNETES_VERSION_MANAGEMENT
+          value: "v1.24.15"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-mink8s-release-1-5
+  - name: pull-cluster-api-e2e-release-1-5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    path_alias: sigs.k8s.io/cluster-api
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "\\[PR-Blocking\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-release-1-5
+  - name: pull-cluster-api-e2e-informing-release-1-5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    optional: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    path_alias: sigs.k8s.io/cluster-api
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[PR-Informing\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-informing-release-1-5
+  - name: pull-cluster-api-e2e-full-dualstack-and-ipv6-release-1-5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    optional: true
+    always_run: false
+    branches:
+      # The script this job runs is not in all branches.
+      - ^release-1.5$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+          args:
+            - runner.sh
+            - "./scripts/ci-e2e.sh"
+          env:
+            # enable IPV6 in bootstrap image
+            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+              value: "true"
+            # Since the PR-Blocking tests are run as part of the cluster-api-e2e job
+            # and the upgrade tests are being run as part of the periodic upgrade jobs.
+            # This jobs ends up running all the other tests in the E2E suite
+            - name: GINKGO_SKIP
+              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-full-dualstack-and-ipv6-release-1-5
+  - name: pull-cluster-api-e2e-full-release-1-5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          # Since the PR-Blocking tests are run as part of the cluster-api-e2e job
+          # and the upgrade tests are being run as part of the periodic upgrade jobs.
+          # This jobs ends up running all the other tests in the E2E suite
+          - name: GINKGO_SKIP
+            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-full-release-1-5
+  - name: pull-cluster-api-e2e-workload-upgrade-1-27-latest-release-1-5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    path_alias: sigs.k8s.io/cluster-api
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: ALWAYS_BUILD_KIND_IMAGES
+            value: "true"
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "stable-1.27"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "ci/latest-1.28"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.5.7-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "v1.10.1"
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-release-1-5-1-27-latest
+  # This job is experimental for now. Please do not duplicate it to release branches.
+  - name: pull-cluster-api-e2e-scale-release-1-5-experimental
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    decorate: true
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.5$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+        env:
+        - name: BOSKOS_HOST
+          value: "boskos.test-pods.svc.cluster.local"
+        - name: GINKGO_FOCUS
+          value: "\\[Scale\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
+      testgrid-tab-name: capi-pr-e2e-scale-release-1-5-experimental

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -8,6 +8,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-1.2
     - sig-cluster-lifecycle-cluster-api-1.3
     - sig-cluster-lifecycle-cluster-api-1.4
+    - sig-cluster-lifecycle-cluster-api-1.5
     - sig-cluster-lifecycle-cluster-api-addon-provider-helm
     - sig-cluster-lifecycle-cluster-api-provider-aws
     - sig-cluster-lifecycle-cluster-api-provider-aws-1.5
@@ -37,6 +38,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-1.2
 - name: sig-cluster-lifecycle-cluster-api-1.3
 - name: sig-cluster-lifecycle-cluster-api-1.4
+- name: sig-cluster-lifecycle-cluster-api-1.5
 - name: sig-cluster-lifecycle-cluster-api-addon-provider-helm
 - name: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
 - name: sig-cluster-lifecycle-cluster-api-provider-aws-2.0


### PR DESCRIPTION
Add jobs for Cluster API v1.5. More information on this release can be found at the below links.

- https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.5.0-beta.0
- https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/releases/release-1.5.md

