### PR TITLE
Fix and add support for proper swap testing

### DIFF
--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -89,7 +89,7 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=crio-install.service\nConditionFirstBoot=no\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \\\"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB \u0026\u0026 sudo chmod 600 /var/swapfile \u0026\u0026 sudo mkswap /var/swapfile \u0026\u0026 sudo swapon /var/swapfile \u0026\u0026 free -h\\\"\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=crio-install.service\nConditionFirstBoot=no\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB \u0026\u0026 sudo chmod 600 /var/swapfile \u0026\u0026 sudo mkswap /var/swapfile \u0026\u0026 sudo swapon /var/swapfile \u0026\u0026 free -h\"\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "swap-enable.service"
       }

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -89,7 +89,7 @@
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=crio-install.service\nConditionFirstBoot=no\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB \u0026\u0026 sudo chmod 600 /var/swapfile \u0026\u0026 sudo mkswap /var/swapfile \u0026\u0026 sudo swapon /var/swapfile \u0026\u0026 free -h\"\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=crio-install.service\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB \u0026\u0026 sudo chmod 600 /var/swapfile \u0026\u0026 sudo mkswap /var/swapfile \u0026\u0026 sudo swapon /var/swapfile \u0026\u0026 free -h\"\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "swap-enable.service"
       }

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-swap1g.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-swap1g.yaml
@@ -1,0 +1,5 @@
+images:
+  fedora:
+    image_family: fedora-coreos-stable
+    project: fedora-coreos-cloud 
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_swap1g.ign"

--- a/jobs/e2e_node/crio/templates/base/swap-1G.yaml
+++ b/jobs/e2e_node/crio/templates/base/swap-1G.yaml
@@ -7,7 +7,6 @@ systemd:
         [Unit]
         Description=Enable swap on CoreOS
         Before=crio-install.service
-        ConditionFirstBoot=no
 
         [Service]
         Type=oneshot

--- a/jobs/e2e_node/crio/templates/base/swap-1G.yaml
+++ b/jobs/e2e_node/crio/templates/base/swap-1G.yaml
@@ -11,7 +11,7 @@ systemd:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/sh -c \"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB && sudo chmod 600 /var/swapfile && sudo mkswap /var/swapfile && sudo swapon /var/swapfile && free -h\"
+        ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB && sudo chmod 600 /var/swapfile && sudo mkswap /var/swapfile && sudo swapon /var/swapfile && free -h"
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -136,7 +136,7 @@ systemd:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/sh -c \"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB && sudo chmod 600 /var/swapfile && sudo mkswap /var/swapfile && sudo swapon /var/swapfile && free -h\"
+        ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB && sudo chmod 600 /var/swapfile && sudo mkswap /var/swapfile && sudo swapon /var/swapfile && free -h"
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -132,7 +132,6 @@ systemd:
         [Unit]
         Description=Enable swap on CoreOS
         Before=crio-install.service
-        ConditionFirstBoot=no
 
         [Service]
         Type=oneshot


### PR DESCRIPTION
Before this PR swap cannot be tested with CRIO's ignition files.

In summary, this PR:
1. Fixes syntax problems in "enable-swap" unit file.
2. Creates a new test config image that uses the corresponding swap ignition file.

I have locally tested the new config image and it works as expected.
In the near future I plan to use this image config file for swap testing upstream.

Please refer to the commits description for more detailed explanation about the specific changes.