### PR TITLE
config/jobs: skip test-e2e on release-0.10

### DIFF
--- a/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
@@ -48,6 +48,8 @@ presubmits:
     cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
+    skip_branches:
+      - release-0.10
     decoration_config:
       timeout: 20m
     labels:


### PR DESCRIPTION
The test-e2e job of prometheus-adapter was introduced after release 0.10, so the target for this test doesn't exist on branch release-0.10.