### PR TITLE
Test kubetest2 with gingko and kind in presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -171,3 +171,37 @@ presubmits:
         - runner.sh
         args:
         - "./kubetest2-tester-node/ci-tests/gce-test.sh"
+
+  - name: pull-kubetest2-kind-build-up-down
+    cluster: eks-prow-build-cluster
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/kubetest2
+    labels:
+      preset-dind-enabled: "true"
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        command:
+        - runner.sh
+        args:
+        - "/bin/bash"
+        - "-c"
+        - set -o errexit;
+          set -o nounset;
+          set -o pipefail;
+          set -o xtrace;
+          make install-all;
+          go install sigs.k8s.io/kind@v0.20.0;
+          kubetest2 kind --up --down --test=exec -- kubectl get all -A
+        securityContext:
+          privileged: true

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -14,6 +14,11 @@ presubmits:
     - base_ref: master
       org: kubernetes
       repo: cloud-provider-gcp
+      path_alias: k8s.io/cloud-provider-gcp
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
@@ -165,15 +170,4 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "/bin/bash"
-        - "-c"
-        - set -o errexit;
-          set -o nounset;
-          set -o pipefail;
-          set -o xtrace;
-          make install-all;
-          cd ${GOPATH}/src/k8s.io/kubernetes;
-          kubetest2 noop --test=node -- \;
-            --provider=gce --repo-root=. --gcp-zone=us-west1-b --focus-regex="\[NodeConformance\]" \;
-            --test-args='--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"' \;
-            --instance-type=e2-standard-2 --image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+        - "./kubetest2-tester-node/ci-tests/gce-test.sh"


### PR DESCRIPTION
- `pull-kubetest2-gce-build-up-down` is being modified to run gingko as well. A bug slipped through that wasn't caught properly.
- Test kind & kubetest2 together as well
- Run the GCE node test via a script

https://github.com/kubernetes-sigs/kubetest2/pull/236

/cc @dims @tzneal