### PR TITLE
fix: lru race condition

### DIFF
--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -194,6 +194,8 @@ func NewInRepoConfigCache(
 	seenOrgRepos := make(map[OrgRepo]int)
 
 	cacheSizeMetrics := func() {
+		lruCache.Mutex.Lock()         // Lock the mutex
+		defer lruCache.Mutex.Unlock() // Unlock the mutex when done
 		// Record all unique orgRepo combinations we've seen so far.
 		for _, key := range lruCache.Keys() {
 			org, repo, err := keyToOrgRepo(key)


### PR DESCRIPTION
There are ongoing failures in the [pull-test-infra-unit-test-race-detector-nonblocking](https://prow.k8s.io/?job=pull-test-infra-unit-test-race-detector-nonblocking) jobs. The failures are related to concurrent access to the underlying LRU cache within the `NewInRepoConfigCache` function, specifically between the `lruCache.Keys()` and `lruCache.GetOrAdd()` calls. These conflicting accesses are causing a data race, as the underlying LRU cache implementation (github.com/hashicorp/golang-lru) does not handle concurrent reads and writes safely. The proposed fix involves adding synchronization around LRU cache Keys operation to ensure that only one goroutine can access the cache at a time, thereby preventing the race condition. Locks are already in place for the GetOrAdd operation. 

ref: https://kubernetes.slack.com/archives/C09QZ4DQB/p1691588437957859

/cc @listx 