### PR TITLE
Increase memory available for pull-release-notes-test

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -147,8 +147,6 @@ presubmits:
   - name: pull-release-notes-test
     always_run: true
     decorate: true
-    decoration_config:
-      timeout: 3h
     cluster: eks-prow-build-cluster
     spec:
       containers:
@@ -162,10 +160,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 4
-            memory: 6Gi
+            memory: 8Gi
     annotations:
       testgrid-num-columns-recent: '30'
       testgrid-create-test-group: 'true'


### PR DESCRIPTION
pull-release-notes-test is currently timing out and seems to be because of resource contention.  This will give an extra 1.5gb of memory to the run.

This reverts https://github.com/kubernetes/test-infra/pull/30073 which bumped the timeout.   Although increasing the timeout helps it seems the real issue is that the test is having resource contention and should actually be completing faster.

Here is the most recent run:
https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&refresh=30s&var-org=kubernetes-sigs&var-repo=release-notes&var-job=pull-release-notes-test&var-build=All&from=now-30m&to=now

![Screenshot 2023-07-12 at 1 24 14 PM](https://github.com/kubernetes/test-infra/assets/151924/6dee066b-5c2e-4e59-a37d-9374ec191e86)
