### PR TITLE
migrate elegable `aws-fsx-openzfs-csi-driver` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-fsx-openzfs-csi-driver/aws-fsx-openzfs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-openzfs-csi-driver/aws-fsx-openzfs-csi-driver-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/aws-fsx-openzfs-csi-driver:
   - name: pull-aws-fsx-openzfs-csi-driver-unit
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -15,6 +16,13 @@ presubmits:
         args:
         - make
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-fsx-openzfs-csi-driver
       testgrid-tab-name: unit-test
@@ -39,6 +47,13 @@ presubmits:
         - test-sanity
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: provider-aws-fsx-openzfs-csi-driver
       testgrid-tab-name: sanity-test


### PR DESCRIPTION
This PR moves the aws-fsx-openzfs-csi-driver jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @jacobwolfaws 