### PR TITLE
expanded cluster-migration output to include stats for elegable jobs

### DIFF
--- a/hack/cluster-migration/main_test.go
+++ b/hack/cluster-migration/main_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"reflect"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	cfg "k8s.io/test-infra/prow/config"
 )
 
@@ -48,12 +50,32 @@ func TestGetPercentage(t *testing.T) {
 		{10, 100, "10.00%"},
 		{1, 3, "33.33%"},
 		{5, 5, "100.00%"},
+		{0, 0, "100.00%"},
 	}
 
 	for _, test := range tests {
 		got := getPercentage(test.int1, test.int2)
 		if got != test.want {
 			t.Errorf("Expected: %v, got: %v", test.want, got)
+		}
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	tests := []struct {
+		s        string
+		list     []string
+		expected bool
+	}{
+		{"testString", []string{"test", "string"}, true},
+		{"testString", []string{"none", "of", "these"}, false},
+		{"", []string{"none", "of", "these"}, false},
+	}
+
+	for _, tt := range tests {
+		result := containsAny(tt.s, tt.list)
+		if result != tt.expected {
+			t.Errorf("for input %q and list %v, expected %v, got %v", tt.s, tt.list, tt.expected, result)
 		}
 	}
 }
@@ -75,26 +97,224 @@ func TestGetSortedKeys(t *testing.T) {
 	}
 }
 
