### PR TITLE
Add pull-kubernetes-node-e2e-containerd-1-7-dra job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2133,6 +2133,52 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+
+  - name: pull-kubernetes-node-e2e-containerd-1-7-dra
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    always_run: false
+    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    optional: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-node-kubelet-containerd-dra
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        args:
+        - --root=/go/src
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --service-account=/etc/service-account/service-account.json
+        - --timeout=90
+        - --scenario=kubernetes_e2e
+        - -- # end bootstrap args, scenario args below
+        - --deployment=node
+        - --env=KUBE_SSH_USER=core
+        - --gcp-zone=us-west1-b
+        - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --node-tests=true
+        - --provider=gce
+        - --test_args=--focus="\[Feature:DynamicResourceAllocation\]" --skip="\[Flaky\]"
+        - --timeout=65m
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
+        resources:
+          requests:
+            cpu: 4
+            memory: 6Gi
+          limits:
+            cpu: 4
+            memory: 6Gi
+
   - name: pull-kubernetes-node-e2e-containerd-serial-ec2
     skip_branches:
       - release-\d+\.\d+  # per-release image

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -171,5 +171,10 @@ dashboards:
     test_group_name: pull-kubernetes-node-e2e-crio-dra
     alert_options:
       alert_mail_to_addresses: eduard.bartosh@intel.com
+  - name: pull-node-dra-containerd-1-7
+    test_group_name: pull-kubernetes-node-e2e-containerd-1-7-dra
+    alert_options:
+      alert_mail_to_addresses: eduard.bartosh@intel.com
+
 - name: sig-node-presubmits
 - name: sig-node-image-pushes

--- a/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
@@ -1,0 +1,5 @@
+images:
+  ubuntu:
+    image_family: pipeline-1-24
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"

--- a/jobs/e2e_node/dra/init-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/init-containerd-1.7.yaml
@@ -1,0 +1,51 @@
+#cloud-config
+
+write_files:
+- content: |
+    {
+      "cniVersion": "0.2.0",
+      "name": "mynet",
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "10.22.0.0/16",
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    }
+  path: /etc/cni/net.d/10-mynet.conf
+
+runcmd:
+  - echo "This will install and configure containerd 1.7 for DRA tests"
+
+  - echo "Stopping containerd"
+  - systemctl stop containerd
+
+  - echo "Download and install CNI plugins"
+  - mkdir -p /tmp/containerd
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - mkdir -p /opt/cni/bin
+  - tar xzf /tmp/containerd/cni.tgz -C /opt/cni/bin --overwrite
+
+  - echo "Download and install Containerd 1.7"
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/containerd/containerd.tgz https://github.com/containerd/containerd/releases/download/v1.7.5/containerd-1.7.5-linux-amd64.tar.gz'
+  - tar xzf /tmp/containerd/containerd.tgz -C /usr --overwrite
+
+  - echo "Configure Containerd"
+  - mkdir -p /etc/containerd
+  - containerd config default > /etc/containerd/config.toml
+  - echo "Enabling CDI"
+  - sed -ie 's/enable_cdi = false/enable_cdi = true/' /etc/containerd/config.toml
+
+  - echo "Restarting containerd"
+  - systemctl daemon-reload
+  - systemctl restart containerd
+
+  - echo "Containerd version is:"
+  - ctr version
+
+  - echo "Configuration complete"


### PR DESCRIPTION
This job runs Node e2e Dynamic Resource tests on Containerd 1.7. Previously this was only done with CRI-O.