### PR TITLE
Use golang 1.19 kubekins-e2e image to run 1.26-minus

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - make
         args:
@@ -39,7 +39,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - make
         args:
@@ -67,7 +67,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - make
         args:
@@ -95,7 +95,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - make
         args:
@@ -126,7 +126,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - "make"
         args:
@@ -155,7 +155,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - "make"
         args:
@@ -187,7 +187,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - "make"
         args:
@@ -220,7 +220,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - runner.sh
         - bash
@@ -270,7 +270,7 @@ presubmits:
     optional: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221107-33c989e684-1.25
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Update to proper image per https://github.com/kubernetes/cloud-provider-vsphere/pull/754#issuecomment-1693127093 and https://github.com/kubernetes/cloud-provider-vsphere/pull/754#issuecomment-1694155529