### PR TITLE
fix cluster for pull-publishing-bot-image job this need the service account that is not available in the eks cluster

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -106,7 +106,6 @@ presubmits:
               cpu: 2
               memory: 2Gi
   - name: pull-publishing-bot-image
-    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: "k8s.io/publishing-bot"
     always_run: true


### PR DESCRIPTION
- fix cluster for pull-publishing-bot-image job this need the service account that is not available in the eks cluster

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes/release-engineering 
