### PR TITLE
config/prow add new external secret for CAPV

### DIFF
--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -66,6 +66,55 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: cluster-api-provider-vsphere-ci
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: cluster-api-provider-vsphere
+  data:
+  - key: capv-gcs-keyfile_json
+    name: capv-gcs-keyfile.json
+    version: latest
+  - key: vmc-capv-services_kubeconfig
+    name: vmc-capv-services.kubeconfig
+    version: latest
+  - key: vmc-e2e-vm-ssh_key
+    name: vmc-e2e-vm-ssh.key
+    version: latest
+  - key: vmc-e2e-vm-ssh_pubkey
+    name: vmc-e2e-vm-ssh.pubkey
+    version: latest
+  - key: vmc-vcenter-password
+    name: vmc-vcenter-password
+    version: latest
+  - key: vmc-vcenter-thumbprint
+    name: vmc-vcenter-thumbprint
+    version: latest
+  - key: vmc-vcenter-url
+    name: vmc-vcenter-url
+    version: latest
+  - key: vmc-vcenter-user
+    name: vmc-vcenter-user
+    version: latest
+  - key: vmc-vpn-ca_crt
+    name: vmc-vpn-ca.crt
+    version: latest
+  - key: vmc-vpn-client_crt
+    name: vmc-vpn-client.crt
+    version: latest
+  - key: vmc-vpn-client_key
+    name: vmc-vpn-client.key
+    version: latest
+  - key: vmc-vpn-config_ovpn
+    name: vmc-vpn-config.ovpn
+    version: latest
+  - key: vmc-vpn-tls_key
+    name: vmc-vpn-tls.key
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: capv-ipam-kubeconfig
   namespace: test-pods
 spec:


### PR DESCRIPTION
Adds a new external secret to consolidate all used secrets we have for cluster-api-provider-vsphere CI.

After merging this we will make use of them in `config/jobs/kubernetes-sigs/cluster-api-provider-vsphere`.

After making use of them we will be able to remove the old ExternalSecrets `capv-ipam-kubeconfig` and `capv-ci-overrides`.