### PR TITLE
migrate `controller-runtime` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 6h
   name: periodic-controller-runtime-test
+  cluster: eks-prow-build-cluster
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
@@ -13,7 +14,11 @@ periodics:
       - ./hack/ci-check-everything.sh
       resources:
         requests:
-          cpu: "7000m"
+          cpu: 7
+          memory: 14Gi
+        limits:
+          cpu: 7
+          memory: 14Gi
   annotations:
     testgrid-dashboards: sig-api-machinery-kubebuilder
     testgrid-tab-name: controller-runtime-periodic-main

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
   - name: pull-controller-runtime-test
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
@@ -14,11 +15,16 @@ presubmits:
         - ./hack/ci-check-everything.sh
         resources:
           requests:
-            cpu: "7000m"
+            cpu: 7
+            memory: 14Gi
+          limits:
+            cpu: 7
+            memory: 14Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-main
   - name: pull-controller-runtime-apidiff
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     optional: true
@@ -30,6 +36,13 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/apidiff.sh
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-main-apidiff

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.13.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.13.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
   - name: pull-controller-runtime-test-release-0-13
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
@@ -13,11 +14,16 @@ presubmits:
         - ./hack/ci-check-everything.sh
         resources:
           requests:
-            cpu: "7000m"
+            cpu: 7
+            memory: 14Gi
+          limits:
+            cpu: 7
+            memory: 14Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.13
   - name: pull-controller-runtime-apidiff-release-0-13
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     optional: true
@@ -29,6 +35,13 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - ./hack/apidiff.sh
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.13-apidiff

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.14.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.14.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
   - name: pull-controller-runtime-test-release-0-14
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
@@ -13,11 +14,16 @@ presubmits:
         - ./hack/ci-check-everything.sh
         resources:
           requests:
-            cpu: "7000m"
+            cpu: 7
+            memory: 14Gi
+          limits:
+            cpu: 7
+            memory: 14Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.14
   - name: pull-controller-runtime-apidiff-release-0-14
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     optional: true
@@ -29,6 +35,13 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.19
         command:
         - ./hack/apidiff.sh
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.14-apidiff

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.15.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.15.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
   - name: pull-controller-runtime-test-release-0-15
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
@@ -13,11 +14,16 @@ presubmits:
         - ./hack/ci-check-everything.sh
         resources:
           requests:
-            cpu: "7000m"
+            cpu: 7
+            memory: 14Gi
+          limits:
+            cpu: 7
+            memory: 14Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.15
   - name: pull-controller-runtime-apidiff-release-0-15
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     optional: true
@@ -29,6 +35,13 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/apidiff.sh
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.15-apidiff

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.16.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.16.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
   - name: pull-controller-runtime-test-release-0-16
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
@@ -13,11 +14,16 @@ presubmits:
         - ./hack/ci-check-everything.sh
         resources:
           requests:
-            cpu: "7000m"
+            cpu: 7
+            memory: 14Gi
+          limits:
+            cpu: 7
+            memory: 14Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.16
   - name: pull-controller-runtime-apidiff-release-0-16
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     optional: true
@@ -29,6 +35,13 @@ presubmits:
       - image: public.ecr.aws/docker/library/golang:1.20
         command:
         - ./hack/apidiff.sh
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-release-0.16-apidiff


### PR DESCRIPTION
This PR moves the controller-runtime jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @alvaroaleman @fillzpp @joelanford @sbueringer @vincepri