### PR TITLE
migrate `client-go` job to community cluster

### DIFF
--- a/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
+++ b/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/client-go:
   - name: pull-client-go-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: k8s.io/client-go
@@ -15,3 +16,10 @@ presubmits:
         args:
         - build
         - ./...
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+            cpu: 2


### PR DESCRIPTION
This PR moves the client-go jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @sttts @nikhita