### PR TITLE
migrate unit and verify `cloud-provider-azure` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
   - name: pull-cloud-provider-azure-check
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     path_alias: sigs.k8s.io/cloud-provider-azure
@@ -605,6 +606,7 @@ presubmits:
       description: "Runs Azure specific e2e tests with cloud controller manager and multiple standard load balancers."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-unit
+    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^site/|^helm/|^tests/e2e/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     path_alias: sigs.k8s.io/cloud-provider-azure
@@ -620,6 +622,13 @@ presubmits:
         args:
         - make
         - test-unit
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-unit

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
     - name: pull-cloud-provider-azure-check-1-25
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -192,6 +193,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure release-1.25 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-25
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -207,6 +209,13 @@ presubmits:
             args:
               - make
               - test-unit
+            resources:
+              limits:
+                memory: "9Gi"
+                cpu: "2"
+              requests:
+                memory: "9Gi"
+                cpu: "2"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-25-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-25

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
     - name: pull-cloud-provider-azure-check-1-26
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -192,6 +193,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure release-1.26 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
     - name: pull-cloud-provider-azure-unit-1-26
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -207,6 +209,13 @@ presubmits:
             args:
               - make
               - test-unit
+            resources:
+              limits:
+                memory: "9Gi"
+                cpu: "2"
+              requests:
+                memory: "9Gi"
+                cpu: "2"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-26

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
     - name: pull-cloud-provider-azure-check-1-27
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -192,6 +193,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
     - name: pull-cloud-provider-azure-unit-1-27
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -207,6 +209,13 @@ presubmits:
             args:
               - make
               - test-unit
+            resources:
+              limits:
+                memory: "9Gi"
+                cpu: "2"
+              requests:
+                memory: "9Gi"
+                cpu: "2"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-27

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
     - name: pull-cloud-provider-azure-check-1-28
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -192,6 +193,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
     - name: pull-cloud-provider-azure-unit-1-28
+      cluster: eks-prow-build-cluster
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -207,6 +209,13 @@ presubmits:
             args:
               - make
               - test-unit
+            resources:
+              limits:
+                memory: "9Gi"
+                cpu: "2"
+              requests:
+                memory: "9Gi"
+                cpu: "2"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-28


### PR DESCRIPTION
This PR moves the cloud-provider-azure jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @andyzhangx @brendandburns @feiskyer @karataliu @khenidak