### PR TITLE
Set the `IMAGE_CONFIG_DIR` value on all ec2 node-e2e jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -180,6 +180,8 @@ periodics:
               value: "true"
             - name: BUILD_EKS_AMI_OS
               value: "al2023"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
@@ -232,6 +234,8 @@ periodics:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
@@ -281,6 +285,8 @@ periodics:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
@@ -331,6 +337,8 @@ periodics:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
@@ -374,6 +382,10 @@ periodics:
           env:
             - name: FOCUS
               value: \[Serial\]
+            - name: IMAGE_CONFIG_DIR
+              value: config
+            - name: IMAGE_CONFIG_FILE
+              value: aws-instance.yaml
             - name: SKIP
               value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
             - name: TEST_ARGS
@@ -420,6 +432,8 @@ periodics:
               value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
             - name: BUILD_EKS_AMI
               value: "true"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
@@ -473,6 +487,8 @@ periodics:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
@@ -524,6 +540,8 @@ periodics:
               value: "true"
             - name: BUILD_EKS_AMI_OS
               value: "al2023"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
@@ -579,6 +597,8 @@ periodics:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -116,6 +116,10 @@ presubmits:
           env:
             - name: FOCUS
               value: NodeConformance
+            - name: IMAGE_CONFIG_DIR
+              value: config
+            - name: IMAGE_CONFIG_FILE
+              value: aws-instance.yaml
             - name: TEST_ARGS
               value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           resources:
@@ -163,6 +167,8 @@ presubmits:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
@@ -217,6 +223,8 @@ presubmits:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
@@ -2131,6 +2139,10 @@ presubmits:
           env:
             - name: FOCUS
               value: \[Serial\]
+            - name: IMAGE_CONFIG_DIR
+              value: config
+            - name: IMAGE_CONFIG_FILE
+              value: aws-instance.yaml
             - name: SKIP
               value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
             - name: TEST_ARGS
@@ -2172,6 +2184,10 @@ presubmits:
             env:
               - name: FOCUS
                 value: NodeConformance
+              - name: IMAGE_CONFIG_DIR
+                value: config
+              - name: IMAGE_CONFIG_FILE
+                value: aws-instance.yaml
               - name: TEST_ARGS
                 value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             resources:
@@ -2212,6 +2228,8 @@ presubmits:
                 value: NodeConformance
               - name: BUILD_EKS_AMI
                 value: "true"
+              - name: IMAGE_CONFIG_DIR
+                value: config
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-eks.yaml
               - name: TEST_ARGS
@@ -2257,6 +2275,8 @@ presubmits:
                 value: "true"
               - name: TARGET_BUILD_ARCH
                 value: "linux/arm64"
+              - name: IMAGE_CONFIG_DIR
+                value: config
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-arm64.yaml
               - name: TEST_ARGS
@@ -2300,6 +2320,10 @@ presubmits:
             env:
               - name: FOCUS
                 value: \[Serial\]
+              - name: IMAGE_CONFIG_DIR
+                value: config
+              - name: IMAGE_CONFIG_FILE
+                value: aws-instance.yaml
               - name: SKIP
                 value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
               - name: TEST_ARGS
@@ -2346,6 +2370,8 @@ presubmits:
                 value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
               - name: BUILD_EKS_AMI
                 value: "true"
+              - name: IMAGE_CONFIG_DIR
+                value: config
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-eks.yaml
               - name: TEST_ARGS
@@ -2393,6 +2419,8 @@ presubmits:
                 value: "true"
               - name: TARGET_BUILD_ARCH
                 value: "linux/arm64"
+              - name: IMAGE_CONFIG_DIR
+                value: config
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-arm64.yaml
               - name: TEST_ARGS


### PR DESCRIPTION
As part of https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/80, I need to remove the default values set in the makefile. I can retain the existing behavior by setting the values on the jobs.

I will remove `IMAGE_CONFIG_DIR` and clean up the code after 1.28 is released.

~I'm also using this opportunity to make `pull-kubernetes-node-e2e-containerd-ec2` a required job on the k/k PRs. It has been stable for a long time. https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-cgroupv1-containerd-node-e2e-ec2~

/cc @dims @tzneal 
