### PR TITLE
migrate `repo-infra` job to community cluster

### DIFF
--- a/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/repo-infra:
   - name: pull-repo-infra-tests
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: k8s.io/repo-infra
@@ -13,6 +14,13 @@ presubmits:
         command:
         - ./presubmit.sh
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: repo-infra


### PR DESCRIPTION
This PR moves the repo-infra jobs to the community owned EKS cluster.

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @cpanato @ameukam 