### PR TITLE
fix `IMAGE_CONFIG_DIR` for a few jobs I missed

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -102,6 +102,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-testing-canaries
     spec:
+      serviceAccountName: node-e2e-tests
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-master
         resources:

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -41,6 +41,10 @@ periodics:
           args:
             - hack/make-rules/test-e2e-node.sh
           env:
+            - name: IMAGE_CONFIG_DIR
+              value: config
+            - name: IMAGE_CONFIG_FILE
+              value: aws-instance.yaml
             - name: FOCUS
               value: \[NodeConformance\]
             - name: TEST_ARGS
@@ -84,6 +88,8 @@ periodics:
               value: \[NodeConformance\]
             - name: BUILD_EKS_AMI
               value: "true"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
@@ -134,6 +140,8 @@ periodics:
               value: "true"
             - name: TARGET_BUILD_ARCH
               value: "linux/arm64"
+            - name: IMAGE_CONFIG_DIR
+              value: config
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS


### PR DESCRIPTION
/cc @dims

Missed a few jobs when merging #30193. Also add missing serviceAccountName field to the kubetest2 aws e2e test.