### PR TITLE
migrate elegable `aws-fsx-csi-driver` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/aws-fsx-csi-driver:
   - name: pull-aws-fsx-csi-driver-verify
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -15,12 +16,20 @@ presubmits:
         args:
         - make
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-fsx-csi-driver
       testgrid-tab-name: verify
       description: aws fsx csi driver basic code verification
       testgrid-num-columns-recent: '30'
   - name: pull-aws-fsx-csi-driver-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -35,6 +44,13 @@ presubmits:
         args:
         - make
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-fsx-csi-driver
       testgrid-tab-name: unit-test
@@ -59,6 +75,13 @@ presubmits:
         - test-e2e
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-fsx-csi-driver
       testgrid-tab-name: e2e-test


### PR DESCRIPTION
This PR moves the aws-fsx-csi-driver jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @leakingtapan @gyuho @bertinatto @wongma7