### PR TITLE
use go1.21 for mdtoc jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/mdtoc
+    cluster: eks-prow-build-cluster
     spec:
       containers:
       - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
@@ -11,6 +12,13 @@ presubmits:
         command:
         - make
         - test
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: mdtoc-test
@@ -20,6 +28,7 @@ presubmits:
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/mdtoc
+    cluster: eks-prow-build-cluster
     spec:
       containers:
       - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
@@ -27,6 +36,13 @@ presubmits:
         command:
         - make
         - verify
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: mdtoc-verify

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
also use the eks prow cluster to run the tests


xref: https://github.com/kubernetes-sigs/mdtoc/pull/18

/assign @saschagrunert @xmudrii @ameukam 
cc @kubernetes/release-engineering 