### PR TITLE
pull-publishing-bot-image needs to run on k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -106,6 +106,7 @@ presubmits:
               cpu: 2
               memory: 2Gi
   - name: pull-publishing-bot-image
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/publishing-bot"
     always_run: true


### PR DESCRIPTION
follow up of #30508 

/assign @xmudrii @saschagrunert @Verolop 
cc @kubernetes/release-engineering 