### PR TITLE
Focus on just pod slos now

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1115,8 +1115,6 @@ def generate_presubmits_scale():
                 'CL2_LOAD_TEST_THROUGHPUT': "50",
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",
-                'CL2_ENABLE_API_AVAILABILITY_MEASUREMENT': "true",
-                'CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD': "99.5",
                 'CONTROL_PLANE_COUNT': "3",
                 'CONTROL_PLANE_SIZE': "c6g.16xlarge",
                 'KOPS_STATE_STORE' : "s3://k8s-infra-kops-scale-tests"

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -124,10 +124,6 @@ presubmits:
           value: "50"
         - name: CL2_RATE_LIMIT_POD_CREATION
           value: "false"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
         - name: CONTROL_PLANE_COUNT
           value: "3"
         - name: CONTROL_PLANE_SIZE


### PR DESCRIPTION
- looks like promethus setup is not enabled during load tests yet;  focus on just pod slos now; for apiserver we would need prom setup and scraping; we can do that incrementally.