### PR TITLE
Update `krte` to use debian:bookworm

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -16,7 +16,7 @@
 # NOTE: we attempt to avoid unnecessary tools and image layers while
 # supporting kubernetes builds, kind installation, etc.
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 # arg that specifies the image name (for debugging)
 ARG IMAGE_ARG
@@ -87,10 +87,11 @@ RUN echo "Installing Packages ..." \
             --usage-reporting=false \
         && gcloud components install kubectl \
     && echo "Installing Docker ..." \
-        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - \
-        && add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
-            $(lsb_release -cs) stable" \
+        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+        && chmod a+r /etc/apt/keyrings/docker.gpg \
+        && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+            tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
         && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
         && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
We require bookworm if we want to sucessfully test kubernetes with the bookworm based golang images in https://github.com/kubernetes/kubernetes/pull/118996

cc @kubernetes/release-managers 