### PR TITLE
add cloud provider GCP plugin config and enable require-matching-label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1141,6 +1141,10 @@ plugins:
     - milestonestatus
     - release-note
     - require-matching-label
+  
+  kubernetes/cloud-provider-gcp:
+    plugins:
+    - require-matching-label
 
   kubernetes/cloud-provider-openstack:
     plugins:


### PR DESCRIPTION
the plugin was previously configured but not enabled.

fixes https://github.com/kubernetes/test-infra/issues/29975