### PR TITLE
Fix label_sync error message for `DoUpdates`

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -693,7 +693,7 @@ func (ru RepoUpdates) DoUpdates(org string, gc client) error {
 		for updateErr := range errChan {
 			updateErrs = append(updateErrs, updateErr)
 		}
-		overallErr = fmt.Errorf("failed to list labels: %v", updateErrs)
+		overallErr = fmt.Errorf("failed to update labels: %v", updateErrs)
 	}
 
 	return overallErr


### PR DESCRIPTION
When `RepoUpdates.DoUpdates` fails, it should return an error
stating that the program failed to "update" the labels.