### PR TITLE
Add a `do-not-merge/needs-area` label to cluster-api

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -660,6 +660,7 @@ tide:
     - kubernetes/sample-cli-plugin
     - kubernetes/sample-controller
     - kubernetes-sigs/cloud-provider-azure
+    - kubernetes-sigs/cluster-api
     labels:
     - lgtm
     - approved
@@ -772,6 +773,23 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     - needs-kind
+  - repos:
+    - kubernetes-sigs/cluster-api
+    labels:
+      - lgtm
+      - approved
+      - "cncf-cla: yes"
+    missingLabels:
+      - do-not-merge
+      - do-not-merge/blocked-paths
+      - do-not-merge/contains-merge-commits
+      - do-not-merge/hold
+      - do-not-merge/invalid-commit-message
+      - do-not-merge/invalid-owners-file
+      - do-not-merge/needs-area
+      - do-not-merge/release-note-label-needed
+      - do-not-merge/work-in-progress
+      - needs-rebase
   merge_method:
     kubernetes-client/csharp: squash
     kubernetes-client/gen: squash

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -855,6 +855,18 @@ require_matching_label:
   issues: true
   prs: true
   regexp: ^priority/
+- missing_label: do-not-merge/needs-area
+  org: kubernetes-sigs
+  repo: cluster-api
+  issues: false
+  prs: true
+  regexp: ^area/
+  missing_comment: |
+    This PR is currently missing an area label, which is used to identify the modified component when generating release notes.
+
+    Area labels can be added by org members by writing `/area ${COMPONENT}` in a comment
+    
+    Please see the [labels list](https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#labels-that-apply-to-kubernetes-sigscluster-api-for-both-issues-and-prs) for possible areas.
 - missing_label: needs-triage
   org: kubernetes-sigs
   repo: cluster-api

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -9,6 +9,7 @@
 - [Labels that apply to all repos, only for issues](#labels-that-apply-to-all-repos-only-for-issues)
 - [Labels that apply to all repos, only for PRs](#labels-that-apply-to-all-repos-only-for-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-for-both-issues-and-prs)
+- [Labels that apply to kubernetes-sigs/cluster-api, only for PRs](#labels-that-apply-to-kubernetes-sigscluster-api-only-for-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-operator, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-operator-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-aws, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-aws-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-aws, only for issues](#labels-that-apply-to-kubernetes-sigscluster-api-provider-aws-only-for-issues)
@@ -222,6 +223,12 @@ larger set of contributors to apply/remove them.
 | <a id="kind/design" href="#kind/design">`kind/design`</a> | Categorizes issue or PR as related to design.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | Issues or PRs related to proposals.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/release-blocking" href="#kind/release-blocking">`kind/release-blocking`</a> | Issues or PRs that need to be closed before the next CAPI release| approvers |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+
+## Labels that apply to kubernetes-sigs/cluster-api, only for PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="do-not-merge/needs-area" href="#do-not-merge/needs-area">`do-not-merge/needs-area`</a> | PR is missing an area label| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 
 ## Labels that apply to kubernetes-sigs/cluster-api-operator, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1878,6 +1878,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: e11d21
+        description: PR is missing an area label
+        name: do-not-merge/needs-area
+        target: prs
+        prowPlugin: require-matching-label
+        addedBy: prow
   kubernetes-sigs/cluster-api-operator:
     labels:
       - color: c7def8


### PR DESCRIPTION
This label will be added automatically when a PR is missing an "area/\*" label in the cluster-api repo, which will block PRs from being merged until an "area/\*" label is added.

https://github.com/kubernetes-sigs/cluster-api/issues/8967