### PR TITLE
resource-mgrs: presubmit: Add upload & service account fields

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -746,6 +746,8 @@ presubmits:
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --service-account=/etc/service-account/service-account.json
             - --timeout=240
             - --root=/go/src
             - --scenario=kubernetes_e2e
@@ -842,6 +844,8 @@ presubmits:
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --service-account=/etc/service-account/service-account.json
             - --timeout=240
             - --root=/go/src
             - --scenario=kubernetes_e2e
@@ -1227,6 +1231,8 @@ presubmits:
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --service-account=/etc/service-account/service-account.json
             - --timeout=240
             - --root=/go/src
             - --scenario=kubernetes_e2e


### PR DESCRIPTION
Submitting a followup to #30685 (which enabled logs for cpu-manager) as we want to ensure that jobs related to other resource managers have build logs as well.