### PR TITLE
hack: Fix update/codegen.sh not working on ARM64 machine

### DIFF
--- a/hack/make-rules/update/codegen.sh
+++ b/hack/make-rules/update/codegen.sh
@@ -57,10 +57,18 @@ ensure-protoc-deps(){
   # Install protoc
   if [[ ! -f "_bin/protoc/bin/protoc" ]]; then
     mkdir -p _bin/protoc
+    OS="linux"
+    if [[ $(uname -s) == "Darwin" ]]; then
+          OS="osx"
+    fi
+    ARCH="x86_64"
+    if [[ $(uname -m) == "arm64" ]]; then
+      ARCH="aarch_64"
+    fi
     # See https://developers.google.com/protocol-buffers/docs/news/2022-05-06 for
     # a note on the versioning scheme change.
     PROTOC_VERSION=21.9
-    PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+    PROTOC_ZIP="protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
     curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
     unzip -o $PROTOC_ZIP -d _bin/protoc bin/protoc
     unzip -o $PROTOC_ZIP -d _bin/protoc 'include/*'


### PR DESCRIPTION
/kind bug

I noticed this when I was trying to run `make verify-codegen` target on my M1 Mac that this script downloaded incorrect version of protoc. I've added 2 small conditionals to ensure that when scripts always downloads the correct version of protoc when running on different system than Linux_x86_64.