### PR TITLE
node e2e: fix CPUManager related jobs.

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -478,7 +478,7 @@ periodics:
           - --
           - --deployment=node
           - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-multi-numa.yaml
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -613,7 +613,7 @@ presubmits:
             - --
             - --deployment=node
             - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
             - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
             - --node-tests=true
             - --provider=gce
@@ -676,7 +676,7 @@ presubmits:
         - --parallelism=1
         - --focus-regex=\[Feature:CPUManager\]
         - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
   - name: pull-kubernetes-node-kubelet-serial-topology-manager
     cluster: k8s-infra-prow-build
     always_run: false

--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -8,12 +8,12 @@ images:
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
     image_regex: ".*[^-cgroupsv1]$"
-    # Using `n1-standard-4` to enable CPU manager node e2e tests.
-    machine: n1-standard-4
+    # Using `n2d-standard-32` that has 2 numa nodes to enable resource managers node e2e tests.
+    machine: n2d-standard-32
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable1:
     image_family: cos-stable
     project: cos-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
-    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    # Using `n1-standard-4` to enable resource managers node e2e tests.
     machine: n1-standard-4


### PR DESCRIPTION
This PR fixes failing/not working jobs of CPU manager:
- ci-kubernetes-node-kubelet-serial-cpu-manager
- pull-kubernetes-node-kubelet-serial-cpu-manager
- pull-kubernetes-node-kubelet-serial-cpu-manager-kubetest2
- kubernetes-node-kubelet-containerd-resource-managers

Changes:
- Use n2d-standard-32 to test complicated NUMA-related options of CPUManager.