### PR TITLE
fix: migrate `aws-load-balancer-controller-unit-test` to GCP cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       description: aws load balancer controller code lint
       testgrid-num-columns-recent: '30'
   - name: pull-aws-load-balancer-controller-unit-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     always_run: true
     decorate: true
     labels:


### PR DESCRIPTION
Partial revert of https://github.com/kubernetes/test-infra/pull/29879 to move the `aws-load-balancer-controller-unit-test` to the gcp cluster. The `k8s-aws-alb-ingress-coveralls-token` secret should be on that cluster per https://github.com/kubernetes/test-infra/issues/27861.

fixes: https://github.com/kubernetes/test-infra/issues/30027