### PR TITLE
Update OWNERS_ALIASES to reflect 2023 Code of Conduct Election

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -173,11 +173,11 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - celestehorgan
-    - karenhchu
-    - palnabarun
-    - tpepper
-    - vllry
+    - AnaMMedina21
+    - endocrimes
+    - hlipsig
+    - jeremyrickard
+    - salaxander
   committee-security-response:
     - cjcullen
     - joelsmith


### PR DESCRIPTION
This PR updates the OWNERS_ALIASES file to correct the code-of-conduct entry to reflect the 2023 Election results. 

Part of https://github.com/kubernetes/community/issues/7482
 
/committee code-of-conduct
