### PR TITLE
windows: revert kubekins update to work around Go 1.20.6 bug

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -81,7 +81,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.24
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -40,7 +40,7 @@ periodics:
     - command:
       - runner.sh
       - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-1.24
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.24
       name: ""
       resources:
         requests:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -44,7 +44,7 @@ periodics:
     - command:
       - runner.sh
       - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-1.25
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.25
       name: ""
       resources:
         requests:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -44,7 +44,7 @@ periodics:
     - command:
       - runner.sh
       - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-1.26
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.26
       name: ""
       resources:
         requests:


### PR DESCRIPTION
Reverts the change in #30084 to bump kubekins to Go v1.20.6 for sig-windows jobs that began failing due to golang/go#61431.

Fixes kubernetes-sigs/cluster-api-provider-azure#3755

See also #30178 and #30194.