### PR TITLE
bootstrap image: update to bookworm

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 WORKDIR /workspace
 RUN mkdir -p /workspace


### PR DESCRIPTION
This notably picks up git 2.39, whose sparse-checkout behavior has https://github.com/git/git/commit/4ce504360bc3b240e570281fabe00a85027532c3.

/cc @cjwagner @timwangmusic @airbornepony 