### PR TITLE
CAPI Operator: Setup new jobs for release-0.5 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-5.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-operator-test-release-0-3
+- name: periodic-cluster-api-operator-test-release-0-5
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -8,11 +8,11 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.3
+    base_ref: release-0.5
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -23,11 +23,11 @@ periodics:
           cpu: "1"
           memory: "2Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-    testgrid-tab-name: capi-operator-test-release-0-3
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+    testgrid-tab-name: capi-operator-test-release-0-5
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-operator-e2e-release-0-3
+- name: periodic-cluster-api-operator-e2e-release-0-5
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -39,11 +39,11 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.3
+    base_ref: release-0.5
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
       command:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -58,7 +58,7 @@ periodics:
           cpu: "1"
           memory: "2Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-    testgrid-tab-name: capi-operator-e2e-release-0-3
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+    testgrid-tab-name: capi-operator-e2e-release-0-5
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-5.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/cluster-api-operator:
-  - name: pull-cluster-api-operator-build-release-0-3
+  - name: pull-cluster-api-operator-build-release-0-5
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -9,10 +9,10 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.3$
+    - ^release-0.5$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -24,9 +24,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-      testgrid-tab-name: capi-operator-pr-build-release-0-3
-  - name: pull-cluster-api-operator-make-release-0-3
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+      testgrid-tab-name: capi-operator-pr-build-release-0-5
+  - name: pull-cluster-api-operator-make-release-0-5
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -36,10 +36,10 @@ presubmits:
       preset-dind-enabled: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.3$
+    - ^release-0.5$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         command:
         - runner.sh
         - ./scripts/ci-make.sh
@@ -54,9 +54,9 @@ presubmits:
             cpu: "4"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-      testgrid-tab-name: capi-operator-pr-make-release-0-3
-  - name: pull-cluster-api-operator-apidiff-release-0-3
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+      testgrid-tab-name: capi-operator-pr-make-release-0-5
+  - name: pull-cluster-api-operator-apidiff-release-0-5
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -65,11 +65,11 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.3$
+    - ^release-0.5$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
@@ -81,9 +81,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-      testgrid-tab-name: capi-operator-pr-apidiff-release-0-3
-  - name: pull-cluster-api-operator-verify-release-0-3
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+      testgrid-tab-name: capi-operator-pr-apidiff-release-0-5
+  - name: pull-cluster-api-operator-verify-release-0-5
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -92,10 +92,10 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.3$
+    - ^release-0.5$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -107,9 +107,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-      testgrid-tab-name: capi-operator-pr-verify-release-0-3
-  - name: pull-cluster-api-operator-test-release-0-3
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+      testgrid-tab-name: capi-operator-pr-verify-release-0-5
+  - name: pull-cluster-api-operator-test-release-0-5
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -117,11 +117,11 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.3$
+    - ^release-0.5$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -133,9 +133,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-      testgrid-tab-name: capi-operator-pr-test-release-0-3
-  - name: pull-cluster-api-operator-e2e-release-0-3
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+      testgrid-tab-name: capi-operator-pr-test-release-0-5
+  - name: pull-cluster-api-operator-e2e-release-0-5
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true
@@ -145,10 +145,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - ^release-0.3$
+    - ^release-0.5$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         command:
           - runner.sh
         args:
@@ -170,5 +170,5 @@ presubmits:
             cpu: "4"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.3
-      testgrid-tab-name: capi-operator-pr-e2e-release-0-3
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
+      testgrid-tab-name: capi-operator-pr-e2e-release-0-5

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -20,7 +20,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-openstack
     - sig-cluster-lifecycle-cluster-api-provider-cloudstack
     - sig-cluster-lifecycle-cluster-api-provider-nested
-    - sig-cluster-lifecycle-cluster-api-operator-0.3
+    - sig-cluster-lifecycle-cluster-api-operator-0.5
     - sig-cluster-lifecycle-cluster-api-operator
     - sig-cluster-lifecycle-kops
     - sig-cluster-lifecycle-etcdadm
@@ -64,7 +64,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
 - name: sig-cluster-lifecycle-cluster-api-provider-cloudstack
 - name: sig-cluster-lifecycle-cluster-api-provider-nested
-- name: sig-cluster-lifecycle-cluster-api-operator-0.3
+- name: sig-cluster-lifecycle-cluster-api-operator-0.5
 - name: sig-cluster-lifecycle-cluster-api-operator
 - name: sig-cluster-lifecycle-kops
 - name: sig-cluster-lifecycle-etcdadm


### PR DESCRIPTION
Latest stable release branch of CAPI Operator is [release-0.5](https://github.com/kubernetes-sigs/cluster-api-operator/tree/release-0.5). This PR adds new periodic/presubmit jobs for the new release branch and drop running the CI in the old one (release-0.3).

