### PR TITLE
ci-kubernetes-e2e-gci-gce-alpha-enabled-default using wrong k8s version

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -638,7 +638,8 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30


### PR DESCRIPTION
from logs:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1699388711948521472/build-log.txt

Snippet:
```
W0906 11:47:17.026] 2023/09/06 11:47:16 extract_k8s.go:143: rm kubernetes
W0906 11:47:17.027] 2023/09/06 11:47:17 extract_k8s.go:295: U=https://storage.googleapis.com/k8s-release-dev/ci R=v1.27.5-20+cf67dd0379b6da get-kube.sh
I0906 11:47:17.127] Downloading kubernetes release v1.27.5-20+cf67dd0379b6da
W0906 11:47:19.012] 2023/09/06 11:47:17 process.go:153: Running: ./get-kube.sh
W0906 11:47:19.013] Copying gs://k8s-release-dev/ci/v1.27.5-20+cf67dd0379b6da/kubernetes.tar.gz...
W0906 11:47:19.172] / [0 files][    0.0 B/506.7 KiB]                                                
/ [1 files][506.7 KiB/506.7 KiB]                                                
I0906 11:47:19.463]   from https://storage.googleapis.com/k8s-release-dev/ci/v1.27.5-20+cf67dd0379b6da/kubernetes.tar.gz
```

to fix the problem, use the same settings as in `ci-kubernetes-e2e-gci-gce-alpha-features` which picks up latest 1.29.xxx 
