### PR TITLE
Fix CAPK required test name

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -526,7 +526,7 @@ branch-protection:
         cluster-api-provider-kubevirt:
           required_status_checks:
             contexts:
-            - unit_test
+            - "unit_test (ubuntu-latest)"
             - integration
             - go-linter
             - check-gen


### PR DESCRIPTION
Since the unit test in the cluster-api-provider-kubevirt is running with github action matrix, the existing `unit_test` name for the required test is wrong, and should be `unit_test (ubuntu-latest)`.

This PR fixes issue caused by #30564 