### PR TITLE
sig-windows: revert kubekins update

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -76,7 +76,7 @@ periodics:
     workdir: true
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.24
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -91,7 +91,7 @@ periodics:
     workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.25
         command:
           - "runner.sh"
           - "env"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -89,7 +89,7 @@ periodics:
     workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
         command:
           - "runner.sh"
           - "env"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -95,7 +95,7 @@ periodics:
     workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
         command:
           - "runner.sh"
           - "env"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -155,7 +155,7 @@ periodics:
     workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
         command:
           - "runner.sh"
           - "env"
@@ -308,7 +308,7 @@ periodics:
     workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
         command:
           - "runner.sh"
           - "env"


### PR DESCRIPTION
Reverts the change in #30084 to bump kubekins to Go v1.20.6 for more sig-windows jobs that began failing due to golang/go#61431.

See also #30178, #30194, #30198, #30201.