### PR TITLE
Use releng-ci bookworm image instead of bullseye

### DIFF
--- a/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -61,7 +61,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
@@ -13,7 +13,7 @@ periodics:
         path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bullseye
+        - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.19-bookworm
           imagePullPolicy: Always
           command:
             - "./scripts/ci-janitor.sh"

--- a/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       cluster: eks-prow-build-cluster
       spec:
         containers:
-          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
             imagePullPolicy: Always
             command:
               - make
@@ -32,7 +32,7 @@ presubmits:
       cluster: eks-prow-build-cluster
       spec:
         containers:
-          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
             imagePullPolicy: Always
             command:
               - make

--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/e2e-framework
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -152,7 +152,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -67,7 +67,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -55,7 +55,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -47,7 +47,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -73,7 +73,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -98,7 +98,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -123,7 +123,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -508,7 +508,7 @@ periodics:
     path_alias: k8s.io/release
   spec:
     containers:
-    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bullseye
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
       imagePullPolicy: Always
       command:
       - make

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -318,7 +318,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:
-    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
       imagePullPolicy: Always
       command:
       - infra/gcp/bash/backup_tools/backup.sh


### PR DESCRIPTION
Using the new bookworm base image instead of bullseye

cc @kubernetes/release-engineering 

Refers to https://github.com/kubernetes/release/issues/3128