### PR TITLE
node-e2e: fix CPU manager related jobs patch 2

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -654,7 +654,7 @@ presubmits:
             - --deployment=node
             - --gcp-zone=us-west1-b
             - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
-            - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+            - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
             - --node-tests=true
             - --provider=gce
             - --test_args=--nodes=1 --skip="" --focus="\[Feature:CPUManager\]"
@@ -715,7 +715,8 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=1
         - --focus-regex=\[Feature:CPUManager\]
-        - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+        - --skip-regex=\[Flaky\]|\[Slow\]
+        - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
   - name: pull-kubernetes-node-kubelet-serial-topology-manager
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
since https://github.com/kubernetes/test-infra/pull/30545 is merged, `ci-kubernetes-node-kubelet-serial-cpu-manager` seems good.

Changes: 

- Add `--cgoup-driver=systemd` since `pull-kubernetes-node-kubelet-serial-cpu-manager` and `pull-kubernetes-node-kubelet-serial-cpu-manager-kubetest2` are using `test-infra/jobs/e2e_node/containerd/config-systemd.toml`
- Specify "skip-regex" in kubetest2 job. The default skip-regex in kubetest2 is  `\[Flaky\]|\[Slow\]|\[Serial\]`([code](https://github.com/kubernetes-sigs/kubetest2/blob/master/pkg/testers/node/node.go#L91)), but all  node-e2e cases of CPU-manager are `[Serial]`. 