### PR TITLE
CAPV: Always enable verify main job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -137,6 +137,7 @@ presubmits:
       description: Verifies the shell scripts have been linted
 
   - name: pull-cluster-api-provider-vsphere-verify-main
+    always_run: true
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:


### PR DESCRIPTION
I accidentally dropped this on my previous PR. 

Let's fix this now so we don't run the risk of merging PRs which break this