### PR TITLE
Refresh primary clone concurrently

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -131,7 +131,11 @@ type RepoOpts struct {
 	// tree, recursively.
 	SparseCheckoutDirs []string
 	// This is the `--share` flag to `git clone`. For cloning from a local
-	// source, it allows bypassing the copying of all objects.
+	// source, it allows bypassing the copying of all objects. If this is true,
+	// you must also set FetchCommits to a non-empty value; otherwise, when the
+	// primary is updated with RemoteUpdate() the `--prune` flag may end up
+	// deleting objects in the primary (which could adversely affect the
+	// secondary).
 	ShareObjectsWithSourceRepo bool
 	// FetchCommits list only those commit SHAs which are needed. If the commit
 	// already exists, it is not fetched to save network costs. If FetchCommits
@@ -357,6 +361,10 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 // org and repo are used for determining where the repo is cloned, cloneURI
 // overrides org/repo for cloning.
 func (c *clientFactory) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpts) (RepoClient, error) {
+	if repoOpts.ShareObjectsWithSourceRepo && repoOpts.FetchCommits.Len() == 0 {
+		return nil, fmt.Errorf("programmer error: cannot share objects between primary and secondary without targeted fetches (FetchCommits)")
+	}
+
 	cacheDir := path.Join(c.cacheDir, org, repo)
 	c.logger.WithFields(logrus.Fields{"org": org, "repo": repo, "dir": cacheDir}).Debug("Creating a client from the cache.")
 	cacheClientCacher, _, _, err := c.bootstrapClients(org, repo, cacheDir)
@@ -376,7 +384,7 @@ func (c *clientFactory) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpt
 
 	// First create or update the primary clone (in "cacheDir").
 	timeBeforeEnsureFreshPrimary := time.Now()
-	c.ensureFreshPrimary(cacheDir, cacheClientCacher, repoOpts)
+	c.ensureFreshPrimary(cacheDir, cacheClientCacher, repoOpts, org, repo)
 	gitMetrics.ensureFreshPrimaryDuration.WithLabelValues(org, repo).Observe((float64(time.Since(timeBeforeEnsureFreshPrimary).Seconds())))
 
 	// Initialize the new derivative repo (secondary clone) from the primary
@@ -387,30 +395,46 @@ func (c *clientFactory) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpt
 	}
 	gitMetrics.secondaryCloneDuration.WithLabelValues(org, repo).Observe((float64(time.Since(timeBeforeSecondaryClone).Seconds())))
 
-	// Here we do a targeted fetch, if the repoOpts for the secondary clone
-	// asked for it.
-	//
-	// TODO(listx): Change ensureCommits() so that it takes a "cacher" interface
-	// instead of a generic RepoClient. However, if ShareObjectsWithSourceRepo
-	// was not set, then we cannot run ensureCommits() with the cacher because
-	// the cacher will run on the primary, not secondary (and without --shared,
-	// this will have no effect on the secondary); we have to handle that case
-	// gracefully (perhaps with some logging also).
+	return repoClient, nil
+}
+
+func (c *clientFactory) ensureFreshPrimary(
+	cacheDir string,
+	cacheClientCacher cacher,
+	repoOpts RepoOpts,
+	org string,
+	repo string,
+) error {
+	if err := c.maybeCloneAndUpdatePrimary(cacheDir, cacheClientCacher, repoOpts); err != nil {
+		return err
+	}
+	// For targeted fetches by SHA objects, there's no need to hold a lock on
+	// the primary because it's safe to do so (git will first write to a
+	// temporary file and replace the file being written to, so if another git
+	// process already wrote to it, the worst case is that it will overwrite the
+	// file with the same data).  Targeted fetch. Only fetch those commits which
+	// we want, and only if they are missing.
 	if repoOpts.FetchCommits.Len() > 0 {
-		// Targeted fetch. Only fetch those commits which we want, and only
-		// if they are missing.
+		// Targeted fetch. Only fetch those commits which we want, and only if
+		// they are missing.
 		timeBeforeFetchBySha := time.Now()
-		if err := repoClientCloner.FetchCommits(repoOpts.NoFetchTags, repoOpts.FetchCommits.UnsortedList()); err != nil {
-			return nil, err
+		if err := cacheClientCacher.FetchCommits(repoOpts.NoFetchTags, repoOpts.FetchCommits.UnsortedList()); err != nil {
+			return err
 		}
 		gitMetrics.fetchByShaDuration.WithLabelValues(org, repo).Observe((float64(time.Since(timeBeforeFetchBySha).Seconds())))
 	}
 
-	return repoClient, nil
+	return nil
 }
 
-func (c *clientFactory) ensureFreshPrimary(cacheDir string, cacheClientCacher cacher, repoOpts RepoOpts) error {
-	// Protect access to the shared repoLocks map.
+// maybeCloneAndUpdatePrimary clones the primary if it doesn't exist yet, and
+// also runs a RemoteUpdate() against it if FetchCommits is empty. The
+// operations in this function are protected by a lock so that only one thread
+// can run at a given time for the same cacheDir (primary clone path).
+func (c *clientFactory) maybeCloneAndUpdatePrimary(cacheDir string, cacheClientCacher cacher, repoOpts RepoOpts) error {
+	// Protect access to the shared repoLocks map. The main point of all this
+	// locking is to ensure that we only try to create the primary clone (if it
+	// doesn't exist) in a serial manner.
 	var repoLock *sync.Mutex
 	c.masterLock.Lock()
 	if _, exists := c.repoLocks[cacheDir]; exists {
@@ -434,16 +458,18 @@ func (c *clientFactory) ensureFreshPrimary(cacheDir string, cacheClientCacher ca
 	} else if err != nil {
 		// something unexpected happened
 		return err
-	} else {
+	} else if repoOpts.FetchCommits.Len() == 0 {
 		// We have cloned the repo previously, but will refresh it. By default
 		// we refresh all refs with a call to `git remote update`.
 		//
 		// This is the default behavior if FetchCommits is empty or nil (i.e.,
 		// when we don't define a targeted list of commits to fetch directly).
-		if repoOpts.FetchCommits.Len() == 0 {
-			if err := cacheClientCacher.RemoteUpdate(); err != nil {
-				return err
-			}
+		//
+		// This call to RemoteUpdate() still needs to be protected by a lock
+		// because it updates possibly hundreds, if not thousands, of refs
+		// (quite literally, files in .git/refs/*).
+		if err := cacheClientCacher.RemoteUpdate(); err != nil {
+			return err
 		}
 	}
 

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -83,6 +83,8 @@ type cacher interface {
 	MirrorClone() error
 	// RemoteUpdate fetches all updates from the remote.
 	RemoteUpdate() error
+	// FetchCommits fetches only the given commits.
+	FetchCommits(bool, []string) error
 }
 
 // cloner knows how to clone repositories from a central cache
@@ -90,8 +92,6 @@ type cloner interface {
 	// Clone clones the repository from a local path.
 	Clone(from string) error
 	CloneWithRepoOpts(from string, repoOpts RepoOpts) error
-	// FetchCommits fetches only the given commits.
-	FetchCommits(bool, []string) error
 }
 
 // MergeOpt holds options for git merge operations.


### PR DESCRIPTION
That is, only lock the primary clone when we first create it (and when we check for its existence as part of the "does the primary exist" check).

This is blocked by #30294 

/cc @cjwagner @airbornepony @timwangmusic 
/hold