### PR TITLE
sig-testing: reduce resources for lint job on EKS

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -150,13 +150,13 @@ presubmits:
         - "-c"
         - "hack/verify-golangci-lint.sh -r ${PULL_BASE_SHA} -n"
         resources:
-          # Consider reducing memory limits after looking at real data from
-          # https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&refresh=30s&var-org=kubernetes&var-repo=kubernetes&var-job=All
+          # It peaks at around 7 cores of the EKS cluster. We can fit more jobs onto
+          # a node without a real slowdown by requesting one quarter of a node (= 4).
           limits:
-            cpu: 7
+            cpu: 4
             memory: 12Gi
           requests:
-            cpu: 7
+            cpu: 4
             memory: 12Gi
   - name: pull-kubernetes-verify-go-canary
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
This is based on
https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?from=now-24h&to=now&orgId=1&refresh=30s&var-org=kubernetes&var-repo=kubernetes&var-job=pull-kubernetes-linter-hints-eks&var-build=All showing short bursts of ~7.5GB and 8 cores. We can let it run a bit longer with less cores to fit more jobs onto a node.

/assign @dims 