### PR TITLE
[Windows] Fix typo causing job failure in 1.28 CI

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -31,7 +31,7 @@ periodics:
     path_alias: sigs.k8s.io/windows-testing
     repo: windows-testing
     workdir: true
-  - base_ref: relese-1.28
+  - base_ref: release-1.28
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cloud-provider-azure
     repo: cloud-provider-azure


### PR DESCRIPTION
Fix failing test: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-windows-1-28/1694718514599825408

/sig windows
/assign @marosset 