### PR TITLE
Add ec2 non-blocking presubmit ci jobs to presubmits-ec2 dashboard

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -7,6 +7,7 @@ presubmits:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
       description: Runs presubmit tests using kubetest2-ec2 against kubernetes master on EC2 (equivalent of pull-kubernetes-e2e-gce)
     labels:
       preset-e2e-containerd-ec2: "true"
@@ -67,6 +68,7 @@ presubmits:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
forgot to do this in the previous commit