### PR TITLE
temporary change to CL2 test to validate prow job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -68,6 +68,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: presubmit-kops-aws-scale-amazonvpc-using-cl2
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: false
@@ -129,6 +130,9 @@ presubmits:
           value: "true"
         resources:
           requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
             cpu: "2"
             memory: "6Gi"
     annotations:


### PR DESCRIPTION
Looks like this change got reverted as part of this PR https://github.com/kubernetes/test-infra/pull/30300
We need this temporarily to check if the prow jobs for scale test is running in the new scale account.