### PR TITLE
Bump ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2 to 1000 nodes

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -54,7 +54,7 @@ periodics:
       - name: CNI_PLUGIN
         value: "amazonvpc"
       - name: KUBE_NODE_COUNT
-        value: "500"
+        value: "1000"
       - name: RUN_CL2_TEST
         value: "true"
       - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD


### PR DESCRIPTION
presubmit ( https://testgrid.k8s.io/sig-cluster-lifecycle-kops#presubmit-kops-aws-scale-amazonvpc-using-cl2 ) hit at least one 🟢 run.

So let's bump the CI job as well.