### PR TITLE
ensureCommits: skip NOP fetch

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -398,12 +398,20 @@ func ensureCommits(repoClient RepoClient, repoOpts RepoOpts) error {
 
 	// For each commit SHA, check if it already exists. If so, don't bother
 	// fetching it.
+	var missingCommits bool
 	for _, commitSHA := range repoOpts.FetchCommits {
 		if exists, _ := repoClient.ObjectExists(commitSHA); exists {
 			continue
 		}
 
 		fetchArgs = append(fetchArgs, commitSHA)
+		missingCommits = true
+	}
+
+	// Skip the fetch operation altogether if nothing is missing (we already
+	// fetched everything previously at some point).
+	if !missingCommits {
+		return nil
 	}
 
 	if err := repoClient.Fetch(fetchArgs...); err != nil {


### PR DESCRIPTION
Don't bother running the fetch operation if there are no new commits to fetch.

/cc @cjwagner @airbornepony @timwangmusic 