### PR TITLE
[releng] Move 1.27 version marker to stable

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -40,7 +40,7 @@ variants:
   '1.27':
     CONFIG: '1.27'
     GO_VERSION: 1.20.7
-    K8S_RELEASE: latest-1.27
+    K8S_RELEASE: stable-1.27
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.26':


### PR DESCRIPTION
This PR changed the 1.27 marker in in the kubekins variants file to stable

/cc @jeremyrickard 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>