### PR TITLE
promote EC2 conformance jobs to release-master informing

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -121,7 +121,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-ec2-conformance-latest
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2
+    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2, sig-release-master-informing
     testgrid-tab-name: Conformance - EC2 - master
     description: Runs conformance tests using kubetest against kubernetes master on EC2
   labels:
@@ -178,7 +178,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-ec2-arm64-conformance-latest
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2
+    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2, sig-release-master-informing
     testgrid-tab-name: Conformance - EC2 - arm64 - master
     description: Runs conformance tests using kubetest against kubernetes master on EC2 (arm64)
   labels:


### PR DESCRIPTION
Dear release team,

I'd like us to propose that we watch our very first `arm64` CI job for 1.29 release. Happy to be on point for these 2 CI jobs that use [`kubetest2-ec2`](https://github.com/kubernetes-sigs/provider-aws-test-infra/tree/main/kubetest2-ec2) to stand up the cluster where the conformance tests then run on.

- https://testgrid.k8s.io/conformance-all#Conformance%20-%20EC2%20-%20arm64%20-%20master&width=20
- https://testgrid.k8s.io/conformance-all#Conformance%20-%20EC2%20-%20master&width=20

thanks,
Dims