### PR TITLE
Fixing issue were windows PR job has duplicate name for 1.28 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
@@ -1,0 +1,53 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-capz-windows-1.28
+    always_run: false
+    branches:
+    - release-1.28
+    decorate: true
+    extra_refs:
+    - base_ref: release-1.10
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      repo: cluster-api-provider-azure
+      workdir: false
+    - base_ref: release-1.28
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      repo: cloud-provider-azure
+    - org: kubernetes-sigs
+      repo: windows-testing
+      base_ref: master
+      path_alias: k8s.io/windows-testing
+      workdir: true
+    labels:
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+      preset-azure-cred-only: "true"
+      preset-capz-containerd-1-7-latest: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-windows-common-pull: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-windows-private-registry-cred: "true"
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: azure.*\.go$|.*windows\.go$|test/e2e/windows/.*
+    spec:
+      containers:
+      - command:
+        - "runner.sh"
+        - "env"
+        - "./capz/run-capz-e2e.sh"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9Gi
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-capz-windows-1-28
+      testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-capz-windows-1.28
+  - name: pull-kubernetes-e2e-capz-windows-1-28
     always_run: false
     branches:
     - release-1.28

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -1,0 +1,119 @@
+presets:
+- labels:
+    preset-capz-windows-common-128: "true"
+  env:
+  - name: "KUBERNETES_VERSION"
+    value: "latest-1.28"
+  - name: E2E_ARGS
+    value: "-kubetest.use-ci-artifacts"
+  - name: WINDOWS
+    value: "true"
+  - name: TEST_WINDOWS #temp to unblock failing jobs on windows while we fix this in capz (https://github.com/kubernetes/kubernetes/issues/116474)
+    value: "true"
+  - name: AZURE_NODE_MACHINE_TYPE
+    value: "Standard_D4s_v3"
+periodics:
+- name: ci-kubernetes-e2e-capz-windows-1-28
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-release-1.28-informing, sig-windows-1.28-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1-28
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: release-1.10
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    repo: cluster-api-provider-azure
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+    workdir: true
+  - base_ref: relese-1.28
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    repo: cloud-provider-azure
+  interval: 3h
+  labels:
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-containerd-1-7-latest: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-windows-common-128: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - env
+      - KUBERNETES_VERSION=latest-1.28
+      - ./capz/run-capz-e2e.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      name: ""
+      resources:
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- name: ci-kubernetes-e2e-capz-1-28-windows-serial-slow
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-capz-containerd-1-7-latest: "true"
+    preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
+    preset-capz-windows-common-128: "true"
+    preset-capz-windows-2022: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.10
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest-1.28"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|RebootHost|\[sig-autoscaling\].\[Feature:HPA\]
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.28-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1-28-serial-slow

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -11,7 +11,7 @@ presets:
     value: "Standard_D4s_v3"
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-capz-windows
+  - name: pull-kubernetes-e2e-capz-windows-master
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -540,57 +540,6 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
-- annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
-    testgrid-dashboards: sig-release-1.28-informing, sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-1.28
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: release-1.10
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    repo: cluster-api-provider-azure
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/windows-testing
-    repo: windows-testing
-    workdir: true
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    repo: cloud-provider-azure
-  interval: 3h
-  labels:
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
-    preset-azure-cred-only: "true"
-    preset-capz-containerd-1-7-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-windows-private-registry-cred: "true"
-  name: ci-kubernetes-e2e-capz-master-windows-1-28
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - env
-      - KUBERNETES_VERSION=latest-1.28
-      - ./capz/run-capz-e2e.sh
-      env:
-      - name: IMAGE_VERSION
-        value: 127.1.20230417
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
-      name: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:
@@ -2019,47 +1968,6 @@ presubmits:
           requests:
             cpu: "7"
             memory: 12Gi
-  - always_run: false
-    branches:
-    - release-1.28
-    context: pull-kubernetes-e2e-capz-windows-1.28
-    decorate: true
-    extra_refs:
-    - base_ref: release-1.10
-      org: kubernetes-sigs
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      repo: cluster-api-provider-azure
-      workdir: true
-    - base_ref: master
-      org: kubernetes-sigs
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      repo: cloud-provider-azure
-    labels:
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
-      preset-azure-cred-only: "true"
-      preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2019: "true"
-      preset-capz-windows-common-pull: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    name: pull-kubernetes-e2e-capz-windows-1.28
-    optional: true
-    path_alias: k8s.io/kubernetes
-    run_if_changed: azure.*\.go$|.*windows\.go$|test/e2e/windows/.*
-    spec:
-      containers:
-      - command:
-        - runner.sh
-        - ./scripts/ci-conformance.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
-        name: ""
-        resources:
-          requests:
-            cpu: "2"
-            memory: 9Gi
-        securityContext:
-          privileged: true
   kubernetes/perf-tests:
   - always_run: false
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -2022,7 +2022,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.28
-    context: pull-kubernetes-e2e-capz-windows
+    context: pull-kubernetes-e2e-capz-windows-1.28
     decorate: true
     extra_refs:
     - base_ref: release-1.10
@@ -2043,7 +2043,7 @@ presubmits:
       preset-capz-windows-common-pull: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    name: pull-kubernetes-e2e-capz-windows
+    name: pull-kubernetes-e2e-capz-windows-1.28
     optional: true
     path_alias: k8s.io/kubernetes
     run_if_changed: azure.*\.go$|.*windows\.go$|test/e2e/windows/.*

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
     - sig-windows-1.25-release
     - sig-windows-1.26-release
     - sig-windows-1.27-release
+    - sig-windows-1.28-release
     - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
@@ -21,6 +22,7 @@ dashboards:
 - name: sig-windows-1.25-release
 - name: sig-windows-1.26-release
 - name: sig-windows-1.27-release
+- name: sig-windows-1.28-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce


### PR DESCRIPTION
Because the job name didn't have `master` in it the job got forked as part of setting up the v1.28 release branches but the jobs did not get a unique name.

This PR fixes but the issue with the job forking and the release-1.28 job with a duplicate name

/sig windows
/assign @jsturtevant @jeremyrickard 