### PR TITLE
Revert switch to old style in tree gce provider (use "external" cloud provider which is the default)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -86,8 +86,6 @@ periodics:
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
         kubetest2 gce -v 2 \;
-          --cloud-provider "gce" \;
-          --feature-gates "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false" \;
           --repo-root $REPO_ROOT \;
           --legacy-mode \;
           --build \;

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -553,8 +553,6 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
-      - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
-      - --env=CLOUD_PROVIDER_FLAG=gce
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
@@ -776,8 +774,6 @@ periodics:
       - --cluster=err-e2e
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
-      - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
-      - --env=CLOUD_PROVIDER_FLAG=gce
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -38,8 +38,6 @@ periodics:
       - --env=KUBE_NODE_OS_DISTRIBUTION=gci
       - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
       - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
-      - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
-      - --env=CLOUD_PROVIDER_FLAG=gce
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -436,8 +436,6 @@ periodics:
       - --check-leaked-resources
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
-      - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
-      - --env=CLOUD_PROVIDER_FLAG=gce
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -198,8 +198,6 @@ periodics:
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
-      - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
-      - --env=CLOUD_PROVIDER_FLAG=gce
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -101,8 +101,6 @@ periodics:
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
-      - --env=KUBE_FEATURE_GATES=DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
-      - --env=CLOUD_PROVIDER_FLAG=gce
       - --gcp-nodes=5000
       - --gcp-project-type=scalability-scale-project
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
We had temporarily done this when we saw failures in a bunch of jobs including:
https://github.com/kubernetes/kubernetes/issues/120367

@aojea has tracked down the issue and a PR has merged:
https://github.com/kubernetes/kubernetes/pull/120389

So we should be good to roll these back.