### PR TITLE
Use dockerized build for arm64 based target instances

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -101,6 +101,7 @@ periodics:
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
       preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
     extra_refs:
@@ -127,12 +128,17 @@ periodics:
               value: "true"
             - name: BUILD_EKS_AMI_ARCH
               value: "arm64"
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
               value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
           resources:
             limits:
               cpu: 8
@@ -193,6 +199,7 @@ periodics:
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
       preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
     extra_refs:
@@ -221,12 +228,17 @@ periodics:
               value: "al2023"
             - name: BUILD_EKS_AMI_ARCH
               value: "arm64"
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
               value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
           resources:
             limits:
               cpu: 8
@@ -428,6 +440,7 @@ periodics:
       timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
     extra_refs:
@@ -456,12 +469,17 @@ periodics:
               value: "true"
             - name: BUILD_EKS_AMI_ARCH
               value: "arm64"
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
               value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
           resources:
             limits:
               cpu: 8
@@ -526,6 +544,7 @@ periodics:
       timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
     extra_refs:
@@ -556,12 +575,17 @@ periodics:
               value: "al2023"
             - name: BUILD_EKS_AMI_ARCH
               value: "arm64"
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
               value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
           resources:
             limits:
               cpu: 8


### PR DESCRIPTION
to run node e2e tests for ec2/eks arm64 instances