### PR TITLE
Use run-capz-e2e  scripts which are running in nightly jobs for 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows-presubmits.yaml
@@ -72,25 +72,36 @@ presubmits:
       preset-capz-containerd-1-6-latest: "true"
       preset-capz-windows-common-pull: "true"
       preset-azure-capz-sa-cred: "true"
+      preset-windows-private-registry-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: release-1.10
       path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
+      workdir: false
     - org: kubernetes-sigs
       repo: cloud-provider-azure
       base_ref: release-1.24
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
+    - org: kubernetes-sigs
+      repo: windows-testing
+      base_ref: master
+      path_alias: k8s.io/windows-testing
+      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.24
         command:
-        - runner.sh
-        - ./scripts/ci-conformance.sh
+        - "runner.sh"
+        - "env"
+        - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
+        env:
+          # Skip tests that require etcd image for 1.24 Windows jobs because the etcd image referenced in this branch does not container Windows images.
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Aggregator.Should.be.able.to.support.the.1.17.Sample.API.Server|be.restarted.with.a.GRPC.liveness.probe
         resources:
           requests:
             cpu: 2


### PR DESCRIPTION
Use run-capz-e2e  scripts which are running in nightly jobs for 1.24

/assign @marosset 
/sig windows