### PR TITLE
Fix kubetest2 flakes

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -36,6 +36,43 @@ presubmits:
         securityContext:
           privileged: true
 
+  - name: pull-kubetest2-gce-legacy-build-up-down
+    decorate: true
+    always_run: true
+    optional: true
+    cluster: k8s-infra-prow-build
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      repo: cloud-provider-gcp
+      path_alias: k8s.io/cloud-provider-gcp
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        command:
+        - "runner.sh"
+        args:
+        - "./kubetest2-gce/ci-tests/buildupdown-legacy.sh"
+        securityContext:
+          privileged: true
+
   - name: pull-kubetest2-gke-up-down-singlecluster
     decorate: true
     always_run: true
@@ -92,6 +129,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
+    optional: true # OOM Flaking
     path_alias: sigs.k8s.io/kubetest2
     extra_refs:
       - org: kubernetes-sigs


### PR DESCRIPTION
1. Creating a new test that runs the `kubetest2 gce` deployer in legacy mode
2. `pull-kubetest2-aws-node-e2e` is flaky till https://github.com/kubernetes/kubernetes/issues/119763 is fixed. Marking as optional till then. That test ensures that kubetest2 HEAD can spin up the EC2 tests

/cc @dims @tzneal