### PR TITLE
kubeadm: update k/kubeadm presubmits and plugin config

### DIFF
--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -4,8 +4,9 @@ presubmits:
 
   # kinder presubmits
   - name: pull-kubeadm-kinder-verify
-    path_alias: "k8s.io/kubeadm"
     decorate: true
+    optional: false
+    path_alias: "k8s.io/kubeadm"
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
@@ -14,8 +15,8 @@ presubmits:
         - "./kinder/hack/verify-all.sh"
 
   - name: pull-kubeadm-kinder-upgrade-latest
-    optional: false
     decorate: true
+    optional: false
     run_if_changed: '^kinder\/.*$'
     skip_branches:
     - release-\d+\.\d+ # revisit once the k/kubeadm repo has branches
@@ -44,31 +45,12 @@ presubmits:
             memory: "9000Mi"
             cpu: 2000m
 
-  # operator presubmits
-  - name: pull-kubeadm-operator-verify
-    path_alias: "k8s.io/kubeadm"
-    decorate: true
-    run_if_changed: '^operator\/.*$'
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-        command:
-        - runner.sh
-        - "./operator/hack/verify-all.sh"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9000Mi"
-            cpu: 2000m
-
-  # kinder canary presubmits
+  # kinder presubmits (canary on eks-prow-build-cluster)
   - name: pull-kubeadm-kinder-verify-canary
     cluster: eks-prow-build-cluster
     path_alias: "k8s.io/kubeadm"
     decorate: true
+    optional: true
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
@@ -92,7 +74,7 @@ presubmits:
 
   - name: pull-kubeadm-kinder-upgrade-latest-canary
     cluster: eks-prow-build-cluster
-    optional: false
+    optional: true
     decorate: true
     run_if_changed: '^kinder\/.*$'
     skip_branches:
@@ -115,37 +97,6 @@ presubmits:
         - "../kubeadm/kinder/ci/kinder-run.sh"
         args:
         - "presubmit-upgrade-latest"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9000Mi"
-            cpu: 2000m
-          limits:
-            cpu: 2000m
-            memory: 9000Mi
-      tolerations:
-      - key: "dedicated"
-        value: "kind-tests"
-        operator: "Equal"
-        effect: "NoSchedule"
-      nodeSelector:
-        kind-exclusive: "true"
-
-  # operator canary presubmits
-  - name: pull-kubeadm-operator-verify-canary
-    cluster: eks-prow-build-cluster
-    path_alias: "k8s.io/kubeadm"
-    decorate: true
-    run_if_changed: '^operator\/.*$'
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-        command:
-        - runner.sh
-        - "./operator/hack/verify-all.sh"
         securityContext:
           privileged: true
         resources:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -868,7 +868,7 @@ require_matching_label:
     This PR is currently missing an area label, which is used to identify the modified component when generating release notes.
 
     Area labels can be added by org members by writing `/area ${COMPONENT}` in a comment
-    
+
     Please see the [labels list](https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#labels-that-apply-to-kubernetes-sigscluster-api-for-both-issues-and-prs) for possible areas.
 - missing_label: needs-triage
   org: kubernetes-sigs
@@ -1163,7 +1163,7 @@ plugins:
     - milestonestatus
     - release-note
     - require-matching-label
-  
+
   kubernetes/cloud-provider-gcp:
     plugins:
     - require-matching-label
@@ -1210,7 +1210,9 @@ plugins:
 
   kubernetes/kubeadm:
     plugins:
+    - mergecommitblocker
     - milestone
+    - override
 
   kubernetes/kubectl:
     plugins:
@@ -1437,7 +1439,7 @@ plugins:
 
   kubernetes-sigs/cluster-api-operator:
     plugins:
-    - require-matching-label   
+    - require-matching-label
 
   kubernetes-sigs/cluster-api-provider-aws:
     plugins:


### PR DESCRIPTION
we saw some canneries were added / copied from existing kubeadm presubmits to be on the new EKS cluster:
https://github.com/kubernetes/test-infra/pull/30480

but these are failing with:
> There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors (skip schedule deleting pod: test-pods/5de98213-a51d-453e-a939-ae41958ff042)

and we have no way to skip them.

doing a couple of changes:

jobs/../kubeadm: make EKS canaries optional
```
- Delete "operator" jobs as the code was deleted long time ago
- Make existing jobs non-optional
- Make the new EKS canary jobs optional
````

config/prow/plugins: add some plugins to k/kubeadm
```
Add:
+    - mergecommitblocker

Useful to catch merge commits.

+    - override

Allows us to override failing tests e.g. the new EKS cluster canaries.

Includes auto-whitespace cleanup from vscode.
```