### PR TITLE
increase timeout for kubetest2 ec2 CI job to 4 hours

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -29,6 +29,8 @@ presubmits:
    optional: true
    cluster: eks-prow-build-cluster
    decorate: true
+   decoration_config:
+     timeout: 4h
    extra_refs:
      - org: kubernetes-sigs
        repo: provider-aws-test-infra


### PR DESCRIPTION
conformance takes 2hours 30mins approx. there are some things failing so keep it at 4h for now.

latest run is here - https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-node-e2e-ec2-containerd-kubetest2/1689317043532206080