### PR TITLE
Skip Network tests in `pull-kubernetes-e2e-gce-cos-alpha-features`

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -360,7 +360,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=api/all=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-cos-alpha-features
-        - --test_args=--ginkgo.focus=\[Feature:(WatchList|AdmissionWebhookMatchConditions|GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|CSINodeExpandSecret)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:(WatchList|AdmissionWebhookMatchConditions|GRPCContainerProbe|InPlacePodVerticalScaling|ProbeTerminationGracePeriod|APIServerTracing|APISelfSubjectReview|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|StatefulSetMinReadySeconds|ProxyTerminatingEndpoints|NodeOutOfServiceVolumeDetach|CSINodeExpandSecret)\] --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         resources:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/30127#issuecomment-1648297243

Currently, `pull-kubernetes-e2e-gce-cos-alpha-features` are timed out almost always.
This PR makes `pull-kubernetes-e2e-gce-cos-alpha-features` skip Network tests to decrease the total amount of time of the job.

/assign @aojea 