### PR TITLE
cpu-manager-presubmit: Add upload & service account fields

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -647,6 +647,8 @@ presubmits:
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --service-account=/etc/service-account/service-account.json
             - --timeout=240
             - --root=/go/src
             - --scenario=kubernetes_e2e


### PR DESCRIPTION
In order to ensure that logs are uploaded, we add upload and service account fields