### PR TITLE
rebuild alpine image

### DIFF
--- a/images/alpine/cloudbuild.yaml
+++ b/images/alpine/cloudbuild.yaml
@@ -17,5 +17,6 @@ steps:
     - add-tag
     - gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
     - gcr.io/$PROJECT_ID/alpine:latest
+
 substitutions:
   _GIT_TAG: '12345'


### PR DESCRIPTION
It's been over a year since we last built this image (latest tag says v20220505-bca727ee56 at
https://console.cloud.google.com/gcr/images/k8s-prow/GLOBAL/alpine).

This NOP change should force a rebuild, just like the NOP change that was done in https://github.com/kubernetes/test-infra/pull/24010.

/cc @airbornepony 