### PR TITLE
Upgrade reformat-gherkins to 3.0.1

### DIFF
--- a/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
+++ b/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
@@ -74,9 +74,7 @@ presubmits:
         command:
         - runner.sh
         args:
-        - bash
-        - -c
-        - pip3 install reformat-gherkin==3.0.1 --ignore-installed PyYAML && make verify-gherkin
+        - ./hack/verify-gherkin.sh
         resources:
           limits:
             cpu: 1

--- a/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
+++ b/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
@@ -76,7 +76,7 @@ presubmits:
         args:
         - bash
         - -c
-        - pip3 install reformat-gherkin==3.0.0 --ignore-installed PyYAML && make verify-gherkin
+        - pip3 install reformat-gherkin==3.0.1 --ignore-installed PyYAML && make verify-gherkin
         resources:
           limits:
             cpu: 1

--- a/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
+++ b/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
@@ -76,7 +76,7 @@ presubmits:
         args:
         - bash
         - -c
-        - pip3 install reformat-gherkin==2.0.0 --ignore-installed PyYAML && make verify-gherkin
+        - pip3 install reformat-gherkin==3.0.0 --ignore-installed PyYAML && make verify-gherkin
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
Upgrade reformat-gherkins to 3.0.1 as the older version (2.0.0) no longer works with newer docker testing images.

Fixes https://github.com/kubernetes/test-infra/issues/30439