### PR TITLE
Bump alpine image to latest v20230718-8d3170488d

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,54 +1,54 @@
 # Distroless images:
 # defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
-  k8s.io/test-infra/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/deck: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
-  k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
   k8s.io/test-infra/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/gangway: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/grandmatriarch: gcr.io/cloud-builders/gcloud@sha256:5b49dfb5e366dd75a5fc6d5d447be584f8f229c5a790ee0c3b0bd0cf70ec41dd
-  k8s.io/test-infra/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/hook: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
-  k8s.io/test-infra/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/initupload: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/cmd/invitations-accepter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/invitations-accepter: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
-  k8s.io/test-infra/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/sub: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/tide: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/cmd/tot: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/tot: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
-  k8s.io/test-infra/prow/cmd/admission: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/mkpj: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/mkpod: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/cmd/pipeline: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/prow/external-plugins/needs-rebase: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/admission: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/prow/cmd/mkpj: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/prow/cmd/mkpod: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/prow/cmd/pipeline: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/prow/external-plugins/needs-rebase: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   # external
   k8s.io/test-infra/prow/external-plugins/cherrypicker: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/prow/external-plugins/refresh: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/ghproxy: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/label_sync: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/robots/commenter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/external-plugins/refresh: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/ghproxy: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/label_sync: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/robots/commenter: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-prow/git:v20220215-ddc3ad9
-  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
-  k8s.io/test-infra/gencred: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
+  k8s.io/test-infra/gencred: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   # prow integration test
-  k8s.io/test-infra/prow/test/integration/cmd/fakeghserver: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/test/integration/cmd/fakeghserver: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/test/integration/cmd/fakegitserver: gcr.io/k8s-prow/git:v20220523-6026203ca9
   k8s.io/test-infra/prow/test/integration/cmd/fakepubsub: google/cloud-sdk:389.0.0
-  k8s.io/test-infra/prow/test/integration/cmd/fakegcsserver: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/test/integration/cmd/fakegcsserver: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
 
 # https://pkg.go.dev/cmd/link
 # -s: omit symbol/debug info


### PR DESCRIPTION
Advance to a newer version which closes several vulnerabilities.