### PR TITLE
capv: use test-junit instead of test to also get junit reports for better visualization

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
@@ -21,7 +21,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test
+      - test-junit
   annotations:
     testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
     testgrid-tab-name: periodic-test-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
@@ -21,7 +21,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test
+      - test-junit
   annotations:
     testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
     testgrid-tab-name: periodic-test-release-1-5

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -21,7 +21,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test
+      - test-junit
   annotations:
     testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
     testgrid-tab-name: periodic-test-release-1-6

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
@@ -21,7 +21,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test
+      - test-junit
   annotations:
     testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
     testgrid-tab-name: periodic-test-release-1-7

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
@@ -21,7 +21,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test
+      - test-junit
   annotations:
     testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
     testgrid-tab-name: periodic-test-release-1-8

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
@@ -143,7 +143,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test
+        - test-junit
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
@@ -66,7 +66,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test
+        - test-junit
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-release-1-5

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -64,7 +64,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test
+        - test-junit
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-release-1-6

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
@@ -64,7 +64,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test
+        - test-junit
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-release-1-7

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
@@ -64,7 +64,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test
+        - test-junit
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test-release-1-8


### PR DESCRIPTION
To be merged after https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2140 + cherry-pick mergers

Some more context at https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2122#issuecomment-1662180033

fixes: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2122