### PR TITLE
Bump release notes timeout

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -147,6 +147,8 @@ presubmits:
   - name: pull-release-notes-test
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     cluster: eks-prow-build-cluster
     spec:
       containers:


### PR DESCRIPTION
The release notes test has consistently been timing out after 2 hours and so we need to increase it to allow jobs to succeed. The discussion for it is here:

https://kubernetes.slack.com/archives/CN1KH4K9A/p1689105567783259?thread_ts=1688742866.424819&cid=CN1KH4K9A

We are trying to get this PR merged:
https://github.com/kubernetes-sigs/release-notes/pull/552

Here is the most recent timeout:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_release-notes/552/pull-release-notes-test/1678798132818743296