### PR TITLE
migrate `ingress-nginx` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
@@ -2,6 +2,7 @@ presubmits:
 
   kubernetes/ingress-nginx:
   - name: pull-ingress-nginx-boilerplate
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 15m
@@ -15,11 +16,19 @@ presubmits:
       - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20220823-ge19026fe4@sha256:038fc60379b6ce9a0134c2ff9134edccad1f8ecbd9c6ebed9660711d05b0ed95
         command:
         - ./hack/verify-boilerplate.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: boilerplate
 
   - name: pull-ingress-nginx-codegen
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 15m
@@ -33,11 +42,19 @@ presubmits:
       - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20220823-ge19026fe4@sha256:038fc60379b6ce9a0134c2ff9134edccad1f8ecbd9c6ebed9660711d05b0ed95
         command:
         - ./hack/verify-codegen.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: codegen
 
   - name: pull-ingress-nginx-lualint
+    cluster: eks-prow-build-cluster
     always_run: false
     decorate: true
     path_alias: k8s.io/ingress-nginx
@@ -50,11 +67,19 @@ presubmits:
       - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20220823-ge19026fe4@sha256:038fc60379b6ce9a0134c2ff9134edccad1f8ecbd9c6ebed9660711d05b0ed95
         command:
         - ./hack/verify-lualint.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: lualint
 
   - name: pull-ingress-nginx-test-lua
+    cluster: eks-prow-build-cluster
     always_run: false
     decorate: true
     decoration_config:
@@ -70,6 +95,13 @@ presubmits:
         command:
         - make
         - lua-test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: test-lua


### PR DESCRIPTION
This PR moves the ingress-nginx jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @aojea @bowei @cadmuxe @ElvinEfendi @mrhohn