### PR TITLE
CAPI: bump jobs for v1.28

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -1,58 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main
-  interval: 24h
-  decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-  rerun_auth_config:
-    github_team_slugs:
-    - org: kubernetes-sigs
-      slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    serviceAccountName: prowjob-default-sa
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: ALWAYS_BUILD_KIND_IMAGES
-          value: "true"
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.22"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.23"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.3-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.6"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7300m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-22-1-23
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-main
   interval: 24h
   decorate: true
@@ -265,7 +212,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-27-latest-main
+- name: periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-main
   interval: 24h
   decorate: true
   decoration_config:
@@ -299,9 +246,62 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.27"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "ci/latest-1.28"
+        value: "stable-1.28"
       - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.7-0"
+        value: "3.5.9-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.10.1"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-27-1-28
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-28-latest-main
+  interval: 24h
+  decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.28"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.29"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.9-0"
       - name: COREDNS_VERSION_UPGRADE_TO
         value: "v1.10.1"
       - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -58,7 +58,7 @@ periodics:
       # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
       # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
       - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-        value: "1.24.2"
+        value: "1.25.0"
       resources:
         requests:
           cpu: 7300m
@@ -187,8 +187,10 @@ periodics:
         value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
+      # Please also make sure to refer a version where a kindest/node image exists
+      # for (see https://github.com/kubernetes-sigs/kind/releases/tag)
       - name: KUBERNETES_VERSION_MANAGEMENT
-        value: "v1.24.15"
+        value: "v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5-upgrades.yaml
@@ -265,7 +265,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-27-latest-release-1-5
+- name: periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-release-1-5
   interval: 24h
   decorate: true
   decoration_config:
@@ -299,9 +299,9 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.27"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "ci/latest-1.28"
+        value: "stable-1.28"
       - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.7-0"
+        value: "3.5.9-0"
       - name: COREDNS_VERSION_UPGRADE_TO
         value: "v1.10.1"
       - name: GINKGO_FOCUS
@@ -314,6 +314,6 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
-    testgrid-tab-name: capi-e2e-release-1-5-1-27-latest
+    testgrid-tab-name: capi-e2e-release-1-5-1-27-1-28
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -113,7 +113,7 @@ presubmits:
         # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
         # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
         - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-          value: "1.24.2"
+          value: "1.25.0"
         resources:
           requests:
             cpu: 7300m
@@ -294,7 +294,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
-  - name: pull-cluster-api-e2e-workload-upgrade-1-27-latest-main
+  - name: pull-cluster-api-e2e-workload-upgrade-1-28-latest-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -323,11 +323,11 @@ presubmits:
           - name: ALWAYS_BUILD_KIND_IMAGES
             value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.27"
+            value: "stable-1.28"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.28"
+            value: "ci/latest-1.29"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.7-0"
+            value: "3.5.9-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.10.1"
           - name: GINKGO_FOCUS
@@ -340,7 +340,7 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-main-1-27-latest
+      testgrid-tab-name: capi-pr-e2e-main-1-28-latest
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-main-experimental
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
@@ -294,7 +294,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-full-release-1-5
-  - name: pull-cluster-api-e2e-workload-upgrade-1-27-latest-release-1-5
+  - name: pull-cluster-api-e2e-workload-upgrade-1-27-1-28-release-1-5
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -325,9 +325,9 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.27"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.28"
+            value: "stable-1.28"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.7-0"
+            value: "3.5.9-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.10.1"
           - name: GINKGO_FOCUS
@@ -340,7 +340,7 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
-      testgrid-tab-name: capi-pr-e2e-release-1-5-1-27-latest
+      testgrid-tab-name: capi-pr-e2e-release-1-5-1-27-1-28
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-release-1-5-experimental
     labels:


### PR DESCRIPTION
According to https://github.com/kubernetes-sigs/cluster-api/issues/8708 : Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):

  * For the main branch and the release branch of the latest supported Cluster API minor release:
    
    * Add new periodic upgrade job.
    * Adjust presubmit jobs so that we have the latest upgrade jobs available on PRs.
  * For the main branch:
    
    * periodics & presubmits:
      
      * Bump `KUBEBUILDER_ENVTEST_KUBERNETES_VERSION` of the `test-mink8s` jobs to the new minimum supported management cluster version.
    * periodics:
      
      * Bump `KUBERNETES_VERSION_MANAGEMENT` of the `e2e-mink8s` job to the new minimum supported management cluster version.
      * Drop the oldest upgrade job as the oldest Kubernetes minor version is now out of support.
  * Prior art: [Bump cluster-api jobs for v1.25/v1.26 kubernetes/test-infra#27421](https://github.com/kubernetes/test-infra/pull/27421)


TODO:

- [ ] Wait for https://github.com/kubernetes-sigs/cluster-api/pull/9160 to merge
 
Relates to https://github.com/kubernetes-sigs/cluster-api/issues/8708