### PR TITLE
migrate `scheduler-plugins` to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-master
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-master
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-master
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-gofmt-release-1-18
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify-gofmt
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-18
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-18
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-18
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-gofmt-release-1-19
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify-gofmt
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-19
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-19
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-19
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.20.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-gofmt-release-1-20
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify-gofmt
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-20
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-20
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-20
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.21.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-gofmt-release-1-21
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-21
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-21
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-21
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.22.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-gofmt-release-1-22
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-22
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-22
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-22
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.23.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-release-1-23
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-23
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-23
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-23
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.24.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-release-1-24
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-24
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-24
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-24
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.25.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-release-1-25
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-25
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-25
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-25
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.26.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/scheduler-plugins:
   - name: pull-scheduler-plugins-verify-release-1-26
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -14,7 +15,15 @@ presubmits:
         - make
         args:
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-verify-build-release-1-26
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -27,7 +36,15 @@ presubmits:
         - make
         args:
         - build
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-unit-test-release-1-26
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -40,7 +57,15 @@ presubmits:
         - make
         args:
         - unit-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-scheduler-plugins-integration-test-release-1-26
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -53,3 +78,10 @@ presubmits:
         - make
         args:
         - integration-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the scheduler-plugins  jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722