### PR TITLE
use go1.21 for release-utils jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
xref: https://github.com/kubernetes-sigs/release-utils/pull/93


/assign @saschagrunert @xmudrii @Verolop @ameukam 
cc @kubernetes/release-engineering 