### PR TITLE
sig-windows: update CAPZ and cloud-provider branches

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
@@ -17,11 +17,11 @@ presubmits:
       preset-capz-windows-2019: "true"
       preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
+      preset-azure-capz-sa-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      # TODO: update to release-1.10 when Go 1.20 is backported to kubekins-e2e.
-      base_ref: release-1.8
+      base_ref: release-1.10
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -27,11 +27,11 @@ periodics:
     preset-capz-windows-parallel: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    # TODO: update to release-1.10 when Go 1.20 is backported to kubekins-e2e.
-    base_ref: release-1.8
+    base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -72,11 +72,11 @@ periodics:
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
     preset-windows-private-registry-cred: "true"
+    preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    # TODO: update to release-1.10 when Go 1.20 is backported to kubekins-e2e.
-    base_ref: release-1.8
+    base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -16,11 +16,11 @@ presubmits:
       preset-capz-windows-2019: "true"
       preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
+      preset-azure-capz-sa-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      # TODO: update to release-1.10 when Go 1.20 is backported to kubekins-e2e.
-      base_ref: release-1.8
+      base_ref: release-1.10
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -20,8 +20,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    # TODO: update to release-1.10 when Go 1.20 is backported to kubekins-e2e.
-    base_ref: release-1.8
+    base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -39,6 +38,7 @@ periodics:
     preset-capz-windows-parallel: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-azure-capz-sa-cred: "true"
   spec:
     containers:
     - command:
@@ -72,10 +72,11 @@ periodics:
     preset-capz-windows-common-126: "true"
     preset-capz-windows-2019: "true"
     preset-windows-private-registry-cred: "true"
+    preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: windows-testing

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       workdir: true
     - org: kubernetes-sigs
       repo: cloud-provider-azure
-      base_ref: master # TODO: Update to release-1.27 once it's created
+      base_ref: release-1.27
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -30,7 +30,7 @@ periodics:
     workdir: false
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: master # TODO: Update to release-1.27 once it's created
+    base_ref: release-1.27
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   interval: 24h
@@ -78,10 +78,11 @@ periodics:
     preset-capz-windows-common-127: "true"
     preset-capz-windows-2022: "true"
     preset-windows-private-registry-cred: "true"
+    preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.8
+    base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: windows-testing


### PR DESCRIPTION
Updates the cluster-api-provider-azure branch under test in sig-windows jobs to release-1.10. (release-1.8 is not updated to work around the Go v1.20.6 HTTP host issue.) Also updates cloud-provider-azure branches to resolve those // TODOs.