### PR TITLE
bump resource limits for cli-utils stress test

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -81,11 +81,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: "16Gi"
+            cpu: 6000m
           limits:
-            memory: "8000Mi"
-            cpu: 4000m
+            memory: "16Gi"
+            cpu: 6000m
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master-stress


### PR DESCRIPTION
These limits were added with a recent change, and this presubmit is now failing with the current configuration (e.g. Pod deleted unexpectedly). This change doubles the resource limits in an attempt to get the job passing again.

Related change: https://github.com/kubernetes/test-infra/pull/29742