### PR TITLE
Switch to go 1.21 for release-sdk jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -67,7 +67,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
PTAL @cpanato, this would be required for https://github.com/kubernetes-sigs/release-sdk/pull/243