### PR TITLE
migrate `structured-merge-diff` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-structured-merge-diff-test
+  cluster: eks-prow-build-cluster
   interval: 12h
   labels:
     preset-service-account: "true"
@@ -18,10 +19,18 @@ periodics:
       - test
       - -race
       - ./...
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-api-machinery-structured-merge-diff
     testgrid-tab-name: ci-test
 - name: ci-structured-merge-diff-gofmt
+  cluster: eks-prow-build-cluster
   interval: 12h
   labels:
     preset-service-account: "true"
@@ -38,6 +47,13 @@ periodics:
       - bash
       - -c
       - test -z "$({ find . -name "*.go" | grep -v "\\/vendor\\/" | xargs gofmt -s -d | tee /dev/stderr; })"
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-api-machinery-structured-merge-diff
     testgrid-tab-name: ci-gofmt

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/structured-merge-diff:
   - name: pull-structured-merge-diff-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
     always_run: true
@@ -15,11 +16,19 @@ presubmits:
         - test
         - -race
         - ./...
+        resources:
+          requests:
+            cpu: "6000m"
+            memory: "6Gi"
+          limits:
+            cpu: "6000m"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-api-machinery-structured-merge-diff
       testgrid-tab-name: pr-test
       testgrid-num-columns-recent: '30'
   - name: pull-structured-merge-diff-vet
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
     always_run: true
@@ -33,11 +42,19 @@ presubmits:
         args:
         - vet
         - ./...
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-structured-merge-diff
       testgrid-tab-name: pr-vet
       testgrid-num-columns-recent: '30'
   - name: pull-structured-merge-diff-gofmt
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
     always_run: true
@@ -50,11 +67,19 @@ presubmits:
         - bash
         - -c
         - test -z "$({ find . -name "*.go" | grep -v "\\/vendor\\/" | xargs gofmt -s -d | tee /dev/stderr; })"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-structured-merge-diff
       testgrid-tab-name: pr-gofmt
       testgrid-num-columns-recent: '30'
   - name: pull-structured-merge-diff-benchmark
+    cluster: eks-prow-build-cluster
     always_run: false
     skip_report: true
     decorate: true


### PR DESCRIPTION
This PR moves the structured-merge-diff jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722