### PR TITLE
migrate `secrets-store-csi-driver` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -138,6 +138,7 @@ presubmits:
       description: "Run vulnerability scans for Secrets Store CSI driver images."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-vault
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -163,6 +164,13 @@ presubmits:
             make e2e-bootstrap e2e-helm-deploy e2e-vault
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-vault
@@ -367,18 +375,19 @@ presubmits:
         securityContext:
           privileged: true
         resources:
-          requests:
-            cpu: "4"
-            memory: "6Gi"
           limits:
-            cpu: "4"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-aws
       description: "Run e2e test with aws provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-build
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -400,6 +409,13 @@ presubmits:
             make build build-windows
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-build
@@ -437,9 +453,12 @@ presubmits:
         - name: KUBERNETES_VERSION
           value: "1.24.7"
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
@@ -477,9 +496,12 @@ presubmits:
         - name: KUBERNETES_VERSION
           value: "1.25.3"
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
@@ -517,9 +539,12 @@ presubmits:
         - name: KUBERNETES_VERSION
           value: "1.26.0"
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-26-0
@@ -557,9 +582,12 @@ presubmits:
         - name: KUBERNETES_VERSION
           value: "1.27.1"
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-27-0
@@ -640,12 +668,12 @@ presubmits:
           - name: RELEASE
             value: "true"
         resources:
-          requests:
-            cpu: "4"
-            memory: "6Gi"
           limits:
-            cpu: "4"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
       testgrid-tab-name: release-secrets-store-csi-driver-e2e-aws
@@ -653,6 +681,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: release-secrets-store-csi-driver-e2e-vault
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -683,12 +712,12 @@ presubmits:
           - name: RELEASE
             value: "true"
         resources:
-          requests:
-            cpu: "4"
-            memory: "4Gi"
           limits:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
       testgrid-tab-name: release-secrets-store-csi-driver-e2e-vault
@@ -779,6 +808,7 @@ presubmits:
 postsubmits:
   kubernetes-sigs/secrets-store-csi-driver:
   - name: secrets-store-csi-driver-e2e-vault-postsubmit
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -804,9 +834,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-vault-postsubmit
@@ -857,6 +890,7 @@ postsubmits:
       - aramase
       - ritazh
   - name: secrets-store-csi-driver-e2e-gcp-postsubmit
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -883,9 +917,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: "4"
-            memory: "4Gi"
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-gcp-postsubmit
@@ -924,12 +961,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
-          requests:
-            cpu: "4"
-            memory: "6Gi"
           limits:
-            cpu: "4"
-            memory: "6Gi"
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-aws-postsubmit
@@ -943,6 +980,7 @@ postsubmits:
 periodics:
 - interval: 24h
   name: periodic-secrets-store-csi-driver-image-scan
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 10m
@@ -966,6 +1004,13 @@ periodics:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-image-scan
@@ -1010,6 +1055,7 @@ periodics:
     testgrid-num-columns-recent: '30'
 - interval: 12h
   name: periodic-secrets-store-csi-driver-inplace-upgrade-test-e2e-provider
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 30m
@@ -1036,6 +1082,13 @@ periodics:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-inplace-upgrade-test-e2e-provider


### PR DESCRIPTION
This PR moves secrets-store-csi-driver jobs to the community owned EKS cluster. Additionally, updates k8s versions in jobs, removes 1.24 and adds 1.28 job. 

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @aramase @nilekhc @ritazh @tam7t