### PR TITLE
remove capdo lint job in favor of gh actions and update owners file for capdo

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -2,11 +2,13 @@
 
 reviewers:
 - cpanato
-- MorrisLaw
+- gottwald
 - prksu
 - timoreimann
 approvers:
 - cpanato
-- MorrisLaw
+- gottwald
 - prksu
 - timoreimann
+emeritus_approvers:
+- MorrisLaw

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -71,31 +71,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-verify
-  - name: pull-cluster-api-provider-digitalocean-lint
-    always_run: true
-    optional: false
-    decorate: true
-    cluster: eks-prow-build-cluster
-    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
-    branches:
-    - ^main$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
-        command:
-        - make
-        args:
-        - lint
-        resources:
-          limits:
-            cpu: 4
-            memory: 4Gi
-          requests:
-            cpu: 4
-            memory: 4Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
-      testgrid-tab-name: capdo-pr-lint
   - name: pull-cluster-api-provider-digitalocean-e2e
     always_run: true
     optional: false


### PR DESCRIPTION
- remove capdo lint job in favor of gh actions 
- update owners file for capdo


xref: https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/517

/assign @gottwald @timoreimann 