### PR TITLE
Add more metrics and increase bucket granularity

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -79,7 +79,7 @@ var gerritMetrics = struct {
 	triggerLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_trigger_latency",
 		Help:    "Histogram of seconds between triggering event and ProwJob creation time.",
-		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 600, 1200},
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 450, 600, 750, 900, 1050, 1200},
 	}, []string{
 		"org",
 		// We would normally omit 'repo' to avoid excessive cardinality due to the number of buckets, but we need the data.
@@ -89,14 +89,14 @@ var gerritMetrics = struct {
 	triggerHelpLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_trigger_help_latency",
 		Help:    "Histogram of seconds between triggering event (help) and ProwJob creation time.",
-		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 60, 120, 180, 300, 600, 1200},
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 60, 120, 180, 300, 450, 600, 750, 900, 1050, 1200},
 	}, []string{
 		"org",
 	}),
 	processSingleChangeDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_process_single_change_duration",
 		Help:    "Histogram of seconds spent processing a single gerrit change, by instance and repo.",
-		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 600},
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 450, 600},
 	}, []string{
 		"org",
 		"repo",
@@ -104,14 +104,14 @@ var gerritMetrics = struct {
 	changeProcessDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_instance_process_duration",
 		Help:    "Histogram of seconds spent processing changes, by instance and repo. This measures the portion of a sync after we've queried for changes.",
-		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 600, 1200},
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 450, 600, 750, 900, 1050, 1200},
 	}, []string{
 		"org", "repo",
 	}),
 	changeSyncDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_instance_change_sync_duration",
 		Help:    "Histogram of seconds spent syncing changes from a single gerrit instance or repo. Includes gerrit_repo_query_duration and gerrit_instance_process_duration.",
-		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 600, 1200},
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 450, 600, 750, 900, 1050, 1200},
 	}, []string{"org", "repo"}),
 	gerritRepoQueryDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gerrit_repo_query_duration",

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -23,11 +23,29 @@ import (
 	"path"
 	"runtime"
 	"sync"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
 )
+
+var gitMetrics = struct {
+	fetchByShaDuration *prometheus.HistogramVec
+}{
+	fetchByShaDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "git_fetch_by_sha_duration",
+		Help:    "Histogram of seconds spent fetching commit SHAs, by org and repo.",
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120, 180, 300, 450, 600, 750, 900, 1050, 1200},
+	}, []string{
+		"org", "repo",
+	}),
+}
+
+func init() {
+	prometheus.MustRegister(gitMetrics.fetchByShaDuration)
+}
 
 // ClientFactory knows how to create clientFactory for repos
 type ClientFactory interface {
@@ -351,9 +369,11 @@ func (c *clientFactory) ClientForWithRepoOpts(org, repo string, repoOpts RepoOpt
 	if repoOpts.FetchCommits.Len() > 0 {
 		// Targeted fetch. Only fetch those commits which we want, and only
 		// if they are missing.
+		timeBeforeFetchBySha := time.Now()
 		if err := repoClientCloner.FetchCommits(repoOpts.NoFetchTags, repoOpts.FetchCommits.UnsortedList()); err != nil {
 			return nil, err
 		}
+		gitMetrics.fetchByShaDuration.WithLabelValues(org, repo).Observe((float64(time.Since(timeBeforeFetchBySha).Seconds())))
 	}
 
 	return repoClient, nil


### PR DESCRIPTION
Add some more metrics to measure latencies. The git client metrics give more granularity for the git client acquisition metric we already have in the gerrit adapter. The `jobCreationDuration` metric measures the amount of latency we experience for calling into the K8s API server in the Prow service cluster to create the ProwJob custom resource.

If it turns out that there is some non-negligible cost to creating the ProwJob resource, we should consider batching up the job objects together to create a single batched request (a single request to the K8s API server with a larger payload).

This PR also adds more buckets to increase their granularity for some of the existing metrics.

/cc @cjwagner @airbornepony @timwangmusic 