### PR TITLE
deduplicate gerrit changes from paginated queries

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -671,7 +671,12 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 	seenPos := map[int]int{}
 	add := func(ci gerrit.ChangeInfo) {
 		if p, ok := seenPos[ci.Number]; ok {
+			for ; p < len(pending)-1; p++ {
+				pending[p] = pending[p+1]
+				seenPos[pending[p].Number]--
+			}
 			pending[p] = ci
+			seenPos[ci.Number] = p
 			return
 		}
 		seenPos[ci.Number] = len(pending)

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -657,6 +657,29 @@ func (h *gerritInstanceHandler) QueryChangesForProject(log logrus.FieldLogger, p
 	return changes, err
 }
 
+type deduper struct {
+	result  []gerrit.ChangeInfo
+	seenPos map[int]int
+}
+
+// dedupeIntoResult dedupes items in a slice, but preserves their order. E.g.,
+// [1, 2, 3, 1] results in [2, 3, 1] (the "1" that came second (last seen) is
+// preserved over the original "1" that came first, but also its order is at the
+// end as well).
+func (d *deduper) dedupeIntoResult(ci gerrit.ChangeInfo) {
+	if pos, ok := d.seenPos[ci.Number]; ok {
+		for ; pos < len(d.result)-1; pos++ {
+			d.result[pos] = d.result[pos+1]
+			d.seenPos[d.result[pos].Number]--
+		}
+		d.result[pos] = ci
+		d.seenPos[ci.Number] = pos
+		return
+	}
+	d.seenPos[ci.Number] = len(d.result)
+	d.result = append(d.result, ci)
+}
+
 func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.FieldLogger, project string, lastUpdate time.Time, rateLimit int, additionalFilters ...string) ([]gerrit.ChangeInfo, error) {
 	var opt gerrit.QueryChangeOptions
 	opt.Query = append(opt.Query, strings.Join(append(additionalFilters, "project:"+project), "+"))
@@ -665,22 +688,11 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 	log = log.WithFields(logrus.Fields{"query": opt.Query, "additional_fields": opt.AdditionalFields})
 	var start int
 
-	pending := []gerrit.ChangeInfo{}
 	// Deduplicate changes repeated due to pagination, preserving order, and
 	// keeping the last seen.
-	seenPos := map[int]int{}
-	add := func(ci gerrit.ChangeInfo) {
-		if p, ok := seenPos[ci.Number]; ok {
-			for ; p < len(pending)-1; p++ {
-				pending[p] = pending[p+1]
-				seenPos[pending[p].Number]--
-			}
-			pending[p] = ci
-			seenPos[ci.Number] = p
-			return
-		}
-		seenPos[ci.Number] = len(pending)
-		pending = append(pending, ci)
+	deduper := &deduper{
+		result:  []gerrit.ChangeInfo{},
+		seenPos: make(map[int]int),
 	}
 
 	for {
@@ -701,7 +713,7 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 
 		if changes == nil || len(*changes) == 0 {
 			log.Info("No more changes")
-			return pending, nil
+			return deduper.result, nil
 		}
 
 		log.WithField("changes", len(*changes)).Debug("Found gerrit changes from page.")
@@ -722,7 +734,7 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 			// stop when we find a change last updated before lastUpdate
 			if !updated.After(lastUpdate) {
 				log.Debug("No more recently updated changes")
-				return pending, nil
+				return deduper.result, nil
 			}
 
 			// process recently updated change
@@ -735,7 +747,7 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 					continue
 				}
 				log.Debug("Found merged change")
-				add(change)
+				deduper.dedupeIntoResult(change)
 			case New:
 				// we need to make sure the change update is from a fresh commit change
 				rev, ok := change.Revisions[change.CurrentRevision]
@@ -774,7 +786,7 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 				if !newMessages {
 					log.Debug("Found updated change")
 				}
-				add(change)
+				deduper.dedupeIntoResult(change)
 			default:
 				// change has been abandoned, do nothing
 				log.Debug("Ignored change")

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -890,6 +889,19 @@ func TestQueryChange(t *testing.T) {
 					},
 					{
 						Project:         "bar",
+						ID:              "2",
+						Number:          2,
+						CurrentRevision: "2-1",
+						Updated:         makeStamp(now.Add(-time.Minute)),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"2-1": {
+								Created: makeStamp(now.Add(-time.Minute)),
+							},
+						},
+						Status: "NEW",
+					},
+					{
+						Project:         "bar",
 						ID:              "1",
 						Number:          1,
 						CurrentRevision: "1-2",
@@ -907,7 +919,7 @@ func TestQueryChange(t *testing.T) {
 				},
 			},
 			revisions: map[string][]string{
-				"foo": {"1-2"},
+				"foo": {"2-1", "1-2"},
 			},
 		},
 	}
@@ -938,7 +950,7 @@ func TestQueryChange(t *testing.T) {
 		}
 
 		testLastSync := LastSyncState{"foo": tc.lastUpdate, "baz": tc.lastUpdate}
