### PR TITLE
migrate kubeadm to community cluster

### DIFF
--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
 
   # kinder presubmits
   - name: pull-kubeadm-kinder-verify
+    cluster: eks-prow-build-cluster
     path_alias: "k8s.io/kubeadm"
     decorate: true
     run_if_changed: '^kinder\/.*$'
@@ -12,8 +13,16 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230719-72ce785784-master
         command:
         - "./kinder/hack/verify-all.sh"
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 9000Mi
+          requests:
+            cpu: 2000m
+            memory: 9000Mi
 
   - name: pull-kubeadm-kinder-upgrade-latest
+    cluster: eks-prow-build-cluster
     optional: false
     decorate: true
     run_if_changed: '^kinder\/.*$'
@@ -43,9 +52,13 @@ presubmits:
           requests:
             memory: "9000Mi"
             cpu: 2000m
+          limits:
+            cpu: 2000m
+            memory: 9000Mi
 
   # operator presubmits
   - name: pull-kubeadm-operator-verify
+    cluster: eks-prow-build-cluster
     path_alias: "k8s.io/kubeadm"
     decorate: true
     run_if_changed: '^operator\/.*$'
@@ -63,3 +76,6 @@ presubmits:
           requests:
             memory: "9000Mi"
             cpu: 2000m
+          limits:
+            cpu: 2000m
+            memory: 9000Mi


### PR DESCRIPTION
This PR moves the kubeadm jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722