### PR TITLE
git v2 client: object existence is independent of current branch

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -182,7 +182,7 @@ func prowYAMLGetter(
 
 func ensureCommits(repo git.RepoClient, baseSHA string, headSHAs ...string) error {
 	//Ensure baseSHA exists.
-	if exists, _ := repo.CommitExists(baseSHA); !exists {
+	if exists, _ := repo.ObjectExists(baseSHA); !exists {
 		if err := repo.Fetch(baseSHA); err != nil {
 			return fmt.Errorf("failed to fetch baseSHA: %s: %v", baseSHA, err)
 		}
@@ -190,7 +190,7 @@ func ensureCommits(repo git.RepoClient, baseSHA string, headSHAs ...string) erro
 	//Ensure headSHAs exist
 	for _, sha := range headSHAs {
 		// This is best effort. No need to check for error
-		if exists, _ := repo.CommitExists(sha); !exists {
+		if exists, _ := repo.ObjectExists(sha); !exists {
 			if err := repo.Fetch(sha); err != nil {
 				return fmt.Errorf("failed to fetch headSHA: %s: %v", sha, err)
 			}

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -93,8 +93,8 @@ func (a *repoClientAdapter) PushToNamedFork(forkName, branch string, force bool)
 	return a.Repo.PushToNamedFork(forkName, branch, force)
 }
 
-func (a *repoClientAdapter) CommitExists(sha string) (bool, error) {
-	return false, errors.New("no CommitExists implementation exists in the v1 repo client")
+func (a *repoClientAdapter) ObjectExists(sha string) (bool, error) {
+	return false, errors.New("no ObjectExists implementation exists in the v1 repo client")
 }
 
 func (a *repoClientAdapter) PushToCentral(branch string, force bool) error {


### PR DESCRIPTION
The CommitExists() function previously relied on the "git branch --contains" porcelain command to check if the given commit SHA existed in the currently checked out branch. This wasn't wholly accurate because a commit can exist outside of the current branch (for example, it could exist on a different branch).

Instead use the "git cat-file -e" plumbing command which asks the Git object store without any assumptions about the object (it can be a commit object, tree, blob, etc). The "-e" flag suppresses output and makes the command exit with a 1 if the object is not found. Because this plumbing command works for many kinds of objects, not just commits, rename CommitExists() to ObjectExists().

This command should also be slightly faster than "git branch --contains", because the manpage for it says

    With --contains, shows only the branches that contain the named
    commit (in other words, the branches whose tip commits are
    descendants of the named commit)

and because the cat-file command does not have to perform a similar search of all applicable branch names (it can return as soon as it finds the object).

/hold