### PR TITLE
git v2 client: dedupe FetchCommits

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	gerritsource "k8s.io/test-infra/prow/gerrit/source"
 
 	"k8s.io/test-infra/prow/git/types"
@@ -141,7 +142,10 @@ func prowYAMLGetter(
 
 	timeBeforeClone := time.Now()
 	repoOpts := inrepoconfigRepoOpts
-	repoOpts.FetchCommits = append(headSHAs, baseSHA)
+	// For Gerrit, the baseSHA could appear as a headSHA for postsubmits if the
+	// change was a fast-forward merge. So we need to dedupe it with sets.
+	repoOpts.FetchCommits = sets.New(baseSHA)
+	repoOpts.FetchCommits.Insert(headSHAs...)
 	repo, err := gc.ClientForWithRepoOpts(orgRepo.Org, orgRepo.Repo, repoOpts)
 	inrepoconfigMetrics.gitCloneDuration.WithLabelValues(orgRepo.Org, orgRepo.Repo).Observe((float64(time.Since(timeBeforeClone).Seconds())))
 	if err != nil {


### PR DESCRIPTION
It has been observed that sometimes we end up passing in the same SHA object into FetchCommits. It turns out that for Gerrit postsubmits, a headSHA can be the same as the baseSHA if the change was a fast-forward merge.

Deduplicate FetchCommits by using a set instead of a slice.

/cc @cjwagner @timwangmusic @airbornepony 