### PR TITLE
Install kubetest2 properly in the image

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -93,9 +93,11 @@ RUN if [ -n "${KIND_VERSION}" ]; then \
     fi
 
 # install kubetest2 binaries if a version is provided
+# kubetest2 must be installed from git as the makefile embeds the git short hash and the day it was built.
 ARG KUBETEST2_VERSION
 RUN if [ -n "${KUBETEST2_VERSION}" ]; then \
-    go install sigs.k8s.io/kubetest2/...@"${KUBETEST2_VERSION}"; \
+    git clone --depth=1 --branch ${KUBETEST2_VERSION}  https://github.com/kubernetes-sigs/kubetest2.git  /tmp/kubetest2 && \
+    cd /tmp/kubetest2 && make install-all && rm -rf /tmp/kubetest2; \
     fi
 
 # configure dockerd to use mirror.gcr.io

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -45,7 +45,7 @@ substitutions:
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
   _KIND_VERSION: ''
-  _KUBETEST2_VERSION: 'latest'
+  _KUBETEST2_VERSION: 'master'
   _YQ_VERSION: v4.23.1
 timeout: 1800s  
 options:


### PR DESCRIPTION
/cc @dims 

This was the cause of test failures last week. Also some important build flags(git commit info) are set when kubetest2 is installed via make.
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kubetest2/237/pull-kubetest2-aws-node-e2e/1688569280477532160/artifacts/metadata.json

kubetest2 was added to the kubekins-e2e image in https://github.com/kubernetes/test-infra/pull/29825
