### PR TITLE
reduce scheduler throughput for cl2 tests

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1111,7 +1111,7 @@ def generate_presubmits_scale():
                 'CNI_PLUGIN': "amazonvpc",
                 'KUBE_NODE_COUNT': "500",
                 'RUN_CL2_TEST': "true",
-                'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "25",
+                'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "20",
                 'CONTROL_PLANE_COUNT': "3",
                 'CONTROL_PLANE_SIZE': "c6g.16xlarge",
                 'KOPS_STATE_STORE' : "s3://k8s-infra-kops-scale-tests"

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -119,7 +119,7 @@ presubmits:
         - name: RUN_CL2_TEST
           value: "true"
         - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
-          value: "25"
+          value: "20"
         - name: CONTROL_PLANE_COUNT
           value: "3"
         - name: CONTROL_PLANE_SIZE


### PR DESCRIPTION
kops prow scale test jobs are failing at the moment because of high scheduler throughput - https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/15599/presubmit-kops-aws-scale-amazonvpc-using-cl2/1695552966049665024