### PR TITLE
fix ec2 instance type for kubetest2 canary job and bump verify job cpu limit

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -127,7 +127,7 @@ presubmits:
             /aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id \;
             --query 'Parameters[0].[Value]' --output text);
           kubetest2 noop --test=node -- \;
-            --provider=aws --repo-root=. --instance-type=m6g.large \;
+            --provider=aws --repo-root=. --instance-type=m6a.large \;
             --images=$AMI_ID --user-data-file=config/ubuntu2204.yaml
 
   - name: pull-kubetest2-gce-node-e2e

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
@@ -16,10 +16,10 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 4
             memory: 4Gi
         securityContext:
           privileged: true
@@ -39,10 +39,10 @@ presubmits:
         - build-all
         resources:
           limits:
-            cpu: 1
+            cpu: 2
             memory: 4Gi
           requests:
-            cpu: 1
+            cpu: 2
             memory: 4Gi
         securityContext:
           privileged: true


### PR DESCRIPTION
/cc @dims

Required for https://github.com/kubernetes-sigs/kubetest2/pull/234
