### PR TITLE
capz: update maintainers and reviewers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -4,12 +4,14 @@ approvers:
 - CecileRobertMichon
 - jackfrancis
 - mboersma
-- marosset
-- jsturtevant
+- nojnhuh
+- sonasingh46
 reviewers:
 - Jont828
+- jsturtevant
+- marosset
 - nawazkh
-- nojnhuh
+- willie-yao
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Updates maintainers and reviewers of the cluster-api-provider-azure (CAPZ) project to match its current [`OWNERS_ALIASES`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES).

(One change is still pending but soon to merge, so I opened this clerical PR now because they're not strictly linked.)

Note that @jsturtevant and @marosset were listed as maintainers here but are reviewers in CAPZ, so this effectively "demotes" them for this part of test-infra. Was there a (perhaps Windows-related) reason for this discrepency? Happy to leave them as maintainers if that's preferable.