### PR TITLE
add contribex TLs to Peribolos OWNERS

### DIFF
--- a/prow/cmd/peribolos/OWNERS
+++ b/prow/cmd/peribolos/OWNERS
@@ -2,7 +2,9 @@
 
 reviewers:
 - cjwagner
+- sig-contributor-experience-technical-leads
 approvers:
 - cjwagner
+- sig-contributor-experience-technical-leads
 labels:
  - area/prow/peribolos


### PR DESCRIPTION
Add SIG Contributor Experience Technical Leads to the Peribolos OWNERS file as approvers.

/sig contributor-experience
/assign @MadhavJivrajani @nikhita 