### PR TITLE
inrepoconfig: retire secondary clone serialization for same-repo requests

### DIFF
--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -152,8 +152,6 @@ type InRepoConfigCache struct {
 
 // NewInRepoConfigCache creates a new LRU cache for ProwYAML values, where the keys
 // are CacheKeys (that is, JSON strings) and values are pointers to ProwYAMLs.
-// The provided git.ClientFactory will be wrapped with NewInRepoConfigGitCache() so
-// ensure the input parameter is not prewrapped with this.
 func NewInRepoConfigCache(
 	size int,
 	configAgent prowConfigAgentClient,
@@ -237,7 +235,7 @@ func NewInRepoConfigCache(
 		configAgent,
 		// Make the cache be able to handle cache misses (by calling out to Git
 		// to construct the ProwYAML value).
-		NewInRepoConfigGitCache(gitClientFactory),
+		gitClientFactory,
 	}
 
 	return cache, nil

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -24,7 +24,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	gitignore "github.com/denormal/go-gitignore"
@@ -326,105 +325,6 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 	}
 
 	return utilerrors.NewAggregate(errs)
-}
-
-// InRepoConfigGitCache is a wrapper around a git.ClientFactory that allows for
-// threadsafe reuse of git.RepoClients when one already exists for the specified repo.
-type InRepoConfigGitCache struct {
-	git.ClientFactory
-	cache map[string]*skipCleanRepoClient
-	sync.RWMutex
-}
-
-func NewInRepoConfigGitCache(factory git.ClientFactory) git.ClientFactory {
-	if factory == nil {
-		// Don't wrap a nil git factory, keep it nil so that errors are handled properly.
-		return nil
-	}
-	return &InRepoConfigGitCache{
-		ClientFactory: factory,
-		cache:         map[string]*skipCleanRepoClient{},
-	}
-}
-
-func (c *InRepoConfigGitCache) ClientFor(org, repo string) (git.RepoClient, error) {
-	key := fmt.Sprintf("%s/%s", org, repo)
-	getCache := func(threadSafe bool) (git.RepoClient, error) {
-		if client, ok := c.cache[key]; ok {
-			client.Lock()
-			// if repo is dirty, perform git reset --hard instead of deleting entire repo
-			if isDirty, err := client.RepoClient.IsDirty(); err != nil || isDirty {
-				if err := client.ResetHard("HEAD"); err != nil {
-					if threadSafe {
-						// Called within client `Lock`, safe to delete from map,
-						// return with nil so that a fresh clone will be performed
-						delete(c.cache, key)
-						client.Clean() // best effort clean, to avoid jam up disk
-					}
-					// Called with client `RLock`, not safe to delete from map,
-					// also return because fetch doesn't make much sense any more
-					client.Unlock()
-					return nil, nil
-				}
-			}
-			// Don't unlock the client unless we get an error or the consumer
-			// indicates they are done by Clean()ing.
-			// This fetch operation is repeated executed in the clone repo,
-			// which fails if there is a commit being deleted from remote. This
-			// is a corner case, but when it happens it would be really
-			// annoying, adding `--prune` tag here for mitigation.
-			if err := client.Fetch("--prune"); err != nil {
-				client.Unlock()
-				return nil, err
-			}
-			return client, nil
-		}
-		return nil, nil
-	}
-	c.RLock()
-	cached, err := getCache(false)
-	c.RUnlock()
-	if cached != nil || err != nil {
-		return cached, err
-	}
-
-	// The repo client was not cached, create a new one.
-	c.Lock()
-	defer c.Unlock()
-	// On cold start, all threads pass RLock and wait here, we need to do one more
-	// check here to avoid more than one cloning.
-	// (It would be nice if we could upgrade from `RLock` to `Lock`)
-	cached, err = getCache(true)
-	if cached != nil || err != nil {
-		return cached, err
-	}
-	coreClient, err := c.ClientFactory.ClientForWithRepoOpts(org, repo, inrepoconfigRepoOpts)
-	if err != nil {
-		return nil, err
-	}
-	// This is the easiest way we can find for fetching all pull heads
-	if err := coreClient.Config("--add", "remote.origin.fetch", "+refs/pull/*/head:refs/remotes/origin/pr/*"); err != nil {
-		return nil, err
-	}
-	client := &skipCleanRepoClient{
-		RepoClient: coreClient,
-	}
-	client.Lock()
-	c.cache[key] = client
-	return client, nil
-}
-
-var _ git.RepoClient = &skipCleanRepoClient{}
-
-type skipCleanRepoClient struct {
-	git.RepoClient
-	sync.Mutex
-}
-
-func (rc *skipCleanRepoClient) Clean() error {
-	// Skip cleaning and unlock to allow reuse as a cached entry.
-	rc.Mutex.Unlock()
-	return nil
 }
 
 // ContainsInRepoConfigPath indicates whether the specified list of changed

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -559,7 +559,7 @@ func createTestRepoCache(t *testing.T, ca *fca) (*config.InRepoConfigCache, erro
 	cache, err := config.NewInRepoConfigCache(
 		10,
 		ca,
-		config.NewInRepoConfigGitCache(cf))
+		cf)
 	if err != nil {
 		t.Errorf("error creating cache: %v", err)
 	}


### PR DESCRIPTION
Before 916ed2b4b7 (Merge pull request #30400 from
listx/inrepoconfig-optimizations, 2023-08-17), we were under the
impression that the secondary clones of inrepoconfig repos were
unavoidably large. So we created the InRepoConfigGitCache wrapper in
3098b88178 (Merge pull request #23264 from cjwagner/inrepo-config-cache,
2021-08-18) to make it so we would never delete and recreate the
secondary clone for every request (the default behavior of the wrapped
git v2 client); instead, we would reuse the existing secondary clones
across requests if those requests were for the same repo. This resulted
in the need to ensure that only one such request would touch the
associated secondary clone at any given time, which meant that we had to
serialize the use of these secondary clones.

It turns out that the secondary clone optimizations in 916ed2b4b7 make
these clones cheaper on disk by multiple orders of magnitude. In manual
tests, we saw reductions in size from 3.1GB to just 19MB for the disk
space used for a secondary clone for a large repo using inrepoconfigs
(where the bulk of the 19MB came from other unrelated files in the
toplevel folder of the repo, due to the way sparse checkouts work).

Because the secondary clones are so cheap now, there's no need to try to
reuse the same one during the lifetime of a process. We just create and
delete each time we need to service a request.

Note that we already have a call to repo.Clean() inside prowYAMLGetter,
so that will delete the repo after we read the inrepoconfig values.
However, the main "gitcache" directory (holding the mirror clone) will
still be around and will not be deleted.

/cc @cjwagner @airbornepony @timwangmusic 