### PR TITLE
node: ci: multi-numa: Update machine in image config file

### DIFF
--- a/jobs/e2e_node/image-config-serial-multi-numa.yaml
+++ b/jobs/e2e_node/image-config-serial-multi-numa.yaml
@@ -6,10 +6,17 @@ images:
     image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
     # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager and Memory manager node e2e tests.
-    machine: n2d-standard-32
+    # machine: n2d-standard-32
+    # NOTE: All the jobs referring to this image config file are failing so attempting to narrow down the root
+    # cause of the issue by changing the underlying machine.
+    # Typically one CPU is reserved and there are CPU Manager tests that expect CPU node capacity to be > 4
+    # (e.g. https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/cpu_manager_test.go#L623)
+    # making n1-standard-4 machine unsuitable for running those tests so we are specifying n1-standard-8 here.
+    machine: n1-standard-8
   cos-stable1:
     image_family: cos-97-lts # deprecated after March 2024 (https://cloud.google.com/container-optimized-os/docs/release-notes)
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
     # Using `n2d-standard-32` that has 2 numa nodes to enable Topology manager and Memory manager node e2e tests.
-    machine: n2d-standard-32
+    # machine: n2d-standard-32
+    machine: n1-standard-8


### PR DESCRIPTION
All the jobs referring to this image config file are failing so attempting to narrow down the root cause of the [issue](https://github.com/kubernetes/kubernetes/issues/119601) by changing the underlying machine.

Typically one CPU is reserved and there are CPU Manager tests that expect CPU node capacity to be > 4:
(e.g. https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/cpu_manager_test.go#L623)
making n1-standard-4 machine unsuitable for running those tests so we are specifying n1-standard-8 here.