### PR TITLE
images/bootstrap: Allow pip an external python installation

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
+    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip setuptools wheel
 
 # Install gcloud
 


### PR DESCRIPTION
Follow of:
  - https://github.com/kubernetes/test-infra/pull/30409

the image [failed](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-bootstrap/1692297379941715968) to build with:

```
Step #1: ╰─> To install Python packages system-wide, try apt install
Step #1:     python3-xyz, where xyz is the package you are trying to
Step #1:     install.
Step #1:
Step #1:     If you wish to install a non-Debian-packaged Python package,
Step #1:     create a virtual environment using python3 -m venv path/to/venv.
Step #1:     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
Step #1:     sure you have python3-full installed.
Step #1:
Step #1:     If you wish to install a non-Debian packaged Python application,
Step #1:     it may be easiest to use pipx install xyz, which will manage a
Step #1:     virtual environment for you. Make sure you have pipx installed.
Step #1:
Step #1:     See /usr/share/doc/python3.11/README.venv for more information.
```

Starting with bookworm, pip enforces [PEP 668](https://peps.python.org/pep-0668/).

This is an attempt to ensure we don't break python packages installation.