### PR TITLE
Provide HeadRef for tide github pull requests

### DIFF
--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -402,10 +402,11 @@ func (gi *GitHubProvider) refsForJob(sp subpool, prs []CodeReviewCommon) (prowap
 		refs.Pulls = append(
 			refs.Pulls,
 			prowapi.Pull{
-				Number: pr.Number,
-				Title:  pr.Title,
-				Author: string(pr.AuthorLogin),
-				SHA:    pr.HeadRefOID,
+				Number:  pr.Number,
+				Title:   pr.Title,
+				Author:  string(pr.AuthorLogin),
+				SHA:     pr.HeadRefOID,
+				HeadRef: pr.HeadRefName,
 			},
 		)
 	}


### PR DESCRIPTION
When tide runs a serial build of a presubmit job, it is better if the PULL_HEAD_REF environment variable can be set for the job (as when run by trigger).  This change preserves the HeadRef data so that it can be propagated to the job in this case so the presubmit build environment is more consistent in tide.