### PR TITLE
Add `pr-node-kubelet-serial-containerd-sidecar-containers`

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -570,6 +570,48 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+  # TODO(gjkim42, SidecarContainers): Remove this once SidecarContainers
+  # graduates to beta.
+  - name: pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers
+    always_run: false
+    optional: true
+    skip_report: false
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-node-kubelet-serial-containerd-sidecar-containers
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - --timeout=260
+          - --root=/go/src
+          - "--upload=gs://kubernetes-jenkins/pr-logs"
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+          - '--node-test-args=--feature-gates=SidecarContainers=true --service-feature-gates=SidecarContainers=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --timeout=4h --focus="\[Serial\].*\[NodeAlphaFeature:SidecarContainers\]|\[NodeAlphaFeature:SidecarContainers\].*\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeFeature:Eviction\]"
+          - --timeout=240m
+          env:
+          - name: GOPATH
+            value: /go
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
   - name: pull-kubernetes-node-kubelet-serial-containerd-kubetest2
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-containerd-kubetest2 to run
     always_run: false


### PR DESCRIPTION
This adds `pr-node-kubelet-serial-containerd-sidecar-containers`, enabling the serial e2e-node test with SidecarContainers enabled.


/assign @SergeyKanzhelev 