### PR TITLE
Bump Go version for cli-utils build

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:


### PR DESCRIPTION
Kubernetes v1.27 requires Go 1.20, so use that version. Will be needed for/after https://github.com/kubernetes-sigs/cli-utils/pull/619.

/assign @mortent