### PR TITLE
migrate `gengo` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/gengo/gengo-config.yaml
+++ b/config/jobs/kubernetes/gengo/gengo-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/gengo:
   - name: pull-gengo-test
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-api-machinery-gengo
       testgrid-tab-name: test
@@ -17,8 +18,16 @@ presubmits:
           args:
             - -c
             - 'go test -v -race ./...'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 4Gi
+              cpu: 2
 
   - name: pull-gengo-verify
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-api-machinery-gengo
       testgrid-tab-name: verify
@@ -36,3 +45,10 @@ presubmits:
            - -c
            - |
             go run ./examples/import-boss/main.go -i $(go list k8s.io/gengo/... | grep -v import-boss/tests | paste -sd',' -) --verify-only
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 4Gi
+              cpu: 2


### PR DESCRIPTION
This PR moves the gengo jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @aojea @lavalamp @thockin