### PR TITLE
migrate manual `k-csi` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-25
+    cluster: eks-prow-build-cluster
     always_run: true
     optional: true
     decorate: true
@@ -45,11 +46,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
 
 periodics:
 - interval: 6h
@@ -60,6 +61,7 @@ periodics:
   # that slipped through pre-merge testing, so we have to use canary
   # images.
   name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-26
+  cluster: eks-prow-build-cluster
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -111,14 +113,15 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
 - interval: 6h
   # 1.24 will change the CSIStorageCapacity API: v1beta1 becomes deprecated and v1 gets added.
   name: ci-kubernetes-csi-canary-distributed-on-kubernetes-master
+  cluster: eks-prow-build-cluster
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -170,8 +173,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-unmanaged.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-unmanaged.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-iscsi:
   - name: pull-csi-driver-iscsi-sanity
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/csi-driver-iscsi
@@ -21,6 +22,13 @@ presubmits:
         - sanity-test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-iscsi-sanity

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
@@ -3,6 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-nfs:
   - name: pull-csi-driver-nfs-sanity
+    cluster: default #This job uses azure-creds
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/csi-driver-nfs
@@ -22,12 +23,20 @@ presubmits:
         - sanity-test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-nfs-sanity
       description: "Run sanity tests for NFS CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-nfs-unit
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/csi-driver-nfs
@@ -45,12 +54,20 @@ presubmits:
         - unit-test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-nfs-unit
       description: "Run unit tests for NFS CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-nfs-integration
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/csi-driver-nfs
@@ -69,12 +86,20 @@ presubmits:
         - integration-test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-nfs-integration
       description: "Run integration tests for NFS CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-nfs-e2e
+    cluster: default #This job uses azure-creds
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-nfs
@@ -115,6 +140,13 @@ presubmits:
         - --test-csi-driver-nfs
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-nfs-e2e
@@ -122,6 +154,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: pull-csi-driver-nfs-external-e2e
+    cluster: default #This job uses azure-creds
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-nfs
@@ -162,6 +195,13 @@ presubmits:
         - --test-csi-driver-nfs
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
         env:
           - name: EXTERNAL_E2E_TEST
             value: "true"


### PR DESCRIPTION
This PR moves the remaining csi jobs from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @msau42 @saad-ali @xing-yang @jsafrane @pohly