### PR TITLE
Switch NPD jobs to GCP-hosted clusters

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,6 +1,7 @@
 periodics:
 - name: ci-npd-build
-  cluster: k8s-infra-prow-build
+  # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+  cluster: default
   interval: 2h
   decorate: true
   labels:
@@ -36,7 +37,7 @@ periodics:
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
 - name: ci-npd-test
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/node-problem-detector:
   - name: pull-npd-build
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -18,6 +18,8 @@ presubmits:
         args:
         - bash
         - -c
+        # TODO: this job doesn't match the CI version (no .env file push).
+        # Consider making it similar or even deleting it.
         - >-
           ./test/build.sh install-lib &&
           make build
@@ -31,13 +33,11 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-
-
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -63,12 +63,12 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-node
-    cluster: k8s-infra-prow-build
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -122,7 +122,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci
-    cluster: eks-prow-build-cluster
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -167,7 +168,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
-    cluster: eks-prow-build-cluster
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -254,7 +256,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
-    cluster: eks-prow-build-cluster
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -299,7 +302,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    cluster: eks-prow-build-cluster
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true


### PR DESCRIPTION
## What does this PR do?
Update the cluster for NPD jobs to `k8s-infra-prow-build`, which is community-owned (some jobs can run in EKS-hosted cluster, but I think it's better to have them all in the same GCP-hosted cluster for consistency reasons).

The only exception is for jobs that require to upload files to a GCS bucket. These jobs will remain on Google-owned cluster `default` until we are able to grant all the missing permissions to cluster `k8s-infra-prow-build`:
- `ci-npd-build`
- `pull-npd-e2e-node`
- `pull-npd-e2e-kubernetes-gce-gci`
- `pull-npd-e2e-kubernetes-gce-gci-custom-flags`
- `pull-npd-e2e-kubernetes-gce-ubuntu`
- `pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags`

/assign @SergeyKanzhelev 
/cc @MartinForReal 