### PR TITLE
migrate `usage-metrics-collector` to `eks-prow-build-cluster`

### DIFF
--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-usage-metrics-collector-test
+  cluster: eks-prow-build-cluster
   interval: 8h
   decorate: true
   extra_refs:
@@ -17,7 +18,7 @@ periodics:
         resources:
           requests:
             cpu: 1
-            memory: "1Gi"
+            memory: "2Gi"
           limits:
             cpu: 1
             memory: "2Gi"

--- a/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/usage-metrics-collector/usage-metrics-collector-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/usage-metrics-collector:
   - name: pull-usage-metrics-collector-verify
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/usage-metrics-collector
     always_run: true
@@ -12,10 +13,18 @@ presubmits:
         - runner.sh
         - make
         - verify
+        resources:
+          requests:
+            cpu: 1
+            memory: "2Gi"
+          limits:
+            cpu: 1
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-instrumentation-usage-metrics-collector
       testgrid-tab-name: pr-verify
   - name: pull-usage-metrics-collector-test
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/usage-metrics-collector
     always_run: true
@@ -30,7 +39,7 @@ presubmits:
         resources:
           requests:
             cpu: 1
-            memory: "1Gi"
+            memory: "2Gi"
           limits:
             cpu: 1
             memory: "2Gi"


### PR DESCRIPTION
Migrate jobs to the eks cluster for the community migration.

ref: https://github.com/kubernetes/test-infra/issues/29722