### PR TITLE
Remove obsolete check for `alpha` tests

### DIFF
--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -262,12 +262,8 @@ expand_tests () {
 pull_optional() {
     local tests="$1"
     local kubernetes="$2"
-    local deployment_suffix="$3"
 
-    # https://github.com/kubernetes-csi/csi-driver-host-path/pull/282 has not been merged yet,
-    # therefore pull jobs which depend on the new deployment flavors have to be optional.
-    # TODO: remove this check once merged.
-    if [ "$tests" == "alpha" ] || [ "$deployment_suffix" ] ; then
+    if [ "$tests" == "alpha" ]; then
         echo "true"
     elif [ "$kubernetes" == "$experimental_k8s_version" ]; then
         # New k8s versions may require updates to kind or release-tools.
@@ -368,7 +364,7 @@ EOF
   - name: $(job_name "pull" "$repo" "$tests" "$deployment$deployment_suffix" "$kubernetes")
     cluster: $(job_cluster "$repo")
     always_run: $(pull_alwaysrun "$tests")
-    optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix")
+    optional: $(pull_optional "$tests" "$kubernetes")
     decorate: true
     skip_report: false
     skip_branches: [$(skip_branches $repo)]

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -136,7 +136,7 @@ type PullRequestClient interface {
 	CreatePullRequestReviewComment(org, repo string, number int, rc ReviewComment) error
 	ListReviews(org, repo string, number int) ([]Review, error)
 	ClosePullRequest(org, repo string, number int) error
-	ReopenPR(org, repo string, number int) error
+	ReopenPullRequest(org, repo string, number int) error
 	CreateReview(org, repo string, number int, r DraftReview) error
 	RequestReview(org, repo string, number int, logins []string) error
 	UnrequestReview(org, repo string, number int, logins []string) error
@@ -3243,12 +3243,11 @@ func (c *client) ClosePullRequest(org, repo string, number int) error {
 	return err
 }
 
-// ReopenPR re-opens the existing, closed PR provided
-// TODO: Rename to ReopenPullRequest
+// ReopenPullRequest re-opens the existing, closed PR provided
 //
 // See https://developer.github.com/v3/pulls/#update-a-pull-request
-func (c *client) ReopenPR(org, repo string, number int) error {
-	durationLogger := c.log("ReopenPR", org, repo, number)
+func (c *client) ReopenPullRequest(org, repo string, number int) error {
+	durationLogger := c.log("ReopenPullRequest", org, repo, number)
 	defer durationLogger()
 
 	_, err := c.request(&request{

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -135,7 +135,7 @@ type PullRequestClient interface {
 	ListPullRequestComments(org, repo string, number int) ([]ReviewComment, error)
 	CreatePullRequestReviewComment(org, repo string, number int, rc ReviewComment) error
 	ListReviews(org, repo string, number int) ([]Review, error)
-	ClosePR(org, repo string, number int) error
+	ClosePullRequest(org, repo string, number int) error
 	ReopenPR(org, repo string, number int) error
 	CreateReview(org, repo string, number int, r DraftReview) error
 	RequestReview(org, repo string, number int, logins []string) error
@@ -3226,12 +3226,11 @@ func (c *client) ReopenIssue(org, repo string, number int) error {
 	return stateCannotBeChangedOrOriginalError(err)
 }
 
-// ClosePR closes the existing, open PR provided
-// TODO: Rename to ClosePullRequest
+// ClosePullRequest closes the existing, open PR provided
 //
 // See https://developer.github.com/v3/pulls/#update-a-pull-request
-func (c *client) ClosePR(org, repo string, number int) error {
-	durationLogger := c.log("ClosePR", org, repo, number)
+func (c *client) ClosePullRequest(org, repo string, number int) error {
+	durationLogger := c.log("ClosePullRequest", org, repo, number)
 	defer durationLogger()
 
 	_, err := c.request(&request{

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1618,7 +1618,7 @@ func TestClosePullRequest(t *testing.T) {
 	}
 }
 
-func TestReopenPR(t *testing.T) {
+func TestReopenPullRequest(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("Bad method: %s", r.Method)
@@ -1641,7 +1641,7 @@ func TestReopenPR(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	if err := c.ReopenPR("k8s", "kuber", 5); err != nil {
+	if err := c.ReopenPullRequest("k8s", "kuber", 5); err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	}
 }

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1590,7 +1590,7 @@ func TestReopenIssue(t *testing.T) {
 	}
 }
 
-func TestClosePR(t *testing.T) {
+func TestClosePullRequest(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("Bad method: %s", r.Method)
@@ -1613,7 +1613,7 @@ func TestClosePR(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	if err := c.ClosePR("k8s", "kuber", 5); err != nil {
+	if err := c.ClosePullRequestR("k8s", "kuber", 5); err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	}
 }


### PR DESCRIPTION
Removed outdated check and simplify `pull_optional()` function.
The [PR](https://github.com/kubernetes-csi/csi-driver-host-path/pull/282) has been merged and the specific check for "alpha" tests and deployment suffix is no longer necessary.
