### PR TITLE
New presubmit using kubetest2-ec2 (mimic pull-kubernetes-e2e-gce)

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -47,6 +47,67 @@ presubmits:
                --test=ginkgo \
                -- \
                --use-built-binaries true \
+               --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-conformance
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: k8s.io/kubernetes
+    always_run: false
+    optional: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: sigs.k8s.io/provider-aws-test-infra
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+              kubetest2 ec2 \
+               --build \
+               --instance-type=m6a.large  \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --stage provider-aws-test-infra \
+               --up \
+               --down \
+               --user-data-file=${GOPATH}/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/ubuntu2204.yaml \
+               --ssh-user=ec2-user \
+               --ssh-env=aws \
+               --test=ginkgo \
+               -- \
+               --use-built-binaries true \
                --focus-regex='\[Conformance\]'
           env:
             - name: USE_DOCKERIZED_BUILD

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -75,6 +75,9 @@ dashboards:
   - name: pull-kubernetes-e2e-ec2
     test_group_name: pull-kubernetes-e2e-ec2
     base_options: width=10
+  - name: pull-kubernetes-e2e-ec2-conformance
+    test_group_name: pull-kubernetes-e2e-ec2-conformance
+    base_options: width=10
   - name: pull-kubernetes-e2e-gce-cos
     test_group_name: pull-kubernetes-e2e-gce-cos
     base_options: width=10


### PR DESCRIPTION
- The previous job runs conformance tests so make sure the name reflects that.
- Add a new CI job that uses the same ginkgo arguments as the `pull-kubernetes-e2e-gce` CI job:
  https://github.com/kubernetes/test-infra/blob/1d758ed73caef84d6ce51120edc416ad140f5cf6/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L255C41-L255C118