### PR TITLE
Generalize the GitHub client throttler and reuse it with the Gerrit client.

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -49,6 +49,7 @@ type options struct {
 	cookiefilePath   string
 	github           prowflagutil.GitHubOptions
 	githubEnablement prowflagutil.GitHubEnablementOptions
+	gerrit           prowflagutil.GerritOptions
 
 	config configflagutil.ConfigOptions
 
@@ -84,6 +85,9 @@ func (o *options) validate() error {
 	if o.gerritWorkers > 0 {
 		if o.cookiefilePath == "" {
 			logrus.Info("--cookiefile is not set, using anonymous authentication")
+		}
+		if err := o.gerrit.Validate(o.dryrun); err != nil {
+			return err
 		}
 	}
 
@@ -126,6 +130,7 @@ func (o *options) parseArgs(fs *flag.FlagSet, args []string) error {
 
 	o.config.AddFlags(fs)
 	o.github.AddFlags(fs)
+	o.gerrit.AddFlags(fs)
 	o.client.AddFlags(fs)
 	o.storage.AddFlags(fs)
 	o.instrumentationOptions.AddFlags(fs)
@@ -212,7 +217,7 @@ func main() {
 		orgRepoConfigGetter := func() *config.GerritOrgRepoConfigs {
 			return cfg().Gerrit.OrgReposConfig
 		}
-		gerritReporter, err := gerritreporter.NewReporter(orgRepoConfigGetter, o.cookiefilePath, mgr.GetClient())
+		gerritReporter, err := gerritreporter.NewReporter(orgRepoConfigGetter, o.cookiefilePath, mgr.GetClient(), o.gerrit.MaxQPS, o.gerrit.MaxBurst)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error starting gerrit reporter")
 		}

--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -132,10 +132,10 @@ type JobReport struct {
 }
 
 // NewReporter returns a reporter client
-func NewReporter(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, cookiefilePath string, pjclientset ctrlruntimeclient.Client) (*Client, error) {
+func NewReporter(orgRepoConfigGetter func() *config.GerritOrgRepoConfigs, cookiefilePath string, pjclientset ctrlruntimeclient.Client, maxQPS, maxBurst int) (*Client, error) {
 	// Initialize an empty client, the orgs/repos will be filled in by
 	// ApplyGlobalConfig later.
-	gc, err := client.NewClient(nil, 5)
+	gc, err := client.NewClient(nil, maxQPS, maxBurst)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/flagutil/gerrit.go
+++ b/prow/flagutil/gerrit.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import "flag"
+
+type GerritOptions struct {
+	GerritFields
+	defaults GerritFields
+}
+
+type GerritFields struct {
+	MaxQPS, MaxBurst int // No throttling when unset.
+}
+
+func (o *GerritOptions) SetDefaultThrottle(MaxQPS, MaxBurst int) {
+	o.defaults.MaxQPS = MaxQPS
+	o.defaults.MaxBurst = MaxBurst
+}
+
+func (o *GerritOptions) AddFlags(fs *flag.FlagSet) {
+	fs.IntVar(&o.MaxQPS, "gerrit-max-qps", o.defaults.MaxQPS, "The maximum allowed queries per second to the Gerrit API from this component.")
+	fs.IntVar(&o.MaxBurst, "gerrit-max-burst", o.defaults.MaxBurst, "The maximum allowed burst size of queries to the Gerrit API from this component.")
+}
+
+func (o *GerritOptions) Validate(dryrun bool) error {
+	return nil
+}

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -132,7 +132,7 @@ type LastSyncTracker interface {
 
 // NewController returns a new gerrit controller client
 func NewController(ctx context.Context, prowJobClient prowv1.ProwJobInterface, op io.Opener,
-	ca *config.Agent, cookiefilePath, tokenPathOverride, lastSyncFallback string, workerPoolSize int, instanceConcurrencyLimit uint, inRepoConfigCache *config.InRepoConfigCache) *Controller {
+	ca *config.Agent, cookiefilePath, tokenPathOverride, lastSyncFallback string, workerPoolSize int, maxQPS, maxBurst int, inRepoConfigCache *config.InRepoConfigCache) *Controller {
 
 	cfg := ca.Config
 	projectsOptOutHelpMap := map[string]sets.Set[string]{}
@@ -144,7 +144,7 @@ func NewController(ctx context.Context, prowJobClient prowv1.ProwJobInterface, o
 	if err := lastSyncTracker.Init(cfg().Gerrit.OrgReposConfig.AllRepos()); err != nil {
 		logrus.WithError(err).Fatal("Error initializing lastSyncFallback.")
 	}
-	gerritClient, err := client.NewClient(nil, instanceConcurrencyLimit)
+	gerritClient, err := client.NewClient(nil, maxQPS, maxBurst)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating gerrit client.")
 	}

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -29,7 +29,6 @@ import (
 	gerrit "github.com/andygrunwald/go-gerrit"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/io"
 )
@@ -293,14 +292,12 @@ func TestUpdateClients(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &Client{
-				handlers:                 make(map[string]*gerritInstanceHandler),
-				instanceConcurrencyLimit: 5,
+				handlers: make(map[string]*gerritInstanceHandler),
 			}
 			for instance, projects := range tc.existingInstances {
 				client.handlers[instance] = &gerritInstanceHandler{
-					instance:           instance,
-					projects:           projects,
-					concurrencyLimiter: semaphore.NewWeighted(5),
+					instance: instance,
+					projects: projects,
 				}
 			}
 
@@ -852,7 +849,6 @@ func TestQueryChange(t *testing.T) {
 
 	for _, tc := range testcases {
 		client := &Client{
-			instanceConcurrencyLimit: 5,
 			handlers: map[string]*gerritInstanceHandler{
 				"foo": {
 					instance: "foo",
@@ -862,8 +858,7 @@ func TestQueryChange(t *testing.T) {
 						instance: "foo",
 						comments: tc.comments,
 					},
-					concurrencyLimiter: semaphore.NewWeighted(5),
-					log:                logrus.WithField("host", "foo"),
+					log: logrus.WithField("host", "foo"),
 				},
 				"baz": {
 					instance: "baz",
@@ -872,8 +867,7 @@ func TestQueryChange(t *testing.T) {
 						changes:  tc.changes,
 						instance: "baz",
 					},
-					concurrencyLimiter: semaphore.NewWeighted(5),
-					log:                logrus.WithField("host", "baz"),
+					log: logrus.WithField("host", "baz"),
 				},
 			},
 		}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -32,7 +32,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/test-infra/ghproxy/ghcache"
+	"k8s.io/test-infra/prow/throttle"
 	"k8s.io/test-infra/prow/version"
 )
 
@@ -318,7 +318,7 @@ type delegate struct {
 	dry          bool
 	fake         bool
 	usesAppsAuth bool
-	throttle     throttler
+	throttle     ghThrottler
 	getToken     func() []byte
 	censor       func([]byte) []byte
 
@@ -416,92 +416,17 @@ type gqlClient interface {
 	forUserAgent(userAgent string) gqlClient
 }
 
-// throttler sets a ceiling on the rate of GitHub requests.
+// ghThrottler sets a ceiling on the rate of GitHub requests.
 // Configure with Client.Throttle().
 // It gets reconstructed whenever forUserAgent() is called,
-// whereas its *throttlerDelegate remains.
-type throttler struct {
+// whereas its *throttle.Throttler remains.
+type ghThrottler struct {
 	graph gqlClient
-	*throttlerDelegate
+	http  httpClient
+	*throttle.Throttler
 }
 
-type throttlerDelegate struct {
-	ticker   map[string]*time.Ticker
-	throttle map[string]chan time.Time
-	http     httpClient
-	slow     map[string]*int32 // Helps log once when requests start/stop being throttled
-	lock     sync.RWMutex
-}
-
-func (t *throttler) Wait(ctx context.Context, org string) error {
-	start := time.Now()
-	log := logrus.WithFields(logrus.Fields{"client": "github", "throttled": true})
-	defer func() {
-		waitTime := time.Since(start)
-		switch {
-		case waitTime > 15*time.Minute:
-			log.WithField("throttle-duration", waitTime.String()).Warn("Throttled clientside for more than 15 minutes")
-		case waitTime > time.Minute:
-			log.WithField("throttle-duration", waitTime.String()).Debug("Throttled clientside for more than a minute")
-		}
-	}()
-	t.lock.RLock()
-	defer t.lock.RUnlock()
-	if _, found := t.ticker[org]; !found {
-		org = throttlerGlobalKey
-	}
-	if _, hasThrottler := t.ticker[org]; !hasThrottler {
-		return nil
-	}
-
-	var more bool
-	select {
-	case _, more = <-t.throttle[org]:
-		// If we were throttled and the channel is now somewhat (25%+) full, note this
-		if len(t.throttle[org]) > cap(t.throttle[org])/4 && atomic.CompareAndSwapInt32(t.slow[org], 1, 0) {
-			log.Debug("Unthrottled")
-		}
-		if !more {
-			log.Debug("Throttle channel closed")
-		}
-		return nil
-	default: // Do not wait if nothing is available right now
-	}
-	// If this is the first time we are waiting, note this
-	if slow := atomic.SwapInt32(t.slow[org], 1); slow == 0 {
-		log.Debug("Throttled")
-	}
-
-	select {
-	case _, more = <-t.throttle[org]:
-		if !more {
-			log.Debug("Throttle channel closed")
-		}
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	return nil
-}
-
-const throttlerGlobalKey = "*"
-
-func (t *throttler) Refund(org string) {
-	t.lock.RLock()
-	defer t.lock.RUnlock()
-	if _, found := t.ticker[org]; !found {
-		org = throttlerGlobalKey
-	}
-	if _, hasThrottler := t.ticker[org]; !hasThrottler {
-		return
-	}
-	select {
-	case t.throttle[org] <- time.Now():
-	default:
-	}
-}
-
-func (t *throttler) Do(req *http.Request) (*http.Response, error) {
+func (t *ghThrottler) Do(req *http.Request) (*http.Response, error) {
 	org := extractOrgFromContext(req.Context())
 	if err := t.Wait(req.Context(), org); err != nil {
 		return nil, err
@@ -532,96 +457,37 @@ func (t *throttler) Do(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func (t *throttler) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
+func (t *ghThrottler) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
 	if err := t.Wait(ctx, extractOrgFromContext(ctx)); err != nil {
 		return err
 	}
 	return t.graph.QueryWithGitHubAppsSupport(ctx, q, vars, org)
 }
 
-func (t *throttler) MutateWithGitHubAppsSupport(ctx context.Context, m interface{}, input githubql.Input, vars map[string]interface{}, org string) error {
+func (t *ghThrottler) MutateWithGitHubAppsSupport(ctx context.Context, m interface{}, input githubql.Input, vars map[string]interface{}, org string) error {
 	if err := t.Wait(ctx, extractOrgFromContext(ctx)); err != nil {
 		return err
 	}
 	return t.graph.MutateWithGitHubAppsSupport(ctx, m, input, vars, org)
 }
 
-func (t *throttler) forUserAgent(userAgent string) gqlClient {
-	return &throttler{
-		graph:             t.graph.forUserAgent(userAgent),
-		throttlerDelegate: t.throttlerDelegate,
+func (t *ghThrottler) forUserAgent(userAgent string) gqlClient {
+	return &ghThrottler{
+		graph:     t.graph.forUserAgent(userAgent),
+		Throttler: t.Throttler,
 	}
 }
 
 // Throttle client to a rate of at most hourlyTokens requests per hour,
 // allowing burst tokens.
 func (c *client) Throttle(hourlyTokens, burst int, orgs ...string) error {
-	org := "*"
 	if len(orgs) > 0 {
 		if !c.usesAppsAuth {
 			return errors.New("passing an org to the throttler is only allowed when using github apps auth")
 		}
-		if len(orgs) > 1 {
-			return fmt.Errorf("may only pass one org for throttling, got %d", len(orgs))
-		}
-		org = orgs[0]
 	}
-	c.log("Throttle", hourlyTokens, burst, org)
-	c.throttle.lock.Lock()
-	defer c.throttle.lock.Unlock()
-	if hourlyTokens <= 0 || burst <= 0 { // Disable throttle
-		if c.throttle.throttle[org] != nil {
-			delete(c.throttle.throttle, org)
-			delete(c.throttle.slow, org)
-			c.throttle.ticker[org].Stop()
-			delete(c.throttle.ticker, org)
-		}
-		return nil
-	}
-	period := time.Hour / time.Duration(hourlyTokens) // Duration between token refills
-	ticker := time.NewTicker(period)
-	throttle := make(chan time.Time, burst)
-	for i := 0; i < burst; i++ { // Fill up the channel
-		throttle <- time.Now()
-	}
-	go func() {
-		// Before refilling, wait the amount of time it would have taken to refill the burst channel.
-		// This prevents granting too many tokens in the first hour due to the initial burst.
-		for i := 0; i < burst; i++ {
-			<-ticker.C
-		}
-		// Refill the channel
-		for t := range ticker.C {
-			select {
-			case throttle <- t:
-			default:
-			}
-		}
-	}()
-	if c.throttle.http == nil { // Wrap clients if we haven't already
-		c.throttle.http = c.client
-		c.throttle.graph = c.gqlc
-		c.client = &c.throttle
-		c.gqlc = &c.throttle
-	}
-
-	if c.throttle.ticker == nil {
-		c.throttle.ticker = map[string]*time.Ticker{}
-	}
-	c.throttle.ticker[org] = ticker
-
-	if c.throttle.throttle == nil {
-		c.throttle.throttle = map[string]chan time.Time{}
-	}
-	c.throttle.throttle[org] = throttle
-
-	if c.throttle.slow == nil {
-		c.throttle.slow = map[string]*int32{}
-	}
-	var i int32
-	c.throttle.slow[org] = &i
-
-	return nil
+	c.log("Throttle", hourlyTokens, burst, orgs)
+	return c.throttle.Throttle(hourlyTokens, burst, orgs...)
 }
 
 func (c *client) SetMax404Retries(max int) {
@@ -706,6 +572,14 @@ func NewAppsAuthClientWithFields(fields logrus.Fields, censor func([]byte) []byt
 	}.Default())
 }
 
+// This should only be called once when the client is created.
+func (c *client) wrapThrottler() {
+	c.throttle.http = c.client
+	c.throttle.graph = c.gqlc
+	c.client = &c.throttle
+	c.gqlc = &c.throttle
+}
+
 // NewClientFromOptions creates a new client from the options we expose. This method should be used over the more-specific ones.
 func NewClientFromOptions(fields logrus.Fields, options ClientOptions) (TokenGenerator, UserGenerator, Client, error) {
 	options = options.Default()
@@ -738,7 +612,7 @@ func NewClientFromOptions(fields logrus.Fields, options ClientOptions) (TokenGen
 			time:          &standardTime{},
 			client:        httpClient,
 			bases:         options.Bases,
-			throttle:      throttler{throttlerDelegate: &throttlerDelegate{}},
+			throttle:      ghThrottler{Throttler: &throttle.Throttler{}},
 			getToken:      options.GetToken,
 			censor:        options.Censor,
 			dry:           options.DryRun,
@@ -750,6 +624,9 @@ func NewClientFromOptions(fields logrus.Fields, options ClientOptions) (TokenGen
 		},
 	}
 	c.gqlc = c.gqlc.forUserAgent(c.userAgent())
+
+	// Wrap clients with the throttler
+	c.wrapThrottler()
 
 	var tokenGenerator func(_ string) (string, error)
 	var userGenerator func() (string, error)

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -32,7 +32,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/diff"
 
-	"k8s.io/test-infra/ghproxy/ghcache"
+	"k8s.io/test-infra/prow/throttle"
 	"k8s.io/test-infra/prow/version"
 )
 
@@ -65,11 +64,11 @@ func getClient(url string) *client {
 
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
-	return &client{
+	c := &client{
 		logger: logrus.NewEntry(logger),
 		delegate: &delegate{
 			time:     &testTime{},
-			throttle: throttler{throttlerDelegate: &throttlerDelegate{}},
+			throttle: ghThrottler{Throttler: &throttle.Throttler{}},
 			getToken: getToken,
 			censor: func(content []byte) []byte {
 				return content
@@ -86,6 +85,8 @@ func getClient(url string) *client {
 			maxSleepTime:  DefaultMaxSleepTime,
 		},
 	}
+	c.wrapThrottler()
+	return c
 }
 
 func TestRequestRateLimit(t *testing.T) {
@@ -2177,160 +2178,6 @@ func TestRemoveTeamMembershipBySlug(t *testing.T) {
 	}
 }
 
-func TestThrottle(t *testing.T) {
-	logrus.SetLevel(logrus.DebugLevel)
-	t.Parallel()
-	testCases := []struct {
-		name string
-
-		setupThrottling  func(t *testing.T, c *client)
-		expectThrottling bool
-	}{
-		{
-			name: "No apps auth, global throttler",
-			setupThrottling: func(t *testing.T, c *client) {
-				if err := c.Throttle(1, 2); err != nil {
-					t.Fatalf("calling Throttle failed: %v", err)
-				}
-			},
-			expectThrottling: true,
-		},
-		{
-			name: "Apps auth, our org is throttled",
-			setupThrottling: func(t *testing.T, c *client) {
-				c.usesAppsAuth = true
-				if err := c.Throttle(1, 2, "org"); err != nil {
-					t.Fatalf("calling Throttle failed: %v", err)
-				}
-			},
-			expectThrottling: true,
-		},
-		{
-			name: "Apps auth, different org is throttled, ours is not",
-			setupThrottling: func(t *testing.T, c *client) {
-				c.usesAppsAuth = true
-				if err := c.Throttle(1, 2, "something-else"); err != nil {
-					t.Fatalf("calling Throttle failed: %v", err)
-				}
-			},
-		},
-		{
-			name: "Apps auth, global throttler and throttler for our org",
-			setupThrottling: func(t *testing.T, c *client) {
-				c.usesAppsAuth = true
-				// Make sure this is not the budget we end up using.
-				if err := c.Throttle(100, 100); err != nil {
-					t.Fatalf("failed to set global throttler: %v", err)
-				}
-				if err := c.Throttle(1, 2, "org"); err != nil {
-					t.Fatalf("throttling our org failed: %v", err)
-				}
-			},
-			expectThrottling: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == "/repos/org/repo/issues/1/events" {
-					b, err := json.Marshal([]ListedIssueEvent{{Event: IssueActionClosed}})
-					if err != nil {
-						t.Fatalf("Didn't expect error: %v", err)
-					}
-					fmt.Fprint(w, string(b))
-				} else if r.URL.Path == "/repos/org/repo/issues/2/events" {
-					w.Header().Set(ghcache.CacheModeHeader, string(ghcache.ModeRevalidated))
-					b, err := json.Marshal([]ListedIssueEvent{{Event: IssueActionOpened}})
-					if err != nil {
-						t.Fatalf("Didn't expect error: %v", err)
-					}
-					fmt.Fprint(w, string(b))
-				} else {
-					t.Fatalf("Bad request path: %s", r.URL.Path)
-				}
-			}))
-			c := getClient(ts.URL)
-			tc.setupThrottling(t, c)
-			throttlerKey := throttlerGlobalKey
-			if c.usesAppsAuth {
-				throttlerKey = "org"
-			}
-
-			if c.client != &c.throttle {
-				t.Errorf("Bad client %v, expecting %v", c.client, &c.throttle)
-			}
-			var expectItems int
-			if tc.expectThrottling {
-				expectItems = 2
-			}
-			if n := len(c.throttle.throttle[throttlerKey]); n != expectItems {
-				t.Fatalf("Expected %d items in throttle channel, found %d", expectItems, n)
-			}
-			if n := cap(c.throttle.throttle[throttlerKey]); n != expectItems {
-				t.Fatalf("Expected throttle channel capacity of %d, found %d", expectItems, n)
-			}
-			check := func(events []ListedIssueEvent, err error, expectedAction IssueEventAction) {
-				t.Helper()
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if len(events) != 1 || events[0].Event != expectedAction {
-					t.Errorf("Expected one %q event, found: %v", string(expectedAction), events)
-				}
-				if tc.expectThrottling {
-					if len(c.throttle.throttle[throttlerKey]) != 1 {
-						t.Errorf("Expected one item in throttle channel, found %d", len(c.throttle.throttle[throttlerKey]))
-					}
-				} else if _, throttleChannelExists := c.throttle.throttle[throttlerKey]; throttleChannelExists {
-					t.Error("didn't expect throttling, but throttler existed")
-				}
-			}
-			events, err := c.ListIssueEvents("org", "repo", 1)
-			check(events, err, IssueActionClosed)
-			// The following 2 calls should be refunded.
-			events, err = c.ListIssueEvents("org", "repo", 2)
-			check(events, err, IssueActionOpened)
-			events, err = c.ListIssueEvents("org", "repo", 2)
-			check(events, err, IssueActionOpened)
-
-			// Check that calls are delayed while throttled.
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			go func() {
-				if _, err := c.ListIssueEvents("org", "repo", 1); err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if _, err := c.ListIssueEvents("org", "repo", 1); err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				cancel()
-			}()
-			slowed := false
-			for ctx.Err() == nil {
-				// Wait for the client to get throttled
-				val := c.throttle.slow[throttlerKey]
-				if val == nil || atomic.LoadInt32(val) == 0 {
-					continue
-				}
-				// Throttled, now add to the channel
-				slowed = true
-				select {
-				case c.throttle.throttle[throttlerKey] <- time.Now(): // Add items to the channel
-				case <-ctx.Done():
-				}
-			}
-			if slowed != tc.expectThrottling {
-				t.Errorf("expected throttling: %t, got throttled: %t", tc.expectThrottling, slowed)
-			}
-			if err := ctx.Err(); err != context.Canceled {
-				t.Errorf("Expected context cancellation did not happen: %v", err)
-			}
-		})
-	}
-}
-
 func TestGetBranches(t *testing.T) {
 	ts := simpleTestServer(t, "/repos/org/repo/branches", []Branch{
 		{Name: "master", Protected: false},
@@ -3247,8 +3094,8 @@ func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
 				}
 				return &http.Response{Body: io.NopCloser(&bytes.Buffer{})}, nil
 			}}
-			ghClient.(*client).client.(*http.Client).Transport = checkingRoundTripper
-			ghClient.(*client).gqlc.(*graphQLGitHubAppsAuthClientWrapper).Client = githubv4.NewClient(&http.Client{Transport: checkingRoundTripper})
+			ghClient.(*client).client.(*ghThrottler).http.(*http.Client).Transport = checkingRoundTripper
+			ghClient.(*client).gqlc.(*ghThrottler).graph.(*graphQLGitHubAppsAuthClientWrapper).Client = githubv4.NewClient(&http.Client{Transport: checkingRoundTripper})
 
 			// We don't care about the result at all, the verification happens via the roundTripper
 			_ = call()

--- a/prow/test/integration/test/gerrit_test.go
+++ b/prow/test/integration/test/gerrit_test.go
@@ -109,7 +109,7 @@ func TestGerrit(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			gerritClient, err := client.NewClient(map[string]map[string]*config.GerritQueryFilter{gerritServer: {"fakegerritserver": nil}}, 5)
+			gerritClient, err := client.NewClient(map[string]map[string]*config.GerritQueryFilter{gerritServer: {"fakegerritserver": nil}}, 0, 0)
 			if err != nil {
 				t.Fatalf("Failed creating gerritClient: %v", err)
 			}

--- a/prow/throttle/throttle.go
+++ b/prow/throttle/throttle.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package throttle
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const throttlerGlobalKey = "*"
+
+type Throttler struct {
+	ticker   map[string]*time.Ticker
+	throttle map[string]chan time.Time
+	slow     map[string]*int32 // Helps log once when requests start/stop being throttled
+	lock     sync.RWMutex
+}
+
+func (t *Throttler) Wait(ctx context.Context, org string) error {
+	start := time.Now()
+	log := logrus.WithFields(logrus.Fields{"throttled": true})
+	defer func() {
+		waitTime := time.Since(start)
+		switch {
+		case waitTime > 15*time.Minute:
+			log.WithField("throttle-duration", waitTime.String()).Warn("Throttled clientside for more than 15 minutes")
+		case waitTime > time.Minute:
+			log.WithField("throttle-duration", waitTime.String()).Debug("Throttled clientside for more than a minute")
+		}
+	}()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	if _, found := t.ticker[org]; !found {
+		org = throttlerGlobalKey
+	}
+	if _, hasThrottler := t.ticker[org]; !hasThrottler {
+		return nil
+	}
+
+	var more bool
+	select {
+	case _, more = <-t.throttle[org]:
+		// If we were throttled and the channel is now somewhat (25%+) full, note this
+		if len(t.throttle[org]) > cap(t.throttle[org])/4 && atomic.CompareAndSwapInt32(t.slow[org], 1, 0) {
+			log.Debug("Unthrottled")
+		}
+		if !more {
+			log.Debug("Throttle channel closed")
+		}
+		return nil
+	default: // Do not wait if nothing is available right now
+	}
+	// If this is the first time we are waiting, note this
+	if slow := atomic.SwapInt32(t.slow[org], 1); slow == 0 {
+		log.Debug("Throttled")
+	}
+
+	select {
+	case _, more = <-t.throttle[org]:
+		if !more {
+			log.Debug("Throttle channel closed")
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+func (t *Throttler) Refund(org string) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	if _, found := t.ticker[org]; !found {
+		org = throttlerGlobalKey
+	}
+	if _, hasThrottler := t.ticker[org]; !hasThrottler {
+		return
+	}
+	select {
+	case t.throttle[org] <- time.Now():
+	default:
+	}
+}
+
+// Throttle client to a rate of at most hourlyTokens requests per hour,
+// allowing burst tokens.
+func (t *Throttler) Throttle(hourlyTokens, burst int, orgs ...string) error {
+	org := "*"
+	if len(orgs) > 0 {
+		if len(orgs) > 1 {
+			return fmt.Errorf("may only pass one org for throttling, got %d", len(orgs))
+		}
+		org = orgs[0]
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if hourlyTokens <= 0 || burst <= 0 { // Disable throttle
+		if t.throttle[org] != nil {
+			delete(t.throttle, org)
+			delete(t.slow, org)
+			t.ticker[org].Stop()
+			delete(t.ticker, org)
+		}
+		return nil
+	}
+	period := time.Hour / time.Duration(hourlyTokens) // Duration between token refills
+	ticker := time.NewTicker(period)
+	throttle := make(chan time.Time, burst)
+	for i := 0; i < burst; i++ { // Fill up the channel
+		throttle <- time.Now()
+	}
+	go func() {
+		// Before refilling, wait the amount of time it would have taken to refill the burst channel.
+		// This prevents granting too many tokens in the first hour due to the initial burst.
+		for i := 0; i < burst; i++ {
+			<-ticker.C
+		}
+		// Refill the channel
+		for t := range ticker.C {
+			select {
+			case throttle <- t:
+			default:
+			}
+		}
+	}()
+
+	if t.ticker == nil {
+		t.ticker = map[string]*time.Ticker{}
+	}
+	t.ticker[org] = ticker
+
+	if t.throttle == nil {
+		t.throttle = map[string]chan time.Time{}
+	}
+	t.throttle[org] = throttle
+
+	if t.slow == nil {
+		t.slow = map[string]*int32{}
+	}
+	var i int32
+	t.slow[org] = &i
+
+	return nil
+}

--- a/prow/throttle/throttle_test.go
+++ b/prow/throttle/throttle_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package throttle
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestThrottle(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	t.Parallel()
+	testCases := []struct {
+		name string
+
+		setup []struct {
+			hourly int
+			burst  int
+			org    string
+		}
+		expectThrottling bool
+	}{
+		{
+			name: "global throttler",
+			setup: []struct {
+				hourly int
+				burst  int
+				org    string
+			}{
+				{1, 2, ""},
+			},
+			expectThrottling: true,
+		},
+		{
+			name: "our org is throttled",
+
+			setup: []struct {
+				hourly int
+				burst  int
+				org    string
+			}{
+				{1, 2, "org"},
+			},
+			expectThrottling: true,
+		},
+		{
+			name: "different org is throttled, ours is not",
+
+			setup: []struct {
+				hourly int
+				burst  int
+				org    string
+			}{
+				{1, 2, "something-else"},
+			},
+		},
+		{
+			name: "global throttler and throttler for our org",
+
+			setup: []struct {
+				hourly int
+				burst  int
+				org    string
+			}{
+				{100, 100, ""},
+				{1, 2, "org"},
+			},
+			expectThrottling: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			throttler := &Throttler{}
+			throttlerKey := throttlerGlobalKey
+			for _, setup := range tc.setup {
+				if setup.org != "" {
+					throttler.Throttle(setup.hourly, setup.burst, setup.org)
+					if setup.org == "org" {
+						throttlerKey = "org"
+					}
+				} else {
+					throttler.Throttle(setup.hourly, setup.burst)
+				}
+			}
+
+			var expectItems int
+			if tc.expectThrottling {
+				expectItems = 2
+			}
+			if n := len(throttler.throttle[throttlerKey]); n != expectItems {
+				t.Fatalf("Expected %d items in throttle channel, found %d", expectItems, n)
+			}
+			if n := cap(throttler.throttle[throttlerKey]); n != expectItems {
+				t.Fatalf("Expected throttle channel capacity of %d, found %d", expectItems, n)
+			}
+			check := func(err error) {
+				t.Helper()
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if tc.expectThrottling {
+					if len(throttler.throttle[throttlerKey]) != 1 {
+						t.Errorf("Expected one item in throttle channel, found %d", len(throttler.throttle[throttlerKey]))
+					}
+				} else if _, throttleChannelExists := throttler.throttle[throttlerKey]; throttleChannelExists {
+					t.Error("didn't expect throttling, but throttler existed")
+				}
+			}
+			err := throttler.Wait(context.Background(), "org")
+			check(err)
+			// The following two waits should be properly refunded.
+			err = throttler.Wait(context.Background(), "org")
+			throttler.Refund("org")
+			check(err)
+			err = throttler.Wait(context.Background(), "org")
+			throttler.Refund("org")
+			check(err)
+
+			// Check that calls are delayed while throttled.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			go func() {
+				if err := throttler.Wait(context.Background(), "org"); err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if err := throttler.Wait(context.Background(), "org"); err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				cancel()
+			}()
+			slowed := false
+			for ctx.Err() == nil {
+				// Wait for the client to get throttled
+				val := throttler.slow[throttlerKey]
+				if val == nil || atomic.LoadInt32(val) == 0 {
+					continue
+				}
+				// Throttled, now add to the channel
+				slowed = true
+				select {
+				case throttler.throttle[throttlerKey] <- time.Now(): // Add items to the channel
+				case <-ctx.Done():
+				}
+			}
+			if slowed != tc.expectThrottling {
+				t.Errorf("expected throttling: %t, got throttled: %t", tc.expectThrottling, slowed)
+			}
+			if err := ctx.Err(); err != context.Canceled {
+				t.Errorf("Expected context cancellation did not happen: %v", err)
+			}
+		})
+	}
+}

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -104,6 +104,7 @@ func NewGerritController(
 	logger *logrus.Entry,
 	configOptions configflagutil.ConfigOptions,
 	cookieFilePath string,
+	maxQPS, maxBurst int,
 ) (*Controller, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
@@ -124,7 +125,7 @@ func NewGerritController(
 	if err != nil {
 		return nil, fmt.Errorf("failed creating inrepoconfig cache getter: %v", err)
 	}
-	provider := newGerritProvider(logger, cfgAgent.Config, mgr.GetClient(), cacheGetter, cookieFilePath, "")
+	provider := newGerritProvider(logger, cfgAgent.Config, mgr.GetClient(), cacheGetter, cookieFilePath, "", maxQPS, maxBurst)
 	syncCtrl, err := newSyncController(ctx, logger, mgr, provider, cfgAgent.Config, gc, hist, false, statusUpdate)
 	if err != nil {
 		return nil, err
@@ -158,8 +159,9 @@ func newGerritProvider(
 	inRepoConfigCache *config.InRepoConfigCache,
 	cookiefilePath string,
 	tokenPathOverride string,
+	maxQPS, maxBurst int,
 ) *GerritProvider {
-	gerritClient, err := client.NewClient(nil, 5)
+	gerritClient, err := client.NewClient(nil, maxQPS, maxBurst)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating gerrit client.")
 	}

--- a/prow/tide/gerrit_test.go
+++ b/prow/tide/gerrit_test.go
@@ -290,7 +290,7 @@ func TestQuery(t *testing.T) {
 				},
 			}
 
-			fc := newGerritProvider(logrus.WithContext(context.Background()), func() *config.Config { return &cfg }, nil, nil, "", "")
+			fc := newGerritProvider(logrus.WithContext(context.Background()), func() *config.Config { return &cfg }, nil, nil, "", "", 0, 0)
 			fgc := newFakeGerritClient()
 
 			for instance, projs := range tc.prs {


### PR DESCRIPTION
/assign @listx @airbornepony 
/sig testing

A few things to note before reviewing:
- I made a separate commit to extract the throttling logic out of the GitHub client. I recommend reviewing that commit separately for ease of review.
-  There is no concept of refunding a rate limit token for Gerrit like there is for GitHub so this is not used by the Gerrit client.
- Gerrit quotas are not per org they are global. With GitHub app auth there are per org quotas, but with other forms of auth there is just a global quota for the user. Our throttling logic supports both so no changes are needed, I'm just noting that the per org quotas are only ever used in the GitHub case.
- Units of QPS will be used to configure Gerrit throttling rather than hourly tokens (queries per hour) with GitHub.

A few things to note before deploying this:
- This throttling mechanism replaces the `--instance-concurrency-limit` **without migration** so we'll need to remove that flag at the same time we bump the gerrit component to pick up this change. This is technically backwards incompatible, but I'm confident we're the only ones using this flag given that we just added it last week as an emergency mitigation.
- I have not set default values for the max QPS or burst so throttling will be disabled by default. We'll need to set these values for `gerrit`, `crier`, and `tide`. We should probably include this in the bump that introduces this change and removes the old concurrency flag. In particular we should grant most of our quota to `gerrit`, some to `crier` and minimal to `tide` to start off.