### PR TITLE
Revert "sig-cl: migrate all jobs to eks cluster"

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-no-addons-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -178,7 +178,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-25
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -46,7 +46,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-28
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -178,7 +178,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-25
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -46,7 +46,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-28
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -178,7 +178,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-25
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -46,7 +46,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-28
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -178,7 +178,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-25
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-28-on-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -46,7 +46,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-27-on-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-26-on-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-27-on-1-28
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -266,7 +266,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-26-on-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -310,7 +310,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -354,7 +354,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-learner-mode.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-learner-mode.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-learner-mode-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-patches-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-rootless-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade-addons-before-controlplane.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade-addons-before-controlplane.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-addons-before-controlplane-1-28-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-28-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-26-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-25-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-latest-on-1-28
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -46,7 +46,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-28-on-1-27
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -90,7 +90,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-27-on-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-26-on-1-25
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -2,7 +2,7 @@
 periodics:
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-latest
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:
@@ -134,7 +134,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-26
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:
@@ -178,7 +178,7 @@ periodics:
           cpu: 2000m
 
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-25
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   labels:


### PR DESCRIPTION
This reverts commit 27d2d8b978564ee0615742aea1f1dfdb5427f3b4.

Because of https://github.com/kubernetes/k8s.io/issues/5473 issues we decided to move kubeadm jobs back to GKE cluster. This has been discussed on yesterday's sig-infra-meeting (unfortunately the video hasn't been uploaded yet). Putting it shortly, we have a suspicion that those jobs are problematic and want to see if moving them back to GKE improves stability of EKS clusters. Investigation will be done post 1.28.

/assign @xmudrii
/cc @dims @ameukam @BenTheElder 

