### PR TITLE
Create sig-cl canary jobs on EKS build cluster

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -44,3 +44,54 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-no-addons-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-no-addons-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test if 'join' and 'upgrade' works with missing addon ConfigMaps"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "upgrade-latest-no-addon-config-maps"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -220,3 +220,258 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-discovery-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-discovery-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test alternative discovery methods for kubeadm join"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "8"
+    testgrid-alert-stale-results-hours: "16"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "discovery-latest"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-discovery-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test alternative discovery methods for kubeadm join"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "discovery-1.28"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-discovery-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test alternative discovery methods for kubeadm join"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "discovery-1.27"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-discovery-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test alternative discovery methods for kubeadm join"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "discovery-1.26"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-discovery-1-25-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-discovery-1-25-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and test alternative discovery methods for kubeadm join"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.25
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "discovery-1.25"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
@@ -220,3 +220,258 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-dryrun-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "8"
+    testgrid-alert-stale-results-hours: "16"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "dryrun-latest"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-dryrun-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "dryrun-1.28"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-dryrun-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "dryrun-1.27"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-dryrun-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "dryrun-1.26"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-dryrun-1-25-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-dryrun-1-25-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "48"
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.25
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "dryrun-1.25"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: "9000Mi"
+          cpu: 2000m
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+    tolerations:
+    - key: "dedicated"
+      value: "kind-tests"
+      operator: "Equal"
+      effect: "NoSchedule"
+    nodeSelector:
+      kind-exclusive: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -220,3 +220,259 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-ca-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and tests kubeadm''s support for external CA mode'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-ca-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-ca-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and tests kubeadm''s support for external CA mode'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-ca-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-ca-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and tests kubeadm''s support for external CA mode'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-ca-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-ca-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and tests kubeadm''s support for external CA mode'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-ca-1.26
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-ca-1-25-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-ca-1-25-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and tests kubeadm''s support for external CA mode'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.25
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-ca-1.25
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -220,3 +220,259 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-etcd-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with external etcd and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-etcd-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with external etcd and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-etcd-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with external etcd and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-etcd-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with external etcd and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-etcd-1.26
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-25-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-25-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with external etcd and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.25
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - external-etcd-1.25
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -396,3 +396,472 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-28-on-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-28-on-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.28-on-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-27-on-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-27-on-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.27-on-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-26-on-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-26-on-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.26-on-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-27-on-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-27-on-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.27-on-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-26-on-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-26-on-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.26-on-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-25-on-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.25-on-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-26-on-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-26-on-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.26-on-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-25-on-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.25-on-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-kubelet-1-25-on-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    description: 'OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses
+      kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-kubelet-1.25-on-1.26
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-learner-mode.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-learner-mode.yaml
@@ -44,3 +44,56 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-learner-mode-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-learner-mode-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster using etcd learner mode to join control-plane and run kubeadm-e2e
+      and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - learner-mode-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -44,3 +44,55 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-patches-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-patches-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with patches on static Pod manifests'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - patches-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
@@ -44,3 +44,56 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-rootless-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-rootless-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with rootless control-plane and run kubeadm-e2e and the conformance
+      suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - rootless-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade-addons-before-controlplane.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade-addons-before-controlplane.yaml
@@ -44,3 +44,56 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-addons-before-controlplane-1-28-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-upgrade-addons-before-controlplane-1-28-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster, upgrade it and run kubeadm-e2e and the conformance suite with the
+      UpgradeAddonsBeforeControlPlane feature gate enabled'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - upgrade-addons-before-controlplane-1.28-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -176,3 +176,208 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-28-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-28-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster, upgrade it and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - upgrade-1.28-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-27-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-27-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster, upgrade it and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - upgrade-1.27-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-26-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-26-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster, upgrade it and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - upgrade-1.26-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-25-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-25-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster, upgrade it and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - upgrade-1.25-1.26
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -176,3 +176,208 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-latest-on-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-latest-on-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with version skew and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-latest-on-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-28-on-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-28-on-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with version skew and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-1.28-on-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-27-on-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-27-on-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with version skew and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-1.27-on-1.26
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-26-on-1-25-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-26-on-1-25-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster with version skew and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.25
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - skew-1.26-on-1.25
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -220,3 +220,259 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-latest-canary
+  cluster: eks-prow-build-cluster
+  interval: 2h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-latest-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '8'
+    testgrid-alert-stale-results-hours: '16'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - regular-latest
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-28-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-28-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.28
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.28
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - regular-1.28
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-27-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-27-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.27
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - regular-1.27
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-26-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-26-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.26
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - regular-1.26
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-25-canary
+  cluster: eks-prow-build-cluster
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: 'true'
+    preset-kind-volume-mounts: 'true'
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: kubeadm-kinder-1-25-canary
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
+    description: 'OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create
+      a cluster and run kubeadm-e2e and the conformance suite'
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '4'
+    testgrid-alert-stale-results-hours: '48'
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.25
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: main
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      command:
+      - runner.sh
+      - ../kubeadm/kinder/ci/kinder-run.sh
+      args:
+      - regular-1.25
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9000Mi
+          cpu: 2000m
+        requests:
+          memory: 9000Mi
+          cpu: 2000m
+    tolerations:
+    - key: dedicated
+      value: kind-tests
+      operator: Equal
+      effect: NoSchedule
+    nodeSelector:
+      kind-exclusive: 'true'


### PR DESCRIPTION
To investigate https://github.com/kubernetes/k8s.io/issues/5473 we want to run a set of canary jobs on a dedicated EKS node group. This PR duplicates cluster lifecycle jobs and schedules them on a dedicated EKS node group.

/assign @xmudrii
/cc @dims @ameukam