### PR TITLE
fix: increase the timeout and resources of `kubernetes-verify-go-linses-periodical`

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -180,7 +180,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
-    timeout: 5m
+    timeout: 10m
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -209,10 +209,10 @@ periodics:
         value: /workspace/k8s.io/kubernetes
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
Fix continuous failures of [kubernetes-verify-go-linses-periodical](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/kubernetes-verify-go-licenses-periodical?buildId=)

/cc @ameukam 