### PR TITLE
CPO: Make playbook changes trigger tests

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: false
     branches:
       - ^master$
-    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -80,7 +80,7 @@ presubmits:
     always_run: false
     branches:
       - ^master$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -117,7 +117,7 @@ presubmits:
     always_run: false
     branches:
       - ^master$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -147,7 +147,7 @@ presubmits:
   - name: openstack-cloud-csi-cinder-sanity-test
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^master$
@@ -174,7 +174,7 @@ presubmits:
   - name: openstack-cloud-csi-manila-sanity-test
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^master$
@@ -208,7 +208,7 @@ presubmits:
     always_run: false
     branches:
       - ^master$
-    run_if_changed: '^(pkg\/util\/|pkg\/identity\/|cmd\/k8s-keystone-auth\/|tests\/e2e\/k8s-keystone-auth\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/identity\/|cmd\/k8s-keystone-auth\/|tests\/e2e\/k8s-keystone-auth\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: openstack-cloud-csi-cinder-sanity-test-release-125
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.25$
@@ -37,7 +37,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.25$
-    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -74,7 +74,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.25$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -111,7 +111,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.25$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -141,7 +141,7 @@ presubmits:
   - name: openstack-cloud-csi-manila-sanity-test-release-125
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.25$

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.26$
-    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -47,7 +47,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.26$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -84,7 +84,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.26$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -114,7 +114,7 @@ presubmits:
   - name: openstack-cloud-csi-cinder-sanity-test-release-126
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.26$
@@ -141,7 +141,7 @@ presubmits:
   - name: openstack-cloud-csi-manila-sanity-test-release-126
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.26$

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.27$
-    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -47,7 +47,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.27$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -84,7 +84,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.27$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -114,7 +114,7 @@ presubmits:
   - name: openstack-cloud-csi-cinder-sanity-test-release-127
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.27$
@@ -141,7 +141,7 @@ presubmits:
   - name: openstack-cloud-csi-manila-sanity-test-release-127
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.27$

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.28-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.28-config.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.28$
-    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -47,7 +47,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.28$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/|manifests\/cinder-csi-plugin\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -84,7 +84,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.28$
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/e2e\/csi\/manila\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:
@@ -114,7 +114,7 @@ presubmits:
   - name: openstack-cloud-csi-cinder-sanity-test-release-128
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/sanity\/cinder\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.28$
@@ -141,7 +141,7 @@ presubmits:
   - name: openstack-cloud-csi-manila-sanity-test-release-128
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/csi\/manila\/|cmd\/manila-csi-plugin\/|tests\/sanity\/manila\/|Dockerfile|tests\/playbooks)'
     decorate: true
     branches:
       - ^release-1.28$
@@ -175,7 +175,7 @@ presubmits:
     always_run: false
     branches:
       - ^release-1.28$
-    run_if_changed: '^(pkg\/util\/|pkg\/identity\/|cmd\/k8s-keystone-auth\/|tests\/e2e\/k8s-keystone-auth\/|Dockerfile)'
+    run_if_changed: '^(pkg\/util\/|pkg\/identity\/|cmd\/k8s-keystone-auth\/|tests\/e2e\/k8s-keystone-auth\/|Dockerfile|tests\/playbooks)'
     optional: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
Playbook changes directly affect test jobs. We should make sure all of them are run on any change in the playbooks to make sure patches won't break anything.