### PR TITLE
migrate `cluster-api 1.3` jobs to the community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
@@ -76,7 +76,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:
@@ -132,7 +131,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:
@@ -188,7 +186,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:
@@ -244,7 +241,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:
@@ -300,7 +296,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:
@@ -356,7 +351,6 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -412,7 +406,6 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3-upgrades.yaml
@@ -56,10 +56,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -102,6 +101,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-19-1-20
@@ -109,10 +112,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -155,6 +157,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-20-1-21
@@ -162,10 +168,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -208,6 +213,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-21-1-22
@@ -215,10 +224,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -261,6 +269,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-22-1-23
@@ -268,10 +280,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -314,6 +325,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-23-1-24
@@ -321,10 +336,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -367,6 +381,10 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-24-1-25
@@ -374,10 +392,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -420,6 +437,10 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3-1-25-1-26

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
@@ -1,9 +1,8 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -22,16 +21,19 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-test-release-1-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -58,16 +60,19 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-test-mink8s-release-1-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -100,16 +105,19 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-release-1-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-3
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -150,6 +158,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
     testgrid-tab-name: capi-e2e-mink8s-release-1-3

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-3.yaml
@@ -13,7 +13,6 @@ periodics:
     base_ref: release-1.3
     path_alias: sigs.k8s.io/cluster-api
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       command:
@@ -44,7 +43,6 @@ periodics:
     base_ref: release-1.3
     path_alias: sigs.k8s.io/cluster-api
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       command:
@@ -90,7 +88,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -135,7 +132,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
@@ -8,7 +8,6 @@ presubmits:
     branches:
     - ^release-1.3$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         command:
@@ -33,7 +32,6 @@ presubmits:
     - ^release-1.3$
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         command:
@@ -59,7 +57,6 @@ presubmits:
     branches:
     - ^release-1.3$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         command:
@@ -85,7 +82,6 @@ presubmits:
     - ^release-1.3$
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -109,7 +105,6 @@ presubmits:
     - ^release-1.3$
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -144,7 +139,6 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -178,7 +172,6 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -214,7 +207,6 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -253,7 +245,6 @@ presubmits:
     - ^release-1.3$
     path_alias: sigs.k8s.io/cluster-api
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:
@@ -295,7 +286,6 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
@@ -1,9 +1,8 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-release-1-3
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -15,13 +14,19 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+        resources:
+          requests:
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-build-release-1-3
   - name: pull-cluster-api-apidiff-release-1-3
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -30,17 +35,23 @@ presubmits:
     spec:
       serviceAccountName: prowjob-default-sa
       containers:
-      - command:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+        command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+        resources:
+          requests:
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-apidiff-release-1-3
   - name: pull-cluster-api-verify-release-1-3
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -57,15 +68,18 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-verify-release-1-3
   - name: pull-cluster-api-test-release-1-3
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     branches:
     - ^release-1.3$
@@ -80,13 +94,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-test-release-1-3
   - name: pull-cluster-api-test-mink8s-release-1-3
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     branches:
     - ^release-1.3$
@@ -109,16 +126,19 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-test-mink8s-release-1-3
   - name: pull-cluster-api-e2e-release-1-3
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     branches:
     - ^release-1.3$
     path_alias: sigs.k8s.io/cluster-api
@@ -139,16 +159,19 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-release-1-3
   - name: pull-cluster-api-e2e-informing-release-1-3
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     branches:
     - ^release-1.3$
@@ -172,16 +195,19 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-informing-release-1-3
   - name: pull-cluster-api-e2e-informing-ipv6-release-1-3
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     branches:
     - ^release-1.3$
@@ -208,16 +234,19 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-informing-ipv6-release-1-3
   - name: pull-cluster-api-e2e-full-release-1-3
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     always_run: false
     branches:
@@ -242,16 +271,19 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-full-release-1-3
   - name: pull-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-3
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     optional: true
     always_run: false
     branches:
@@ -288,6 +320,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.3
       testgrid-tab-name: capi-pr-e2e-release-1-3-1-25-1-26


### PR DESCRIPTION
- This PR reapplies the commit 8085262 and 6fd37fa
- From the discussion at https://kubernetes.slack.com/archives/C8TSNPY4T/p1691595275955099, removing `gcs_credentials_secret: ""` seems to be the best plausible way to go ahead and migrate CAPI release v1.3 jobs to community eks clusters. 
- This PR being the cherry-pick of 8085262, also brings in `limits` and `requests` for each of the testgrid jobs. 