### PR TITLE
migrate `k-csi` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -140,7 +140,7 @@ job_cluster() {
   local repo=$1
 
   case "$repo" in
-   external-snapshotter|external-resizer)
+   external-snapshotter|external-resizer|lib-volume-populator|livenessprobe|node-driver-registrar|volume-data-source-validator)
      echo "eks-prow-build-cluster"
      ;;
    *)

--- a/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
+++ b/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/lib-volume-populator:
   - name: pull-kubernetes-csi-lib-volume-populator
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/livenessprobe:
   - name: pull-kubernetes-csi-livenessprobe-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/node-driver-registrar:
   - name: pull-kubernetes-csi-node-driver-registrar-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
+++ b/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/volume-data-source-validator:
   - name: pull-kubernetes-csi-volume-data-source-validator
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false


### PR DESCRIPTION
This PR moves additional csi jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @msau42 @saad-ali @xing-yang @jsafrane @pohly