### PR TITLE
CAPI: Drop decoration_config field from periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-3 jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
@@ -4,8 +4,6 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs


### PR DESCRIPTION
Remove decoration_config field which is anyways always overriden / set to an empty value 