### PR TITLE
Bump scheduler throughput in 5k-node tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -281,7 +281,7 @@ presubmits:
         #   Given that individual controllers have separate QPS limits, we allow
         #   scheduler to keep up with the load from deployment, daemonset and job
         #   performing pod creations at once.
-        - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
+        - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=500 --kube-api-burst=500
         # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
         - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0 --profiling --contention-profiling
         - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
@@ -733,7 +733,7 @@ presubmits:
         #   Given that individual controllers have separate QPS limits, we allow
         #   scheduler to keep up with the load from deployment, daemonset and job
         #   performing pod creations at once.
-        - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
+        - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=500 --kube-api-burst=500
         # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
         - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0 --profiling --contention-profiling
         - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -117,7 +117,7 @@ periodics:
       #   Given that individual controllers have separate QPS limits, we allow
       #   scheduler to keep up with the load from deployment, daemonset and job
       #   performing pod creations at once.
-      - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=300 --kube-api-burst=300
+      - --env=SCHEDULER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=500 --kube-api-burst=500
       # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true


### PR DESCRIPTION
Ref https://github.com/kubernetes/perf-tests/issues/1311

We can create daemonsets, jobs, deployments and statefulsets at the same time - hence 300 is potentially too low.