### PR TITLE
Specify image-family/project for NPD/ubuntu CI jobs

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -245,6 +245,8 @@ periodics:
         --gcp-node-image=ubuntu
         --gcp-zone=us-west1-b
         --ginkgo-parallel=30
+        --image-family=pipeline-1-24
+        --image-project=ubuntu-os-gke-cloud
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
       resources:
@@ -290,6 +292,8 @@ periodics:
         --gcp-node-image=ubuntu
         --gcp-zone=us-west1-b
         --ginkgo-parallel=30
+        --image-family=pipeline-1-24
+        --image-project=ubuntu-os-gke-cloud
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
       resources:


### PR DESCRIPTION
NPD worker nodes should have been ubuntu...but the logs show debian:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-npd-e2e-kubernetes-gce-ubuntu/1699565612906319872/artifacts/e2e-ffe6c6c601-7a0d1-minion-group-1m2x/serial-1.log

So let's use the settings from a job that works `ci-cos-containerd-e2e-ubuntu-gce` and specify the image family/project.

Hoping this fixes the perma-failure in 2 of the CI jobs:
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu&width=20
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags&width=20