### PR TITLE
move periodic CAPI e2e workload upgrade 1.18 1.19 release 1.3 to eks

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
@@ -1,6 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -22,7 +23,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:
@@ -47,6 +47,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-18-1-19


### PR DESCRIPTION
This PR is to test the working of `periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-3` job on eks community clusters. 
We had reverted the release 1.3 CAPI test jobs via https://github.com/kubernetes/test-infra/pull/30334 as we were running into below error
```
  completionTime: "2023-08-09T14:53:48Z"
  description: 'Pod can not be created: create pod test-pods/c123e258-68c8-4eba-9fce-3091c344c7e0
    in cluster eks-prow-build-cluster: pods "c123e258-68c8-4eba-9fce-3091c344c7e0"
    is forbidden: error looking up service account test-pods/prowjob-default-sa: serviceaccount
```