### PR TITLE
Revert "Reduce number of pods created for getting jobs to succeed"

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -116,12 +116,6 @@ presubmits:
           value: "true"
         - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
           value: "25"
-        - name: PODS_PER_NODE
-          value: "1"
-        - name: BIG_GROUP_SIZE
-          value: "5"
-        - name: MEDIUM_GROUP_SIZE
-          value: "5"
         - name: CONTROL_PLANE_COUNT
           value: "3"
         - name: CONTROL_PLANE_SIZE


### PR DESCRIPTION
I don't think this is needed anymore, already added the setting back via env var:
https://github.com/kubernetes/kops/pull/15599/commits/cec8535246b2bb93cc47597fcbb87abbe4c9d1ba

Reverts kubernetes/test-infra#30408