### PR TITLE
Use KUBE_CONTROLLER_MANAGER_TEST_ARGS in pull-kubernetes-e2e-gce-scale-performance-manual

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -273,8 +273,9 @@ presubmits:
         - --env=CL2_LOAD_TEST_THROUGHPUT=50
         - --env=CL2_DELETE_TEST_THROUGHPUT=50
         - --env=CL2_RATE_LIMIT_POD_CREATION=false
+        - --env=KUBE_CONTROLLER_MANAGER_TEST_ARGS=--endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
         # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
+        - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100
         # Overrides SCHEDULER_TEST_ARGS from preset-e2e-scalability-periodics.
         # TODO(#1311): Clean this up after the experiment - it should allow
         #   to hugely decrease pod-startup-latency across the whole test.


### PR DESCRIPTION
Missed during last update #30647

/sig scalability
/cc @wojtek-t