### PR TITLE
migrate `cluster-api-provider-nested` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-nested-build
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
   extra_refs:
@@ -21,10 +22,14 @@ periodics:
         requests:
           memory: "6Gi"
           cpu: "2"
+        limits:
+          memory: "6Gi"
+          cpu: "2"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
     testgrid-tab-name: periodic-cluster-api-provider-nested-build
 - name: periodic-cluster-api-provider-nested-test
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
   extra_refs:
@@ -44,6 +49,9 @@ periodics:
       - "./scripts/ci-test.sh"
       resources:
         requests:
+          memory: "6Gi"
+          cpu: "2"
+        limits:
           memory: "6Gi"
           cpu: "2"
   annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits-release-0-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits-release-0-1.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-nested:
   - name: pull-cluster-api-provider-nested-test-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -18,10 +19,14 @@ presubmits:
           requests:
             memory: "6Gi"
             cpu: "2"
+          limits:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
       testgrid-tab-name: pr-test-release-0-1
   - name: pull-cluster-api-provider-nested-build-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -39,10 +44,14 @@ presubmits:
           requests:
             memory: "6Gi"
             cpu: "2"
+          limits:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
       testgrid-tab-name: pr-build-release-0-1
   - name: pull-cluster-api-provider-nested-make-release-0-1
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -64,6 +73,9 @@ presubmits:
         - "./scripts/ci-make.sh"
         resources:
           requests:
+            memory: "6Gi"
+            cpu: "2"
+          limits:
             memory: "6Gi"
             cpu: "2"
     annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-nested:
   - name: pull-cluster-api-provider-nested-test
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -18,10 +19,14 @@ presubmits:
           requests:
             memory: "6Gi"
             cpu: "2"
+          limits:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
       testgrid-tab-name: pr-test
   - name: pull-cluster-api-provider-nested-build
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -39,10 +44,14 @@ presubmits:
           requests:
             memory: "6Gi"
             cpu: "2"
+          limits:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
       testgrid-tab-name: pr-build
   - name: pull-cluster-api-provider-nested-make
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -64,6 +73,9 @@ presubmits:
         - "./scripts/ci-make.sh"
         resources:
           requests:
+            memory: "6Gi"
+            cpu: "2"
+          limits:
             memory: "6Gi"
             cpu: "2"
     annotations:


### PR DESCRIPTION
This PR moves the cluster-api-provider-nested jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @charleszheng44 @christopherhein @Fei-Guo @vincepri