### PR TITLE
migrate `kube-storage-version-migrator` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -119,10 +119,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: 9Gi
+            memory: 6Gi
             cpu: 2
           limits:
-            memory: 9Gi
+            memory: 6Gi
             cpu: 2
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-storage-version-migrator:
   - name: pull-kube-storage-version-migrator-test
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
     spec:
@@ -9,6 +10,13 @@ presubmits:
         command:
         - make
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
@@ -79,6 +87,7 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-fully-automated
   - name: pull-kube-storage-version-migrator-ha-master
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/kube-storage-version-migrator"
     decorate: true
     decoration_config:
@@ -110,8 +119,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "9000Mi"
-            cpu: 2000m
+            memory: 9Gi
+            cpu: 2
+          limits:
+            memory: 9Gi
+            cpu: 2
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-ha-master


### PR DESCRIPTION
This PR moves the kube-storage-version-migrator jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @caesarxuchao @deads2k @lavalamp