### PR TITLE
Build and inject the cloud-provider-aws image into kubetest2 presubmits

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -61,12 +61,29 @@ presubmits:
             - -c
             - |
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+
+              VERSION=$(git describe --dirty --tags --match='v*')
+              BUILD_IMAGE=provider-aws/cloud-controller-manager:${VERSION}
+              REGION=${REGION:-"us-east-1"}
+
+              make switch-to-latest-k8s ko-build-local
+
+              AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+              IMAGE_NAME=${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/provider-aws/cloud-controller-manager
+              IMAGE_TAG=${VERSION}
+
+              echo "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
+              aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+              docker tag "${BUILD_IMAGE}" "${IMAGE_NAME}:${IMAGE_TAG}"
+              docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+
               kubetest2 ec2 \
                --build \
                --region us-east-1 \
                --target-build-arch linux/amd64 \
                --stage provider-aws-test-infra \
                --external-cloud-provider true \
+               --external-cloud-provider-image="${IMAGE_NAME}:${IMAGE_TAG}" \
                --up \
                --down \
                --test=ginkgo \
@@ -106,6 +123,11 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
     spec:
       serviceAccountName: node-e2e-tests
       containers:
@@ -117,10 +139,27 @@ presubmits:
             - -c
             - |
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+
+              VERSION=$(git describe --dirty --tags --match='v*')
+              BUILD_IMAGE=provider-aws/cloud-controller-manager:${VERSION}
+              REGION=${REGION:-"us-east-1"}
+
+              make switch-to-latest-k8s ko-build-local
+
+              AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+              IMAGE_NAME=${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/provider-aws/cloud-controller-manager
+              IMAGE_TAG=${VERSION}
+
+              echo "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
+              aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+              docker tag "${BUILD_IMAGE}" "${IMAGE_NAME}:${IMAGE_TAG}"
+              docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+
               VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
               kubetest2 ec2 \
                --stage https://dl.k8s.io/ci/ \
                --external-cloud-provider true \
+               --external-cloud-provider-image="${IMAGE_NAME}:${IMAGE_TAG}" \
                --version $VERSION \
                --up \
                --down \


### PR DESCRIPTION
Now that the harness is working, let's layer on the actual building of the image (using latest kubernetes/kubernetes from master)