### PR TITLE
Fix typos in kubetest2 jobs and use master instead of experimental images

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -152,7 +152,7 @@ presubmits:
       testgrid-dashboards: sig-testing-canaries
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
         resources:
           limits:
             cpu: 4
@@ -170,7 +170,7 @@ presubmits:
           set -o pipefail;
           set -o xtrace;
           make install-all;
-          cd ${GOPATH}/src/sigs.k8s.io/kubernetes;
+          cd ${GOPATH}/src/k8s.io/kubernetes;
           kubetest2 noop --test=node -- \
             --provider=gce --repo-root=. --gcp-zone=us-west1-b --focus-regex="\[NodeConformance\]" \
             --test-args='--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"' \

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -123,7 +123,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-gce-cos-kubetest2
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         resources:
           requests:
             cpu: 4

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -6,6 +6,8 @@ presets:
         value: linux/amd64
       - name: AWS_REGION
         value: us-east-1
+      - name: AWS_DEFAULT_REGION
+        value: us-east-1
       - name: SSH_USER
         value: ec2-user
       - name: DELETE_INSTANCES

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -145,9 +145,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -257,7 +257,7 @@ presubmits:
       testgrid-num-failures-to-alert: "10"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         command:
         - runner.sh
         args:
@@ -312,9 +312,7 @@ presubmits:
       testgrid-num-failures-to-alert: "10"
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         resources:
           limits:
             cpu: 4
@@ -411,9 +409,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         env:
         - name: GOPATH
           value: /go
@@ -552,9 +548,7 @@ presubmits:
       testgrid-tab-name: pr-node-kubelet-serial-containerd-kubetest2
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         env:
         - name: GOPATH
           value: /go
@@ -651,9 +645,7 @@ presubmits:
       testgrid-tab-name: pr-kubelet-serial-gce-e2e-cpu-manager-kubetest2
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         env:
         - name: GOPATH
           value: /go
@@ -749,9 +741,7 @@ presubmits:
       testgrid-tab-name: pr-kubelet-serial-gce-e2e-topology-manager-kubetest2
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         env:
         - name: GOPATH
           value: /go
@@ -937,9 +927,7 @@ presubmits:
       testgrid-tab-name: pr-crio-cgrpv2-gce-e2e-kubetest2
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         resources:
           limits:
             cpu: 4
@@ -1134,9 +1122,7 @@ presubmits:
       testgrid-tab-name: pr-crio-gce-e2e-kubetest2
     spec:
       containers:
-      # experimental have the kubetest2 binaries
-      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         resources:
           limits:
             cpu: 4


### PR DESCRIPTION
/cc @dims

Fixing typos from #30195
Also, kubekins-e2e has had kubetest2 installed in it(https://github.com/kubernetes/test-infra/pull/29825) for a while now. There is no need to use the experimental versions of the image.