### PR TITLE
fix ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master being in wrong directory

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -191,6 +191,7 @@ periodics:
           export TEST_PACKAGE_VERSION="v1.25.0";
           echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
         fi;
+        cd $GOPATH/src/k8s.io/cloud-provider-gcp;
         e2e/add-kubernetes-to-workspace.sh;
         kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --ginkgo.flakeAttempts=3' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 - interval: 3h


### PR DESCRIPTION
Recent failure: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master/1696868545398312960/build-log.txt 

This job is failing due to being in the wrong directory when running e2e/add-kubernetes-to-workspace.sh
```
+ e2e/add-kubernetes-to-workspace.sh
/bin/bash: line 1: e2e/add-kubernetes-to-workspace.sh: No such file or directory
```