### PR TITLE
migrate `dns` job to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -207,6 +207,7 @@ presubmits:
 
   kubernetes/dns:
   - name: pull-kubernetes-dns-test
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: true
@@ -224,6 +225,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 periodics:
 - interval: 6h
   name: ci-kubernetes-e2e-gce-alpha-api


### PR DESCRIPTION
This PR moves the k/dns job from the GCP cluster to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @aojea @bowei @cadmuxe @mrhohn @rramkumar1