### PR TITLE
install kubetest2-ec2 directly - avoid mirror/proxy

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -44,7 +44,7 @@ presubmits:
            - bash
            - -c
            - |
-             go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
              kubetest2 ec2 \
               --build \
               --instance-type=m6a.large  \


### PR DESCRIPTION
Sometimes there's a lag, let's hit up the github repo directly and install from there.