### PR TITLE
[Peribolos] disable GH sync in "post-org-peribolos" & "ci-peribolos" job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -15,7 +15,10 @@ postsubmits:
         - --github-endpoint=http://ghproxy.default.svc.cluster.local
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github-token/oauth
-        - --confirm
+        # TODO: uncomment below to
+        # re-enable sync once Peribolos tool
+        # is fixed for managing team repo perms
+        # - --confirm
         volumeMounts:
         - name: github
           mountPath: /etc/github-token
@@ -562,7 +565,10 @@ periodics:
       - --github-endpoint=http://ghproxy.default.svc.cluster.local
       - --github-endpoint=https://api.github.com
       - --github-token-path=/etc/github-token/oauth
-      - --confirm
+      # TODO: uncomment below to
+      # re-enable sync once Peribolos tool
+      # is fixed for managing team repo perms
+      # - --confirm
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
This PR disables the GH sync using Peribolos, which is currently happening as part of `post-org-peribolos` postsubmit and `ci-peribolos` periodic job.

There will be a follow-up PR to re-enable the sync in both the jobs, once there's a fix available for Peribolos properl managing GH team repo permissions.

Part of investigation for failing job - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1686411134162178048

/sig contributor-experience
/assign @MadhavJivrajani 