### PR TITLE
update and add more metrics for gerrit and inrepoconfig

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -58,7 +58,7 @@ var gerritMetrics = struct {
 }{
 	processingResults: prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "gerrit_processing_results",
-		Help: "Count of change processing by instance, repo, and result.",
+		Help: "Count of change processing by instance, repo, and result (ERROR or SUCCESS).",
 	}, []string{
 		"org",
 		"repo",
@@ -83,14 +83,14 @@ var gerritMetrics = struct {
 	}),
 	changeProcessDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_instance_process_duration",
-		Help:    "Histogram of seconds spent processing a single gerrit instance or repo.",
+		Help:    "Histogram of seconds spent processing changes, by instance and repo. Includes gerrit_repo_query_latency and gerrit_instance_change_sync_duration.",
 		Buckets: []float64{5, 10, 20, 30, 60, 120, 180, 300, 600, 1200, 3600},
 	}, []string{
 		"org", "repo",
 	}),
 	changeSyncDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_instance_change_sync_duration",
-		Help:    "Histogram of seconds spent syncing changes from a single gerrit instance or repo.",
+		Help:    "Histogram of seconds spent syncing changes (syncChange()) from a single gerrit instance or repo.",
 		Buckets: []float64{5, 10, 20, 30, 60, 120, 180, 300, 600, 1200, 3600},
 	}, []string{"org", "repo"}),
 }

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -261,6 +261,7 @@ func (c *Controller) Sync() {
 			return
 		}
 
+		timeSyncChangesForProject := time.Now()
 		var wg sync.WaitGroup
 		wg.Add(len(changes))
 
@@ -280,7 +281,7 @@ func (c *Controller) Sync() {
 			changeChan <- Change{changeInfo: change, instance: instance}
 		}
 		wg.Wait()
-		gerritMetrics.changeSyncDuration.WithLabelValues(instance, project).Observe((float64(time.Since(timeQueryChangesForProject).Seconds())))
+		gerritMetrics.changeSyncDuration.WithLabelValues(instance, project).Observe((float64(time.Since(timeSyncChangesForProject).Seconds())))
 		close(changeChan)
 		c.tracker.Update(latest)
 	}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -444,7 +444,7 @@ func TestFailedJobs(t *testing.T) {
 }
 
 func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCache, error) {
-	// processChange takes a ClientFactory. If provided a nil clientFactory it will skip inRepoConfig
+	// triggerJobs takes a ClientFactory. If provided a nil clientFactory it will skip inRepoConfig
 	// otherwise it will get the prow yaml using the client provided. We are mocking ProwYamlGetter
 	// so we are creating a localClientFactory but leaving it unpopulated.
 	var cf git.ClientFactory
@@ -474,7 +474,7 @@ func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCache, erro
 	return cache, nil
 }
 
-func TestProcessChange(t *testing.T) {
+func TestTriggerJobs(t *testing.T) {
 	testInstance := "https://gerrit"
 	var testcases = []struct {
 		name           string
@@ -3082,7 +3082,7 @@ func TestProcessChange(t *testing.T) {
 				inRepoConfigFailuresTracker: make(map[string]bool),
 			}
 
-			err = c.processChange(logrus.WithField("name", tc.name), tc.instance, tc.change)
+			err = c.triggerJobs(logrus.WithField("name", tc.name), tc.instance, tc.change)
 			if tc.wantError {
 				if err == nil {
 					t.Fatal("Expected error, got nil.")

--- a/prow/git/v2/executor.go
+++ b/prow/git/v2/executor.go
@@ -19,7 +19,6 @@ package git
 import (
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -65,7 +64,6 @@ type censoringExecutor struct {
 
 func (e *censoringExecutor) Run(args ...string) ([]byte, error) {
 	logger := e.logger.WithField("args", strings.Join(args, " "))
-	now := time.Now()
 	b, err := e.execute(e.dir, e.git, args...)
 	b = e.censor(b)
 	if err != nil {
@@ -73,6 +71,5 @@ func (e *censoringExecutor) Run(args ...string) ([]byte, error) {
 	} else {
 		logger.Debug("Running command succeeded.")
 	}
-	logger.WithFields(logrus.Fields{"duration": time.Since(now), "dir": e.dir}).Info("Time taken to execute command.")
 	return b, err
 }


### PR DESCRIPTION
This adds metrics for gerrit and inrepoconfig to get a better idea about how long certain operations take. It also breaks up the `triggerLatency` into two parts --- the original and the new `triggerHelpLatency` to measure trigger delay for posting the help comment.

/cc @cjwagner @timwangmusic 