### PR TITLE
[crio_swap1g.ign]: Use cgroup v2 instead of v1

### DIFF
--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -2,11 +2,6 @@
   "ignition": {
     "version": "3.3.0"
   },
-  "kernelArguments": {
-    "shouldExist": [
-      "systemd.unified_cgroup_hierarchy=0"
-    ]
-  },
   "storage": {
     "files": [
       {

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -140,6 +140,3 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-kernel_arguments:
-  should_exist:
-    - systemd.unified_cgroup_hierarchy=0

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -33,7 +33,7 @@ declare -A CONFIGURATIONS=(
     ["crio_cgrpv2"]="root"
     ["crio_cgrpv2_serial"]="root authorized-key"
     ["crio_cgrpv2_k8s_infra_prow_build"]="root authorized-key"
-    ["crio_swap1g"]="root cgroups-v1 authorized-key swap-1G"
+    ["crio_swap1g"]="root authorized-key swap-1G"
 )
 
 CONTAINER_RUNTIME=$(which podman 2>/dev/null) ||


### PR DESCRIPTION
Since in Beta1 NodeSwap does not support cgroup v1, the jobs using `crio_swap1g.ign` should be using cgroup v2. See https://github.com/kubernetes/kubernetes/pull/118764 for more info.

This PR is a pre-requisite for https://github.com/kubernetes/kubernetes/pull/119327, which aims to fail kubelet when swap is being used with cgroup v1. As of now, jobs like `pull-kubernetes-node-swap-fedora`, which use `crio_swap1g.ign`, fail instantly with this PR since they use cgroup v1. With this PR merged, I wish all tests would pass with the above PR.

Fixes https://github.com/kubernetes/kubernetes/issues/119726

------

Here's what I did in order to make sure all of the jobs that use swap will now be set with cgroup v2.

First, from this repo's root, I execute:
```bash
> grep -l "NodeSwap=true" . -R
./config/jobs/kubernetes/sig-node/containerd.yaml
./config/jobs/kubernetes/sig-node/node-kubelet.yaml
./config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
```

These files define jobs with the `NodeSwap` feature-gate on. For each such job, I've inspected the file that's used as a parameter for `--node-args`. For example:
```yaml
- --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
```

This file refers to other files, such as `crio_swap1g.ign`. I've tried to search this files for cgoup definitions. In `crio_swap1g.ign`'s example, I saw:
```
  "kernelArguments": {
    "shouldExist": [
      "systemd.unified_cgroup_hierarchy=0"
    ]
  },
```

which is deleted by this PR.

As far as I'm aware, the affected jobs are:
- pull-kubernetes-node-swap-fedora
- pull-kubernetes-node-swap-fedora-serial 