### PR TITLE
Revert "git v2 client: keep the primary clone up to date"

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -146,10 +146,6 @@ func prowYAMLGetter(
 	// change was a fast-forward merge. So we need to dedupe it with sets.
 	repoOpts.FetchCommits = sets.New(baseSHA)
 	repoOpts.FetchCommits.Insert(headSHAs...)
-	// Only update the primary with the baseSHA, because it may be that the
-	// headSHAs never get merged into the base (perhaps the PR gets rejected or
-	// abandoned).
-	repoOpts.PrimaryCloneUpdateCommits = sets.New(baseSHA)
 	repo, err := gc.ClientForWithRepoOpts(orgRepo.Org, orgRepo.Repo, repoOpts)
 	inrepoconfigMetrics.gitCloneDuration.WithLabelValues(orgRepo.Org, orgRepo.Repo).Observe((float64(time.Since(timeBeforeClone).Seconds())))
 	if err != nil {

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -101,12 +101,6 @@ type RepoOpts struct {
 	// NoFetchTags determines whether we disable fetching tag objects). Defaults
 	// to false (tag objects are fetched).
 	NoFetchTags bool
-	// PrimaryCloneUpdateCommits are any additional SHAs we need to fetch into
-	// the primary clone to bring it up to speed. This should at least be the
-	// current base branch SHA. Needed when we're using shared objects because
-	// otherwise the primary will slowly get stale with no updates to it after
-	// its initial creation.
-	PrimaryCloneUpdateCommits sets.Set[string]
 }
 
 // Apply allows to use a ClientFactoryOpts as Opt
@@ -398,10 +392,6 @@ func (c *clientFactory) ensureFreshPrimary(cacheDir string, cacheClientCacher ca
 		// when we don't define a targeted list of commits to fetch directly).
 		if repoOpts.FetchCommits.Len() == 0 {
 			if err := cacheClientCacher.RemoteUpdate(); err != nil {
-				return err
-			}
-		} else if repoOpts.PrimaryCloneUpdateCommits.Len() > 0 {
-			if err := cacheClientCacher.FetchCommits(repoOpts.NoFetchTags, repoOpts.PrimaryCloneUpdateCommits.UnsortedList()); err != nil {
 				return err
 			}
 		}

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -80,8 +80,6 @@ type cacher interface {
 	MirrorClone() error
 	// RemoteUpdate fetches all updates from the remote.
 	RemoteUpdate() error
-	// FetchCommits fetches only the given commits.
-	FetchCommits(bool, []string) error
 }
 
 // cloner knows how to clone repositories from a central cache


### PR DESCRIPTION
This reverts commit e46df0a581d22545f3c77e3106594ab328f71f2a.

We've thought of ways to make this faster. The main issue with this is that we block secondary clones from happening while the primary fetches the base SHA. Also, for presubmits, we still have to do a second fetch of the headSHA anyway, so this technically slows things down.

Revert for now while we explore better options.

/cc @cjwagner @airbornepony @timwangmusic 