### PR TITLE
Split ec2 node e2e jobs into separate dashboard

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -16,7 +16,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-e2e-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-e2e-ec2
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -59,7 +59,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv1-containerd-node-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -104,7 +104,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -159,7 +159,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -206,7 +206,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -263,7 +263,7 @@ periodics:
   - name: ci-kubernetes-node-arm64-e2e-containerd-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-kubernetes-node-arm64-e2e-containerd-ec2
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -314,7 +314,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
@@ -366,7 +366,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-e2e-serial-ec2
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-e2e-serial-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
@@ -410,7 +410,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -458,7 +458,7 @@ periodics:
   - name: ci-cgroupv1-containerd-node-arm64-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv1-containerd-node-arm64-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -516,7 +516,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -566,7 +566,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m

--- a/config/testgrids/amazon/amazon.yaml
+++ b/config/testgrids/amazon/amazon.yaml
@@ -3,6 +3,7 @@
 #
 dashboards:
 - name: amazon-ec2
+- name: amazon-ec2-node
 
 #
 # Start dashboard groups
@@ -11,3 +12,4 @@ dashboard_groups:
 - name: amazon
   dashboard_names:
   - amazon-ec2
+  - amazon-ec2-node


### PR DESCRIPTION
Split the single dasbhoard into two ... one for the e2e node tests, another for the rest