### PR TITLE
update COSI controller build test to use named make target

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -13,8 +13,9 @@ presubmits:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.18.4
         command:
-        # Plain make runs also verify
         - make
+        args:
+        - build
         resources:
           limits:
             cpu: 2


### PR DESCRIPTION
Update build test for Container Object Storage Interface (COSI) to use the named `make build` target instead of just `make`.