### PR TITLE
migrate `node-feature-discovery` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-release-06-09
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.6
@@ -17,6 +18,13 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.16
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-image-generic
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-10.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-release-0-10
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.10
@@ -14,7 +15,15 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-verify-docs-release-0-10
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     branches:
     - ^release-0.10
@@ -28,7 +37,15 @@ presubmits:
       - image: ruby:2.7
         command:
         - scripts/test-infra/mdlint.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-release-0-10
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.10
@@ -42,3 +59,10 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/build.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-11.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-release-0-11
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.11
@@ -14,7 +15,15 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-verify-docs-release-0-11
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     branches:
     - ^release-0.11
@@ -28,7 +37,15 @@ presubmits:
       - image: ruby:2.7
         command:
         - scripts/test-infra/mdlint.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-release-0-11
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.11
@@ -42,3 +59,10 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.17
         command:
         - scripts/test-infra/build.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-12.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-release-0-12
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.12
@@ -14,7 +15,15 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-verify-docs-release-0-12
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     branches:
     - ^release-0.12
@@ -28,7 +37,15 @@ presubmits:
       - image: ruby:slim
         command:
         - scripts/test-infra/mdlint.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-release-0-12
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.12
@@ -42,3 +59,10 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - scripts/test-infra/build.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-13.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-13.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-release-0-13
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.13
@@ -14,7 +15,15 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/verify.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-verify-docs-release-0-13
+    cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"
     branches:
     - ^release-0.13
@@ -28,7 +37,15 @@ presubmits:
       - image: ruby:slim
         command:
         - scripts/test-infra/mdlint.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-node-feature-discovery-build-release-0-13
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^release-0.13
@@ -42,3 +59,10 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - scripts/test-infra/build.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
This PR moves the node-feature-discovery jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @kad @marquiz @ArangoGutierrez