### PR TITLE
proposing cpanato & xmudrii as approvers and verolop as reviewer

### DIFF
--- a/images/kubekins-e2e/OWNERS
+++ b/images/kubekins-e2e/OWNERS
@@ -9,13 +9,16 @@ reviewers:
 - puerco
 - saschagrunert
 - spiffxp
+- Verolop
 - xmudrii
 approvers:
 - BenTheElder
+- cpanato
 - justaugustus
-- spiffxp
+- xmudrii
 emeritus_approvers:
 - amwat
+- spiffxp
 
 labels:
 - sig/release


### PR DESCRIPTION
We'd like to propose adding @cpanato & @xmudrii as approvers, given their contributions to this repo. This will also help distribute the workload more evenly among qualified team members, based on their availability.

Additionally, I'm adding myself to the list of reviewers.

/assign @justaugustus 
cc @kubernetes/release-engineering 