### PR TITLE
Switch ci-kubernetes-gce-conformance-latest-kubetest2 to old-style "gce" cloud provider

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -86,6 +86,8 @@ periodics:
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
         kubetest2 gce -v 2 \;
+          --cloud-provider "gce" \;
+          --feature-gates "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false" \;
           --repo-root $REPO_ROOT \;
           --legacy-mode \;
           --build \;


### PR DESCRIPTION
This CI job does not yet work with the "external" cloud provider, so let's set `gce` explicitly. 

(now that https://github.com/kubernetes-sigs/kubetest2/pull/241/ has merged!)

xref: https://github.com/kubernetes/kubernetes/issues/120367