### PR TITLE
Set node-os-arch explicitly in ec2-arm64-ubuntu-master-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -333,6 +333,7 @@ periodics:
              -- \
              --use-built-binaries true \
              --parallel=30 \
+             --test-args='--node-os-arch=arm64' \
              --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
         env:
           - name: USE_DOCKERIZED_BUILD


### PR DESCRIPTION
Trying to fix the failure in:
https://testgrid.k8s.io/amazon-ec2#ec2-arm64-ubuntu-master-containerd&width=20

There's a skip check here:
https://github.com/kubernetes/kubernetes/blob/master/test/e2e/kubectl/kubectl.go#L570

but i think it's defaulting to `amd64`, so let's set it explicitly as we know we are launching `arm64` nodes