### PR TITLE
add containerd log for alpha features ci

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -351,6 +351,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
         - --env=ENABLE_APISERVER_TRACING=true


### PR DESCRIPTION
https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/114847/pull-kubernetes-e2e-gce-cos-alpha-features/1681923570676011008/artifacts/e2e-1ad2daaa03-92f64-minion-group-1wnj/ 
included `docker.log` but no `containerd.log`
