### PR TITLE
Use unique name for the periodic scale test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -68,7 +68,7 @@ periodics:
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
-        value: "e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io"
+        value: "scale-1000.periodic.test-cncf-aws.k8s.io"
       - name: KOPS_IRSA
         value: "true"
       resources:


### PR DESCRIPTION
Cluster name must be unique.
The job is a copy of the corresponding pre-submit from the kOps repo.
https://github.com/kubernetes/test-infra/blob/0be15f17ee5cdc24b9c187201e4359679d91e6f9/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml#L140
https://github.com/kubernetes/test-infra/blob/0be15f17ee5cdc24b9c187201e4359679d91e6f9/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml#L71