### PR TITLE
migrate `capi-provider-vsphere` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-vsphere-test-main
+  cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
   rerun_auth_config:
@@ -15,8 +16,12 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
       resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: "500m"
+          cpu: 2
+          memory: 4Gi
       command:
       - runner.sh
       args:
@@ -30,6 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-main
+  cluster: eks-prow-build-cluster
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -53,9 +59,12 @@ periodics:
         capabilities:
           add: ["NET_ADMIN"]
       resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
         requests:
-          cpu: "4000m"
-          memory: "6Gi"
+          cpu: 4
+          memory: 6Gi
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-vsphere-test-release-1-5
+  cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
   rerun_auth_config:
@@ -15,8 +16,12 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.24
       resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: "500m"
+          cpu: 2
+          memory: 4Gi
       command:
       - runner.sh
       args:
@@ -30,6 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-5
+  cluster: eks-prow-build-cluster
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -53,9 +59,12 @@ periodics:
         capabilities:
           add: ["NET_ADMIN"]
       resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
         requests:
-          cpu: "4000m"
-          memory: "6Gi"
+          cpu: 4
+          memory: 6Gi
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-vsphere-test-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
   rerun_auth_config:
@@ -15,8 +16,12 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: "500m"
+          cpu: 2
+          memory: 4Gi
       command:
       - runner.sh
       args:
@@ -30,6 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-6
+  cluster: eks-prow-build-cluster
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -53,9 +59,12 @@ periodics:
         capabilities:
           add: ["NET_ADMIN"]
       resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
         requests:
-          cpu: "4000m"
-          memory: "6Gi"
+          cpu: 4
+          memory: 6Gi
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-vsphere-test-release-1-7
+  cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
   rerun_auth_config:
@@ -15,8 +16,12 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
       resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: "500m"
+          cpu: 2
+          memory: 4Gi
       command:
       - runner.sh
       args:
@@ -30,6 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-7
+  cluster: eks-prow-build-cluster
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -53,9 +59,12 @@ periodics:
         capabilities:
           add: ["NET_ADMIN"]
       resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
         requests:
-          cpu: "4000m"
-          memory: "6Gi"
+          cpu: 4
+          memory: 6Gi
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-vsphere-test-release-1-8
+  cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
   rerun_auth_config:
@@ -15,8 +16,12 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
       resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: "500m"
+          cpu: 2
+          memory: 4Gi
       command:
       - runner.sh
       args:
@@ -30,6 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-8
+  cluster: eks-prow-build-cluster
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -53,9 +59,12 @@ periodics:
         capabilities:
           add: ["NET_ADMIN"]
       resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
         requests:
-          cpu: "4000m"
-          memory: "6Gi"
+          cpu: 4
+          memory: 6Gi
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
@@ -85,6 +85,7 @@ presets:
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-main
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     always_run: false
@@ -100,12 +101,20 @@ presubmits:
         - runner.sh
         args:
         - ./hack/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff-main
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-main
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     labels:
@@ -124,11 +133,19 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-main
 
   - name: pull-cluster-api-provider-vsphere-test-main
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     always_run: false
@@ -140,8 +157,12 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: "500m"
+            cpu: 2
+            memory: 4Gi
         command:
         - runner.sh
         args:
@@ -153,6 +174,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-main
+    cluster: eks-prow-build-cluster
     branches:
     - ^main$
     labels:
@@ -172,9 +194,12 @@ presubmits:
           capabilities:
             add: ["NET_ADMIN"]
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4000m"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.5$
     always_run: false
@@ -16,12 +17,20 @@ presubmits:
         - runner.sh
         args:
         - ./hack/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff-release-1-5
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.5$
     labels:
@@ -40,11 +49,19 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-release-1-5
 
   - name: pull-cluster-api-provider-vsphere-test-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.5$
     labels:
@@ -58,8 +75,12 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.24
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: "500m"
+            cpu: 2
+            memory: 4Gi
         command:
         - runner.sh
         args:
@@ -71,6 +92,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-5
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.5$
     labels:
@@ -90,9 +112,12 @@ presubmits:
           capabilities:
             add: ["NET_ADMIN"]
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4000m"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-release-1-6
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.6$
     always_run: false
@@ -16,12 +17,20 @@ presubmits:
         - runner.sh
         args:
         - ./hack/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff-release-1-6
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-release-1-6
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.6$
     labels:
@@ -40,11 +49,19 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-release-1-6
 
   - name: pull-cluster-api-provider-vsphere-test-release-1-6
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.6$
     always_run: false
@@ -56,8 +73,12 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: "500m"
+            cpu: 2
+            memory: 4Gi
         command:
         - runner.sh
         args:
@@ -69,6 +90,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-6
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.6$
     labels:
@@ -88,9 +110,12 @@ presubmits:
           capabilities:
             add: ["NET_ADMIN"]
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4000m"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-release-1-7
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.7$
     always_run: false
@@ -16,12 +17,20 @@ presubmits:
         - runner.sh
         args:
         - ./hack/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff-release-1-7
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-release-1-7
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.7$
     labels:
@@ -40,11 +49,19 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-release-1-7
 
   - name: pull-cluster-api-provider-vsphere-test-release-1-7
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.7$
     always_run: false
@@ -56,8 +73,12 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: "500m"
+            cpu: 2
+            memory: 4Gi
         command:
         - runner.sh
         args:
@@ -69,6 +90,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-7
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.7$
     labels:
@@ -88,9 +110,12 @@ presubmits:
           capabilities:
             add: ["NET_ADMIN"]
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4000m"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-release-1-8
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.8$
     always_run: false
@@ -16,12 +17,20 @@ presubmits:
         - runner.sh
         args:
         - ./hack/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff-release-1-8
       description: Checks for API changes in the PR
 
   - name: pull-cluster-api-provider-vsphere-verify-release-1-8
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.8$
     labels:
@@ -40,11 +49,19 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-release-1-8
 
   - name: pull-cluster-api-provider-vsphere-test-release-1-8
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.8$
     always_run: false
@@ -56,8 +73,12 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: "500m"
+            cpu: 2
+            memory: 4Gi
         command:
         - runner.sh
         args:
@@ -69,6 +90,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-8
+    cluster: eks-prow-build-cluster
     branches:
     - ^release-1.8$
     labels:
@@ -88,9 +110,12 @@ presubmits:
           capabilities:
             add: ["NET_ADMIN"]
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4000m"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
         command:
         - runner.sh
         args:


### PR DESCRIPTION
This PR moves the capi-provider-vsphere jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @chrischdi @gab-satchi @killianmuldoon @randomvariable @sbueringer