### PR TITLE
Deduplicate changes in Gerrit query results.

### DIFF
--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	gerrit "github.com/andygrunwald/go-gerrit"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/io"
 )
@@ -323,8 +324,9 @@ func TestQueryChange(t *testing.T) {
 		lastUpdate map[string]time.Time
 		changes    map[string][]gerrit.ChangeInfo
 		comments   map[string]map[string][]gerrit.CommentInfo
-		revisions  map[string][]string
-		messages   map[string][]gerrit.ChangeMessageInfo
+		// expected
+		revisions map[string][]string
+		messages  map[string][]gerrit.ChangeMessageInfo
 	}{
 		{
 			name: "no changes",
@@ -343,6 +345,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now.Add(-time.Hour)),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -366,6 +369,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "bar~branch~random-string",
+						Number:          1,
 						ChangeID:        "random-string",
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
@@ -450,6 +454,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "100",
+						Number:          100,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -481,6 +486,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -506,6 +512,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -531,6 +538,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -554,6 +562,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -577,6 +586,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "evil",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -600,6 +610,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -612,6 +623,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -637,6 +649,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -649,6 +662,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now.Add(-time.Hour)),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -675,6 +689,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -687,6 +702,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -701,6 +717,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "boo",
 						ID:              "3",
+						Number:          3,
 						CurrentRevision: "3-2",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -716,6 +733,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "evil",
 						ID:              "4",
+						Number:          4,
 						CurrentRevision: "4-1",
 						Updated:         makeStamp(now.Add(-time.Hour)),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -742,6 +760,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now),
@@ -763,6 +782,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now),
@@ -782,6 +802,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now.Add(-2 * time.Minute)),
@@ -801,6 +822,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Status:          "ABANDONED",
@@ -829,6 +851,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now.Add(-time.Hour)),
@@ -844,6 +867,48 @@ func TestQueryChange(t *testing.T) {
 				},
 			},
 			revisions: map[string][]string{},
+		},
+		{
+			name: "one up-to-date change found twice due to pagination. Duplicate should be removed",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Hour),
+			},
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						Number:          1,
+						CurrentRevision: "1-1",
+						Updated:         makeStamp(now.Add(-time.Minute)),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"1-1": {
+								Created: makeStamp(now.Add(-time.Minute)),
+							},
+						},
+						Status: "NEW",
+					},
+					{
+						Project:         "bar",
+						ID:              "1",
+						Number:          1,
+						CurrentRevision: "1-2",
+						Updated:         makeStamp(now),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"1-1": {
+								Created: makeStamp(now.Add(-time.Minute)),
+							},
+							"1-2": {
+								Created: makeStamp(now),
+							},
+						},
+						Status: "NEW",
+					},
+				},
+			},
+			revisions: map[string][]string{
+				"foo": {"1-2"},
+			},
 		},
 	}
 
@@ -877,9 +942,14 @@ func TestQueryChange(t *testing.T) {
 
 		revisions := map[string][]string{}
 		messages := map[string][]gerrit.ChangeMessageInfo{}
+		seen := sets.NewInt()
 		for instance, changes := range changes {
 			revisions[instance] = []string{}
 			for _, change := range changes {
+				if seen.Has(change.Number) {
+					t.Errorf("Change number %d appears multiple times in the query results.", change.Number)
+				}
+				seen.Insert(change.Number)
 				revisions[instance] = append(revisions[instance], change.CurrentRevision)
 				messages[change.ChangeID] = append(messages[change.ChangeID], change.Messages...)
 			}


### PR DESCRIPTION
The additional validation we recently added has identified numerous instances of duplicated changes in query results from the Gerrit API. We think this is due to the fixed offset pagination control rather than an index based pagination key.

This PR works around the issue by deduplicating changes after the query has completed.
/assign @timwangmusic @airbornepony 