### PR TITLE
inrepoconfig: minimal fetch

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -92,6 +92,13 @@ type RepoOpts struct {
 	// This is the `--share` flag to `git clone`. For cloning from a local
 	// source, it allows bypassing the copying of all objects.
 	ShareObjectsWithSourceRepo bool
+	// FetchCommits list only those commit SHAs which are needed. If the commit
+	// already exists, it is not fetched to save network costs. If FetchCommits
+	// is set, we do not call RemoteUpdate() for the primary clone (git cache).
+	FetchCommits []string
+	// NoFetchTags determines whether we disable fetching tag objects). Defaults
+	// to false (tag objects are fetched).
+	NoFetchTags bool
 }
 
 // Apply allows to use a ClientFactoryOpts as Opt
@@ -339,9 +346,18 @@ func (c *clientFactory) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpt
 		// something unexpected happened
 		return nil, err
 	} else {
-		// we have cloned the repo previously, but will refresh it
-		if err := cacheClientCacher.RemoteUpdate(); err != nil {
-			return nil, err
+		// We have cloned the repo previously, but will refresh it. By default
+		// we refresh all refs with a call to `git remote update`.
+		if repoOpts.FetchCommits == nil {
+			if err := cacheClientCacher.RemoteUpdate(); err != nil {
+				return nil, err
+			}
+		} else if len(repoOpts.FetchCommits) > 0 {
+			// Targeted fetch. Only fetch those commits which we want, and only
+			// if they are missing.
+			if err := ensureCommits(repoClient, repoOpts); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -356,4 +372,28 @@ func (c *clientFactory) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpt
 // Clean removes the caches used to generate clients
 func (c *clientFactory) Clean() error {
 	return os.RemoveAll(c.cacheDir)
+}
+
+func ensureCommits(repoClient RepoClient, repoOpts RepoOpts) error {
+	fetchArgs := []string{}
+
+	if repoOpts.NoFetchTags {
+		fetchArgs = append(fetchArgs, "--no-tags")
+	}
+
+	// For each commit SHA, check if it already exists. If so, don't bother
+	// fetching it.
+	for _, commitSHA := range repoOpts.FetchCommits {
+		if exists, _ := repoClient.ObjectExists(commitSHA); exists {
+			continue
+		}
+
+		fetchArgs = append(fetchArgs, commitSHA)
+	}
+
+	if err := repoClient.Fetch(fetchArgs...); err != nil {
+		return fmt.Errorf("failed to fetch %s: %v", fetchArgs, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This builds on the work in https://github.com/kubernetes/test-infra/pull/30451 and https://github.com/kubernetes/test-infra/pull/30452. Click on the tip commit to see the non-redundant bits.

Do not fetch tags, or write to FETCH_HEAD (anecdotally, a mirror clone's
FETCH_HEAD could grow rather large, as high as 30MB). Only fetch the
commit SHAs directly if RepoOpts specifies FetchCommits. This avoids the
costly RemoteUpdate call which fetches every remote tracking branch (as
well as all new ones that show up on the remote).

Also, only perform a fetch once. Previously in ensureCommits we did at
least 2 separate fetch operations for every presubmit job, because a
presubmit has a baseSHA and a headSHA (PR HEAD). Now we combine them
into a single fetch command, so that we talk to the server once instead
of twice.

/hold