### PR TITLE
[RFC][WIP] prow/plugins: add a warn-owners-aliases plugin

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -72,7 +72,7 @@ type githubClient interface {
 }
 
 type ownersClient interface {
-	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error)
+	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error)
 }
 
 type state struct {

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1372,7 +1372,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 type fakeOwnersClient struct{}
 
-func (foc fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (foc fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return fakeRepoOwners{}, nil
 }
 
@@ -1410,6 +1410,10 @@ func (fro fakeRepoOwners) Reviewers(path string) layeredsets.String {
 
 func (fro fakeRepoOwners) RequiredReviewers(path string) sets.Set[string] {
 	return sets.New[string]()
+}
+
+func (fro fakeRepoOwners) OwnersAliases() repoowners.RepoAliases {
+	return make(repoowners.RepoAliases)
 }
 
 func TestHandleGenericComment(t *testing.T) {

--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -129,7 +129,7 @@ type githubClient interface {
 }
 
 type repoownersClient interface {
-	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error)
+	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error)
 }
 
 func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -101,7 +101,7 @@ type fakeRepoownersClient struct {
 	foc *fakeOwnersClient
 }
 
-func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return froc.foc, nil
 }
 
@@ -207,6 +207,10 @@ func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig
 
 func (foc *fakeOwnersClient) TopLevelApprovers() sets.Set[string] {
 	return sets.Set[string]{}
+}
+
+func (foc *fakeOwnersClient) OwnersAliases() repoowners.RepoAliases {
+	return make(repoowners.RepoAliases)
 }
 
 var (

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -45,13 +45,13 @@ type fakeOwnersClient struct {
 	reviewers map[string]layeredsets.String
 }
 
-func (f *fakeOwnersClient) LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwner, error) {
+func (f *fakeOwnersClient) LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwnerWithAliases, error) {
 	return &fakeRepoOwners{approvers: f.approvers, reviewers: f.reviewers}, nil
 }
 
 var _ repoowners.Interface = &fakeOwnersClient{}
 
-func (f *fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (f *fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return &fakeRepoOwners{approvers: f.approvers, reviewers: f.reviewers}, nil
 }
 
@@ -91,6 +91,10 @@ func (f *fakeRepoOwners) AllReviewers() sets.Set[string] {
 
 func (f *fakeRepoOwners) Filenames() ownersconfig.Filenames {
 	return ownersconfig.FakeFilenames
+}
+
+func (f *fakeRepoOwners) OwnersAliases() repoowners.RepoAliases {
+	return make(repoowners.RepoAliases)
 }
 
 type fakePruner struct {

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -70,7 +70,7 @@ type prowJobClient interface {
 }
 
 type ownersClient interface {
-	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error)
+	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error)
 }
 
 type overrideClient interface {
@@ -153,7 +153,7 @@ func presubmitForContext(presubmits []config.Presubmit, context string) *config.
 	return nil
 }
 
-func (c client) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (c client) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return c.ownersClient.LoadRepoOwners(org, repo, base)
 }
 

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -52,7 +52,7 @@ type fakeRepoownersClient struct {
 	foc *fakeOwnersClient
 }
 
-func (froc *fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (froc *fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return froc.foc, nil
 }
 
@@ -126,6 +126,10 @@ func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleCo
 
 func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig, error) {
 	return repoowners.FullConfig{}, nil
+}
+
+func (foc *fakeOwnersClient) OwnersAliases() repoowners.RepoAliases {
+	return make(repoowners.RepoAliases)
 }
 
 type fakeClient struct {
@@ -317,7 +321,7 @@ func (c *fakeClient) Create(_ context.Context, pj *prowapi.ProwJob, _ metav1.Cre
 	return pj, nil
 }
 
-func (c *fakeClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (c *fakeClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return c.owners.LoadRepoOwners(org, repo, base)
 }
 

--- a/prow/plugins/reward-owners/reward-owners.go
+++ b/prow/plugins/reward-owners/reward-owners.go
@@ -67,7 +67,7 @@ type githubClient interface {
 }
 
 type ownersClient interface {
-	LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwner, error)
+	LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwnerWithAliases, error)
 }
 
 type info struct {

--- a/prow/plugins/reward-owners/reward-owners_test.go
+++ b/prow/plugins/reward-owners/reward-owners_test.go
@@ -34,7 +34,7 @@ import (
 
 type fakeOwnersClient struct{}
 
-func (f *fakeOwnersClient) LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwner, error) {
+func (f *fakeOwnersClient) LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwnerWithAliases, error) {
 	return &fakeRepoOwners{sha: sha}, nil
 }
 
@@ -72,6 +72,8 @@ func (f *fakeRepoOwners) AllOwners() sets.Set[string] {
 func (f *fakeRepoOwners) AllReviewers() sets.Set[string] {
 	return ownersBySha[f.sha]
 }
+
+func (f *fakeRepoOwners) OwnersAliases() repoowners.RepoAliases { return nil }
 
 var ownersBySha = map[string]sets.Set[string]{
 	"base":         sets.New[string]("alice", "bob"),

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -103,7 +103,7 @@ type ownersClient interface {
 }
 
 type repoownersClient interface {
-	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error)
+	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error)
 }
 
 type githubClient interface {

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -204,7 +204,7 @@ type fakeRepoownersClient struct {
 	foc *fakeOwnersClient
 }
 
-func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwnerWithAliases, error) {
 	return froc.foc, nil
 }
 
@@ -272,6 +272,10 @@ func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool {
 
 func (foc *fakeOwnersClient) IsAutoApproveUnownedSubfolders(path string) bool {
 	return false
+}
+
+func (foc *fakeOwnersClient) OwnersAliases() repoowners.RepoAliases {
+	return make(repoowners.RepoAliases)
 }
 
 func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {

--- a/prow/plugins/warn-owners-aliases/warn-owners-aliases.go
+++ b/prow/plugins/warn-owners-aliases/warn-owners-aliases.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package warnownersaliases
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/ownersconfig"
+	"k8s.io/test-infra/prow/repoowners"
+)
+
+const (
+	// PluginName defines this plugin's registered name.
+	PluginName = "warn-owners-aliases"
+)
+
+func init() {
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(_ *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: fmt.Sprintf("The warn-owners-aliases plugin watches %s files for modifications and comments with OWNERS files that contain the modified alias.", ownersconfig.DefaultOwnersAliasesFile),
+	}
+	return pluginHelp, nil
+}
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
+}
+
+type ownersClient interface {
+	LoadRepoOwnersSha(org, repo, base, sha string, updateCache bool) (repoowners.RepoOwnerWithAliases, error)
+}
+
+type info struct {
+	base         github.PullRequestBranch
+	head         github.PullRequestBranch
+	number       int
+	org          string
+	repo         string
+	repoFullName string
+	user         string
+}
+
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
+	// Only consider newly opened PRs
+	if pre.Action != github.PullRequestActionOpened {
+		return nil
+	}
+
+	prInfo := info{
+		base:         pre.PullRequest.Base,
+		head:         pre.PullRequest.Head,
+		number:       pre.Number,
+		org:          pre.Repo.Owner.Login,
+		repo:         pre.Repo.Name,
+		repoFullName: pre.Repo.FullName,
+		user:         pre.PullRequest.User.Login,
+	}
+
+	return handle(pc.GitHubClient, pc.OwnersClient, pc.Logger, prInfo, pc.PluginConfig.OwnersFilenames)
+}
+
+func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, info info, resolver ownersconfig.Resolver) error {
+	// Get changes.
+	changes, err := ghc.GetPullRequestChanges(info.org, info.repo, info.number)
+	if err != nil {
+		return fmt.Errorf("error getting PR changes: %w", err)
+	}
+
+	// Check if OWNERS_ALIASES has been modified.
+	var ownersAliasesModified bool
+	filenames := resolver(info.org, info.repo)
+	for _, change := range changes {
+		if change.Filename == filenames.OwnersAliases &&
+			change.Status != github.PullRequestFileRemoved {
+			ownersAliasesModified = true
+			break
+		}
+	}
+	if !ownersAliasesModified {
+		return nil
+	}
+
+	log.Debug("Resolving repository owners for base branch...")
+	baseRepo, err := oc.LoadRepoOwnersSha(info.org, info.repo, info.base.Ref, info.base.SHA, false)
+	if err != nil {
+		return err
+	}
+	// This shouldn't happen, but if the repo had no owners
+	// aliases defined, don't do anything and return.
+	if len(baseRepo.OwnersAliases()) == 0 {
+		return nil
+	}
+
+	log.Debug("Resolving repository owners for head branch...")
+	headRepo, err := oc.LoadRepoOwnersSha(info.org, info.repo, info.head.Ref, info.head.SHA, false)
+	if err != nil {
+		return err
+	}
+	// If for some reason all owners aliases were deleted as part of this PR,
+	// don't do anything and return.
+	if len(headRepo.OwnersAliases()) == 0 {
+		return nil
+	}
+
+	aliasesAddedTo := findOwnersAliasesAddedTo(baseRepo.OwnersAliases(), headRepo.OwnersAliases())
+	// if no relevant changes, don't do anything.
+	if len(aliasesAddedTo) == 0 {
+		return nil
+	}
+
+	return ghc.CreateComment(info.org, info.repo, info.number, constructComment(info.org, info.repo, info.user, aliasesAddedTo))
+}
+
+// findOwnersAliasesAddedTo finds the existing aliases that were added to
+// by comparing the lengths of the owners under each alias.
+func findOwnersAliasesAddedTo(base, head repoowners.RepoAliases) []string {
+	result := []string{}
+	for alias := range head {
+		owners, ok := base[alias]
+		if !ok { // newly added alias.
+			continue
+		}
+		// If someone was added to this already existing alias
+		// as part of this PR, return this alias.
+		if head[alias].Difference(owners).Len() > 0 {
+			result = append(result, alias)
+		}
+	}
+
+	return result
+}
+
+func constructComment(org, repo, user string, aliases []string) string {
+	const message = `@%s **warning**: this PR adds users to one or more owners aliases.
+  
+The changed aliases are present in one or more OWNERS files, please ensure that the added  
+users meet the requirements of a [reviewer/approver](https://github.com/kubernetes/community/blob/master/community-membership.md) for each of the OWNERS files this alias is present in.  
+This helps us regulate unintentional grant of reviewer/approver privileges.
+  
+The list of aliases changes and potential corresponding OWNERS files that contain this alias in this repo is as follows:
+%s`
+
+	changeList := ""
+	for _, alias := range aliases {
+		changeList += fmt.Sprintf("- %s: [OWNERS files containing alias](%s)\n", alias, getHoundLink(org, repo, alias))
+	}
+
+	return fmt.Sprintf(message, user, changeList)
+}
+
+func getHoundLink(org, repo, alias string) string {
+	return fmt.Sprintf("https://cs.k8s.io/?q=%s&i=nope&files=OWNERS$&excludeFiles=vendor&repos=%s/%s", alias, org, repo)
+}


