### PR TITLE
Revert "Merge pull request #29155 from mpherman2/ensure_cache"

### DIFF
--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -122,7 +122,3 @@ func (a *repoClientAdapter) RemoteUpdate() error {
 func (a *repoClientAdapter) FetchRef(refspec string) error {
 	return errors.New("no FetchRef implementation exists in the v1 repo client")
 }
-
-func (a *repoClientAdapter) Fsck() (bool, error) {
-	return false, errors.New("no Fsck implementation exists in the v1 repo client")
-}

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -80,8 +80,6 @@ type cacher interface {
 	MirrorClone() error
 	// RemoteUpdate fetches all updates from the remote.
 	RemoteUpdate() error
-	// Fsck verifies the connectivity and validity of the repo and returns true if passed
-	Fsck() (bool, error)
 }
 
 // cloner knows how to clone repositories from a central cache
@@ -369,14 +367,6 @@ func (i *interactor) MergeAndCheckout(baseSHA string, mergeStrategy string, head
 		}
 	}
 	return nil
-}
-
-func (i *interactor) Fsck() (bool, error) {
-	i.logger.Info("Running file system check")
-	if out, err := i.executor.Run("fsck"); err != nil {
-		return false, fmt.Errorf("error running git file system check: %w %v", err, string(out))
-	}
-	return true, nil
 }
 
 // Am tries to apply the patch in the given path into the current branch


### PR DESCRIPTION
This reverts commit e1db1a99f8408f818d798f5f7ad3399ecaa3f9e5, reversing changes made to 67b11b3ef245cce024dfa6677acfb117add2c1b0.

Remove filesystem checks because it can lead to cold start problems if the container restarts during peak traffic hours. Even though we only run `git fsck` lazily (when a git client is requested for a repo), this can happen with multiple repos at the same time, and they would all attempt to run fsck at the same time. This can lead to a pathological case where multiple large repos are filesystem checked at the same time, thrashing the disk.

Let's remove this for now while we think of a new approach that is more resistant against such performance degradation.