### PR TITLE
CAPV: fix release-1.8 branch name references in presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
@@ -23,7 +23,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     labels:
       preset-dind-enabled: "true"
     always_run: true
@@ -46,7 +46,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-test-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
@@ -70,7 +70,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -103,7 +103,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -141,7 +141,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -177,7 +177,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-conformance-release-1-8
     branches:
-    - ^release-1-8$
+    - ^release-1.8$
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"


### PR DESCRIPTION
The branch is called `release-1.8` (same pattern for previous releases).