### PR TITLE
migrate kubetest2 GCP jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kubetest2:
   - name: gce-build-up-down
+    cluster: k8s-infra-prow-build
     decorate: true
     run_if_changed: "kubetest2-gce/.*"
     labels:
@@ -20,5 +21,12 @@ presubmits:
         - "runner.sh"
         args:
         - "./kubetest2-gce/ci-tests/buildupdown.sh"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-gke-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-gke-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kubetest2:
   - name: pull-kubetest2-gke-up-down-singlecluster
+    cluster: k8s-infra-prow-build
     decorate: true
     run_if_changed: "kubetest2-gke/.*"
     labels:
@@ -15,7 +16,15 @@ presubmits:
         - "./kubetest2-gke/ci-tests/buildupdown.sh"
         - "--cluster-topology"
         - "singlecluster"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-kubetest2-gke-up-down-multicluster
+    cluster: k8s-infra-prow-build
     decorate: true
     run_if_changed: "kubetest2-gke/.*"
     labels:
@@ -30,3 +39,10 @@ presubmits:
         - "./kubetest2-gke/ci-tests/buildupdown.sh"
         - "--cluster-topology"
         - "multicluster"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the kubetest2 jobs from the default cluster to the community owned GCP cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722