### PR TITLE
Increase memory for `pull-k8sio-groups-test`

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/k8sio-presubmit.yaml
@@ -22,10 +22,10 @@ presubmits:
         resources:
           limits:
             cpu: 1
-            memory: "512Mi"
+            memory: "1Gi"
           requests:
             cpu: 1
-            memory: "512Mi"
+            memory: "1Gi"
         env:
         - name: GO111MODULE
           value: "on"


### PR DESCRIPTION
The PR https://github.com/kubernetes/k8s.io/pull/5782 failed twice in a row because of:

```
golang.org/x/sys/unix: /usr/local/go/pkg/tool/linux_amd64/compile: signal: killed
vendor/golang.org/x/text/unicode/norm: /usr/local/go/pkg/tool/linux_amd64/compile: signal: killed
```

I assume increasing the memory will fix that problem since it looks like an OOM kill action.