-		changes := client.QueryChanges(testLastSync, 5)
+		changes := client.QueryChanges(testLastSync, 2)
 
 		revisions := map[string][]string{}
 		messages := map[string][]gerrit.ChangeMessageInfo{}
@@ -953,7 +965,6 @@ func TestQueryChange(t *testing.T) {
 				revisions[instance] = append(revisions[instance], change.CurrentRevision)
 				messages[change.ChangeID] = append(messages[change.ChangeID], change.Messages...)
 			}
-			sort.Strings(revisions[instance])
 		}
 
 		if !reflect.DeepEqual(revisions, tc.revisions) {

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	gerrit "github.com/andygrunwald/go-gerrit"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/io"
 )
@@ -323,8 +324,9 @@ func TestQueryChange(t *testing.T) {
 		lastUpdate map[string]time.Time
 		changes    map[string][]gerrit.ChangeInfo
 		comments   map[string]map[string][]gerrit.CommentInfo
-		revisions  map[string][]string
-		messages   map[string][]gerrit.ChangeMessageInfo
+		// expected
+		revisions map[string][]string
+		messages  map[string][]gerrit.ChangeMessageInfo
 	}{
 		{
 			name: "no changes",
@@ -343,6 +345,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now.Add(-time.Hour)),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -366,6 +369,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "bar~branch~random-string",
+						Number:          1,
 						ChangeID:        "random-string",
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
@@ -450,6 +454,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "100",
+						Number:          100,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -481,6 +486,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -506,6 +512,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -531,6 +538,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -554,6 +562,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -577,6 +586,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "evil",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -600,6 +610,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -612,6 +623,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -637,6 +649,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -649,6 +662,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now.Add(-time.Hour)),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -675,6 +689,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -687,6 +702,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -701,6 +717,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "boo",
 						ID:              "3",
+						Number:          3,
 						CurrentRevision: "3-2",
 						Updated:         makeStamp(now),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -716,6 +733,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "evil",
 						ID:              "4",
+						Number:          4,
 						CurrentRevision: "4-1",
 						Updated:         makeStamp(now.Add(-time.Hour)),
 						Revisions: map[string]gerrit.RevisionInfo{
@@ -742,6 +760,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now),
@@ -763,6 +782,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now),
@@ -782,6 +802,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now.Add(-2 * time.Minute)),
@@ -801,6 +822,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "1",
+						Number:          1,
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
 						Status:          "ABANDONED",
@@ -829,6 +851,7 @@ func TestQueryChange(t *testing.T) {
 					{
 						Project:         "bar",
 						ID:              "2",
+						Number:          2,
 						CurrentRevision: "2-1",
 						Updated:         makeStamp(now),
 						Submitted:       newStamp(now.Add(-time.Hour)),
@@ -844,6 +867,48 @@ func TestQueryChange(t *testing.T) {
 				},
 			},
 			revisions: map[string][]string{},
+		},
+		{
+			name: "one up-to-date change found twice due to pagination. Duplicate should be removed",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Hour),
+			},
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						Number:          1,
+						CurrentRevision: "1-1",
+						Updated:         makeStamp(now.Add(-time.Minute)),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"1-1": {
+								Created: makeStamp(now.Add(-time.Minute)),
+							},
+						},
+						Status: "NEW",
+					},
+					{
+						Project:         "bar",
+						ID:              "1",
+						Number:          1,
+						CurrentRevision: "1-2",
+						Updated:         makeStamp(now),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"1-1": {
+								Created: makeStamp(now.Add(-time.Minute)),
+							},
+							"1-2": {
+								Created: makeStamp(now),
+							},
+						},
+						Status: "NEW",
+					},
+				},
+			},
+			revisions: map[string][]string{
+				"foo": {"1-2"},
+			},
 		},
 	}
 
@@ -877,9 +942,14 @@ func TestQueryChange(t *testing.T) {
 
 		revisions := map[string][]string{}
 		messages := map[string][]gerrit.ChangeMessageInfo{}
+		seen := sets.NewInt()
 		for instance, changes := range changes {
 			revisions[instance] = []string{}
 			for _, change := range changes {
+				if seen.Has(change.Number) {
+					t.Errorf("Change number %d appears multiple times in the query results.", change.Number)
+				}
+				seen.Insert(change.Number)
 				revisions[instance] = append(revisions[instance], change.CurrentRevision)
 				messages[change.ChangeID] = append(messages[change.ChangeID], change.Messages...)
 			}


### PR DESCRIPTION
Reintroduce 78f080f095 (Merge pull request #30361 from
cjwagner/gerrit-dedup, 2023-08-11), but fix the bug where we were not
exiting the outer loop from the nested loop [1].

Add additional test cases to ensure that we are deduplicating as expected, with (`TestQueryChange`) and without (`TestDedupeIntoResult`) pagination involved. Thanks to @airbornepony for providing a version without the use of `goto`, and which still preserves the same ordered behavior as before.

[1] https://github.com/cjwagner/test-infra/commit/103a47146563bb7d17b9747366067c1b8ee377d9#r124917865

/cc @cjwagner @airbornepony @timwangmusic 