### PR TITLE
Add govulncheck presubmit to expose go vulnerabilities in a PR

### DIFF
--- a/config/jobs/kubernetes/sig-security/govulncheck-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-security/govulncheck-presubmit.yaml
@@ -6,11 +6,6 @@ presubmits:
     decoration_config:
       timeout: 5m
     path_alias: k8s.io/kubernetes
-    extra_refs:
-      - org: kubernetes
-        repo: sig-security
-        base_ref: main
-        workdir: true
     always_run: false
     optional: true
     run_if_changed: '^(go.mod|go.sum|vendor)'
@@ -22,8 +17,7 @@ presubmits:
         args:
         - -c
         - |
-          cd ../kubernetes
-          ../sig-security/sig-security-tooling/govulncheck/hack/govulncheck-presubmit.sh
+          ./hack/verify-govulncheck.sh
         resources:
           limits:
             cpu: 2

--- a/config/jobs/kubernetes/sig-security/govulncheck-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-security/govulncheck-presubmit.yaml
@@ -1,0 +1,37 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: check-govulncheck-results
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 5m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+      - org: kubernetes
+        repo: sig-security
+        base_ref: main
+        workdir: true
+    always_run: false
+    optional: true
+    run_if_changed: '^(go.mod|go.sum|vendor)'
+    spec:
+      containers:
+      - image: golang
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          cd ../kubernetes
+          ../sig-security/sig-security-tooling/govulncheck/hack/govulncheck-presubmit.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
+    annotations:
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: sig-security-govulncheck-presubmit
+      description: Runs `govulncheck` for PRs related to go module changes

--- a/config/testgrids/kubernetes/sig-security/config.yaml
+++ b/config/testgrids/kubernetes/sig-security/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
   - sig-security-cvelist-public
   - sig-security-snyk-scan
   - sig-security-cve-feed
+  - sig-security-govulncheck-presubmit
 
 # Dashboards
 #
@@ -13,3 +14,4 @@ dashboards:
 - name: sig-security-cvelist-public
 - name: sig-security-snyk-scan
 - name: sig-security-cve-feed
+- name: sig-security-govulncheck-presubmit


### PR DESCRIPTION
This PR will add a govulncheck presubmit to check for go vulnerabilities when a PR  is opened for go module changes. It will trigger the script from ~~`sig-security/sig-security-tooling/govulncheck/hack/govulncheck-presubmit.sh`~~ `kubernetes/hack/verify-govulncheck.sh`.

Fixes: https://github.com/kubernetes/sig-security/issues/99
Parent Issue: https://github.com/kubernetes/sig-security/issues/95