### PR TITLE
migrate `sig-store-lib-external-provisioner` jobs to eks

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/sig-storage-lib-external-provisioner:
   - name: pull-sig-storage-lib-external-provisioner-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/sig-storage-lib-external-provisioner
@@ -14,8 +15,16 @@ presubmits:
         command:
         # Plain make runs also verify
         - make
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
   - name: pull-sig-storage-lib-external-provisioner-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/sig-storage-lib-external-provisioner
@@ -30,3 +39,10 @@ presubmits:
         - make
         args:
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the sig-store-lib-external-provisioner jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722