### PR TITLE
CAPA: Use latest image for 'pull-cluster-api-provider-aws-e2e' tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -271,7 +271,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.25
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
For e2e tests in the main branch we should use latest 'gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27' images, as they contain the newest golang version.

This should fix the e2e tests [failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/4398/pull-cluster-api-provider-aws-e2e/1682359472258813952) in https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4398