### PR TITLE
pod-utils: Define RunAsUser, RunAsGroup, FsGroup in decoration config

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -159,6 +159,14 @@ spec:
                       service account that should be used by the pod if one is not
                       specified in the podspec.
                     type: string
+                  fs_group:
+                    description: FsGroup defines special supplemental group ID used
+                      in all containers in a Pod. This allows to change the ownership
+                      of particular volumes by kubelet. This field will not override
+                      the existing ProwJob's PodSecurityContext. Equivalent to PodSecurityContext's
+                      FsGroup
+                    format: int64
+                    type: integer
                   gcs_configuration:
                     description: GCSConfiguration holds options for pushing logs and
                       artifacts to GCS from a job.
@@ -385,6 +393,20 @@ spec:
                             type: object
                         type: object
                     type: object
+                  run_as_group:
+                    description: RunAsGroup defines GID of process in all containers
+                      running in a Pod. This field will not override the existing
+                      ProwJob's PodSecurityContext. Equivalent to PodSecurityContext's
+                      RunAsGroup
+                    format: int64
+                    type: integer
+                  run_as_user:
+                    description: RunAsUser defines UID for process in all containers
+                      running in a Pod. This field will not override the existing
+                      ProwJob's PodSecurityContext. Equivalent to PodSecurityContext's
+                      RunAsUser
+                    format: int64
+                    type: integer
                   s3_credentials_secret:
                     description: S3CredentialsSecret is the name of the Kubernetes
                       secret that holds blob storage push credentials.

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -526,6 +526,20 @@ type DecorationConfig struct {
 	// PodUnscheduledTimeout defines how long the controller will wait to abort a prowjob
 	// stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
 	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
+
+	// RunAsUser defines UID for process in all containers running in a Pod.
+	// This field will not override the existing ProwJob's PodSecurityContext.
+	// Equivalent to PodSecurityContext's RunAsUser
+	RunAsUser *int64 `json:"run_as_user,omitempty"`
+	// RunAsGroup defines GID of process in all containers running in a Pod.
+	// This field will not override the existing ProwJob's PodSecurityContext.
+	// Equivalent to PodSecurityContext's RunAsGroup
+	RunAsGroup *int64 `json:"run_as_group,omitempty"`
+	// FsGroup defines special supplemental group ID used in all containers in a Pod.
+	// This allows to change the ownership of particular volumes by kubelet.
+	// This field will not override the existing ProwJob's PodSecurityContext.
+	// Equivalent to PodSecurityContext's FsGroup
+	FsGroup *int64 `json:"fs_group,omitempty"`
 }
 
 type CensoringOptions struct {
@@ -748,6 +762,17 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 		merged.PodUnscheduledTimeout = def.PodUnscheduledTimeout
 	}
 