-func TestGetClusterStatistics(t *testing.T) {
-	jobs := map[string][]cfg.JobBase{}
-	jobs["default"] = []cfg.JobBase{
-		{Cluster: "default", Name: "job1"},
-		{Cluster: "default", Name: "job2"},
-		{Cluster: "cluster2", Name: "job3"},
+func TestContainsDisallowedLabel(t *testing.T) {
+	tests := []struct {
+		labels   map[string]string
+		expected bool
+	}{
+		{map[string]string{"name": "value"}, false},
+		{map[string]string{"credName": "value"}, true},
+		{map[string]string{"name": "credValue"}, false},
+		{map[string]string{}, false},
 	}
 
-	want := map[string][]string{
-		"default":  {"job1", "job2"},
-		"cluster2": {"job3"},
+	for _, tt := range tests {
+		result := containsDisallowedLabel(tt.labels)
+		if result != tt.expected {
+			t.Errorf("for labels %v, expected %v, got %v", tt.labels, tt.expected, result)
+		}
+	}
+}
+
+func TestContainsDisallowedAttributes(t *testing.T) {
+	tests := []struct {
+		container v1.Container
+		expected  bool
+	}{
+		{
+			v1.Container{
+				Env:     []v1.EnvVar{{Name: "NAME", Value: "value"}},
+				Args:    []string{"arg1", "arg2"},
+				Command: []string{"cmd1", "cmd2"},
+			},
+			false,
+		},
+		{
+			v1.Container{
+				Env:     []v1.EnvVar{{Name: "credName", Value: "value"}},
+				Args:    []string{"arg1", "arg2"},
+				Command: []string{"cmd1", "cmd2"},
+			},
+			true,
+		},
+		{
+			v1.Container{
+				Env:     []v1.EnvVar{{Name: "NAME", Value: "value"}},
+				Args:    []string{"arg1", "gcloud"},
+				Command: []string{"cmd1", "cmd2"},
+			},
+			true,
+		},
 	}
 
-	got := getClusterStatistics(jobs)
-	for key := range want {
-		for i := range want[key] {
-			if got[key][i] != want[key][i] {
-				t.Errorf("Expected: %v, got: %v", want, got)
-				break
-			}
+	for _, tt := range tests {
+		result := containsDisallowedAttributes(tt.container)
+		if result != tt.expected {
+			t.Errorf("for container %v, expected %v, got %v", tt.container, tt.expected, result)
+		}
+	}
+}
+
+func TestContainsDisallowedVolumeMount(t *testing.T) {
+	tests := []struct {
+		volumeMounts []v1.VolumeMount
+		expected     bool
+	}{
+		{
+			[]v1.VolumeMount{
+				{Name: "name1", MountPath: "/path/to/dir1"},
+				{Name: "name2", MountPath: "/path/to/dir2"},
+			},
+			false,
+		},
+		{
+			[]v1.VolumeMount{
+				{Name: "credName", MountPath: "/path/to/dir1"},
+				{Name: "name2", MountPath: "/path/to/dir2"},
+			},
+			true,
+		},
+		{
+			[]v1.VolumeMount{
+				{Name: "name1", MountPath: "/path/to/credDir"},
+				{Name: "name2", MountPath: "/path/to/dir2"},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		result := containsDisallowedVolumeMount(tt.volumeMounts)
+		if result != tt.expected {
+			t.Errorf("for volumeMounts %v, expected %v, got %v", tt.volumeMounts, tt.expected, result)
+		}
+	}
+}
+
+func TestContainsDisallowedVolume(t *testing.T) {
+	tests := []struct {
+		volumes  []v1.Volume
+		expected bool
+	}{
+		{
+			[]v1.Volume{{Name: "name1"}, {Name: "name2"}},
+			false,
+		},
+		{
+			[]v1.Volume{{Name: "credName"}, {Name: "name2"}},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		result := containsDisallowedVolume(tt.volumes)
+		if result != tt.expected {
+			t.Errorf("for volumes %v, expected %v, got %v", tt.volumes, tt.expected, result)
+		}
+	}
+}
+
+func TestCheckIfEligable(t *testing.T) {
+	tests := []struct {
+		job      cfg.JobBase
+		expected bool
+	}{
+		// Add various JobBase configurations and test the expected outcome
+		// For example:
+		{
+			cfg.JobBase{Cluster: "test-infra-trusted"},
+			true,
+		},
+		// ... other test cases ...
+	}
+
+	for _, tt := range tests {
+		result := checkIfEligible(tt.job)
+		if result != tt.expected {
+			t.Errorf("for job %v, expected %v, got %v", tt.job, tt.expected, result)
+		}
+	}
+}
+
+func TestAllStaticJobs(t *testing.T) {
+	tests := []struct {
+		config   *cfg.Config
+		expected map[string][]cfg.JobBase
+	}{
+		// Scenario: No jobs in any of the sources
+		{
+			&cfg.Config{JobConfig: cfg.JobConfig{}},
+			map[string][]cfg.JobBase{},
+		},
+		// Scenario: One job in PresubmitsStatic
+		{
+			&cfg.Config{
+				JobConfig: cfg.JobConfig{
+					PresubmitsStatic: map[string][]cfg.Presubmit{
+						"path/to/repo1": {{JobBase: cfg.JobBase{Name: "job1"}}},
+					},
+				},
+			},
+			map[string][]cfg.JobBase{"to": {{Name: "job1"}}},
+		},
+		// Scenario: Multiple jobs in PresubmitsStatic for multiple repos
+		{
+			&cfg.Config{
+				JobConfig: cfg.JobConfig{
+					PresubmitsStatic: map[string][]cfg.Presubmit{
+						"path/to/repo1": {
+							{JobBase: cfg.JobBase{Name: "job1"}},
+							{JobBase: cfg.JobBase{Name: "job2"}},
+						},
+						"path/for/repo2": {
+							{JobBase: cfg.JobBase{Name: "jobA"}},
+						},
+					},
+				},
+			},
+			map[string][]cfg.JobBase{
+				"to":  {{Name: "job1"}, {Name: "job2"}},
+				"for": {{Name: "jobA"}},
+			},
+		},
+		// Scenario: One job in PostsubmitsStatic
+		{
+			&cfg.Config{
+				JobConfig: cfg.JobConfig{
+					PostsubmitsStatic: map[string][]cfg.Postsubmit{
+						"path/to/repo1": {{JobBase: cfg.JobBase{Name: "postJob1"}}},
+					},
+				},
+			},
+			map[string][]cfg.JobBase{"to": {{Name: "postJob1"}}},
+		},
+		// Scenario: Multiple jobs in PostsubmitsStatic for multiple repos
+		{
+			&cfg.Config{
+				JobConfig: cfg.JobConfig{
+					PostsubmitsStatic: map[string][]cfg.Postsubmit{
+						"path/to/repo1": {
+							{JobBase: cfg.JobBase{Name: "postJob1"}},
+							{JobBase: cfg.JobBase{Name: "postJob2"}},
+						},
+						"path/for/repo2": {
+							{JobBase: cfg.JobBase{Name: "postJobA"}},
+						},
+					},
+				},
+			},
+			map[string][]cfg.JobBase{
+				"to":  {{Name: "postJob1"}, {Name: "postJob2"}},
+				"for": {{Name: "postJobA"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		result := allStaticJobs(tt.config)
+		// DeepEqual check for map equality
+		if !reflect.DeepEqual(result, tt.expected) {
+			t.Errorf("for config %v, expected %v, got %v", tt.config, tt.expected, result)
 		}
 	}
 }


### PR DESCRIPTION
This PR make the cluster migration tool more robust and user-friendly. It provides clearer visibility into the status and eligibility of jobs, ensuring a smoother migration process for clusters. 

Example output:
```
|→ go run main.go
Total jobs: 3191
Total eligible jobs: 1763
Currently ineligible jobs: 1428

Cluster                        Eligible/Total  (Percent)
----------------------------------------------------------
default                        342/1770        (19.40%/55.47%)
eks-prow-build-cluster         633/633         (35.90%/19.84%)
k8s-infra-prow-build           504/504         (28.59%/15.79%)
k8s-infra-prow-build-trusted   255/255         (14.46%/7.99%)
test-infra-trusted             29/29           (1.64%/0.91%)

Google jobs    342/1770 (19.40%/55.47%)
Community jobs 1421/1421 (80.60%/44.53%)
```
Previous iterations of the tool didn't account for job eligibility. This PR codifies the guidelines from https://github.com/kubernetes/test-infra/blob/master/docs/eks-jobs-migration.md including. Job Eligibility Checks are perform through the `checkIfEligible` function to determine if a job can be moved based on the following rules:

1. **Valid Clusters**: The job's cluster must be one of the predefined valid clusters. The valid clusters include:

    test-infra-trusted
    k8s-infra-prow-build
    k8s-infra-prow-build-trusted
    eks-prow-build-cluster

1. **Labels**: 
    The labels associated with a job should not contain the substring "cred"

1. **Containers**:
    _Environment Variables_: The environment variables in a job's spec should not contain any disallowed substrings. For example, any environment variable name containing the substring "cred" is flagged.
    _Arguments and Commands_: Both arguments and commands for the containers are checked against disallowed words like gcloud and gcp.
    _Volume Mounts_: The name and mount path of any volume mounts associated with the container should not contain disallowed words, such as "cred" or "secret".

1. Volumes:
    The volume's name should not contain disallowed substrings like "cred".
    The volume type should not be of type Secret.

/cc @michelle192837 @xmudrii 