### PR TITLE
use kubetest2-ec2 from remote go install

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -128,7 +128,7 @@ periodics:
         - bash
         - -c
         - |
-          cd kubetest2-ec2 && GOPROXY=direct go install .
+          GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
           kubetest2 ec2 \
            --build \
            --region us-east-1 \
@@ -191,7 +191,7 @@ periodics:
         - bash
         - -c
         - |
-          cd kubetest2-ec2 && GOPROXY=direct go install .
+          GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
           VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
           kubetest2 ec2 \
            --stage https://dl.k8s.io/ci/ \

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -116,7 +116,7 @@ presubmits:
             - bash
             - -c
             - |
-              cd kubetest2-ec2 && GOPROXY=direct go install .
+              GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
               VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
               kubetest2 ec2 \
                --stage https://dl.k8s.io/ci/ \


### PR DESCRIPTION
avoid checking out kubetest2-ec2 locally (copy-pasta from another job)