### PR TITLE
kube-state-metrics: push images on changes to main

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-metrics-server.yaml
+++ b/config/jobs/image-pushing/k8s-staging-metrics-server.yaml
@@ -8,7 +8,7 @@ postsubmits:
         testgrid-dashboards: sig-instrumentation-image-pushes, sig-k8s-infra-gcb
       decorate: true
       branches:
-        - ^master$
+        - ^main$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:


### PR DESCRIPTION
kube-state-metrics images are not pushed to the staging registry when changes are made to the main branch because the job is still targetting the old master branch