### PR TITLE
Simplify flags for ec2 node jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -133,7 +133,7 @@ presubmits:
             --query 'Parameters[0].[Value]' --output text);
           kubetest2 noop --test=node -- \;
             --provider=aws --repo-root=. --instance-type=m6a.large --focus-regex="\[NodeConformance\]" \;
-            --test-args='--kubelet-flags="--cgroup-driver=systemd --runtime-cgroups=/system.slice/containerd.service"' \;
+            --test-args='--kubelet-flags="--cgroup-driver=systemd"' \;
             --images=$AMI_ID --user-data-file=config/ubuntu2204.yaml
 
   - name: pull-kubetest2-gce-node-e2e

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -48,7 +48,7 @@ periodics:
             - name: FOCUS
               value: \[NodeConformance\]
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 8
@@ -93,7 +93,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 8
@@ -145,7 +145,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -195,7 +195,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 8
@@ -249,7 +249,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -300,7 +300,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=cgroupfs"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -352,7 +352,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -399,7 +399,7 @@ periodics:
             - name: SKIP
               value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 8
@@ -408,6 +408,7 @@ periodics:
               cpu: 8
               memory: 10Gi
   - name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
+    # are you sure this is a cgroupsv1 job? it using systemd
     interval: 6h
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2
@@ -447,7 +448,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 8
@@ -502,7 +503,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -555,7 +556,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 8
@@ -612,7 +613,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -121,7 +121,7 @@ presubmits:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           resources:
             limits:
               cpu: 4
@@ -172,7 +172,7 @@ presubmits:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
-              value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=cgroupfs"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -228,7 +228,7 @@ presubmits:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -2268,7 +2268,7 @@ presubmits:
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-arm64.yaml
               - name: TEST_ARGS
-                value: '--container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+                value: '--kubelet-flags="--cgroup-driver=cgroupfs"'
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -2315,7 +2315,7 @@ presubmits:
               - name: SKIP
                 value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
               - name: TEST_ARGS
-                value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+                value: '--kubelet-flags="--cgroup-driver=systemd"'
             resources:
               limits:
                 cpu: 8
@@ -2363,7 +2363,7 @@ presubmits:
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-eks.yaml
               - name: TEST_ARGS
-                value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+                value: '--kubelet-flags="--cgroup-driver=systemd"'
             resources:
               limits:
                 cpu: 8
@@ -2412,7 +2412,7 @@ presubmits:
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-arm64.yaml
               - name: TEST_ARGS
-                value: '--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+                value: '--kubelet-flags="--cgroup-driver=systemd"'
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
/cc @tzneal @dims 

1. We'll need to merge https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/94 immediately after this change.
2. The simplified test-args flags have been used in the kubetes2 ec2 node presubmit nicely https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kubetest2/237/pull-kubetest2-aws-node-e2e/1690095810697498624
3. For the cgroupv1 jobs, I added the `'--kubelet-flags="--cgroup-driver=cgroupfs"'` flag which the default anyway instead of leaving it empty.
4. Once this is merged, I'll clean up the config-dir stuff and then switch to kubetest2
