### PR TITLE
Upgrade node conformance tests for 1.28 to COS beta

### DIFF
--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
@@ -1,6 +1,6 @@
 images:
-    # TODO(mmiranda96): update to cos-beta once COS releases their beta family
+    # TODO(mmiranda96): update to cos-109-lts once COS beta promotes to stable
   cos-dev:
-    image_family: cos-dev
+    image_family: cos-beta
     project: cos-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
### What does this PR do?
Upgrade node conformance job for 1.28 to COS beta.

/area testing
/sig node
/assign @SergeyKanzhelev 