### PR TITLE
disable review_acts_as_lgtm for publishing-bot

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -242,7 +242,6 @@ lgtm:
   - kubernetes/cloud-provider-aws
   - kubernetes/k8s.io
   - kubernetes/kops
-  - kubernetes/publishing-bot
   - kubernetes/release
   - kubernetes/repo-infra
   - kubernetes/sig-release


### PR DESCRIPTION
Disable review_acts_as_lgtm for kubernetes/publishing-bot. This prevents prow from applying the lgtm label on GitHub level review approvals.