### PR TITLE
migrate `kubeadm` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
 
   # kinder presubmits
   - name: pull-kubeadm-kinder-verify
+    cluster: eks-prow-build-cluster
     path_alias: "k8s.io/kubeadm"
     decorate: true
     run_if_changed: '^kinder\/.*$'
@@ -12,8 +13,16 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         command:
         - "./kinder/hack/verify-all.sh"
+        resources:
+          limits:
+            cpu: 2
+            memory: 9Gi
+          requests:
+            cpu: 2
+            memory: 9Gi
 
   - name: pull-kubeadm-kinder-upgrade-latest
+    cluster: eks-prow-build-cluster
     optional: false
     decorate: true
     run_if_changed: '^kinder\/.*$'
@@ -40,29 +49,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 2
+            memory: 9Gi
           requests:
-            memory: "9000Mi"
-            cpu: 2000m
-
-  # operator presubmits
-  - name: pull-kubeadm-operator-verify
-    path_alias: "k8s.io/kubeadm"
-    decorate: true
-    run_if_changed: '^operator\/.*$'
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-        command:
-        - runner.sh
-        - "./operator/hack/verify-all.sh"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9000Mi"
-            cpu: 2000m
+            cpu: 2
+            memory: 9Gi
 
   # kinder canary presubmits
   - name: pull-kubeadm-kinder-verify-canary
@@ -115,37 +107,6 @@ presubmits:
         - "../kubeadm/kinder/ci/kinder-run.sh"
         args:
         - "presubmit-upgrade-latest"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9000Mi"
-            cpu: 2000m
-          limits:
-            cpu: 2000m
-            memory: 9000Mi
-      tolerations:
-      - key: "dedicated"
-        value: "kind-tests"
-        operator: "Equal"
-        effect: "NoSchedule"
-      nodeSelector:
-        kind-exclusive: "true"
-
-  # operator canary presubmits
-  - name: pull-kubeadm-operator-verify-canary
-    cluster: eks-prow-build-cluster
-    path_alias: "k8s.io/kubeadm"
-    decorate: true
-    run_if_changed: '^operator\/.*$'
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-        command:
-        - runner.sh
-        - "./operator/hack/verify-all.sh"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
This PR moves the kubeadm jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @fabriziopandini @neolit123 @SataQiu @pacoxu @RA489