### PR TITLE
Add presubmits for external-dns

### DIFF
--- a/config/jobs/kubernetes-sigs/external-dns/OWNERS
+++ b/config/jobs/kubernetes-sigs/external-dns/OWNERS
@@ -1,0 +1,20 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/HEAD/contributors/guide/owners.md
+# Synced to the root OWNERS file in sigs.k8s.io/external-dns as of 07/21/23
+
+approvers:
+  - raffo
+  - njuettner
+  - seanmalloy
+  - szuecs
+
+reviewers:
+  - johngmyers
+  - njuettner
+  - raffo
+  - seanmalloy
+  - szuecs
+
+emeritus_approvers:
+  - hjacobs
+  - linki

--- a/config/jobs/kubernetes-sigs/external-dns/external-dns-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/external-dns/external-dns-presubmits.yaml
@@ -1,0 +1,54 @@
+presubmits:
+  kubernetes-sigs/external-dns:
+  - name: pull-external-dns-lint
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - lint
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: sig-network-external-dns
+      testgrid-tab-name: lint
+      description: external-dns code lint
+      testgrid-num-columns-recent: '30'
+  - name: pull-external-dns-unit-test
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: sig-network-external-dns
+      testgrid-tab-name: unit test
+      description: external-dns unit tests
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
This should address the issue where a PR merging broke the build because it was only tested against the branch, not the proposed merge result.

Not making it blocking until it's known to work.

/cc @szuecs @Raffo 