### PR TITLE
migrate `kubebuilder-declarative-pattern` to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kubebuilder-declarative-pattern:
   - name: pull-declarative-test
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/kubebuilder-declarative-pattern
     always_run: true
@@ -9,3 +10,10 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         command:
         - "./hack/ci/test.sh"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the kubebuilder-declarative-pattern jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722