### PR TITLE
Run ci-cloud-provider-aws-e2e-kubetest2* in the eks cluster

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -86,7 +86,7 @@ periodics:
       securityContext:
         privileged: true
 - interval: 6h
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   name: ci-cloud-provider-aws-e2e-kubetest2
   decorate: true
   decoration_config:
@@ -97,7 +97,6 @@ periodics:
     testgrid-num-failures-to-alert: "10"
     testgrid-dashboards: presubmits-ec2, amazon-ec2
   labels:
-    preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-aws-credential-aws-oss-testing: "true"
     preset-k8s-ssh: "true"
@@ -149,7 +148,7 @@ periodics:
       securityContext:
         privileged: true
 - interval: 6h
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   name: ci-cloud-provider-aws-e2e-kubetest2-quick
   decorate: true
   decoration_config:
@@ -160,7 +159,6 @@ periodics:
     testgrid-num-failures-to-alert: "10"
     testgrid-dashboards: presubmits-ec2, amazon-ec2
   labels:
-    preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-aws-credential-aws-oss-testing: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
`serviceAccountName: node-e2e-tests` is valid only in the eks cluster

log snippet from https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-cloud-provider-aws-e2e-kubetest2-quick/1701571330274496512
```
Job execution failed: Pod can not be created: create pod test-pods/bfb75c12-7ad9-4ef8-9538-b1f5eff8b1ff in cluster k8s-infra-prow-build: pods "bfb75c12-7ad9-4ef8-9538-b1f5eff8b1ff" is forbidden: error looking up service account test-pods/node-e2e-tests: serviceaccount "node-e2e-tests" not found
```