### PR TITLE
k/test-infra: unblock Prow markdown files so we can delete them

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -313,13 +313,6 @@ blockades:
   - ^README\.md$
   explanation: "We do not accept changes directly against this repository, unless the change is to the `README.md` itself. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
 - repos:
-  - kubernetes/test-infra
-  blockregexps:
-  - ^prow/.+\.md$
-  exceptionregexps:
-  - ^prow/(ANNOUNCEMENTS|README)\.md$
-  explanation: "All Prow documentation (Markdown files) have moved to https://github.com/kubernetes-sigs/prow as part of https://github.com/kubernetes-sigs/prow/issues/4. Instructions for updating existing docs are at https://docs.prow.k8s.io/docs/contribution-guidelines/#updating-existing-docs."
-- repos:
   - kubernetes/k8s.io
   blockregexps:
   - ^k8s.gcr.io/


### PR DESCRIPTION
Prow documentation was moved from markdowns to a website and we locked
the markdown tombstones so that nobody accidently adds new
documentation. Remove the blockade so that we may delete the files well
after the originally announced removal date:

> This file will be deleted on 2023-02-28

xref: https://github.com/kubernetes/test-infra/pull/30075