### PR TITLE
migrate `test-infra` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-test-infra-benchmark-demo
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   extra_refs:
@@ -17,6 +18,13 @@ periodics:
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
       - --pass-on-error
       - ./experiment/dummybenchmarks/...
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-alert-email: colew@google.com
     testgrid-dashboards: sig-testing-canaries
@@ -24,6 +32,7 @@ periodics:
     description: Demoing JUnit golang benchmark results.
 - interval: 1h
   name: ci-test-infra-multiple-container-test
+  cluster: k8s-infra-prow-build
   decorate: true
   spec:
     containers:
@@ -33,8 +42,8 @@ periodics:
       args: ["I am first"]
       resources:
         requests:
-          memory: "128Mi"
-          cpu: "250m"
+          memory: "256Mi"
+          cpu: "500m"
         limits:
           memory: "256Mi"
           cpu: "500m"
@@ -46,8 +55,8 @@ periodics:
       - "sleep 60 && echo I && sleep 60 && echo am && sleep 60 && echo second"
       resources:
         requests:
-          memory: "128Mi"
-          cpu: "250m"
+          memory: "256Mi"
+          cpu: "500m"
         limits:
           memory: "256Mi"
           cpu: "500m"
@@ -59,8 +68,8 @@ periodics:
       - "sleep 120 && echo I && sleep 120 && echo am && sleep 120 && echo third"
       resources:
         requests:
-          memory: "128Mi"
-          cpu: "250m"
+          memory: "256Mi"
+          cpu: "500m"
         limits:
           memory: "256Mi"
           cpu: "500m"

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-test-infra-continuous-test
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -21,6 +22,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-testing-misc
     testgrid-tab-name: continuous
@@ -52,46 +60,6 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-broken-column-threshold: '0.5'
     description: Monitors Kettle's BigQuery database freshness.
-
-- name: test-infra-fuzz
-  labels:
-    preset-dind-enabled: "true"
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-  interval: 1h
-  spec:
-    serviceAccountName: fuzz-test
-    containers:
-    - image: gcr.io/k8s-testimages/clusterfuzzlite:v20230206-c0c00fd127
-      command:
-        - runner.sh
-      args:
-        - python3
-        - "/opt/oss-fuzz/infra/cifuzz/cifuzz_combined_entrypoint.py"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      env:
-      - name: MODE
-        value: batch
-      - name: REPO_NAME
-        value: test-infra
-      - name: SANITIZER
-        value: 'address'
-      - name: CLOUD_BUCKET
-        value: gs://prow-cifuzz-test/
-      - name: CFL_PLATFORM
-        value: prow
-      - name: LANGUAGE
-        value: go
-  annotations:
-    testgrid-dashboards: sig-testing-misc
-    testgrid-tab-name: test-infra-fuzz
-    testgrid-broken-column-threshold: '0.5'
-    description: Runs clusterfuzzlite every hour
 
 - name: test-infra-cfl-coverage-report
   labels:


### PR DESCRIPTION
This PR moves the test-infra jobs to the community owned GKE cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722
ref: https://github.com/kubernetes/test-infra/issues/31684

/cc @cblecker @wojtek-t @chases2 @dims