### PR TITLE
Revert "Windows ctrd update version"

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
@@ -12,12 +12,12 @@ presets:
     preset-capz-containerd-1-6-latest: "true"
   env:
   - name: WINDOWS_CONTAINERD_URL
-    value: "https://github.com/containerd/containerd/releases/download/v1.6.23/containerd-1.6.23-windows-amd64.tar.gz"
+    value: "https://github.com/containerd/containerd/releases/download/v1.6.19/containerd-1.6.19-windows-amd64.tar.gz"
 - labels:
     preset-capz-containerd-1-7-latest: "true"
   env:
   - name: WINDOWS_CONTAINERD_URL
-    value: "https://github.com/containerd/containerd/releases/download/v1.7.5/containerd-1.7.5-windows-amd64.tar.gz"
+    value: "https://github.com/containerd/containerd/releases/download/v1.7.0/containerd-1.7.0-windows-amd64.tar.gz"
 - labels:
     preset-windows-repo-list: "true"
   env:


### PR DESCRIPTION
Reverts kubernetes/test-infra#30559

A few of the sig-windows jobs got very flake after this PR merged so we'll revert it and investigate

1.28: 
![image](https://github.com/kubernetes/test-infra/assets/18291632/196b1fad-9870-4ef7-85ca-1779bbdf30a2)

1.26:
![image](https://github.com/kubernetes/test-infra/assets/18291632/db8323e1-a93b-497c-bd20-03906b79e420)

/sig windows
/assign @jsturtevant 
