### PR TITLE
update timeout for publishing bot tests

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
   - name: pull-publishing-bot-test-kubernetes-master
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 3h
     annotations:
       testgrid-dashboards: sig-release-publishing-bot
       testgrid-tab-name: pull-publishing-bot-test-k8s-master


### PR DESCRIPTION
update the timeout for pull-publishing-bot-test-kubernetes-master to 3h as the default timeout is not enough to successfully complete the job.

Fixes failures like https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/publishing-bot/359/pull-publishing-bot-test-kubernetes-master/1682276535282700288