### PR TITLE
Run ci-test-infra-triage more often

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -61,7 +61,7 @@ periodics:
       - --jq=/usr/bin/jq
 
 - name: ci-test-infra-triage
-  interval: 12h
+  interval: 4h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   decoration_config:


### PR DESCRIPTION
timeout is 3 hours. So let's re-run every 4 hours. So we can get fresh data on things that fail more frequently

/assign @aojea @tzneal 