### PR TITLE
config/jobs: bump go version for peribolos jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -8,7 +8,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./admin/update.sh
         args:
@@ -555,7 +555,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.18
+    - image: public.ecr.aws/docker/library/golang:1.20
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
The peribolos CI jobs are failing: https://testgrid.k8s.io/sig-contribex-org#post-peribolos
From the failure logs:
```
undefined: atomic.Pointer
```
`atomic.Pointer` was introduced in go1.19. This wasn't an issue since the commit of `kube-openapi` (the dep. that is encountering this bit of code) was at a point in time that didn't really use `atomic.Pointer`s. 

However, `kube-openapi` was bumped recently as part of: https://github.com/kubernetes/test-infra/commit/9be1ab79c2696e56b604a3304d5e7be911f018dd#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R216

This PR bumps the go version of images in peribolos to go1.20 so as to satisfy use of things like `atomic.Pointer`.

/assign @nikhita @Priyankasaggu11929 