### PR TITLE
Enable periodic GH Bug Triage project board syncing for v1.29

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -26,7 +26,7 @@ periodics:
             secretKeyRef:
               name: k8s-release-enhancements-triage-github-token
               key: token
-- name: periodic-sync-bug-triage-github-project-beta-1-28
+- name: periodic-sync-bug-triage-github-project-beta-1-29
   interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -47,7 +47,7 @@ periodics:
         - name: PROJECT_NUMBER
           value: "80"
         - name: MILESTONE
-          value: "v1.28"
+          value: "v1.29"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This PR updates the periodic prow job so that it syncs the Bug Triage board with issues/PRs' targeting v1.29 milestone.
[Bug triage board](https://github.com/orgs/kubernetes/projects/80) used in the previous releases is already renamed from v1.28 to v1.29.

/assign @Priyankasaggu11929 @salaxander