### PR TITLE
migrate `boskos` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubernetes-sigs/boskos:
     - name: ci-boskos-build-test-verify
+      cluster: eks-prow-build-cluster
       decorate: true
       always_run: true
       path_alias: sigs.k8s.io/boskos
@@ -17,6 +18,10 @@ postsubmits:
             resources:
               requests:
                 cpu: 4000m
+                memory: 4Gi
+              limits:
+                cpu: 4000m
+                memory: 4Gi
       annotations:
         testgrid-dashboards: sig-testing-boskos
         testgrid-tab-name: ci-build-test-verify

--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/boskos:
     - name: pull-boskos-build-test-verify
+      cluster: eks-prow-build-cluster
       decorate: true
       always_run: true
       path_alias: sigs.k8s.io/boskos
@@ -17,6 +18,10 @@ presubmits:
             resources:
               requests:
                 cpu: 4000m
+                memory: 4Gi
+              limits:
+                cpu: 4000m
+                memory: 4Gi
       annotations:
         testgrid-dashboards: sig-testing-boskos
         testgrid-tab-name: pull-build-test-verify


### PR DESCRIPTION
This PR moves the cluster-api-provider-nested jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @ixdy @alvaroaleman @stevekuznetsov