### PR TITLE
kops-jobs: reduce jobs to fit on EKS nodes

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -23,11 +23,11 @@ presubmits:
         - "version-dist"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
           limits:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: build
@@ -54,11 +54,11 @@ presubmits:
         - "test"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
           limits:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: test
@@ -326,11 +326,11 @@ presubmits:
         - "govet"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
           limits:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-govet
@@ -355,11 +355,11 @@ presubmits:
         - "verify-golangci-lint"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
           limits:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-golangci-lint
@@ -383,11 +383,11 @@ presubmits:
         - "verify-hashes"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
           limits:
-            memory: "16Gi"
-            cpu: 16
+            memory: "64Gi"
+            cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-hashes


### PR DESCRIPTION
The CI nodes are 16 vCPU and 128 Gi, and so because of overhead we
can't schedule if we request 16 cores.

Reduce the vCPU requirement, and also increase the memory so we're
using the proportional amount.
