### PR TITLE
Use new windows testing scripts that support 2022

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -17,23 +17,30 @@ presubmits:
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
       preset-azure-capz-sa-cred: "true"
+      preset-windows-private-registry-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: release-1.10
       path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
+      workdir: false
     - org: kubernetes-sigs
       repo: cloud-provider-azure
       base_ref: release-1.27
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
+    - org: kubernetes-sigs
+      repo: windows-testing
+      base_ref: master
+      path_alias: k8s.io/windows-testing
+      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         command:
-        - runner.sh
-        - ./scripts/ci-conformance.sh
+        - "runner.sh"
+        - "env"
+        - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
The 1.27 job is using WS2022 which needs run-capz-e2e.sh. See https://github.com/kubernetes/test-infra/pull/29277
fixes [#119734](https://github.com/kubernetes/kubernetes/issues/119734)

/sig windows
/assign @marosset @ffromani 