### PR TITLE
containerd-1-7-dra: add cos image

### DIFF
--- a/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
@@ -3,3 +3,7 @@ images:
     image_family: pipeline-1-25
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"
+  cos:
+    image_family: cos-stable
+    project: cos-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"

--- a/jobs/e2e_node/dra/init-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/init-containerd-1.7.yaml
@@ -20,6 +20,9 @@ write_files:
   path: /etc/cni/net.d/10-mynet.conf
 
 runcmd:
+  - echo "The test runs from /tmp folder, remounting it so that it can run executable."
+  - mount /tmp /tmp -o remount,exec,suid
+
   - echo "This will install and configure containerd 1.7 for DRA tests"
 
   - echo "Stopping containerd"


### PR DESCRIPTION
Added cos image to cover more target distros.
Fedora-coreos is covered by the pull-kubernetes-node-e2e-crio-dra job.
This job will cover Ubuntu and Core-OS.