### PR TITLE
move kops scale job to EKS prow cluster

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -68,6 +68,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: presubmit-kops-aws-scale-amazonvpc-using-cl2
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: false
@@ -129,6 +130,9 @@ presubmits:
           value: "true"
         resources:
           requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
             cpu: "2"
             memory: "6Gi"
     annotations:


### PR DESCRIPTION
This is temporary to make minimum required changes and we will update the template once the jobs are passing.