### PR TITLE
git v2 client: force creation of a new variable

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -42,28 +42,6 @@ const (
 	inRepoConfigDirName  = ".prow"
 )
 
-var inrepoconfigRepoOpts = git.RepoOpts{
-	// Technically we only need inRepoConfigDirName (".prow") because the
-	// default "cone mode" of sparse checkouts already include files at the
-	// toplevel (which would include ".prow.yaml").
-	//
-	// TODO (listx): The version of git shipped in kubekins-e2e (itself
-	// derived from the bootstrap image) uses git version 2.30.2, which does
-	// not populate files at the toplevel. So we have to also set a sparse
-	// checkout of ".prow.yaml". Later when that image is updated, we can
-	// remove the use of inRepoConfigFileName (".prow.yaml"), so that the
-	// unit tests in CI can pass. As for the Prow components themselves,
-	// they use a different version of Git based on alpine (see .ko.yaml in
-	// the root).
-	SparseCheckoutDirs: []string{inRepoConfigDirName, inRepoConfigFileName},
-	// The sparse checkout would avoid creating another copy of Git objects
-	// from the mirror clone into the secondary clone.
-	ShareObjectsWithSourceRepo: true,
-	// Disable fetching tag objects, because they are redundant and useless (we
-	// already have baseSHA and headSHAs).
-	NoFetchTags: true,
-}
-
 var inrepoconfigMetrics = struct {
 	gitCloneDuration *prometheus.HistogramVec
 	gitOtherDuration *prometheus.HistogramVec
@@ -89,6 +67,30 @@ var inrepoconfigMetrics = struct {
 func init() {
 	prometheus.MustRegister(inrepoconfigMetrics.gitCloneDuration)
 	prometheus.MustRegister(inrepoconfigMetrics.gitOtherDuration)
+}
+
+func newInrepoconfigRepoOpts() git.RepoOpts {
+	return git.RepoOpts{
+		// Technically we only need inRepoConfigDirName (".prow") because the
+		// default "cone mode" of sparse checkouts already include files at the
+		// toplevel (which would include ".prow.yaml").
+		//
+		// TODO (listx): The version of git shipped in kubekins-e2e (itself
+		// derived from the bootstrap image) uses git version 2.30.2, which does
+		// not populate files at the toplevel. So we have to also set a sparse
+		// checkout of ".prow.yaml". Later when that image is updated, we can
+		// remove the use of inRepoConfigFileName (".prow.yaml"), so that the
+		// unit tests in CI can pass. As for the Prow components themselves,
+		// they use a different version of Git based on alpine (see .ko.yaml in
+		// the root).
+		SparseCheckoutDirs: []string{inRepoConfigDirName, inRepoConfigFileName},
+		// The sparse checkout would avoid creating another copy of Git objects
+		// from the mirror clone into the secondary clone.
+		ShareObjectsWithSourceRepo: true,
+		// Disable fetching tag objects, because they are redundant and useless (we
+		// already have baseSHA and headSHAs).
+		NoFetchTags: true,
+	}
 }
 
 // +k8s:deepcopy-gen=true
@@ -140,7 +142,7 @@ func prowYAMLGetter(
 	}
 
 	timeBeforeClone := time.Now()
-	repoOpts := inrepoconfigRepoOpts
+	repoOpts := newInrepoconfigRepoOpts()
 	repoOpts.FetchCommits = append(headSHAs, baseSHA)
 	repo, err := gc.ClientForWithRepoOpts(orgRepo.Org, orgRepo.Repo, repoOpts)
 	inrepoconfigMetrics.gitCloneDuration.WithLabelValues(orgRepo.Org, orgRepo.Repo).Observe((float64(time.Since(timeBeforeClone).Seconds())))


### PR DESCRIPTION
It has been observed that sometimes we end up passing in the same SHA object into FetchCommits. As the baseSHA can never be the same as a SHA in the headSHAs, this is a bug with our code.

Specifically, we used to use a inrepoconfigRepoOpts global variable, and one of its fields was a string slice (FetchCommits). This meant that we could have been assigning to the same slice field multiple times from multiple threads.

Avoid the global variable, and instead use a function to return a new value each time.

/cc @cjwagner @timwangmusic @airbornepony 