### PR TITLE
revert `capi-vsphere` integration jobs to GKE cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
@@ -35,7 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-main
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
@@ -35,7 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-5
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -35,7 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-6
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
@@ -35,7 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-7
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
@@ -35,7 +35,7 @@ periodics:
     description: Runs unit tests
 
 - name: periodic-cluster-api-provider-vsphere-test-integration-release-1-8
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
@@ -174,7 +174,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-main
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - ^main$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
@@ -92,7 +92,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-5
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - ^release-1.5$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -90,7 +90,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-6
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - ^release-1.6$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
@@ -90,7 +90,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-7
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - ^release-1.7$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
@@ -90,7 +90,7 @@ presubmits:
       description: Runs unit tests
 
   - name: pull-cluster-api-provider-vsphere-test-integration-release-1-8
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - ^release-1.8$
     labels:


### PR DESCRIPTION
This PR sends the integration jobs to running on the community GKE cluster due to github rate limit issues. 

/cc @chrischdi @sbueringer @killianmuldoon 