### PR TITLE
entrypoint: propagate wrapped error

### DIFF
--- a/prow/entrypoint/options.go
+++ b/prow/entrypoint/options.go
@@ -62,6 +62,10 @@ type Options struct {
 	// Primarily useful in case a subsequent entrypoint will read this entrypoint's marker
 	AlwaysZero bool `json:"always_zero,omitempty"`
 
+	// PropagateErrorCode will cause entrypoint to propagate the error code from its child.
+	// Primarily useful in case you want to exit with a specific error code.
+	PropagateErrorCode bool `json:"propagate_error_code,omitempty"`
+
 	CopyModeOnly bool   `json:"copy_mode_only,omitempty"`
 	CopyDst      string `json:"copy_dst,omitempty"`
 
@@ -73,6 +77,9 @@ type Options struct {
 func (o *Options) Validate() error {
 	if len(o.Args) == 0 {
 		return errors.New("no process to wrap specified")
+	}
+	if o.PropagateErrorCode && o.AlwaysZero {
+		return errors.New("cannot propagate error code and always exit zero")
 	}
 
 	return o.Options.Validate()
@@ -103,6 +110,7 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.StringVar(&o.ArtifactDir, "artifact-dir", "", "directory where test artifacts should be placed for upload to persistent storage")
 	flags.BoolVar(&o.CopyModeOnly, "copy-mode-only", false, "If true, copy current binary to /tools/entrypoint, dst can be overridden by --copy-destination")
 	flags.StringVar(&o.CopyDst, "copy-destination", defaultCopyDst, "Must be used with --copy-mode-only, default is /tools/entrypoint")
+	flags.BoolVar(&o.PropagateErrorCode, "propagate-error-code", false, "If true, propagate the error code from the child process")
 	o.Options.AddFlags(flags)
 }
 

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -540,7 +540,7 @@ func entrypointLocation(tools coreapi.VolumeMount) string {
 }
 
 // InjectEntrypoint will make the entrypoint binary in the tools volume the container's entrypoint, which will output to the log volume.
-func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, prefix, previousMarker string, exitZero bool, log, tools coreapi.VolumeMount) (*wrapper.Options, error) {
+func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, prefix, previousMarker string, propagateErrorCode bool, exitZero bool, log, tools coreapi.VolumeMount) (*wrapper.Options, error) {
 	wrapperOptions := &wrapper.Options{
 		Args:          append(c.Command, c.Args...),
 		ContainerName: c.Name,
@@ -550,12 +550,13 @@ func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, 
 	}
 	// TODO(fejta): use flags
 	entrypointConfigEnv, err := entrypoint.Encode(entrypoint.Options{
-		ArtifactDir:    artifactsDir(log),
-		GracePeriod:    gracePeriod,
-		Options:        wrapperOptions,
-		Timeout:        timeout,
-		AlwaysZero:     exitZero,
-		PreviousMarker: previousMarker,
+		ArtifactDir:        artifactsDir(log),
+		GracePeriod:        gracePeriod,
+		Options:            wrapperOptions,
+		Timeout:            timeout,
+		PropagateErrorCode: propagateErrorCode,
+		AlwaysZero:         exitZero,
+		PreviousMarker:     previousMarker,
 	})
 	if err != nil {
 		return nil, err
@@ -772,8 +773,9 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 	}
 
 	const (
-		previous = ""
-		exitZero = false
+		previous           = ""
+		exitZero           = false
+		propagateErrorCode = false
 	)
 	var secretVolumeMounts []coreapi.VolumeMount
 	var wrappers []wrapper.Options
@@ -783,7 +785,7 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 		if len(spec.Containers) == 1 {
 			prefix = ""
 		}
-		wrapperOptions, err := InjectEntrypoint(&spec.Containers[i], pj.Spec.DecorationConfig.Timeout.Get(), pj.Spec.DecorationConfig.GracePeriod.Get(), prefix, previous, exitZero, logMount, toolsMount)
+		wrapperOptions, err := InjectEntrypoint(&spec.Containers[i], pj.Spec.DecorationConfig.Timeout.Get(), pj.Spec.DecorationConfig.GracePeriod.Get(), prefix, previous, propagateErrorCode, exitZero, logMount, toolsMount)
 		if err != nil {
 			return fmt.Errorf("wrap container: %w", err)
 		}


### PR DESCRIPTION
This PR enables the `entrypoint` to propagate the error code from its child, when receiving SIGTERM.
Primarily useful in case you want to exit with a specific error code, not the default 130.