### PR TITLE
add provider-azure-1.28-signal

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/README.md
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/README.md
@@ -5,5 +5,5 @@ Job configurations for https://testgrid.k8s.io/provider-azure.
 To generate the job configurations for 1.23, 1.24, 1.25, 1.26, and master branch:
 
 ```bash
-./generate.sh 1.24 1.25 1.26 1.27 master
+./generate.sh 1.25 1.26 1.27 1.28 master
 ```

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
@@ -8,7 +8,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.24
+      - release-1.28
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -27,7 +27,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.24
+        base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
       containers:
@@ -58,7 +58,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.24
+      - release-1.28
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -77,7 +77,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.24
+        base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
       containers:
@@ -110,7 +110,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.24
+      - release-1.28
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -129,7 +129,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.24
+        base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
       containers:
@@ -161,7 +161,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.24
+      - release-1.28
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -180,7 +180,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.24
+        base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
       containers:
@@ -214,7 +214,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.24
+      - release-1.28
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -229,7 +229,7 @@ presubmits:
       workdir: true
     - org: kubernetes-sigs
       repo: cloud-provider-azure
-      base_ref: release-1.24
+      base_ref: release-1.28
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
       containers:
@@ -251,7 +251,7 @@ presubmits:
 
 periodics:
 - interval: 3h
-  name: capz-conformance-1-24
+  name: capz-conformance-1-28
   decorate: true
   decoration_config:
     timeout: 3h
@@ -269,7 +269,7 @@ periodics:
     workdir: true
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -282,7 +282,7 @@ periodics:
       - name: E2E_ARGS
         value: "-kubetest.use-ci-artifacts"
       - name: KUBERNETES_VERSION
-        value: "latest-1.24"
+        value: "latest-1.28"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
       securityContext:
@@ -292,13 +292,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.24-signal
+    testgrid-dashboards: provider-azure-1.28-signal
     testgrid-tab-name: capz-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-1-24
+  name: capz-azure-file-1-28
   decorate: true
   decoration_config:
     timeout: 3h
@@ -319,11 +319,11 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -341,7 +341,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.24"
+        value: "latest-1.28"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-file" # In-tree Azure file storage class
       securityContext:
@@ -351,13 +351,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.24-signal
+    testgrid-dashboards: provider-azure-1.28-signal
     testgrid-tab-name: capz-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-vmss-1-24
+  name: capz-azure-file-vmss-1-28
   decorate: true
   decoration_config:
     timeout: 3h
@@ -378,11 +378,11 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -400,7 +400,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.24"
+        value: "latest-1.28"
       - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
@@ -412,13 +412,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.24-signal
+    testgrid-dashboards: provider-azure-1.28-signal
     testgrid-tab-name: capz-azure-file-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-1-24
+  name: capz-azure-disk-1-28
   decorate: true
   decoration_config:
     timeout: 3h
@@ -439,11 +439,11 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -460,7 +460,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.24"
+        value: "latest-1.28"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
       securityContext:
@@ -470,13 +470,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.24-signal
+    testgrid-dashboards: provider-azure-1.28-signal
     testgrid-tab-name: capz-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-vmss-1-24
+  name: capz-azure-disk-vmss-1-28
   decorate: true
   decoration_config:
     timeout: 3h
@@ -497,11 +497,11 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.24
+    base_ref: release-1.28
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
@@ -518,7 +518,7 @@ periodics:
         make e2e-test
       env:
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.24"
+        value: "latest-1.28"
       - name: EXP_MACHINE_POOL # CAPZ config
         value: "true"
       - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
@@ -530,7 +530,7 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.24-signal
+    testgrid-dashboards: provider-azure-1.28-signal
     testgrid-tab-name: capz-azure-disk-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -11,10 +11,10 @@ dashboard_groups:
       - provider-azure-cloud-provider-azure-1-28-presubmit
       - provider-azure-presubmit
       - provider-azure-master-signal
+      - provider-azure-1.28-signal
       - provider-azure-1.27-signal
       - provider-azure-1.26-signal
       - provider-azure-1.25-signal
-      - provider-azure-1.24-signal
 
 dashboards:
   - name: provider-azure-azuredisk-csi-driver
@@ -27,7 +27,7 @@ dashboards:
   - name: provider-azure-cloud-provider-azure-1-28-presubmit
   - name: provider-azure-presubmit
   - name: provider-azure-master-signal
+  - name: provider-azure-1.28-signal
   - name: provider-azure-1.27-signal
   - name: provider-azure-1.26-signal
   - name: provider-azure-1.25-signal
-  - name: provider-azure-1.24-signal


### PR DESCRIPTION
This PR

- updates dashboard group of Provider-Azure at https://testgrid.k8s.io/provider-azure
- adds release-1.28.yaml and removes release-1.24.yaml at test-infra/config/jobs/kubernetes/sig-cloud-provider/azure/