### PR TITLE
[releng] 1.28: fix variant

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -32,7 +32,7 @@ variants:
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.28':
-    CONFIG: main
+    CONFIG: '1.28'
     GO_VERSION: 1.20.6
     K8S_RELEASE: latest-1.28
     BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/test-infra/pull/30215

Currently, the images built but there are not tagged. This should fix it.
  
/sig release
/area release-eng

cc @kubernetes/release-engineering 