### PR TITLE
:sparkles: Update kubebuilder-presubmits.yaml to add tests against 1.28 and remove the tests against 1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -24,6 +24,41 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
+  - name: pull-kubebuilder-e2e-k8s-1-28-0
+    cluster: eks-prow-build-cluster
+    decorate: true
+    always_run: true
+    optional: false
+    path_alias: sigs.k8s.io/kubebuilder
+    branches:
+      - ^master$
+      - ^feature/plugins-.+$
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          command:
+            # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
+            - runner.sh
+            # this MUST be a relative directory with "./" or the runner will fail to find the file
+            - ./test_e2e.sh
+          env:
+            - name: KIND_K8S_VERSION
+              value: "v1.28.0"
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+            requests:
+              cpu: 4000m
+              memory: 8Gi
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: kubebuilder-e2e-1-28-0
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"    
   - name: pull-kubebuilder-e2e-k8s-1-27-1
     cluster: eks-prow-build-cluster
     decorate: true
@@ -94,38 +129,4 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-25-3
-    cluster: eks-prow-build-cluster
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-      - ^master$
-      - ^feature/plugins-.+$
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-          command:
-            # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-            - runner.sh
-            # this MUST be a relative directory with "./" or the runner will fail to find the file
-            - ./test_e2e.sh
-          env:
-            - name: KIND_K8S_VERSION
-              value: "v1.25.3"
-          resources:
-            limits:
-              cpu: 4000m
-              memory: 8Gi
-            requests:
-              cpu: 4000m
-              memory: 8Gi
-          securityContext:
-            privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-25-3
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
+ 


### PR DESCRIPTION
## Description

We need to start to test the project against 1.28 now that it is supported on it.