### PR TITLE
Updating sig cloud provider leads and chairs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -50,7 +50,10 @@ aliases:
     - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
+    - bridgetkromhout
     - cheftako
+    - elmiko
+    - nckturner
   sig-cluster-lifecycle-leads:
     - fabriziopandini
     - justinsb


### PR DESCRIPTION
Update to match https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES#L28-L33.