### PR TITLE
azure: 1.27: windows: use release branch

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
       workdir: true
     - org: kubernetes-sigs
       repo: cloud-provider-azure
-      base_ref: master # TODO: Update to release-1.27 once it's created
+      base_ref: release-1.27
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:


### PR DESCRIPTION
Release branches should track release branches, not main branch. It seems a pending TODO was never been addressed, fixing now.

xref: https://github.com/kubernetes/kubernetes/issues/119734