### PR TITLE
chore: set windows machine pool count to 2 for multi-slb test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -597,6 +597,8 @@ presubmits:
               value: "false"
             - name: TEST_MULTI_SLB
               value: "true"
+            - name: WINDOWS_WORKER_MACHINE_COUNT
+              value: "2"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz


### PR DESCRIPTION
chore: set windows machine pool count to 2 for multi-slb test

/area provider/azure
/kind cleanup