### PR TITLE
Update kube-state-metrics version to compatible version with v1.24.

### DIFF
--- a/config/prow/cluster/kube-state-metrics_deployment.yaml
+++ b/config/prow/cluster/kube-state-metrics_deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.6.0
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.0.0-alpha.1
+        app.kubernetes.io/version: 2.6.0
     spec:
       containers:
-      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:2.0.0-alpha.1
+      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         args:
         - --metric-allowlist="kube_pod_container_status_restarts_total"
         livenessProbe:

--- a/config/prow/cluster/kube-state-metrics_rbac.yaml
+++ b/config/prow/cluster/kube-state-metrics_rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.6.0
   name: kube-state-metrics
   namespace: kube-system
 ---
@@ -12,7 +12,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.6.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.6.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/config/prow/cluster/kube-state-metrics_service.yaml
+++ b/config/prow/cluster/kube-state-metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.6.0
   name: kube-state-metrics
   namespace: kube-system
 spec:

--- a/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: 2.6.0
     app: kube-state-metrics
   name: kube-state-metrics
   namespace: prow-monitoring


### PR DESCRIPTION
Using v2.6.0 based on the compatibility matrix at https://github.com/kubernetes/kube-state-metrics. (I think a later version is also fine but just to be safe). This should take care of some deprecated API warnings.

/assign @cjwagner @listx 