### PR TITLE
Fix extra_refs in CAPO periodics

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -13,10 +13,6 @@ periodics:
     repo: cluster-api-provider-openstack
     base_ref: main
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
-  - org: kubernetes-sigs
-    repo: image-builder
-    base_ref: main
-    path_alias: "sigs.k8s.io/image-builder"
   max_concurrency: 1
   spec:
     containers:
@@ -67,14 +63,6 @@ periodics:
     repo: cluster-api-provider-openstack
     base_ref: main
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
-  - org: kubernetes-sigs
-    repo: image-builder
-    base_ref: main
-    path_alias: "sigs.k8s.io/image-builder"
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   max_concurrency: 1
   spec:
     containers:
@@ -115,9 +103,9 @@ periodics:
   interval: 12h
   extra_refs:
   - org: kubernetes-sigs
-    repo: image-builder
-    base_ref: master
-    path_alias: "sigs.k8s.io/image-builder"
+    repo: cluster-api-provider-openstack
+    base_ref: main
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-master


### PR DESCRIPTION
The extra_ref for
periodic-cluster-api-provider-openstack-e2e-full-test-main was wrong. We also appear to have some legacy extra_refs still around in other jobs, which we remove at the same time.

cc @lentzi90 

Also cc @sbueringer as I think you added these initially. Are you aware of any reason we'd still need to the additional extra_refs in the 2 jobs where I removed all but the first one?