### PR TITLE
e2e-node-canary: use image config to remount /tmp

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -75,11 +75,7 @@ periodics:
       args:
       - --deployment=node
       - --gcp-zone=us-west1-b
-        # node_e2e doesn't support passing an image-family on the CLI, only via
-        # a file, so here we manually specify an image to run tests against.
-        # To find the latest cos-97-lts image run:
-        #   gcloud compute images describe-from-family cos-97-lts --project cos-cloud --format='value(name)'
-      - --node-args=--images=cos-97-16919-29-21 --image-project=cos-cloud
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-canary.yaml
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce

--- a/jobs/e2e_node/image-config-canary.yaml
+++ b/jobs/e2e_node/image-config-canary.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-stable:
+    image_family: cos-97-lts
+    project: cos-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
This job uses '--images=cos-97-16919-29-21' option, which uses cos image as is. /tmp is mounted with 'noexec' option in COS, which makes it impossible to run ginkgo and other test binaries.

Usage of 'image-config' option ensures remounting /tmp with 'exec' option. This is done in the jobs/e2e_node/containerd/init.yaml:
```
runcmd:
  - echo "Test run from /tmp folder, remounting it"
  - mount /tmp /tmp -o remount,exec,suid
```
Fixes: kubernetes/kubernetes#119681