### PR TITLE
migrate `kube-scheduler-simulator` to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/kube-scheduler-simulator:
   - name: pull-kube-scheduler-simulator-backend-lint
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kube-scheduler-simulator-backend-lint
@@ -21,7 +22,15 @@ presubmits:
           make tools &&
           export PATH="${PATH}:${GOPATH}/bin" &&
           make lint
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-kube-scheduler-simulator-frontend-lint
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kube-scheduler-simulator-frontend-lint
@@ -40,3 +49,10 @@ presubmits:
           cd ./web &&
           yarn install --frozen-lockfile &&
           yarn run lint
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/kube-scheduler-simulator:
   - name: pull-kube-scheduler-simulator-backend-unit-test
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kube-scheduler-simulator-backend-unit-test
@@ -19,3 +20,10 @@ presubmits:
         - >
           make mod-download &&
           make test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the kube-scheduler-simulator jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722