### PR TITLE
Revert "migrate `cluster-api 1.3` jobs to the community cluster"

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
@@ -1,9 +1,10 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -45,10 +46,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-18-1-19
@@ -56,9 +53,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -100,10 +98,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-19-1-20
@@ -111,9 +105,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -155,10 +150,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-20-1-21
@@ -166,9 +157,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -210,10 +202,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-21-1-22
@@ -221,9 +209,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -265,10 +254,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-22-1-23
@@ -276,9 +261,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -320,10 +306,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-23-1-24
@@ -331,9 +313,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -375,10 +358,6 @@ periodics:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-24-1-25
@@ -386,9 +365,10 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -430,10 +410,6 @@ periodics:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-25-1-26

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
@@ -1,8 +1,9 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -20,19 +21,16 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
-        limits:
-          cpu: 7300m
-          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-test-release-1-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -58,19 +56,16 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
-        limits:
-          cpu: 7300m
-          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-test-mink8s-release-1-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -102,19 +97,16 @@ periodics:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-3
-  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -154,10 +146,6 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-mink8s-release-1-3

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
@@ -1,8 +1,9 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-release-1-3
-    cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -13,19 +14,13 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
-        resources:
-          requests:
-            cpu: 7300m
-            memory: 9Gi
-          limits:
-            cpu: 7300m
-            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-build-release-1-3
   - name: pull-cluster-api-apidiff-release-1-3
-    cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -33,23 +28,17 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
-        command:
+      - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        resources:
-          requests:
-            cpu: 7300m
-            memory: 9Gi
-          limits:
-            cpu: 7300m
-            memory: 9Gi
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-apidiff-release-1-3
   - name: pull-cluster-api-verify-release-1-3
-    cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -65,18 +54,15 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
-          limits:
-            cpu: 7300m
-            memory: 9Gi
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-verify-release-1-3
   - name: pull-cluster-api-test-release-1-3
-    cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     branches:
     - ^release-1.3$
@@ -90,16 +76,13 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
-          limits:
-            cpu: 7300m
-            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-test-release-1-3
   - name: pull-cluster-api-test-mink8s-release-1-3
-    cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     branches:
     - ^release-1.3$
@@ -121,19 +104,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
-          limits:
-            cpu: 7300m
-            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-test-mink8s-release-1-3
   - name: pull-cluster-api-e2e-release-1-3
-    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     branches:
     - ^release-1.3$
     path_alias: sigs.k8s.io/cluster-api
@@ -153,19 +133,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-release-1-3
   - name: pull-cluster-api-e2e-informing-release-1-3
-    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     branches:
     - ^release-1.3$
@@ -188,19 +165,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-informing-release-1-3
   - name: pull-cluster-api-e2e-informing-ipv6-release-1-3
-    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     branches:
     - ^release-1.3$
@@ -226,19 +200,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-informing-ipv6-release-1-3
   - name: pull-cluster-api-e2e-full-release-1-3
-    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     always_run: false
     branches:
@@ -262,19 +233,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-full-release-1-3
   - name: pull-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-3
-    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     always_run: false
     branches:
@@ -310,10 +278,6 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-release-1-3-1-25-1-26


### PR DESCRIPTION
Reverts kubernetes/test-infra#30279, as a place holder as the tests have not run since august 4th.