### PR TITLE
[sig-windows-networking] Add AKS 1.27 testing & deprecate AKS 1.24 prowjobs

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -63,6 +63,12 @@ dashboards:
   - name: aks-ltsc2022-azurecni-1.26
     description: Runs Kubernetes E2E tests on an AKS deployment (1.26 release) with LTSC 2022 nodes and AzureCNI.
     test_group_name: aks-e2e-ltsc2022-azurecni-1.26
+  - name: aks-ltsc2019-azurecni-1.27
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.27 release) with LTSC 2019 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2019-azurecni-1.27
+  - name: aks-ltsc2022-azurecni-1.27
+    description: Runs Kubernetes E2E tests on an AKS deployment (1.27 release) with LTSC 2022 nodes and AzureCNI.
+    test_group_name: aks-e2e-ltsc2022-azurecni-1.27
 - name: sig-windows-containerd-runtime-signal
   dashboard_tab:
   - name: win-2019-containerd-master-integration
@@ -96,6 +102,10 @@ test_groups:
   gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.26
 - name: aks-e2e-ltsc2022-azurecni-1.26
   gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.26
+- name: aks-e2e-ltsc2019-azurecni-1.27
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.27
+- name: aks-e2e-ltsc2022-azurecni-1.27
+  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.27
 # Containerd Runtime integration test groups
 - name: integration-containerd-windows-ltsc2019
   gcs_prefix: containerd-integration/logs/windows-ltsc2019

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -51,12 +51,6 @@ dashboards:
   - name: ltsc2022-containerd-flannel-sdnoverlay-stable
     description: Runs Windows (LTSC 2022 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
-  - name: aks-ltsc2019-azurecni-1.24
-    description: Runs Kubernetes E2E tests on an AKS deployment (1.24 release) with LTSC 2019 nodes and AzureCNI.
-    test_group_name: aks-e2e-ltsc2019-azurecni-1.24
-  - name: aks-ltsc2022-azurecni-1.24
-    description: Runs Kubernetes E2E tests on an AKS deployment (1.24 release) with LTSC 2022 nodes and AzureCNI.
-    test_group_name: aks-e2e-ltsc2022-azurecni-1.24
   - name: aks-ltsc2019-azurecni-1.25
     description: Runs Kubernetes E2E tests on an AKS deployment (1.25 release) with LTSC 2019 nodes and AzureCNI.
     test_group_name: aks-e2e-ltsc2019-azurecni-1.25
@@ -94,10 +88,6 @@ test_groups:
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
 # AKS with AzureCNI test groups
-- name: aks-e2e-ltsc2019-azurecni-1.24
-  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.24
-- name: aks-e2e-ltsc2022-azurecni-1.24
-  gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.24
 - name: aks-e2e-ltsc2019-azurecni-1.25
   gcs_prefix: k8s-ovn/logs/aks-e2e-ltsc2019-azurecni-1.25
 - name: aks-e2e-ltsc2022-azurecni-1.25


### PR DESCRIPTION
* Remove AKS 1.24 prowjobs:
  * AKS 1.24 is deprecated since [release 2023-07-30](https://github.com/Azure/AKS/releases/tag/2023-07-30).
* Add AKS 1.27 with AzureCNI prowjobs:
  * Add two more test groups for the AKS with AzureCNI 1.27 release testing.