### PR TITLE
Consistently set cloudprovider and its flags in various jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -23,7 +23,8 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,InTreePluginGCEUnregister=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,InTreePluginGCEUnregister=false
+      - --env=CLOUD_PROVIDER_FLAG=gce
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -251,7 +252,8 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,InTreePluginGCEUnregister=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,InTreePluginGCEUnregister=false
+      - --env=CLOUD_PROVIDER_FLAG=gce
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -466,7 +468,8 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,InTreePluginGCEUnregister=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,InTreePluginGCEUnregister=false
+      - --env=CLOUD_PROVIDER_FLAG=gce
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -722,7 +725,8 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,InTreePluginGCEUnregister=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,InTreePluginGCEUnregister=false
+      - --env=CLOUD_PROVIDER_FLAG=gce
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -235,6 +235,7 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+            - --env=CLOUD_PROVIDER_FLAG=gce
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.5
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.9
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
@@ -352,7 +353,8 @@ presubmits:
         - --ginkgo-parallel=1
         - --build=quick
         - --cluster=
-        - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+        - --env=CLOUD_PROVIDER_FLAG=gce
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
         - --env=ENABLE_APISERVER_TRACING=true
@@ -589,6 +591,7 @@ periodics:
           - --
           - --check-leaked-resources
           - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+          - --env=CLOUD_PROVIDER_FLAG=gce
           - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.5
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.9
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
@@ -638,6 +641,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,InTreePluginGCEUnregister=false
+      - --env=CLOUD_PROVIDER_FLAG=gce
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest
@@ -667,7 +671,8 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+      - --env=CLOUD_PROVIDER_FLAG=gce
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest-fast

--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -200,6 +200,7 @@ periodics:
           - --
           - --check-leaked-resources
           - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+          - --env=CLOUD_PROVIDER_FLAG=gce
           - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.5
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.9
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -710,6 +710,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+        - --env=CLOUD_PROVIDER_FLAG=gce
         - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.1
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.7
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -284,7 +284,8 @@ testSuites:
     - --timeout=180m
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,InTreePluginGCEUnregister=false
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,InTreePluginGCEUnregister=false
+    - --env=CLOUD_PROVIDER_FLAG=gce
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true


### PR DESCRIPTION
When we are setting one of DisableCloudProviders feature, DisableKubeletCloudCredentialProviders feature and the --cloud-provider flag, all 3 of them should be set.

When cloud-provider is set to "external" then the two disable flags should be set to true.

When cloud-provider is set to one of the 3 remaining in-tree cloud providers then the disable flags MUST be set to false.