### PR TITLE
run gengo defaulter tests and verify-examples.sh

### DIFF
--- a/config/jobs/kubernetes/gengo/gengo-config.yaml
+++ b/config/jobs/kubernetes/gengo/gengo-config.yaml
@@ -17,7 +17,7 @@ presubmits:
             - bash
           args:
             - -c
-            - 'go test -v -race ./...'
+            - 'go test -v -race ./... k8s.io/gengo/examples/defaulter-gen/output_tests/...'
           resources:
             requests:
               memory: 4Gi
@@ -45,6 +45,21 @@ presubmits:
            - -c
            - |
             go run ./examples/import-boss/main.go -i $(go list k8s.io/gengo/... | grep -v import-boss/tests | paste -sd',' -) --verify-only
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 4Gi
+              cpu: 2
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          command:
+            - runner.sh
+            - bash
+          args:
+           - -c
+           - |
+            hack/verify-examples.sh
           resources:
             requests:
               memory: 4Gi

--- a/config/jobs/kubernetes/gengo/gengo-config.yaml
+++ b/config/jobs/kubernetes/gengo/gengo-config.yaml
@@ -17,7 +17,7 @@ presubmits:
             - bash
           args:
             - -c
-            - 'go test -v -race ./... k8s.io/gengo/examples/defaulter-gen/output_tests/...'
+            - 'go test -v -race ./... && (cd ./examples/defaulter-gen/_output_tests && go test -v -race ./...)'
           resources:
             requests:
               memory: 4Gi
@@ -43,23 +43,7 @@ presubmits:
             - bash
           args:
            - -c
-           - |
-            go run ./examples/import-boss/main.go -i $(go list k8s.io/gengo/... | grep -v import-boss/tests | paste -sd',' -) --verify-only
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-            limits:
-              memory: 4Gi
-              cpu: 2
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-          command:
-            - runner.sh
-            - bash
-          args:
-           - -c
-           - |
-            hack/verify-examples.sh
+           - hack/verify-examples.sh
           resources:
             requests:
               memory: 4Gi


### PR DESCRIPTION
Runs the new `verify-examples.sh` in gengo as a presubmit. 

Also explicitly tests defaulter-gen's _output_tests, which was not captured by `go test ./...` due to being named with an underscore and taking advantage of the new `go.mod` added to that dir to make it testable.

Before this change, our CI does not run any `defaulter-gen` tests, and does not ensure the committed generated code is up to date. After, it does both.

/cc @apelisse
/assign @BenTheElder 