### PR TITLE
migrate `controller-tools` to community cluster 

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -15,11 +15,11 @@ presubmits:
         - test-all
         resources:
           limits:
-            cpu: 6
-            memory: 8Gi
+            cpu: 10
+            memory: 24Gi
           requests:
-            cpu: 6
-            memory: 8Gi
+            cpu: 10
+            memory: 24Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-tools-master

--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-tools:
   - name: pull-controller-tools-test-master
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-tools
@@ -12,6 +13,13 @@ presubmits:
         command:
         - make
         - test-all
+        resources:
+          limits:
+            cpu: 6
+            memory: 8Gi
+          requests:
+            cpu: 6
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-tools-master


### PR DESCRIPTION
This PR moves the `controller-tools` jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722