### PR TITLE
[pull-kubernetes-e2e-ec2] Switch on multiple ginkgo threads to run tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -47,6 +47,7 @@ presubmits:
                --test=ginkgo \
                -- \
                --use-built-binaries true \
+               --parallel=30 \
                --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
           env:
             - name: USE_DOCKERIZED_BUILD


### PR DESCRIPTION
`pull-kubernetes-e2e-gce` uses `--ginkgo-parallel=30`, we should do the same here:
https://github.com/kubernetes/test-infra/blob/d98f75fb3c45702a238948a41202c67368b43b13/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L252