### PR TITLE
Add aws-ebs-csi-driver kustomize presubmit; Switch aws-ebs-csi-driver windows test to non-optional

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -201,3 +201,28 @@ presubmits:
       testgrid-tab-name: pull-external-test-eks
       description: kubernetes/kubernetes external test on pull request on eks
       testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-external-test-kustomize
+    always_run: true
+    optional: true
+    decorate: true
+    skip_branches:
+      - gh-pages
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-external-kustomize
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver
+      testgrid-tab-name: pull-external-test-kustomize
+      description: kubernetes/kubernetes external test on pull request via kustomize
+      testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   kubernetes-sigs/aws-ebs-csi-driver:
   - name: pull-aws-ebs-csi-driver-test-e2e-external-eks-windows
     always_run: true
-    optional: true
     decorate: true
     skip_branches:
     - gh-pages


### PR DESCRIPTION
/hold
Depends on https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1735

- Commit 1: Adds a presubmit job for the aws-ebs-csi-driver to test on Kustomize
- Commit 2: Sets previously optional aws-ebs-csi-driver windows tests to non-optional