### PR TITLE
migrate `k/csi` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-24-test-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -399,7 +399,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -442,7 +442,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-25-test-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -496,7 +496,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -539,7 +539,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-26-test-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -593,7 +593,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -636,7 +636,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-25-test-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -687,7 +687,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-iscsi:
   - name: pull-kubernetes-csi-csi-driver-iscsi
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nfs:
   - name: pull-kubernetes-csi-csi-driver-nfs
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nvmf/csi-driver-nvmf-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nvmf:
   - name: pull-kubernetes-csi-csi-driver-nvmf
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-path-windows
+    cluster: k8s-infra-prow-build
     always_run: false
     decorate: true
     skip_report: false
@@ -38,4 +39,8 @@ presubmits:
           value: "prepull-head.yaml"
         resources:
           requests:
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-lib-utils:
   - name: pull-kubernetes-csi-csi-lib-utils
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-proxy:
   - name: pull-kubernetes-csi-csi-proxy
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-manual-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-manual-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-csi/csi-proxy:
   - name: pull-kubernetes-csi-csi-proxy-integration
+    cluster: k8s-infra-prow-build
     always_run: true
     decorate: true
     skip_report: false
@@ -50,3 +51,10 @@ presubmits:
           value: "us-west1-b"
         securityContext:
             privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-release-tools:
   - name: pull-kubernetes-csi-csi-release-tools
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false
@@ -35,7 +35,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-release-tools-csi-test
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -76,7 +76,7 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-test
   - name: pull-kubernetes-csi-release-tools-external-provisioner
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true
@@ -178,7 +178,7 @@ presubmits:
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
   - name: pull-kubernetes-csi-release-tools-csi-driver-host-path
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true # cannot be required because updates in csi-release-tools may include breaking changes
     decorate: true

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/csi-test:
   - name: pull-kubernetes-csi-csi-test
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-attacher:
   - name: pull-kubernetes-csi-external-attacher-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-attacher-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-health-monitor:
   - name: pull-kubernetes-csi-external-health-monitor
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes-csi/external-provisioner:
   - name: pull-kubernetes-csi-external-provisioner-1-24-on-kubernetes-1-24
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -57,7 +57,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -100,7 +100,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -154,7 +154,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -197,7 +197,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-26-on-kubernetes-1-26
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -251,7 +251,7 @@ presubmits:
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -294,7 +294,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-25-on-kubernetes-1-25
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -345,7 +345,7 @@ presubmits:
             memory: "9Gi"
             cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-unit
-    cluster: default
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/external-provisioner:
   - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1-26
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
@@ -47,12 +48,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-master
+    cluster: eks-prow-build-cluster
     always_run: false
     optional: true
     decorate: true
@@ -97,8 +99,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -140,11 +140,12 @@ job_cluster() {
   local repo=$1
 
   case "$repo" in
-   external-snapshotter|external-resizer|lib-volume-populator|livenessprobe|node-driver-registrar|volume-data-source-validator)
-     echo "eks-prow-build-cluster"
+   # Add any jobs that should be excluded from the community clusters here 
+   "")
+     echo "default"
      ;;
    *)
-     echo "default"
+     echo "eks-prow-build-cluster"
      ;;
   esac
 


### PR DESCRIPTION
This PR moves the majority of csi jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @msau42 @saad-ali @xing-yang @jsafrane @pohly