+	if merged.RunAsUser == nil {
+		merged.RunAsUser = def.RunAsUser
+	}
+
+	if merged.RunAsGroup == nil {
+		merged.RunAsGroup = def.RunAsGroup
+	}
+
+	if merged.FsGroup == nil {
+		merged.FsGroup = def.FsGroup
+	}
 	return &merged
 }
 

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -184,6 +184,21 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.RunAsUser != nil {
+		in, out := &in.RunAsUser, &out.RunAsUser
+		*out = new(int64)
+		**out = **in
+	}
+	if in.RunAsGroup != nil {
+		in, out := &in.RunAsGroup, &out.RunAsGroup
+		*out = new(int64)
+		**out = **in
+	}
+	if in.FsGroup != nil {
+		in, out := &in.FsGroup, &out.FsGroup
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -603,6 +603,11 @@ plank:
             # DefaultServiceAccountName is the name of the Kubernetes service account
             # that should be used by the pod if one is not specified in the podspec.
             default_service_account_name: ""
+            # FsGroup defines special supplemental group ID used in all containers in a Pod.
+            # This allows to change the ownership of particular volumes by kubelet.
+            # This field will not override the existing ProwJob's PodSecurityContext.
+            # Equivalent to PodSecurityContext's FsGroup
+            fs_group: 0
             # GCSConfiguration holds options for pushing logs and
             # artifacts to GCS from a job.
             gcs_configuration:
@@ -695,6 +700,14 @@ plank:
                         "": "0"
                     requests:
                         "": "0"
+            # RunAsGroup defines GID of process in all containers running in a Pod.
+            # This field will not override the existing ProwJob's PodSecurityContext.
+            # Equivalent to PodSecurityContext's RunAsGroup
+            run_as_group: 0
+            # RunAsUser defines UID for process in all containers running in a Pod.
+            # This field will not override the existing ProwJob's PodSecurityContext.
+            # Equivalent to PodSecurityContext's RunAsUser
+            run_as_user: 0
             # S3CredentialsSecret is the name of the Kubernetes secret
             # that holds blob storage push credentials.
             s3_credentials_secret: ""
@@ -781,6 +794,11 @@ plank:
             # DefaultServiceAccountName is the name of the Kubernetes service account
             # that should be used by the pod if one is not specified in the podspec.
             default_service_account_name: ""
+            # FsGroup defines special supplemental group ID used in all containers in a Pod.
+            # This allows to change the ownership of particular volumes by kubelet.
+            # This field will not override the existing ProwJob's PodSecurityContext.
+            # Equivalent to PodSecurityContext's FsGroup
+            fs_group: 0
             # GCSConfiguration holds options for pushing logs and
             # artifacts to GCS from a job.
             gcs_configuration:
@@ -873,6 +891,14 @@ plank:
                         "": "0"
                     requests:
                         "": "0"
+            # RunAsGroup defines GID of process in all containers running in a Pod.
+            # This field will not override the existing ProwJob's PodSecurityContext.
+            # Equivalent to PodSecurityContext's RunAsGroup
+            run_as_group: 0
+            # RunAsUser defines UID for process in all containers running in a Pod.
+            # This field will not override the existing ProwJob's PodSecurityContext.
+            # Equivalent to PodSecurityContext's RunAsUser
+            run_as_user: 0
             # S3CredentialsSecret is the name of the Kubernetes secret
             # that holds blob storage push credentials.
             s3_credentials_secret: ""

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -829,6 +829,21 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 		}
 	}
 
