### PR TITLE
fix: fit cli-utils stress test on k8s-infra

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -82,10 +82,10 @@ presubmits:
         resources:
           requests:
             memory: "8000Mi"
-            cpu: 8000m
+            cpu: 7000m
           limits:
             memory: "8000Mi"
-            cpu: 8000m
+            cpu: 7000m
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master-stress


### PR DESCRIPTION
The cli-utils stress test was recently switched back to the k8s-infra prow cluster. This cluster has smaller nodes available compared to the EKS cluster, which was resulting in this job being unschedulable. Other jobs using this cluster request up to 7 CPU, so this should fit on a node in the k8s-infra cluster.