### PR TITLE
migrate `cosi` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/container-object-storage-interface-api:
   - name: pull-container-object-storage-interface-api-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-api
@@ -14,8 +15,16 @@ presubmits:
         command:
         # Plain make runs also verify
         - make
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
   - name: pull-container-object-storage-interface-api-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-api
@@ -30,3 +39,10 @@ presubmits:
         - make
         args:
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/container-object-storage-interface-controller:
   - name: pull-container-object-storage-interface-controller-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-controller
@@ -14,8 +15,16 @@ presubmits:
         command:
         # Plain make runs also verify
         - make
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
   - name: pull-container-object-storage-interface-controller-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-controller
@@ -30,3 +39,10 @@ presubmits:
         - make
         args:
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-csi-adapter.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-csi-adapter.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/container-object-storage-interface-csi-adapter:
   - name: pull-container-object-storage-interface-csi-adapter-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-csi-adapter
@@ -14,8 +15,16 @@ presubmits:
         command:
         # Plain make runs also verify
         - make
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
   - name: pull-container-object-storage-interface-csi-adapter-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-csi-adapter
@@ -30,3 +39,10 @@ presubmits:
         - make
         args:
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-provisioner-sidecar.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-provisioner-sidecar.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/container-object-storage-interface-provisioner-sidecar:
   - name: pull-container-object-storage-interface-provisioner-sidecar-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-provisioner-sidecar
@@ -14,8 +15,16 @@ presubmits:
         command:
         # Plain make runs also verify
         - make
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
   - name: pull-container-object-storage-interface-provisioner-sidecar-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface-provisioner-sidecar
@@ -30,3 +39,10 @@ presubmits:
         - make
         args:
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the cosi jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @ajsafrane @msau42 @saad-ali @xing-yang @brahmaroutu @wlan0