### PR TITLE
[releng] 1.28: Update kubekins-e2e variants.yaml with 1.28 config

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -31,6 +31,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.28':
+    CONFIG: main
+    GO_VERSION: 1.20.6
+    K8S_RELEASE: latest-1.28
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.27':
     CONFIG: '1.27'
     GO_VERSION: 1.20.6


### PR DESCRIPTION
Update kubekins-e2e variant with 1.28 config

/sig release
/area release-eng

cc @kubernetes/release-engineering 