### PR TITLE
CAPV: rename presets to use the new secrets

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -80,8 +80,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-full-release-1-6
   labels:
     preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config-test: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 24h
   decorate: true
@@ -123,8 +123,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-conformance-release-1-6
   labels:
     preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config-test: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 24h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -1,6 +1,6 @@
 presets:
 - labels:
-    preset-cluster-api-provider-vsphere-e2e-config-test: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
   env:
   - name: GOVC_URL
     valueFrom:
@@ -65,7 +65,7 @@ presets:
       - key: vmc-capv-services.kubeconfig
         path: capv-services.conf
 - labels:
-    preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
   env:
   - name: GCR_KEY_FILE
     value: /root/.capv/keyfile.json

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
@@ -1,6 +1,6 @@
 presets:
 - labels:
-    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-e2e-config-old: "true"
   env:
   - name: GOVC_URL
     valueFrom:
@@ -65,7 +65,7 @@ presets:
       - key: capv-services.conf
         path: capv-services.conf
 - labels:
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds-old: "true"
   env:
   - name: GCR_KEY_FILE
     value: /root/.capv/keyfile.json
@@ -247,6 +247,45 @@ presubmits:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-e2e-main
       description: Runs only PR Blocking e2e tests
+
+  - name: pull-cluster-api-provider-vsphere-e2e-main-oldpreset
+    branches:
+    - ^main$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config-old: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds-old: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
+    run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[PR-Blocking\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-main-oldpreset
+      description: Runs only PR Blocking e2e tests
+
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-main
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -131,8 +131,8 @@ presubmits:
     - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config-test: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -169,8 +169,8 @@ presubmits:
     - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config-test: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -205,8 +205,8 @@ presubmits:
     - ^release-1.6$
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config-test: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds-test: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true


### PR DESCRIPTION
Removes the suffix `-test` from the new CAPV presets and renames the old ones.

Also reverts the presets change for the 1.6 branch.

Note: all jobs for the 1.6 branch are green.

/assign @sbueringer @killianmuldoon 