### PR TITLE
inrepoconfig: optimize secondary clones

### DIFF
--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -681,6 +681,13 @@ func (cf *testClientFactory) ClientFor(org, repo string) (git.RepoClient, error)
 	return &fetchOnlyNoCleanRepoClient{cf.rcMap[repo]}, nil
 }
 
+func (cf *testClientFactory) ClientForWithRepoOpts(org, repo string, repoOpts git.RepoOpts) (git.RepoClient, error) {
+	cf.clientsCreated++
+	// Returning this RepoClient ensures that only Fetch() is called and that Close() is not.
+
+	return &fetchOnlyNoCleanRepoClient{cf.rcMap[repo]}, nil
+}
+
 type fetchOnlyNoCleanRepoClient struct {
 	git.RepoClient // This will be nil during testing, we override the functions that are allowed to be used.
 }

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -59,6 +59,12 @@ func (a *clientFactoryAdapter) ClientFor(org, repo string) (RepoClient, error) {
 	return &repoClientAdapter{Repo: r}, err
 }
 
+// v1 clients do not support customizing pre-repo options.
+func (a *clientFactoryAdapter) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpts) (RepoClient, error) {
+	r, err := a.Client.Clone(org, repo)
+	return &repoClientAdapter{Repo: r}, err
+}
+
 type repoClientAdapter struct {
 	*git.Repo
 }

--- a/prow/git/v2/interactor_test.go
+++ b/prow/git/v2/interactor_test.go
@@ -39,29 +39,29 @@ func TestInteractor_Clone(t *testing.T) {
 	}{
 		{
 			name: "happy case",
-			dir:  "/else",
-			from: "/somewhere",
+			dir:  "/secondaryclone",
+			from: "/mirrorclone",
 			responses: map[string]execResponse{
-				"clone /somewhere /else": {
+				"clone /mirrorclone /secondaryclone": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"clone", "/somewhere", "/else"},
+				{"clone", "/mirrorclone", "/secondaryclone"},
 			},
 			expectedErr: false,
 		},
 		{
 			name: "clone fails",
-			dir:  "/else",
-			from: "/somewhere",
+			dir:  "/secondaryclone",
+			from: "/mirrorclone",
 			responses: map[string]execResponse{
-				"clone /somewhere /else": {
+				"clone /mirrorclone /secondaryclone": {
 					err: errors.New("oops"),
 				},
 			},
 			expectedCalls: [][]string{
-				{"clone", "/somewhere", "/else"},
+				{"clone", "/mirrorclone", "/secondaryclone"},
 			},
 			expectedErr: true,
 		},

--- a/prow/git/v2/interactor_test.go
+++ b/prow/git/v2/interactor_test.go
@@ -93,6 +93,118 @@ func TestInteractor_Clone(t *testing.T) {
 	}
 }
 
+func TestInteractor_CloneWithRepoOpts(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		dir           string
+		from          string
+		remote        RemoteResolver
+		repoOpts      RepoOpts
+		responses     map[string]execResponse
+		expectedCalls [][]string
+		expectedErr   bool
+	}{
+		{
+			name:     "blank RepoOpts",
+			dir:      "/secondaryclone",
+			from:     "/mirrorclone",
+			repoOpts: RepoOpts{},
+			responses: map[string]execResponse{
+				"clone /mirrorclone /secondaryclone": {
+					out: []byte(`ok`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"clone", "/mirrorclone", "/secondaryclone"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "shared git objects",
+			dir:  "/secondaryclone",
+			from: "/mirrorclone",
+			repoOpts: RepoOpts{
+				SparseCheckoutDirs:         nil,
+				ShareObjectsWithSourceRepo: true,
+			},
+			responses: map[string]execResponse{
+				"clone --shared /mirrorclone /secondaryclone": {
+					out: []byte(`ok`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"clone", "--shared", "/mirrorclone", "/secondaryclone"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "shared git objects and sparse checkout (toplevel only)",
+			dir:  "/secondaryclone",
+			from: "/mirrorclone",
+			repoOpts: RepoOpts{
+				SparseCheckoutDirs:         []string{},
+				ShareObjectsWithSourceRepo: true,
+			},
+			responses: map[string]execResponse{
+				"clone --shared --sparse /mirrorclone /secondaryclone": {
+					out: []byte(`ok`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"clone", "--shared", "--sparse", "/mirrorclone", "/secondaryclone"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "shared git objects and sparse checkout (toplevel+subdirs)",
+			dir:  "/secondaryclone",
+			from: "/mirrorclone",
+			repoOpts: RepoOpts{
+				SparseCheckoutDirs:         []string{"a", "b"},
+				ShareObjectsWithSourceRepo: true,
+			},
+			responses: map[string]execResponse{
+				"clone --shared --sparse /mirrorclone /secondaryclone": {
+					out: []byte(`ok`),
+				},
+				"-C /secondaryclone sparse-checkout set a b": {
+					out: []byte(`ok`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"clone", "--shared", "--sparse", "/mirrorclone", "/secondaryclone"},
+				{"-C", "/secondaryclone", "sparse-checkout", "set", "a", "b"},
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := fakeExecutor{
+				records:   [][]string{},
+				responses: testCase.responses,
+			}
+			i := interactor{
+				executor: &e,
+				remote:   testCase.remote,
+				dir:      testCase.dir,
+				logger:   logrus.WithField("test", testCase.name),
+			}
+			actualErr := i.CloneWithRepoOpts(testCase.from, testCase.repoOpts)
+			if testCase.expectedErr && actualErr == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && actualErr != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, actualErr)
+			}
+			if actual, expected := e.records, testCase.expectedCalls; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect git calls: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
 func TestInteractor_MirrorClone(t *testing.T) {
 	var testCases = []struct {
 		name          string


### PR DESCRIPTION
The only data we need from a clone inrepoconfig repo is the .prow contents (aside: we clone it in the first place so that we can merge to the base branch).

The underlying Git client actually uses 2 clones --- first a mirror clone (git clone --mirror ...), and then a secondary local clone into a temporary folder (git clone ...). This secondary clone is the one we are optimizing here.

This adds 2 optimizations:

(1) Avoid populating object files with "--shared" flag. This way, the .git folder of the secondary clone can just have a pointer to the mirror clone. This saves a lot of disk space for large repos (not to mention that both the CPU time and disk usage for creating this clone is vastly reduced, especially when combined with the next optimization).

(2) Avoid a full checkout with sparse-checkout (supported since Git 2.25). This way, we can avoid deflating Git blob objects into file paths on disk for everything except (a) files at the toplevel and (b) files specified by the "git sparse-checkout set <PATH> [...<PATH>]" command. The toplevel files are included as part of "cone mode" which is the recommended mode for sparse checkouts. In our case we specify the ".prow" folder as the only path to make sure we get those inrepoconfig files checked out.

/cc @cjwagner @airbornepony @timwangmusic 