### PR TITLE
Use `USER` instead of `SSH_USER` for ec2 node tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -8,7 +8,7 @@ presets:
         value: us-east-1
       - name: AWS_DEFAULT_REGION
         value: us-east-1
-      - name: SSH_USER
+      - name: USER
         value: ec2-user
       - name: DELETE_INSTANCES
         value: "true"


### PR DESCRIPTION
/cc @dims @tzneal 

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kubetest2/234/pull-kubetest2-aws-node-e2e/1686125178821545984

The test is failing because of `hack/make-rules/test-e2e-node.sh: line 90: USER: unbound variable`

We don't see this in our other ec2 tests because they don't run with `set -o nounset` and the runner sets a default user if we pass an empty value.

https://github.com/kubernetes-sigs/provider-aws-test-infra/blob/main/hack/make-rules/test-e2e-node.sh#L90
https://github.com/kubernetes/kubernetes/blob/v1.27.4/test/e2e_node/remote/ssh.go#L57

Part of https://github.com/kubernetes-sigs/kubetest2/pull/234