### PR TITLE
sched-plugins: bump go version to 1.20 for master branch

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -35,7 +35,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.3
+      - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - make
         args:


### PR DESCRIPTION
cc @zwpaper @denkensk 