### PR TITLE
sig-cloud-provider/gcp/gcp-gce: update FGs for gce-cos-alpha-features

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -351,7 +351,7 @@ presubmits:
         - --ginkgo-parallel=1
         - --build=quick
         - --cluster=
-        - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
         - --env=ENABLE_APISERVER_TRACING=true


### PR DESCRIPTION
The feature gates DisableCloudProviders
and DisableKubeletCloudCredentialProviders must be set to true since the api-server logs show --cloud-provider=external.

fixes https://github.com/kubernetes/kubernetes/issues/120463
(see job failure information / logs)

https://kubernetes.slack.com/archives/CCK68P2Q2/p1694010913914939?thread_ts=1694009731.169959&cid=CCK68P2Q2

https://groups.google.com/a/kubernetes.io/g/dev/c/VG7kUzRYaY4/m/rpvzlWTIAgAJ
