### PR TITLE
git v2 client: keep the primary clone up to date

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -146,6 +146,10 @@ func prowYAMLGetter(
 	// change was a fast-forward merge. So we need to dedupe it with sets.
 	repoOpts.FetchCommits = sets.New(baseSHA)
 	repoOpts.FetchCommits.Insert(headSHAs...)
+	// Only update the primary with the baseSHA, because it may be that the
+	// headSHAs never get merged into the base (perhaps the PR gets rejected or
+	// abandoned).
+	repoOpts.PrimaryCloneUpdateCommits = sets.New(baseSHA)
 	repo, err := gc.ClientForWithRepoOpts(orgRepo.Org, orgRepo.Repo, repoOpts)
 	inrepoconfigMetrics.gitCloneDuration.WithLabelValues(orgRepo.Org, orgRepo.Repo).Observe((float64(time.Since(timeBeforeClone).Seconds())))
 	if err != nil {

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -115,6 +115,10 @@ func (a *repoClientAdapter) FetchFromRemote(resolver RemoteResolver, branch stri
 	return errors.New("no FetchFromRemote implementation exists in the v1 repo client")
 }
 
+func (a *repoClientAdapter) FetchCommits(noFetchTags bool, commitSHAs []string) error {
+	return errors.New("no FetchCommits implementation exists in the v1 repo client")
+}
+
 func (a *repoClientAdapter) RemoteUpdate() error {
 	return errors.New("no RemoteUpdate implementation exists in the v1 repo client")
 }

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -80,6 +80,8 @@ type cacher interface {
 	MirrorClone() error
 	// RemoteUpdate fetches all updates from the remote.
 	RemoteUpdate() error
+	// FetchCommits fetches only the given commits.
+	FetchCommits(bool, []string) error
 }
 
 // cloner knows how to clone repositories from a central cache


### PR DESCRIPTION
The primary clone can get "stale" if it doesn't keep up with the changes
going into the upstream remote. Staleness can result in a performance
penalty for EnsureFreshSecondary(), because it would need to fetch more
objects to get to the commit SHAs specified in repoOpts.FetchCommits.

Git clients that are not using `repoOpts.FetchCommits` cannot get
stale, because they invoke the (expensive) RemoteUpdate() call on the
primary clone which fetches all refs. However, the primary clones for
inrepoconfigs can indeed get stale because it uses
`repoOpts.FetchCommits` to do targeted fetches only for the secondary
clone since bdd601cf6f (git v2 client for inrepoconfig: allow targeted
fetches (2nd attempt), 2023-08-22).

Allow updating the primary clone with a new PrimaryCloneUpdateCommits
field to periodically update the primary clone with new commits. For
inrepoconfigs, we only specify the baseSHA because it may be that the
headSHAs never get merged into the base (perhaps the PR gets rejected or
abandoned).

The first commit in this PR refactors ensureCommits() so that it can be
reused as FetchCommits() in the interactor.

/cc @cjwagner @timwangmusic @airbornepony 
