### PR TITLE
Add canary jobs to test kubetest2-ec2

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -124,6 +124,7 @@ presubmits:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
@@ -180,6 +181,7 @@ presubmits:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -116,6 +116,119 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+  kubernetes-sigs/provider-aws-test-infra:
+  - name: pull-kubernetes-e2e-ec2-canary
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/provider-aws-test-infra
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              cd kubetest2-ec2 && GOPROXY=direct go install .
+              kubetest2 ec2 \
+               --build \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --stage provider-aws-test-infra \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --use-built-binaries true \
+               --parallel=30 \
+               --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-conformance-canary
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/provider-aws-test-infra
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              cd kubetest2-ec2 && GOPROXY=direct go install .
+              kubetest2 ec2 \
+               --build \
+               --instance-type=m6a.large  \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --stage provider-aws-test-infra \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --use-built-binaries true \
+               --focus-regex='\[Conformance\]'
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
 periodics:
 - interval: 6h
   cluster: eks-prow-build-cluster

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -4,6 +4,7 @@ dashboard_groups:
   - presubmits-alibaba-cloud-csi-driver
   - presubmits-cloud-provider-alibaba
   - presubmits-cloud-provider-vsphere-blocking
+  - presubmits-ec2
   - presubmits-kops
   - presubmits-kube-batch
   - presubmits-kubernetes-blocking
@@ -147,3 +148,4 @@ dashboards:
 - name: presubmits-misc
 - name: presubmits-node-problem-detector
 - name: presubmits-test-infra
+- name: presubmits-ec2


### PR DESCRIPTION
Switched the periodic jobs to fixed tag in https://github.com/kubernetes/test-infra/pull/30435

so we need new presubmit(s) to make sure we don't break things.