### PR TITLE
reign in cli-utils stress test resource limits

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -81,11 +81,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "32Gi"
-            cpu: 12
+            memory: "8000Mi"
+            cpu: 8000m
           limits:
-            memory: "32Gi"
-            cpu: 12
+            memory: "8000Mi"
+            cpu: 8000m
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master-stress


### PR DESCRIPTION
Based on observations from the tests after increasing the limits, this job typically caps out around 6-7 CPU and 1GB memory.