### PR TITLE
CAPK: require some checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -523,6 +523,13 @@ branch-protection:
           required_status_checks:
             contexts:
             - lint
+        cluster-api-provider-kubevirt:
+          required_status_checks:
+            contexts:
+            - unit_test
+            - integration
+            - go-linter
+            - check-gen
         cluster-api-provider-vsphere:
           required_status_checks:
             contexts:
@@ -816,6 +823,8 @@ tide:
         - "cla/linuxfoundation"
         repos:
           cluster-api:
+            from-branch-protection: true
+          cluster-api-provider-kubevirt:
             from-branch-protection: true
           cluster-api-provider-vsphere:
             from-branch-protection: true


### PR DESCRIPTION
cluster-api-provider-kubevirt repo uses several github actions. But these actions (e.g. unit test, lint and so on) are not gate for PR merges. This fact cause external contributors' PRs to sometimes get merged with no verification.

This PR requires the unit tests, the linter, the check-gen and the e2e-integration action to pass before merging a PR into the main branch.