### PR TITLE
Inrepoconfig caching service (Moonraker)

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -20,6 +20,7 @@ baseImageOverrides:
   k8s.io/test-infra/prow/cmd/initupload: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/invitations-accepter: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20220215-ddc3ad9
+  k8s.io/test-infra/prow/cmd/moonraker: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20230718-8d3170488d
   k8s.io/test-infra/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20230307-5398de3144
@@ -238,6 +239,13 @@ builds:
   - -s -w
   - -X k8s.io/test-infra/prow/version.Version={{.Env.VERSION}}
   - -X k8s.io/test-infra/prow/version.Name=jenkins-operator
+- id: moonraker
+  dir: .
+  main: prow/cmd/moonraker
+  ldflags:
+  - -s -w
+  - -X k8s.io/test-infra/prow/version.Version={{.Env.VERSION}}
+  - -X k8s.io/test-infra/prow/version.Name=moonraker
 - id: peribolos
   dir: .
   main: prow/cmd/peribolos

--- a/prow/cmd/moonraker/main.go
+++ b/prow/cmd/moonraker/main.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// "Moonraker" is a caching service to cache inrepoconfig (ProwYAML) objects. It
+// handles cloning the Git repo holding the inrepoconfig, parsing the ProwYAML
+// out of it, as well as caching the result in an in-memory LRU cache. Other
+// Prow components in the same service cluster can go through Moonraker to save
+// the trouble of trying to perform inrepoconfig lookups themselves.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"k8s.io/test-infra/greenhouse/diskutil"
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	configflagutil "k8s.io/test-infra/prow/flagutil/config"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/metrics"
+	"k8s.io/test-infra/prow/moonraker"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/pjutil/pprof"
+)
+
+var (
+	diskFree = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "moonraker_disk_free",
+		Help: "Free gb on moonraker disk.",
+	})
+	diskUsed = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "moonraker_disk_used",
+		Help: "Used gb on moonraker disk.",
+	})
+	diskTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "moonrakere_disk_total",
+		Help: "Total gb on moonraker disk.",
+	})
+	diskInodeFree = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "moonrakere_disk_inode_free",
+		Help: "Free inodes on moonraker disk.",
+	})
+	diskInodeUsed = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "moonraker_disk_inode_used",
+		Help: "Used inodes on moonraker disk.",
+	})
+	diskInodeTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "moonraker_disk_inode_total",
+		Help: "Total inodes on moonraker disk.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(diskFree)
+	prometheus.MustRegister(diskUsed)
+	prometheus.MustRegister(diskTotal)
+	prometheus.MustRegister(diskInodeFree)
+	prometheus.MustRegister(diskInodeUsed)
+	prometheus.MustRegister(diskInodeTotal)
+}
+
+type options struct {
+	github         prowflagutil.GitHubOptions
+	port           int
+	cookiefilePath string
+
+	config configflagutil.ConfigOptions
+
+	dryRun                 bool
+	gracePeriod            time.Duration
+	instrumentationOptions prowflagutil.InstrumentationOptions
+	pushGatewayInterval    time.Duration
+}
+
+func gatherOptions(fs *flag.FlagSet, args ...string) options {
+	var o options
+	fs.IntVar(&o.port, "port", 8080, "HTTP port.")
+	// Kubernetes uses a 30-second default grace period for pods to
+	// terminate before sending a SIGKILL to the process in the pod. Our own
+	// grace period must be smaller than this.
+	fs.DurationVar(&o.gracePeriod, "grace-period", 25*time.Second, "On shutdown, try to handle remaining events for the specified duration. Cannot be larger than 30s.")
+	fs.StringVar(&o.cookiefilePath, "cookiefile", "", "Path to git http.cookiefile, leave empty for github or anonymous")
+	fs.DurationVar(&o.pushGatewayInterval, "push-gateway-interval", time.Minute, "Interval at which prometheus metrics for disk space are pushed.")
+	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions, &o.config} {
+		group.AddFlags(fs)
+	}
+
+	fs.Parse(args)
+
+	return o
+}
+
+func (o *options) validate() error {
+	var errs []error
+	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions, &o.config} {
+		if err := group.Validate(o.dryRun); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func main() {
+	logrusutil.ComponentInit()
+
+	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	pprof.Instrument(o.instrumentationOptions)
+
+	// Start serving liveness endpoint /healthz.
+	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
+
+	configAgent, err := o.config.ConfigAgent()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+
+	metrics.ExposeMetrics("moonraker", configAgent.Config().PushGateway, o.instrumentationOptions.MetricsPort)
+
+	persist := false
+	if o.config.InRepoConfigCacheDirBase != "" {
+		persist = true
+	}
+
+	gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun, persist)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Git client.")
+	}
+
+	if o.config.InRepoConfigCacheDirBase != "" {
+		go diskMonitor(o.pushGatewayInterval, o.config.InRepoConfigCacheDirBase)
+	}
+
+	cacheGetter, err := config.NewInRepoConfigCache(o.config.InRepoConfigCacheSize, configAgent, gitClient)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
+	}
+
+	mr := moonraker.Moonraker{
+		ConfigAgent:       configAgent,
+		InRepoConfigCache: cacheGetter,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/%s", moonraker.PathGetInrepoconfig), mr.ServeGetInrepoconfig)
+	server := &http.Server{
+		Addr:    ":" + strconv.Itoa(o.port),
+		Handler: mux,
+	}
+	logrus.Infof("Listening on port %d...", o.port)
+	interrupts.ListenAndServe(server, o.gracePeriod)
+	health.ServeReady(func() bool {
+		return true
+	})
+	interrupts.WaitForGracefulShutdown()
+}
+
+// diskMonitor was copied from ghproxy.
+func diskMonitor(interval time.Duration, diskRoot string) {
+	logger := logrus.WithField("sync-loop", "disk-monitor")
+	ticker := time.NewTicker(interval)
+	for ; true; <-ticker.C {
+		logger.Info("tick")
+		_, bytesFree, bytesUsed, _, inodesFree, inodesUsed, err := diskutil.GetDiskUsage(diskRoot)
+		if err != nil {
+			logger.WithError(err).Error("Failed to get disk metrics")
+		} else {
+			diskFree.Set(float64(bytesFree) / 1e9)
+			diskUsed.Set(float64(bytesUsed) / 1e9)
+			diskTotal.Set(float64(bytesFree+bytesUsed) / 1e9)
+			diskInodeFree.Set(float64(inodesFree))
+			diskInodeUsed.Set(float64(inodesUsed))
+			diskInodeTotal.Set(float64(inodesFree + inodesUsed))
+		}
+	}
+}

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -126,3 +126,7 @@ func (a *repoClientAdapter) RemoteUpdate() error {
 func (a *repoClientAdapter) FetchRef(refspec string) error {
 	return errors.New("no FetchRef implementation exists in the v1 repo client")
 }
+
+func (a *repoClientAdapter) RevParseN(revs []string) (map[string]string, error) {
+	return nil, errors.New("no RevParseN implementation exists in the v1 repo client")
+}

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -95,6 +95,10 @@ type repoClient struct {
 type ClientFactoryOpts struct {
 	// Host, defaults to "github.com" if unset
 	Host string
+	// Whether to use HTTP. By default, HTTPS is used (overrides UseSSH).
+	//
+	// TODO (listx): Combine HTTPS, HTTP, and SSH schemes into a single enum.
+	UseInsecureHTTP *bool
 	// UseSSH, defaults to false
 	UseSSH *bool
 	// The directory in which the cache should be
@@ -143,6 +147,9 @@ type RepoOpts struct {
 func (cfo *ClientFactoryOpts) Apply(target *ClientFactoryOpts) {
 	if cfo.Host != "" {
 		target.Host = cfo.Host
+	}
+	if cfo.UseInsecureHTTP != nil {
+		target.UseInsecureHTTP = cfo.UseInsecureHTTP
 	}
 	if cfo.UseSSH != nil {
 		target.UseSSH = cfo.UseSSH
@@ -234,6 +241,7 @@ func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 	} else {
 		remote = &httpResolverFactory{
 			host:     o.Host,
+			http:     *o.UseInsecureHTTP,
 			username: o.Username,
 			token:    o.Token,
 		}

--- a/prow/git/v2/remote.go
+++ b/prow/git/v2/remote.go
@@ -76,6 +76,8 @@ func (f *sshRemoteResolverFactory) PublishRemote(_, repo string) RemoteResolver 
 }
 
 type httpResolverFactory struct {
+	// Whether to use HTTP.
+	http bool
 	host string
 	// Optional, either both or none must be set
 	username LoginGetter
@@ -86,7 +88,11 @@ type httpResolverFactory struct {
 // for the repository.
 func (f *httpResolverFactory) CentralRemote(org, repo string) RemoteResolver {
 	return HttpResolver(func() (*url.URL, error) {
-		return &url.URL{Scheme: "https", Host: f.host, Path: fmt.Sprintf("%s/%s", org, repo)}, nil
+		scheme := "https"
+		if f.http {
+			scheme = "http"
+		}
+		return &url.URL{Scheme: scheme, Host: f.host, Path: fmt.Sprintf("%s/%s", org, repo)}, nil
 	}, f.username, f.token)
 }
 
@@ -94,6 +100,10 @@ func (f *httpResolverFactory) CentralRemote(org, repo string) RemoteResolver {
 // for the repository that can be published to.
 func (f *httpResolverFactory) PublishRemote(_, repo string) RemoteResolver {
 	return HttpResolver(func() (*url.URL, error) {
+		scheme := "https"
+		if f.http {
+			scheme = "http"
+		}
 		if f.username == nil {
 			return nil, errors.New("username not configured, no publish repo available")
 		}
@@ -101,7 +111,7 @@ func (f *httpResolverFactory) PublishRemote(_, repo string) RemoteResolver {
 		if err != nil {
 			return nil, err
 		}
-		return &url.URL{Scheme: "https", Host: f.host, Path: fmt.Sprintf("%s/%s", o, repo)}, nil
+		return &url.URL{Scheme: scheme, Host: f.host, Path: fmt.Sprintf("%s/%s", o, repo)}, nil
 	}, f.username, f.token)
 }
 

--- a/prow/moonraker/client.go
+++ b/prow/moonraker/client.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moonraker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/version"
+)
+
+type Client struct {
+	host       string
+	httpClient *http.Client
+}
+
+func NewClient(host string, timeout time.Duration) *Client {
+	return &Client{
+		host: host,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+func (c *Client) do(method, path string, payload []byte, params map[string]string) (*http.Response, error) {
+	baseURL, err := url.JoinPath(c.host, path)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, baseURL, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Add("User-Agent", version.UserAgent())
+	q := req.URL.Query()
+	for key, val := range params {
+		q.Set(key, val)
+	}
+	req.URL.RawQuery = q.Encode()
+	return c.httpClient.Do(req)
+}
+
+// GetProwYAML returns the inrepoconfig contents for a repo, based on the Refs
+// struct as the input. From the Refs, Moonraker can determine the org/repo,
+// BaseSHA, and the Pulls[] (additional refs of each PR, if any) to grab the
+// inrepoconfig contents.
+func (c *Client) GetProwYAML(refs *prowapi.Refs) (*config.ProwYAML, error) {
+	payload := payload{
+		Refs: *refs,
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal %v", payload)
+	}
+
+	resp, err := c.do(http.MethodPost, PathGetInrepoconfig, buf, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("got %v response", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	prowYAML := config.ProwYAML{}
+	err = json.Unmarshal(body, &prowYAML)
+	if err != nil {
+		logrus.WithError(err).Info("unable to unmarshal getInrepoconfig request")
+		return nil, err
+	}
+
+	return &prowYAML, nil
+}

--- a/prow/moonraker/moonraker.go
+++ b/prow/moonraker/moonraker.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moonraker
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+const (
+	PathGetInrepoconfig = "inrepoconfig"
+)
+
+type Moonraker struct {
+	ConfigAgent       *config.Agent
+	InRepoConfigCache *config.InRepoConfigCache
+}
+
+// payload is the message payload we use for Moonraker. For
+// forward-compatibility, we don't use a prowapi.Refs directly.
+type payload struct {
+	Refs prowapi.Refs `json:"refs"`
+}
+
+type ProwYAMLGetter interface {
+	GetProwYAML(payload *payload) (*config.ProwYAML, error)
+}
+
+// serveGetInrepoconfig returns a ProwYAML object marshaled into JSON.
+func (mr *Moonraker) ServeGetInrepoconfig(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		logrus.WithError(err).Info("unable to read request")
+		http.Error(w, fmt.Sprintf("bad request %v", err), http.StatusBadRequest)
+		return
+	}
+
+	payload := &payload{}
+	err = json.Unmarshal(body, payload)
+	if err != nil {
+		logrus.WithError(err).Info("unable to unmarshal getInrepoconfig request")
+		http.Error(w, fmt.Sprintf("unable to unmarshal getInrepoconfig request: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	baseSHAGetter := func() (string, error) {
+		return payload.Refs.BaseSHA, nil
+	}
+	var headSHAGetters []func() (string, error)
+	for _, pull := range payload.Refs.Pulls {
+		pull := pull
+		headSHAGetters = append(headSHAGetters, func() (string, error) {
+			return pull.SHA, nil
+		})
+	}
+	identifier := payload.Refs.Org + "/" + payload.Refs.Repo
+
+	prowYAML, err := mr.InRepoConfigCache.GetProwYAML(identifier, baseSHAGetter, headSHAGetters...)
+	if err != nil {
+		logrus.WithError(err).Error("unable to retrieve inrepoconfig ProwYAML")
+		http.Error(w, fmt.Sprintf("unable to retrieve inrepoconfig ProwYAML: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(prowYAML); err != nil {
+		logrus.WithError(err).Error("unable to encode inrepoconfig ProwYAML into JSON")
+		http.Error(w, fmt.Sprintf("unable to encode inrepoconfig ProwYAML into JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+}

--- a/prow/test/integration/config/prow/cluster/200_ingress.yaml
+++ b/prow/test/integration/config/prow/cluster/200_ingress.yaml
@@ -37,6 +37,13 @@ spec:
             name: webhook-server
             port:
               number: 80
+      - path: /moonraker(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: moonraker
+            port:
+              number: 80
       # Fakes.
       - path: /fakeghserver(/|$)(.*)
         pathType: Prefix

--- a/prow/test/integration/config/prow/cluster/moonraker_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/moonraker_deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+# In production, Moonraker should be deployed as a StatefulSet so that its Git
+# repos that it clones can be persisted across deployments. But for integration
+# tests, this is not necessary because we bring up the entire cluster from
+# scratch.
+kind: Deployment
+metadata:
+  namespace: default
+  name: moonraker
+  labels:
+    app: moonraker
+spec:
+  selector:
+    matchLabels:
+      app: moonraker
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: moonraker
+    spec:
+      # For development and CI, we don't care that much about graceful shutdown,
+      # so use 5 seconds to override the default of 25.
+      terminationGracePeriodSeconds: 5
+      serviceAccountName: moonraker
+      containers:
+      - name: moonraker
+        image: localhost:5001/moonraker
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --job-config-path=/etc/job-config
+        # This cookie file is only here to trigger the creation of a
+        # Gerrit-flavored Git client factory. So this makes this moonraker deployment
+        # "tied" to Gerrit.
+        #
+        # TODO (listx): Allow moonraker to be deployed with access to multiple
+        # GitHub/Gerrit credentials (and make it know which one to use based on
+        # the org/repo name). We can't simply deploy a 2nd moonraker deployment
+        # configured with GitHub creds to test that codepath because currently
+        # moonraker will always choose one or the other.
+        - --cookiefile=/etc/cookies/cookies
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - name: cookies
+          mountPath: /etc/cookies
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
+        env:
+        # When cloning from an inrepoconfig repo, don't bother verifying certs.
+        # This allows us to use "https://..." addresses to fakegitserver.
+        - name: GIT_SSL_NO_VERIFY
+          value: "1"
+      volumes:
+      - name: cookies
+        secret:
+          defaultMode: 420
+          secretName: http-cookiefile
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/test/integration/config/prow/cluster/moonraker_rbac.yaml
+++ b/prow/test/integration/config/prow/cluster/moonraker_rbac.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: moonraker
+  namespace: default

--- a/prow/test/integration/config/prow/cluster/moonraker_service.yaml
+++ b/prow/test/integration/config/prow/cluster/moonraker_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moonraker
+  namespace: default
+spec:
+  selector:
+    app: moonraker
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP
+  - name: metrics
+    port: 9090
+    protocol: TCP
+  type: ClusterIP

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -66,6 +66,7 @@ in_repo_config:
    "fakegitserver.default/repo/org1/repo4": true
    "fakegitserver.default/repo/org1/repo5": true
    "fakegitserver.default/repo/some/org/gangway-test-repo-1": true
+   "fakegitserver.default/repo/moonraker-burst": true
 
 # Allowlist of Prow API clients.
 gangway:

--- a/prow/test/integration/lib.sh
+++ b/prow/test/integration/lib.sh
@@ -45,6 +45,7 @@ declare -ra PROW_COMPONENTS=(
   gerrit
   hook
   horologium
+  moonraker
   prow-controller-manager
   sinker
   sub
@@ -63,6 +64,7 @@ declare -rA PROW_IMAGES=(
   [gerrit]=prow/cmd/gerrit
   [hook]=prow/cmd/hook
   [horologium]=prow/cmd/horologium
+  [moonraker]=prow/cmd/moonraker
   [prow-controller-manager]=prow/cmd/prow-controller-manager
   [sinker]=prow/cmd/sinker
   [sub]=prow/cmd/sub
@@ -92,6 +94,7 @@ declare -rA PROW_IMAGES_TO_COMPONENTS=(
   [gerrit]=gerrit
   [hook]=hook
   [horologium]=horologium
+  [moonraker]=moonraker
   [prow-controller-manager]=prow-controller-manager
   [sinker]=sinker
   [sub]=sub
@@ -235,6 +238,12 @@ declare -ra PROW_DEPLOYMENT_ORDER=(
   WAIT_FOR_RESOURCE_clusterrolebindings,webhook-server,default
   WAIT_FOR_RESOURCE_serviceaccounts,webhook-server,default
   WAIT_webhook-server
+
+  moonraker_rbac.yaml
+  moonraker_service.yaml
+  moonraker_deployment.yaml
+  WAIT_FOR_RESOURCE_serviceaccounts,moonraker,default
+  WAIT_moonraker
 
   gangway_rbac.yaml
   gangway_service.yaml

--- a/prow/test/integration/test/moonraker_test.go
+++ b/prow/test/integration/test/moonraker_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
+
+	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/moonraker"
+	"k8s.io/test-infra/prow/test/integration/internal/fakegitserver"
+)
+
+// TestMoonrakerBurst tests Moonraker by flooding it with a burst of 100
+// requests at once. Each request will have the same base SHA, but a different
+// head SHA (pretending to be a unique Pull Request). This way, the requests
+// will avoid getting coalesced into the same LRU cache entry. This in turn will
+// force Moonraker to fetch the same base SHA in parallel while constructing the
+// ProwYAML value. We expect Moonraker to return successfully for all 100
+// requests.
+//
+// The hard part here is constructing the 100 different head SHA values. We need
+// to create 100 different PRs, each with its own unique head SHA. We do this
+// dynamically with our own Git v2 client (this means we will write into our
+// local filesystem). We send a shell script over to fakegitserver (FGS) to
+// create the 100 different commit SHAs, but all using the same base SHA (this
+// is how FGS lets clients seed test repos). We then clone the repo from FGS to
+// our local disk to read the SHA values for these 100 fake PRs. Now that we
+// know the repo location, the base SHA, and the head SHAs, we can construct the
+// GetProwYAML() queries to Moonraker. We then just check that the return values
+// for all 100 requests are the same (because the 100 PRs will not modify the
+// inrepoconfig files).
+//
+// The reason why we do this as an integration test instead of a unit test is
+// because we want to go over the network for fetching the SHA object from FGS,
+// as opposed to "fetching" locally from disk.
+func TestMoonrakerBurst(t *testing.T) {
+	const createRepoWithPRs = `
+echo hello > README.txt
+git add README.txt
+git commit -m "commit 1"
+
+# Create fake PRs. These are "Gerrit" style refs under refs/changes/*.
+for num in $(seq 1 100); do
+	git checkout -d master
+	echo "${num}" > "${num}"
+	git add "${num}"
+	git commit -m "PR${num}"
+	git update-ref "refs/changes/00/123/${num}" HEAD
+done
+
+git checkout master
+
+echo this-is-from-repo%s > README.txt
+git add README.txt
+git commit -m "uniquify"
+
+mkdir .prow
+cat <<EOF >.prow/presubmits.yaml
+presubmits:
+  - name: my-presubmit
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - image: localhost:5001/alpine
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -eu
+          echo "hello from my-presubmit"
+          cat README.txt
+EOF
+
+git add .prow/presubmits.yaml
+git commit -m "add inrepoconfig for my-presubmit"
+`
+
+	repoSetup := fakegitserver.RepoSetup{
+		Name:      "moonraker-burst",
+		Script:    createRepoWithPRs,
+		Overwrite: true,
+	}
+
+	// Set up repos on FGS for just this test case.
+	fgsClient := fakegitserver.NewClient("http://localhost/fakegitserver", 5*time.Second)
+	err := fgsClient.SetupRepo(repoSetup)
+	if err != nil {
+		t.Fatalf("FGS repo setup failed: %v", err)
+	}
+
+	// Clone the repo out of FGS to determine the base SHA of master branch for
+	// repo-moonraker-stres-test, as well as the 100 different PR head SHAs.
+	cacheDirBase := "/var/tmp"
+
+	trueVal := true
+	var gitClientFactoryOpt = func(o *git.ClientFactoryOpts) {
+		o.UseInsecureHTTP = &trueVal
+		o.Host = "localhost"
+		o.CacheDirBase = &cacheDirBase
+	}
+
+	gc, err := git.NewClientFactory(gitClientFactoryOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var repoOpts = git.RepoOpts{
+		ShareObjectsWithSourceRepo: true,
+		NoFetchTags:                true,
+	}
+
+	// repoClient points to the *secondary* clone. Still, because we share all
+	// objects with the primary, it effectively behaves like the primary with
+	// all of the (mirrored) refs in it.
+	repoClient, err := gc.ClientForWithRepoOpts("fakegitserver/repo", repoSetup.Name, repoOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repoClient.Clean()
+
+	baseSHA, err := repoClient.RevParse("HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseSHA = strings.TrimSuffix(baseSHA, "\n")
+
+	// We fetch all refs/changes/* into the secondary clone. Although we share
+	// the underlying SHA objects (ShareObjectsWithSourceRepo), we don't know
+	// what these SHAs look like yet. However, we do know that the
+	// refs/changes/* files act as pointers to the SHAs, so fetch these refs.
+	repoClient.Fetch("refs/changes/*:refs/changes/*")
+	refs := []string{}
+	for i := 1; i <= 100; i++ {
+		ref := fmt.Sprintf("refs/changes/00/123/%d", i)
+		refs = append(refs, ref)
+	}
+	refsToShas, err := repoClient.RevParseN(refs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headSHAs := []string{}
+	for _, headSHA := range refsToShas {
+		headSHAs = append(headSHAs, headSHA)
+	}
+
+	// Set up client to talk to Moonraker inside the KIND cluster. The moonraker
+	// address here uses localhost, because we're initiating the request from
+	// outside the KIND cluster (this file you are reading is executed outside
+	// the cluster).
+	moonrakerClient := moonraker.NewClient("http://localhost/moonraker", 5*time.Second)
+
+	var want = config.Presubmit{
+		JobBase: config.JobBase{
+			Name: "my-presubmit",
+			UtilityConfig: config.UtilityConfig{
+				Decorate: &trueVal,
+			},
+			Spec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image:   "localhost:5001/alpine",
+						Command: []string{"sh"},
+						Args: []string{
+							"-c",
+							`set -eu
+echo "hello from my-presubmit"
+cat README.txt
+`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Collect errors from the workers. This is because otherwise we get a
+	// "call to (*T).Fatal from a non-test goroutine" error.
+	errs := make(chan error, 1)
+
+	var sendGetProwYAMLRequest = func(t *testing.T, headSHA string) {
+		got, err := moonrakerClient.GetProwYAML(&prowjobv1.Refs{
+			// org is the URL of the "org" for the repo, as seen from inside the
+			// KIND cluster (because moonraker is running inside the KIND
+			// cluster). This is why we use the "fakegitserver.default" domain.
+			Org:     "https://fakegitserver.default/repo",
+			Repo:    "moonraker-burst",
+			BaseSHA: baseSHA,
+			Pulls:   []prowjobv1.Pull{{SHA: headSHA}},
+		})
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		gotPresubmit := got.Presubmits[0]
+		// Clear out parts of the response that we don't care about.
+		gotPresubmit.Trigger = ""
+		gotPresubmit.RerunCommand = ""
+		gotPresubmit.Reporter = config.Reporter{}
+		gotPresubmit.Brancher = config.Brancher{}
+		gotPresubmit.JobBase.Agent = ""
+		gotPresubmit.JobBase.Cluster = ""
+		gotPresubmit.JobBase.Namespace = nil
+		gotPresubmit.JobBase.ProwJobDefault = nil
+		gotPresubmit.UtilityConfig.DecorationConfig = nil
+
+		// Check that the gotPresubmit is what we expect (what we created in the
+		// createRepoWithPRs bit at the beginning of this test function above).
+		if diff := cmp.Diff(gotPresubmit, want, cmpopts.IgnoreUnexported(
+			config.Presubmit{},
+			config.Brancher{},
+			config.RegexpChangeMatcher{})); diff != "" {
+			errs <- fmt.Errorf("unexpected moonraker response: %s", diff)
+		} else {
+			errs <- nil
+		}
+	}
+
+	// Now create the burst of 100 requests.
+	for i := 1; i <= 100; i++ {
+		go sendGetProwYAMLRequest(t, headSHAs[i-1])
+	}
+
+	// Check that all 100 requests finished successfully.
+	for i := 1; i <= 100; i++ {
+		err := <-errs
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This adds a new inrepoconfig caching service, named Moonraker (in nautical terms it's a type of sail). It also makes Sub and Gangway use this service to query for inrepoconfig values, instead of querying them (running `git fetch`) themselves. This centralizes the inrepoconfig caching into one place to make things more efficient in the service cluster.

This also adds a new integration test to check that Moonraker can handle a burst of traffic (`TestMoonrakerBurst`), which tests that we can do parallel fetches in the primary clones (this builds on https://github.com/kubernetes/test-infra/pull/30541).

In a follow-up PR, we will make the Gerrit component also use Moonraker. The switch should be straightforward (as demonstrated by the changes to cmd/* in this PR), but is not included here to reduce any potential blast radius. Documentation updates will be done to these components separately once this PR is approved.

/cc @cjwagner @timwangmusic @airbornepony 