### PR TITLE
OWNERS: remove chaodaiG from reviewers/approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ reviewers:
 - BenTheElder # lead
 - spiffxp # chair
 - stevekuznetsov # chair
-- chaodaiG # oncall
 - cjwagner # oncall, lead
 - mpherman2 # oncall
 approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,7 +1,6 @@
 aliases:
   # business hours oncall for prow etc (https://go.k8s.io/oncall)
   test-infra-oncall:
-  - chaodaiG
   - chases2
   - cjwagner
   - listx

--- a/prow/cmd/crier/OWNERS
+++ b/prow/cmd/crier/OWNERS
@@ -1,11 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-- chaodaiG
 - cjwagner
 approvers:
-- chaodaiG
 - cjwagner
 emeritus_approvers:
+- chaodaiG
 - fejta
 - krzyzacy
 labels:

--- a/prow/cmd/deck/OWNERS
+++ b/prow/cmd/deck/OWNERS
@@ -1,15 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-- chaodaiG
 - michelle192837
 - mpherman2
 - smg247
 approvers:
-- chaodaiG
 - michelle192837
 - mpherman2
 - smg247
 emeritus_approvers:
- - Katharine
+- chaodaiG
+- Katharine
 labels:
  - area/prow/deck

--- a/prow/cmd/generic-autobumper/OWNERS
+++ b/prow/cmd/generic-autobumper/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - mpherman2
 approvers:
-- chaodaiG
 - mpherman2
+emeritus_approvers:
+- chaodaiG
 labels:
  - area/prow/hook

--- a/prow/cmd/gerrit/OWNERS
+++ b/prow/cmd/gerrit/OWNERS
@@ -1,13 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - chases2
 approvers:
-- chaodaiG
 - chases2
 emeritus_approvers:
 - amwat
+- chaodaiG
 - fejta
 - krzyzacy
 labels:

--- a/prow/cmd/horologium/OWNERS
+++ b/prow/cmd/horologium/OWNERS
@@ -1,10 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
+- cjwagner
 approvers:
-- chaodaiG
+- cjwagner
 emeritus_approvers:
+- chaodaiG
 - fejta
 labels:
 - area/prow/horologium

--- a/prow/cmd/prow-controller-manager/OWNERS
+++ b/prow/cmd/prow-controller-manager/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - cjwagner
 approvers:
-- chaodaiG
 - cjwagner
+emeritus_approvers:
+- chaodaiG
 labels:
  - area/prow/plank

--- a/prow/cmd/sub/OWNERS
+++ b/prow/cmd/sub/OWNERS
@@ -1,14 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- chaodaiG
 - cjwagner
 - listx
 reviewers:
-- chaodaiG
 - cjwagner
 - listx
 emeritus_approvers:
+- chaodaiG
 - sebastienvas
 labels:
 - area/prow/pubsub

--- a/prow/cmd/tide/OWNERS
+++ b/prow/cmd/tide/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - cjwagner
 approvers:
-- chaodaiG
 - cjwagner
+emeritus_approvers:
+- chaodaiG
 labels:
  - area/prow/tide

--- a/prow/crier/OWNERS
+++ b/prow/crier/OWNERS
@@ -1,11 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-- chaodaiG
 - cjwagner
 approvers:
-- chaodaiG
 - cjwagner
 emeritus_approvers:
+- chaodaiG
 - fejta
 - krzyzacy
 - Katharine

--- a/prow/deck/OWNERS
+++ b/prow/deck/OWNERS
@@ -1,13 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-- chaodaiG
 - michelle192837
 - mpherman2
 - smg247
 approvers:
-- chaodaiG
 - michelle192837
 - mpherman2
 - smg247
+emeritus_approvers:
+- chaodaiG
 labels:
  - area/prow/deck

--- a/prow/gerrit/OWNERS
+++ b/prow/gerrit/OWNERS
@@ -1,12 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - chases2
 approvers:
-- chaodaiG
 - chases2
 emeritus_approvers:
+- chaodaiG
 - fejta
 - Katharine
 labels:

--- a/prow/plank/OWNERS
+++ b/prow/plank/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - cjwagner
 approvers:
-- chaodaiG
 - cjwagner
+emeritus_approvers:
+- chaodaiG
 labels:
  - area/prow/plank

--- a/prow/pubsub/OWNERS
+++ b/prow/pubsub/OWNERS
@@ -1,14 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- chaodaiG
 - cjwagner
 - listx
 reviewers:
-- chaodaiG
 - cjwagner
 - listx
 emeritus_approvers:
+- chaodaiG
 - sebastienvas
 - yutongz
 labels:

--- a/prow/spyglass/OWNERS
+++ b/prow/spyglass/OWNERS
@@ -1,16 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - michelle192837
 - mpherman2
 - smg247
 approvers:
-- chaodaiG
 - michelle192837
 - mpherman2
 - smg247
 emeritus_approvers:
+- chaodaiG
 - Katharine
 - paulangton
 labels:

--- a/prow/test/integration/OWNERS
+++ b/prow/test/integration/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - listx
 approvers:
-- chaodaiG
 - listx
+emeritus_approvers:
+- chaodaiG

--- a/prow/tide/OWNERS
+++ b/prow/tide/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- chaodaiG
 - cjwagner
 approvers:
-- chaodaiG
 - cjwagner
+emeritus_approvers:
+- chaodaiG
 labels:
  - area/prow/tide


### PR DESCRIPTION
Chao no longer works on Prow or test-infra-related duties (it has been a few months now).

This change was (mostly) created with:

    $ for f in $(git ls-files | grep OWNERS)
    do
            sed -i '/chaodaiG/d' $f
    done

For horologium, this resulted in an invalid YAML because Chao was the only reviewer/approver in that OWNERS file. So there cjwagner was added as a replacement.

Where Chao was an approver, he was moved to `emeritus_approvers` per the Kubernetes Contributors docs guidelines [1].

[1] https://www.kubernetes.dev/docs/guide/owners/#emeritus

/cc @chaodaiG @cjwagner 