### PR TITLE
Add a test pass for node log query alpha feature on windows

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -522,3 +522,56 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master
+- name: ci-kubernetes-e2e-capz-master-windows-alpha
+  interval: 3h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-capz-windows-common: "true"
+    preset-capz-containerd-1-7-latest: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[Feature:NodeLogQuery\]|\[sig-windows\]) # run the features and a few windows related tests
+          - name: NODE_FEATURE_GATES
+            value: "NodeLogQuery=true"
+          - name: WINDOWS_SERVER_VERSION
+            value: "windows-2022"
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: capz-windows-master-alpha-features


### PR DESCRIPTION
Adding a test pass that enables some alpha feature gates and runs the node log query e2e tests.

the e2e tests were added in https://github.com/kubernetes/kubernetes/pull/117011/files

/sig windows

/hold 
https://github.com/kubernetes-sigs/windows-testing/pull/385 needs to merge first

/assign @jsturtevant @aravindhp 
/cc @fabi200123 