### PR DESCRIPTION
### Commit 1

prow: extend RepoOwner functionality to return owners aliases
    
RepoOwner by itself could not be used to retrieve owner aliases even though
the information was present in the cache entries.

Extending RepoOwner into a new interface allows us to not break existing
users of the repoowners client as much as possible.

The commit also makes changes to prow plugins that use this interface.

### Commit 2 (look at this first if you want an idea of what this PR is about)

prow/plugins: add a warn-owners-aliases plugin

OWNERS_ALIASES provide a convenient way to centralise owners
configuration. However, a downside with this is that if users
are added to an alias, it isn't implausible to imagine that the
alias is part of an OWNERS file in part of a codebase that the
user might not have the requisite experience/expertise in as
keeping in line with the reviewer/approver guidelines of the
community. This runs a risk of unintentionally granting reviewer
and approval rights to a user.

This plugin checks whether a user or users have been *added* to
one or more aliases, and if so, it comments with a warning asking
the author of the PR to verify the reviewer/approver requirements
are met. The author can do so by clicking on the Hound link that is
part of the comment, which will take them to cs.k8s.io displaying
the different OWNERS files that contain this alias.

This plugin **does not** block adding users to OWNER_ALIASES at all.
It is meant to be treated as a warning, and next steps are left to
the discretion of the PR author/subproject owners.

Ref: https://github.com/kubernetes/test-infra/pull/30274#discussion_r1282115546

---

/sig testing contributor-experience
/cc @Priyankasaggu11929 @BenTheElder 
/cc @kubernetes/sig-contributor-experience-leads 