### PR TITLE
Switch roles, avoid mixing node-e2e and kubetest2 roles

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -111,7 +111,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: node-e2e-tests
+    serviceAccountName: provider-aws-test-role
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
       resources:
@@ -173,7 +173,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: node-e2e-tests
+    serviceAccountName: provider-aws-test-role
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
       resources:

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -51,7 +51,7 @@ presubmits:
         base_ref: master
         path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: node-e2e-tests
+      serviceAccountName: provider-aws-test-role
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
           command:
@@ -129,7 +129,7 @@ presubmits:
         base_ref: master
         path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: node-e2e-tests
+      serviceAccountName: provider-aws-test-role
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
           command:


### PR DESCRIPTION
kubetest2 related CI jobs need more oomph! 