+	if pj.Spec.DecorationConfig != nil {
+		if spec.SecurityContext == nil {
+			spec.SecurityContext = new(coreapi.PodSecurityContext)
+		}
+		if pj.Spec.DecorationConfig.RunAsUser != nil && spec.SecurityContext.RunAsUser == nil {
+			spec.SecurityContext.RunAsUser = pj.Spec.DecorationConfig.RunAsUser
+		}
+		if pj.Spec.DecorationConfig.RunAsGroup != nil && spec.SecurityContext.RunAsGroup == nil {
+			spec.SecurityContext.RunAsGroup = pj.Spec.DecorationConfig.RunAsGroup
+		}
+		if pj.Spec.DecorationConfig.FsGroup != nil && spec.SecurityContext.FSGroup == nil {
+			spec.SecurityContext.FSGroup = pj.Spec.DecorationConfig.FsGroup
+		}
+	}
+
 	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.SetLimitEqualsMemoryRequest != nil && *pj.Spec.DecorationConfig.SetLimitEqualsMemoryRequest {
 		for i, container := range spec.Containers {
 			if container.Resources.Requests == nil {

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -47,6 +47,9 @@ import (
 func pStr(str string) *string {
 	return &str
 }
+func pInt64(i int64) *int64 {
+	return &i
+}
 
 func cookieVolumeOnly(secret string) coreapi.Volume {
 	v, _, _ := cookiefileVolume(secret)
@@ -1033,6 +1036,66 @@ func TestProwJobToPod(t *testing.T) {
 					// Specify K8s SA rather than cloud storage secret key.
 					DefaultServiceAccountName: pStr("default-SA"),
 					CookiefileSecret:          pStr("yummy/.gitcookies"),
+				},
+				Agent: prowapi.KubernetesAgent,
+				Refs: &prowapi.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []prowapi.Pull{{
+						Number:  1,
+						Author:  "author-name",
+						SHA:     "pull-sha",
+						HeadRef: "orig-branch-name",
+					}},
+					PathAlias: "somewhere/else",
+				},
+				ExtraRefs: []prowapi.Refs{},
+				PodSpec: &coreapi.PodSpec{
+					Containers: []coreapi.Container{
+						{
+							Image:   "tester",
+							Command: []string{"/bin/thing"},
+							Args:    []string{"some", "args"},
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			podName: "pod",
+			buildID: "blabla",
+			labels:  map[string]string{"needstobe": "inherited"},
+			pjSpec: prowapi.ProwJobSpec{
+				Type:    prowapi.PresubmitJob,
+				Job:     "job-name",
+				Context: "job-context",
+				DecorationConfig: &prowapi.DecorationConfig{
+					Timeout:     &prowapi.Duration{Duration: 120 * time.Minute},
+					GracePeriod: &prowapi.Duration{Duration: 10 * time.Second},
+					UtilityImages: &prowapi.UtilityImages{
+						CloneRefs:  "clonerefs:tag",
+						InitUpload: "initupload:tag",
+						Entrypoint: "entrypoint:tag",
+						Sidecar:    "sidecar:tag",
+					},
+					GCSConfiguration: &prowapi.GCSConfiguration{
+						Bucket:       "my-bucket",
+						PathStrategy: "legacy",
+						DefaultOrg:   "kubernetes",
+						DefaultRepo:  "kubernetes",
+						MediaTypes:   map[string]string{"log": "text/plain"},
+					},
+					// Specify K8s SA rather than cloud storage secret key.
+					DefaultServiceAccountName: pStr("default-SA"),
+					CookiefileSecret:          pStr("yummy/.gitcookies"),
+					RunAsGroup:                pInt64(1000),
+					RunAsUser:                 pInt64(1000),
+					FsGroup:                   pInt64(2000),
 				},
 				Agent: prowapi.KubernetesAgent,
 				Refs: &prowapi.Refs{

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -130,6 +130,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -130,6 +130,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -131,6 +131,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -131,6 +131,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -86,6 +86,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -106,6 +106,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -189,6 +189,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext: {}
   terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_9.yaml
@@ -37,7 +37,7 @@ spec:
     - name: JOB_NAME
       value: job-name
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
+      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies","run_as_user":1000,"run_as_group":1000,"fs_group":2000}}'
     - name: JOB_TYPE
       value: presubmit
     - name: PROW_JOB_ID
@@ -74,7 +74,7 @@ spec:
     workingDir: /home/prow/go/src/somewhere/else
   - env:
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
+      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies","run_as_user":1000,"run_as_group":1000,"fs_group":2000}}'
     - name: SIDECAR_OPTIONS
       value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"censoring_options":{}}'
     image: sidecar:tag
@@ -108,7 +108,7 @@ spec:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
+      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha","head_ref":"orig-branch-name"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies","run_as_user":1000,"run_as_group":1000,"fs_group":2000}}'
     image: initupload:tag
     name: initupload
     resources: {}
@@ -126,7 +126,10 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  securityContext: {}
+  securityContext:
+    fsGroup: 2000
+    runAsGroup: 1000
+    runAsUser: 1000
   serviceAccountName: default-SA
   terminationGracePeriodSeconds: 12
   volumes:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_basic_happy_case.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_basic_happy_case.yaml
@@ -85,6 +85,7 @@ initContainers:
   volumeMounts:
   - mountPath: /tools
     name: tools
+securityContext: {}
 serviceAccountName: tester
 terminationGracePeriodSeconds: 4500
 volumes:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_censor_secrets_in_sidecar.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_censor_secrets_in_sidecar.yaml
@@ -87,6 +87,7 @@ initContainers:
   volumeMounts:
   - mountPath: /tools
     name: tools
+securityContext: {}
 serviceAccountName: tester
 terminationGracePeriodSeconds: 4500
 volumes:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_default_memory_request.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_default_memory_request.yaml
@@ -112,6 +112,7 @@ initContainers:
   volumeMounts:
   - mountPath: /tools
     name: tools
+securityContext: {}
 serviceAccountName: tester
 terminationGracePeriodSeconds: 4500
 volumes:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_enforcing_memory_limit.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_enforcing_memory_limit.yaml
@@ -87,6 +87,7 @@ initContainers:
   volumeMounts:
   - mountPath: /tools
     name: tools
+securityContext: {}
 serviceAccountName: tester
 terminationGracePeriodSeconds: 4500
 volumes:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_ignore_interrupts_in_sidecar.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_ignore_interrupts_in_sidecar.yaml
@@ -85,6 +85,7 @@ initContainers:
   volumeMounts:
   - mountPath: /tools
     name: tools
+securityContext: {}
 serviceAccountName: tester
 terminationGracePeriodSeconds: 4500
 volumes:


### PR DESCRIPTION
Allow defining PodSecurityContext fields through decoration config. If these fields are already defined, the already existing fields will be respected.

Adding this field allows enforcing rootless execution on global level if used with `default_decoration_config` without the need for defining it per ProwJob level

/kind feature
/area prow