### PR TITLE
Add milestone_applier rule for k/k release-1.28

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -458,6 +458,7 @@ milestone_applier:
     master: v1.29
   kubernetes/kubernetes:
     master: v1.29
+    release-1.28: v1.28
     release-1.27: v1.27
     release-1.26: v1.26
     release-1.25: v1.25


### PR DESCRIPTION
This PR adds a missing milestone_applier rule for kubernetes/kubernetes release-1.28 branch.

Thanks to @neolit123 for pointing out this issue!

/assign @saschagrunert @cpanato @dims 
