### PR TITLE
Pull containerd binaries from `gs://k8s-staging-cri-tools` bucket

### DIFF
--- a/jobs/e2e_node/containerd/containerd-main-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-main-presubmit/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/main'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/main'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-main/env
+++ b/jobs/e2e_node/containerd/containerd-main/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/main'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-release-1.6-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.6-presubmit/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-release-1.6/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.6/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.6'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/release-1.6'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-release-1.7/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.7/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.7'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/release-1.7'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'


### PR DESCRIPTION
/cc @akhilerm @dims @SergeyKanzhelev 

Part of https://github.com/kubernetes/test-infra/issues/29995

The bucket is still missing release binaries jobs, it will be populated in 24 hours.

```
 mahamed  REDACTED  ~  $  gsutil ls gs://k8s-staging-cri-tools/containerd
gs://k8s-staging-cri-tools/containerd/main/
```
