### PR TITLE
peribolos: fix conditional for invoking --skip-removal flag

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -144,7 +144,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 		return fmt.Errorf("--fix-team-repos requires --fix-teams")
 	}
 
-	if o.skipRemovals && (o.fixTeams || o.fixTeamRepos || o.fixTeamMembers || o.fixOrg || o.fixOrgMembers) {
+	if o.skipRemovals && !(o.fixTeams || o.fixTeamRepos || o.fixTeamMembers || o.fixOrg || o.fixOrgMembers) {
 		return fmt.Errorf("--skip-removals requires atleast one of --fix-teams, --fix-team-repos, --fix-team-members, --fix-org, --fix-org-members")
 	}
 


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/pull/30264

Minor fix in the `if` conditional logic for parsing `--skip-removals` flag option in  `parseArgs()` function.

---

Hopes to fix the following error in the currently failing `ci-org-peribolos` & `post-peribolos` CI jobs.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1686483044187246592
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-org-peribolos/1686566705985228800 

```
{"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:77","func":"main.parseOptions","level":"fatal","msg":"Invalid flags: --skip-removals requires atleast one of --fix-teams, --fix-team-repos, --fix-team-members, --fix-org, --fix-org-members","severity":"fatal","time":"2023-08-02T02:38:24Z"}
```

/sig contributor-experience
/assign @MadhavJivrajani 
/hold