### PR TITLE
Create periodic jobs for 1.27 and 1.28 and delete for 1.24

### DIFF
--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -1,38 +1,4 @@
 periodics:
-- name: ci-kubernetes-node-release-branch-1-24
-  interval: 24h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-        args:
-          - --repo=k8s.io/kubernetes=release-1.24
-          - --timeout=240
-          - --root=/go/src
-          - --scenario=kubernetes_e2e
-          - --
-          - --deployment=node
-          - --gcp-project-type=node-e2e-project
-          - --gcp-zone=us-central1-a
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.24.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          - --timeout=180m
-        env:
-          - name: GOPATH
-            value: /go
-        resources:
-          requests:
-            memory: "6Gi"
-  annotations:
-    testgrid-dashboards: sig-node-release-blocking
-    testgrid-tab-name: node-conformance-release-1.24
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: Node conformance tests in release branch 1.24
 - name: ci-kubernetes-node-release-branch-1-25
   interval: 24h
   labels:
@@ -101,3 +67,71 @@ periodics:
     testgrid-tab-name: node-conformance-release-1.26
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.26
+- name: ci-kubernetes-node-release-branch-1-27
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        args:
+          - --repo=k8s.io/kubernetes=release-1.27
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-central1-a
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          requests:
+            memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-node-release-blocking
+    testgrid-tab-name: node-conformance-release-1.27
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: Node conformance tests in release branch 1.27
+- name: ci-kubernetes-node-release-branch-1-28
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        args:
+          - --repo=k8s.io/kubernetes=release-1.28
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-central1-a
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          requests:
+            memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-node-release-blocking
+    testgrid-tab-name: node-conformance-release-1.28
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: Node conformance tests in release branch 1.28

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
@@ -1,5 +1,5 @@
 images:
-  cos-97:
-    image_family: cos-97-lts
+  cos-105:
+    image_family: cos-105-lts
     project: cos-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
@@ -1,0 +1,6 @@
+images:
+    # TODO(mmiranda96): update to cos-beta once COS releases their beta family
+  cos-dev:
+    image_family: cos-dev
+    project: cos-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
### What does this PR do?
- Create node-conformance-release jobs for branches 1.27 and 1.28
- Delete node-conformance-release job for branch 1.24
Job for 1.28 is using cos-dev. COS will soon (next week-ish) provide beta image, and it will become COS-109-LTS in about 1 month.

/sig node
/cc @SergeyKanzhelev @ndixita 