### PR TITLE
migrate `kind` to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -2,6 +2,7 @@
 postsubmits:
   kubernetes-sigs/kind:
   - name: ci-kind-test
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -17,6 +18,13 @@ postsubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
     annotations:
       testgrid-dashboards: sig-testing-kind
       testgrid-tab-name: ci unit test

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/kind:
   - name: pull-kind-build
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -16,6 +17,13 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
   - name: pull-kind-test
     decorate: true
     path_alias: sigs.k8s.io/kind
@@ -32,6 +40,13 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
   - name: pull-kind-verify
     decorate: true
     path_alias: sigs.k8s.io/kind
@@ -48,6 +63,13 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   # GA-only variant

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kind-unit-test
+  cluster: eks-prow-build-cluster
   interval: 6h
   decorate: true
   extra_refs:
@@ -19,6 +20,13 @@ periodics:
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: "4"
+          memory: 9000Mi
+        requests:
+          cpu: "4"
+          memory: 9000Mi
   annotations:
     testgrid-dashboards: sig-testing-kind
     testgrid-tab-name: kind-ci-unit-test
@@ -27,7 +35,7 @@ periodics:
 # conformance test against kubernetes master branch with `kind`
 - interval: 1h
   name: ci-kubernetes-kind-conformance
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -71,7 +79,7 @@ periodics:
 # conformance test against kubernetes master branch with `kind` ipv6
 - interval: 1h
   name: ci-kubernetes-kind-conformance-ipv6
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -122,7 +130,7 @@ periodics:
 # serial tests so it runs in ~20m
 - interval: 1h
   name: ci-kubernetes-kind-conformance-parallel
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -167,7 +175,7 @@ periodics:
 # conformance test against kubernetes master branch with `kind` ipv6
 - interval: 1h
   name: ci-kubernetes-kind-conformance-parallel-ipv6
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"


### PR DESCRIPTION
This PR moves the kind  jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

~~note: This PR Only update for all of the job in the default cluster: https://prow.k8s.io/?repo=kubernetes-sigs%2Fkind&cluster=default~~
