### PR TITLE
New periodic ci jobs based on kubetest2 ec2

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -16,7 +16,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-e2e-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-e2e-ec2
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -59,7 +59,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv1-containerd-node-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -104,7 +104,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -159,7 +159,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -206,7 +206,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -263,7 +263,7 @@ periodics:
   - name: ci-kubernetes-node-arm64-e2e-containerd-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-kubernetes-node-arm64-e2e-containerd-ec2
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -314,7 +314,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
@@ -366,7 +366,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-e2e-serial-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-e2e-serial-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
@@ -410,7 +410,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -458,7 +458,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-arm64-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv1-containerd-node-arm64-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -516,7 +516,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -566,7 +566,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd
+      testgrid-dashboards: sig-node-containerd,amazon-ec2
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m

--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -35,15 +35,11 @@ presubmits:
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
               kubetest2 ec2 \
                --build \
-               --instance-type=m6a.large  \
                --region us-east-1 \
                --target-build-arch linux/amd64 \
                --stage provider-aws-test-infra \
                --up \
                --down \
-               --user-data-file=${GOPATH}/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/ubuntu2204.yaml \
-               --ssh-user=ec2-user \
-               --ssh-env=aws \
                --test=ginkgo \
                -- \
                --use-built-binaries true \
@@ -103,9 +99,6 @@ presubmits:
                --stage provider-aws-test-infra \
                --up \
                --down \
-               --user-data-file=${GOPATH}/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/ubuntu2204.yaml \
-               --ssh-user=ec2-user \
-               --ssh-env=aws \
                --test=ginkgo \
                -- \
                --use-built-binaries true \
@@ -123,3 +116,234 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+periodics:
+- interval: 12h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-ec2-conformance-latest
+  annotations:
+    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2
+    testgrid-tab-name: Conformance - EC2 - master
+    description: Runs conformance tests using kubetest against kubernetes master on EC2
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/amd64 \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --focus-regex='\[Conformance\]'
+        env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 12h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-ec2-arm64-conformance-latest
+  annotations:
+    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2
+    testgrid-tab-name: Conformance - EC2 - arm64 - master
+    description: Runs conformance tests using kubetest against kubernetes master on EC2 (arm64)
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/arm64 \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --focus-regex='\[Conformance\]'
+        env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 12h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-e2e-ubuntu-ec2-containerd
+  annotations:
+    testgrid-dashboards: amazon-ec2
+    testgrid-tab-name: ec2-ubuntu-master-containerd
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster (ubuntu based and uses containerd) created with kubetest2-ec2
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/amd64 \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --parallel=30 \
+             --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+        env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 12h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-e2e-ubuntu-ec2-arm64-containerd
+  annotations:
+    testgrid-dashboards: amazon-ec2
+    testgrid-tab-name: ec2-arm64-ubuntu-master-containerd
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster (ubuntu based and uses containerd) created with kubetest2-ec2
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/arm64 \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --parallel=30 \
+             --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+        env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi

--- a/config/testgrids/amazon/OWNERS
+++ b/config/testgrids/amazon/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- dims
+- tzneal

--- a/config/testgrids/amazon/amazon.yaml
+++ b/config/testgrids/amazon/amazon.yaml
@@ -1,0 +1,13 @@
+#
+# Start dashboards
+#
+dashboards:
+- name: amazon-ec2
+
+#
+# Start dashboard groups
+#
+dashboard_groups:
+- name: amazon
+  dashboard_names:
+  - amazon-ec2

--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -3,6 +3,7 @@ dashboard_groups:
   dashboard_names:
     - conformance-all
     - conformance-apisnoop
+    - conformance-ec2
     - conformance-gce
     - conformance-kind
     - conformance-cloud-provider-huaweicloud
@@ -97,6 +98,7 @@ dashboards:
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.22
 
 - name: conformance-apisnoop
+- name: conformance-ec2
 - name: conformance-gce
 
 - name: conformance-cloud-provider-huaweicloud

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -46,6 +46,7 @@ type SQConfig struct {
 
 var (
 	companies = []string{
+		"amazon",
 		"canonical",
 		"cos",
 		"containerd",


### PR DESCRIPTION
Runs twice a day for now, just to test.

- `ci-kubernetes-ec2-conformance-latest` (Same tests as `ci-kubernetes-gce-conformance-latest`)
- `ci-kubernetes-ec2-arm64-conformance-latest` (Variation of above using arm64)
- `ci-kubernetes-e2e-ubuntu-ec2-containerd` (Same tests as `ci-kubernetes-e2e-ubuntu-gce-containerd`)
- `ci-kubernetes-e2e-ubuntu-ec2-arm64-containerd` (Variation of above using arm64)

Added a couple of new dashboards to make it easy to monitor the periodic ec2 based CI jobs.