### PR TITLE
Use a fixed tag of kubetest2-ec2 for periodic jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -150,7 +150,7 @@ periodics:
           - bash
           - -c
           - |
-            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@v0.1.0
             kubetest2 ec2 \
              --build \
              --target-build-arch linux/amd64 \
@@ -207,7 +207,7 @@ periodics:
           - bash
           - -c
           - |
-            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@v0.1.0
             kubetest2 ec2 \
              --build \
              --target-build-arch linux/arm64 \
@@ -264,7 +264,7 @@ periodics:
           - bash
           - -c
           - |
-            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@v0.1.0
             kubetest2 ec2 \
              --build \
              --target-build-arch linux/amd64 \
@@ -322,7 +322,7 @@ periodics:
           - bash
           - -c
           - |
-            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@v0.1.0
             kubetest2 ec2 \
              --build \
              --target-build-arch linux/arm64 \


### PR DESCRIPTION
So the churn in `kubetest2-ec2` repo doesn't affect the periodic jobs.