### PR TITLE
migrate `wg-multi-tenancy` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml
@@ -6,6 +6,7 @@
 postsubmits:
   kubernetes-sigs/hierarchical-namespaces:
   - name: hnc-postsubmit-test
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: wg-multi-tenancy-hnc
       testgrid-tab-name: postsubmit-tests
@@ -28,15 +29,19 @@ postsubmits:
         securityContext:
           privileged: true # Required for docker-in-docker
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: 1
-            memory: "4Gi"
+            cpu: 2
+            memory: 4Gi
 
 # The periodics are the same as the postsubmits, but we run them occasionally
 # to ensure there's no flakiness during periods where there aren't lots of
 # submissions. Please keep them as closely in sync as possible.
 periodics:
 - name: hnc-periodic-test
+  cluster: eks-prow-build-cluster
   annotations:
     testgrid-dashboards: wg-multi-tenancy-hnc
     testgrid-tab-name: periodic-e2e-tests
@@ -63,6 +68,9 @@ periodics:
       securityContext:
         privileged: true # Required for docker-in-docker
       resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: 1
-          memory: "4Gi"
+          cpu: 2
+          memory: 4Gi

--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/hierarchical-namespaces:
   - name: pull-hnc-test
+    cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: wg-multi-tenancy-hnc
       testgrid-tab-name: presubmit-tests
@@ -12,3 +13,10 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/ci-test.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/mtb-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/mtb-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
     kubernetes-sigs/multi-tenancy:
     - name: pull-mtb-test
+      cluster: eks-prow-build-cluster
       annotations:
         testgrid-dashboards: wg-multi-tenancy-mtb
         testgrid-tab-name: presubmit-tests
@@ -18,3 +19,10 @@ presubmits:
             - ./benchmarks/kubectl-mtb/hack/ci-test.sh
           securityContext:
             privileged: true
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 2
+              memory: 4Gi


### PR DESCRIPTION
This PR moves the wg-multi-tenancy jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @lrjbez17 @srampal @tashimi