### PR TITLE
migrate `krm-functions-registry` job to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/krm-functions-registry/krm-functions-registry-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/krm-functions-registry/krm-functions-registry-presubmits-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/krm-functions-registry:
   - name: pull-krm-functions-registry-test-master
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     labels:
@@ -22,8 +23,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: "4000m"
+            cpu: 4
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: krm-functions-registry-presubmit-master


### PR DESCRIPTION
This PR moves the krm-functions-registry jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @jeremyrickard @KnVerey @mengqiy