### PR TITLE
CAPV: move v1.6 release jobs to new preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -80,8 +80,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-full-release-1-6
   labels:
     preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
     preset-kind-volume-mounts: "true"
   interval: 24h
   decorate: true
@@ -123,8 +123,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-conformance-release-1-6
   labels:
     preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
     preset-kind-volume-mounts: "true"
   interval: 24h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -1,0 +1,83 @@
+presets:
+- labels:
+    preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+  env:
+  - name: GOVC_URL
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-url
+  - name: GOVC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-user
+  - name: GOVC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-password
+  - name: VSPHERE_TLS_THUMBPRINT
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-thumbprint
+  - name: VM_SSH_PUB_KEY
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-e2e-vm-ssh.pubkey
+  volumeMounts:
+  - name: vmc-e2e-vm-ssh-key
+    mountPath: /root/ssh/.private-key
+  - name: vmc-vpn
+    mountPath: /root/.openvpn
+  - name: vmc-capv-services-kubeconfig
+    mountPath: /root/ipam-conf
+  volumes:
+  - name: vmc-e2e-vm-ssh-key
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-e2e-vm-ssh.key
+        path: private-key
+  - name: vmc-vpn
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-vpn-config.ovpn
+        path: prow.ovpn
+      - key: vmc-vpn-client.crt
+        path: client.crt
+      - key: vmc-vpn-client.key
+        path: client.key
+      - key: vmc-vpn-ca.crt
+        path: ca.crt
+      - key: vmc-vpn-tls.key
+        path: tls.key
+  - name: vmc-capv-services-kubeconfig
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-capv-services.kubeconfig
+        path: capv-services.conf
+- labels:
+    preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+  env:
+  - name: GCR_KEY_FILE
+    value: /root/.capv/keyfile.json
+  volumeMounts:
+  - name: capv-gcs-keyfile
+    mountPath: /root/.capv
+    readOnly: true
+  volumes:
+  - name: capv-gcs-keyfile
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      items:
+      - key: capv-gcs-keyfile.json
+        path: keyfile.json
+        mode: 288

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -131,8 +131,8 @@ presubmits:
     - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -169,8 +169,8 @@ presubmits:
     - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -205,8 +205,8 @@ presubmits:
     - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true


### PR DESCRIPTION
This PR configures the new presets on the v1.6 release branch.

If this works we will revert the release-1.6 changes, remove the old presets and rename the new presets (remove the `-test` suffix)