### PR TITLE
migrate additional `sig-cli` job to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -56,6 +56,7 @@ periodics:
     description: kubectl gce e2e tests for master branch
 - interval: 12h
   name: ci-kubernetes-e2e-kops-aws-sig-cli
+  cluster: eks-prow-build-cluster
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -76,6 +77,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 8Gi
+        requests:
+          cpu: 2
+          memory: 8Gi
 
   # kubectl skew tests
   annotations:


### PR DESCRIPTION
This PR moves sig-cli job to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @AdoHe @pwittrock @soltysh