### PR TITLE
Fix the gpu device plugin presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -39,6 +39,11 @@ presubmits:
         - --build=quick
         - --cluster=
         - --extract=local
+        # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+        # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
+        - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+        - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
+        - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
         - --gcp-node-image=gci
         - --gcp-nodes=4
         - --gcp-project=k8s-jkns-pr-gce-gpus

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -929,7 +929,11 @@ presubmits:
         - --build=quick
         - --cluster=
         - --extract=local
-        - --gcp-node-image=gci
+        # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+        # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
+        - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+        - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
+        - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
         - --gcp-nodes=4
         - --gcp-project=k8s-jkns-pr-gce-gpus
         - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -924,6 +924,11 @@ presubmits:
         - --build=quick
         - --cluster=
         - --extract=local
+        # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+        # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
+        - --env=KUBE_NODE_OS_DISTRIBUTION=gci
+        - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
+        - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
         - --gcp-node-image=gci
         - --gcp-nodes=4
         - --gcp-project=k8s-jkns-pr-gce-gpus


### PR DESCRIPTION
The gpu device plugin presubmit tests require the COS image to explicitly to be set because there is a dependency between the driver installer version and COS version.

This is copying the same config as we have here - https://github.com/kubernetes/test-infra/blob/f342a1bfb6343e442924c96e53bd85e45330f090/config/jobs/kubernetes/sig-node/containerd.yaml#L372-L378