### PR TITLE
fix DecorationConfig in starter yaml files

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -96,7 +96,7 @@ data:
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
-        - config:
+      - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -96,7 +96,7 @@ data:
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
-        - config:
+      - config:
           gcs_configuration:
             bucket: gs://your-bucket-name
             path_strategy: explicit

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -94,7 +94,7 @@ data:
             [Your PR dashboard](http://<< your-minikube/kind IP >>:30002/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
-        - config:
+      - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -96,7 +96,7 @@ data:
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_config_entries:
-        - config:
+      - config:
           gcs_configuration:
             bucket: s3://prow-logs
             path_strategy: explicit


### PR DESCRIPTION
The indentation is wrong for the `config` entry of the `default_decoration_configs` setting. It causes the `prow-controller-manager` to fail in startup.

Fix the indentation error and make it compatible with the data struct here: https://pkg.go.dev/k8s.io/test-infra/prow/config#Plank
