### PR TITLE
e2e-node: use systemd as cgroup driver on arm64 e2e-node jobs.

### DIFF
--- a/jobs/e2e_node/arm/image-config-serial.yaml
+++ b/jobs/e2e_node/arm/image-config-serial.yaml
@@ -5,6 +5,6 @@ images:
   ubuntu:
     image_family: pipeline-1-25-arm64
     machine: t2a-standard-2 # These tests need a lot of memory
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
     project: ubuntu-os-gke-cloud
 


### PR DESCRIPTION
Use systemd on arm64 e2e-node jobs.

Signed-off-by: Ruquan Zhao <ruquan.zhao@arm.com>