### PR TITLE
CAPV: use v1.9 milestone on main

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -521,7 +521,7 @@ milestone_applier:
     release-0.4: v0.4
     release-0.3: v0.3
   kubernetes-sigs/cluster-api-provider-vsphere:
-    main: v1.8
+    main: v1.9
     release-1.8: v1.8
     release-1.7: v1.7
     release-1.6: v1.6


### PR DESCRIPTION
We're going to release CAPV v1.8 today. So as we don't fast-forward the release-1.8 branch anymore we should start applying the v1.9 milestone on main

Signed-off-by: Stefan Büringer buringerst@vmware.com

Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2175