### PR TITLE
fix: move `cli-utils-presubmit-master-stress` to `k8s-infra-prow-build`

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -59,7 +59,7 @@ presubmits:
       testgrid-tab-name: cli-utils-presubmit-master-e2e
       description: cli-utils presubmit e2e tests on master branch
   - name: cli-utils-presubmit-master-stress
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/cli-utils


### PR DESCRIPTION
This change moves the `k-sig/cli-utils cli-utils-presubmit-master-stress` job from the EKS cluster to the GKE cluster. 

ref: https://github.com/kubernetes/test-infra/pull/29742#issuecomment-1646091740

/cc @sdowell 