### PR TITLE
migrate `secrets-store-csi-driver` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -138,6 +138,7 @@ presubmits:
       description: "Run vulnerability scans for Secrets Store CSI driver images."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-vault
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -163,6 +164,13 @@ presubmits:
             make e2e-bootstrap e2e-helm-deploy e2e-vault
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-vault
@@ -402,6 +410,7 @@ presubmits:
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -435,13 +444,17 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.7"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -475,13 +488,17 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.25.3"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-26-0
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -515,13 +532,17 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-26-0
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.26.0"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-27-1
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -555,7 +576,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-27-0
@@ -645,6 +669,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: release-secrets-store-csi-driver-e2e-vault
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -677,7 +702,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
       testgrid-tab-name: release-secrets-store-csi-driver-e2e-vault
@@ -768,6 +796,7 @@ presubmits:
 postsubmits:
   kubernetes-sigs/secrets-store-csi-driver:
   - name: secrets-store-csi-driver-e2e-vault-postsubmit
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -795,7 +824,10 @@ postsubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-vault-postsubmit
@@ -928,6 +960,7 @@ postsubmits:
 periodics:
 - interval: 24h
   name: periodic-secrets-store-csi-driver-image-scan
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 10m
@@ -951,6 +984,13 @@ periodics:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-image-scan
@@ -995,6 +1035,7 @@ periodics:
     testgrid-num-columns-recent: '30'
 - interval: 12h
   name: periodic-secrets-store-csi-driver-inplace-upgrade-test-e2e-provider
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 30m
@@ -1021,6 +1062,13 @@ periodics:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-inplace-upgrade-test-e2e-provider


### PR DESCRIPTION
This PR moves the secrets-store-csi-driver jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @aramase @nilekhc @ritazh @tam7t