### PR TITLE
migrate `sig-arch` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -1,5 +1,6 @@
 periodics:
 - interval: 3h
+  cluster: eks-prow-build-cluster
   name: apisnoop-conformance-gate
   annotations:
     testgrid-dashboards: sig-arch-conformance
@@ -15,3 +16,10 @@ periodics:
       command:
       - /usr/local/bin/docker-entrypoint.sh
       - postgres
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: 2
+        limits:
+          memory: 4Gi
+          cpu: 2

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: check-dependency-stats
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 5m
@@ -31,6 +32,13 @@ presubmits:
           git checkout -b base "${PULL_BASE_SHA}"
           depstat stats -m "k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')" -v > "${WORKDIR}/stats-base.txt"
           diff -s -u --ignore-all-space "${WORKDIR}"/stats-base.txt "${WORKDIR}"/stats.txt || true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+            cpu: 2
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-testing-misc


### PR DESCRIPTION
This PR moves the sig-arch jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @cheftako @oomichi @johnbelamaric @bobymcbobs