### PR TITLE
Make the gerrit API client limit concurrency per instance, default to 5.

### DIFF
--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -93,10 +93,11 @@ func TestFlags(t *testing.T) {
 					SupplementalProwConfigsFileNameSuffix: "_prowconfig.yaml",
 					InRepoConfigCacheSize:                 1000,
 				},
-				dryRun:                 false,
-				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
-				changeWorkerPoolSize:   1,
-				pushGatewayInterval:    time.Minute,
+				dryRun:                   false,
+				instrumentationOptions:   flagutil.DefaultInstrumentationOptions(),
+				changeWorkerPoolSize:     1,
+				pushGatewayInterval:      time.Minute,
+				instanceConcurrencyLimit: 5,
 			}
 			if tc.expected != nil {
 				tc.expected(expected)

--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -135,7 +135,7 @@ type JobReport struct {
 func NewReporter(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, cookiefilePath string, pjclientset ctrlruntimeclient.Client) (*Client, error) {
 	// Initialize an empty client, the orgs/repos will be filled in by
 	// ApplyGlobalConfig later.
-	gc, err := client.NewClient(nil)
+	gc, err := client.NewClient(nil, 5)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -130,7 +130,7 @@ type LastSyncTracker interface {
 
 // NewController returns a new gerrit controller client
 func NewController(ctx context.Context, prowJobClient prowv1.ProwJobInterface, op io.Opener,
-	ca *config.Agent, cookiefilePath, tokenPathOverride, lastSyncFallback string, workerPoolSize int, inRepoConfigCache *config.InRepoConfigCache) *Controller {
+	ca *config.Agent, cookiefilePath, tokenPathOverride, lastSyncFallback string, workerPoolSize int, instanceConcurrencyLimit uint, inRepoConfigCache *config.InRepoConfigCache) *Controller {
 
 	cfg := ca.Config
 	projectsOptOutHelpMap := map[string]sets.Set[string]{}
@@ -142,7 +142,7 @@ func NewController(ctx context.Context, prowJobClient prowv1.ProwJobInterface, o
 	if err := lastSyncTracker.Init(cfg().Gerrit.OrgReposConfig.AllRepos()); err != nil {
 		logrus.WithError(err).Fatal("Error initializing lastSyncFallback.")
 	}
-	gerritClient, err := client.NewClient(nil)
+	gerritClient, err := client.NewClient(nil, instanceConcurrencyLimit)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating gerrit client.")
 	}

--- a/prow/test/integration/test/gerrit_test.go
+++ b/prow/test/integration/test/gerrit_test.go
@@ -109,7 +109,7 @@ func TestGerrit(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			gerritClient, err := client.NewClient(map[string]map[string]*config.GerritQueryFilter{gerritServer: {"fakegerritserver": nil}})
+			gerritClient, err := client.NewClient(map[string]map[string]*config.GerritQueryFilter{gerritServer: {"fakegerritserver": nil}}, 5)
 			if err != nil {
 				t.Fatalf("Failed creating gerritClient: %v", err)
 			}

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -159,7 +159,7 @@ func newGerritProvider(
 	cookiefilePath string,
 	tokenPathOverride string,
 ) *GerritProvider {
-	gerritClient, err := client.NewClient(nil)
+	gerritClient, err := client.NewClient(nil, 5)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating gerrit client.")
 	}


### PR DESCRIPTION
Also start logging the headers of error responses from the API since these will be helpful for debugging.

/assign @listx 