### PR TITLE
Skip writing fetch head

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -404,7 +404,7 @@ func (c *clientFactory) Clean() error {
 }
 
 func ensureCommits(repoClient RepoClient, repoOpts RepoOpts) error {
-	fetchArgs := []string{}
+	fetchArgs := []string{"--no-write-fetch-head"}
 
 	if repoOpts.NoFetchTags {
 		fetchArgs = append(fetchArgs, "--no-tags")


### PR DESCRIPTION
This builds on https://github.com/kubernetes/test-infra/pull/30472. In a previous version of that PR we bundled in this flag, but we've decided to separate it out so that we can deploy it separately in production.

Below is the commit message for the tip commit:

git v2 client: allow skipping the write to FETCH_HEAD

For inrepoconfigs, since we already have the exact commit SHAs, we don't
need to write FETCH_HEAD. It has been observed that for very large
repos, the FETCH_HEAD file can grow in size, linearly with the number of
remote refs that are fetched (upwards of 30MB).  Disabling the write
should make the fetches slightly faster.

For some background on the evolution of the --no-write-fetch-head flag
itself, see [1].

[1] https://stackoverflow.com/questions/9237348/what-does-fetch-head-in-git-mean

/cc @cjwagner @airbornepony @timwangmusic 