### PR TITLE
[sig-windows] Use known good image during investigation

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -18,32 +18,39 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h0m0s
-  labels:
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-    preset-capz-containerd-1-6-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common-125: "true"
-    preset-capz-windows-parallel: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
     base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
+    workdir: false
   - org: kubernetes-sigs
     repo: cloud-provider-azure
     base_ref: release-1.25
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+    workdir: true
+  labels:
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-windows-common-125: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - command:
       - runner.sh
-      - ./scripts/ci-conformance.sh
+      - env
+      - KUBERNETES_VERSION=latest-1.25
+      - ./capz/run-capz-e2e.sh
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.25
       name: ""
       resources:
@@ -52,6 +59,9 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+      env:
+        - name: IMAGE_VERSION
+          value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.25-informing, sig-windows-1.25-release, sig-windows-signal

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -22,28 +22,35 @@ periodics:
     repo: cluster-api-provider-azure
     base_ref: release-1.10
     path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
+    workdir: false
   - org: kubernetes-sigs
     repo: cloud-provider-azure
     base_ref: release-1.26
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+    workdir: true
   interval: 24h
   labels:
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
     preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-containerd-1-6-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-126: "true"
-    preset-capz-windows-parallel: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - command:
       - runner.sh
-      - ./scripts/ci-conformance.sh
+      - env
+      - KUBERNETES_VERSION=latest-1.26
+      - ./capz/run-capz-e2e.sh
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.26
       name: ""
       resources:
@@ -52,6 +59,9 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+      env:
+        - name: IMAGE_VERSION
+          value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.26-informing, sig-windows-signal,  sig-windows-1.26-release

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -61,6 +61,9 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+      env:
+        - name: IMAGE_VERSION
+          value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
 - name: ci-kubernetes-e2e-capz-1-28-windows-serial-slow
   interval: 48h
   decorate: true


### PR DESCRIPTION
After updating to patch releases and containerd version last month we noticed issues with tests flaking.  see https://github.com/kubernetes/test-infra/pull/30675 for another case where we are going back to known good configuration.

/sig windows
/assign @marosset @claudiubelu 