### PR TITLE
add 1.27 e2e test for jobset for presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
@@ -154,6 +154,39 @@ presubmits:
           requests:
             cpu: 2
             memory: 8Gi
+  - name: pull-jobset-test-e2e-main-1-27
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-jobset-test-e2e-main-1-27
+      description: "Run jobset end to end tests for Kubernetes 1.27"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.27.3
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 8Gi
+          requests:
+            cpu: 2
+            memory: 8Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
Add a e2e test for 1.27 as this is the latest release for Kubernetes.