### PR TITLE
Adjust presubmit CI jobs for kubernetes-sigs/provider-aws-test-infra repo

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2239,8 +2239,8 @@ presubmits:
         preset-e2e-containerd-ec2: "true"
         preset-dind-enabled: "true"
       path_alias: sigs.k8s.io/provider-aws-test-infra
-      always_run: true
-      optional: false
+      always_run: false
+      optional: true
       cluster: eks-prow-build-cluster
       decorate: true
       extra_refs:
@@ -2381,8 +2381,8 @@ presubmits:
         preset-e2e-containerd-ec2: "true"
         preset-dind-enabled: "true"
       path_alias: sigs.k8s.io/provider-aws-test-infra
-      always_run: true
-      optional: false
+      always_run: false
+      optional: true
       cluster: eks-prow-build-cluster
       decorate: true
       extra_refs:

--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -129,6 +129,8 @@ presubmits:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
     path_alias: sigs.k8s.io/provider-aws-test-infra
+    always_run: true
+    optional: false
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
@@ -186,6 +188,8 @@ presubmits:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
     path_alias: sigs.k8s.io/provider-aws-test-infra
+    always_run: true
+    optional: false
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:


### PR DESCRIPTION
- leave arm64 jobs as optional
- add the new presubmits which serve as canary for k/k as required