### PR TITLE
CI job for testing kubetest2-ec2 against k/k

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -12,6 +12,68 @@ presets:
         value: ec2-user
       - name: DELETE_INSTANCES
         value: "true"
+presubmits:
+ kubernetes/kubernetes:
+ - name: pull-kubernetes-node-e2e-containerd-ec2-kubetest2
+   skip_branches:
+     - release-\d+\.\d+  # per-release image
+   annotations:
+     testgrid-alert-stale-results-hours: "24"
+     testgrid-create-test-group: "true"
+     testgrid-num-failures-to-alert: "10"
+   labels:
+     preset-e2e-containerd-ec2: "true"
+     preset-dind-enabled: "true"
+   path_alias: k8s.io/kubernetes
+   always_run: false
+   optional: true
+   cluster: eks-prow-build-cluster
+   decorate: true
+   extra_refs:
+     - org: kubernetes-sigs
+       repo: provider-aws-test-infra
+       base_ref: main
+       path_alias: sigs.k8s.io/provider-aws-test-infra
+   spec:
+     serviceAccountName: node-e2e-tests
+     containers:
+       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+         command:
+           - runner.sh
+         args:
+           - bash
+           - -c
+           - |
+             go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+             kubetest2 ec2 \
+              --build \
+              --instance-type=m6a.large  \
+              --images=ami-02675d30b814d1daa \
+              --region us-east-1 \
+              --target-build-arch linux/amd64 \
+              --stage provider-aws-test-infra \
+              --up \
+              --down \
+              --user-data-file=./../../sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/ubuntu2204.yaml \
+              --ssh-user=ec2-user \
+              --ssh-env=aws \
+              --test=ginkgo \
+              -- \
+              --use-built-binaries true \
+              --focus-regex='\[Conformance\]'
+         env:
+           - name: USE_DOCKERIZED_BUILD
+             value: "true"
+         # docker-in-docker needs privileged mode
+         securityContext:
+           privileged: true
+         resources:
+           limits:
+             cpu: 8
+             memory: 10Gi
+           requests:
+             cpu: 8
+             memory: 10Gi
 periodics:
   - name: ci-cgroupv2-containerd-node-e2e-ec2
     interval: 6h

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -14,7 +14,7 @@ presets:
         value: "true"
 presubmits:
  kubernetes/kubernetes:
- - name: pull-kubernetes-node-e2e-containerd-ec2-kubetest2
+ - name: pull-kubernetes-node-e2e-ec2-containerd-kubetest2
    skip_branches:
      - release-\d+\.\d+  # per-release image
    annotations:
@@ -54,7 +54,7 @@ presubmits:
               --stage provider-aws-test-infra \
               --up \
               --down \
-              --user-data-file=./../../sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/ubuntu2204.yaml \
+              --user-data-file=${GOPATH}/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/ubuntu2204.yaml \
               --ssh-user=ec2-user \
               --ssh-env=aws \
               --test=ginkgo \

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -129,6 +129,9 @@ dashboards:
   - name: pull-kubernetes-node-e2e-containerd-kubetest2
     test_group_name: pull-kubernetes-node-e2e-containerd-kubetest2
     base_options: width=10
+  - name: pull-kubernetes-node-e2e-containerd-ec2-kubetest2
+    test_group_name: pull-kubernetes-node-e2e-ec2-containerd-kubetest2
+    base_options: width=10
   - name: pull-kubernetes-node-e2e-containerd-features-kubetest2
     test_group_name: pull-kubernetes-node-e2e-containerd-features-kubetest2
     base_options: width=10

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -69,6 +69,9 @@ dashboards:
     - name: pull-kubernetes-node-e2e-containerd-ec2
       test_group_name: pull-kubernetes-node-e2e-containerd-ec2
       base_options: width=10
+    - name: pull-kubernetes-node-e2e-containerd-ec2-kubetest2
+      test_group_name: pull-kubernetes-node-e2e-ec2-containerd-kubetest2
+      base_options: width=10
     - name: pull-kubernetes-node-e2e-containerd-ec2-canary
       test_group_name: pull-kubernetes-node-e2e-containerd-ec2-canary
       base_options: width=10


### PR DESCRIPTION
`kubetest2-ec2` is a new `kubetest2` deployer that starts a ec2 node with kubeadm and runs tests against it.