### PR TITLE
🐛 Add missing perf-tests extra_refs for the aws/kops/500-node periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -16,6 +16,10 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
     repo: kops
     base_ref: master
     path_alias: k8s.io/kops


### PR DESCRIPTION
```
F0828 22:51:39.943563    6334 cl2.go:135] failed to run clusterloader2 tester: chdir /home/prow/go/src/k8s.io/perf-tests/clusterloader2: no such file or directory
Error: exit status 255
```