### PR TITLE
Remove k/noderesourcetopology-api from tide config

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -651,7 +651,6 @@ tide:
     - kubernetes/metrics
     - kubernetes/mount-utils
     - kubernetes/node-api
-    - kubernetes/noderesourcetopology-api
     - kubernetes/pod-security-admission
     - kubernetes/sample-apiserver
     - kubernetes/sample-cli-plugin


### PR DESCRIPTION
Missed removing this entry when cleaning up noderesourcetopology-api
ref: https://github.com/kubernetes/org/issues/4224