### PR TITLE
wip: add default to all jobs missing a cluster

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-cluster-bundle/k8s-cluster-bundle.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-cluster-bundle/k8s-cluster-bundle.yaml
@@ -1,6 +1,7 @@
 presubmits:
   GoogleCloudPlatform/k8s-cluster-bundle:
   - name: pull-k8s-cluster-bundle-bazel-test
+    cluster: default
     always_run: true         # Run for every PR, or only when requested.
     decorate: true
     labels:
@@ -25,6 +26,7 @@ presubmits:
 postsubmits:
   GoogleCloudPlatform/k8s-cluster-bundle:
   - name: post-k8s-cluster-bundle-bazel-test
+    cluster: default
     decorate: true
     labels:
       preset-service-account: "true"

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -19,6 +19,7 @@ presets:
 presubmits:
   google/cadvisor:
   - name: pull-cadvisor-e2e
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -58,6 +59,7 @@ presubmits:
 
   kubernetes/kubernetes: # Temporary test for https://github.com/kubernetes/kubernetes/pull/116517
   - name: pull-cadvisor-e2e-kubernetes
+    cluster: default
     always_run: false
     labels:
       preset-service-account: "true"
@@ -96,6 +98,7 @@ presubmits:
       testgrid-tab-name: cadvisor-temp
 periodics:
 - name: ci-cadvisor-e2e
+  cluster: default
   interval: 8h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-csi/csi-driver-smb:
   - name: pull-csi-driver-smb-verify
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -24,6 +25,7 @@ presubmits:
       description: "Run code verification tests for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-unit
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -47,6 +49,7 @@ presubmits:
       description: "Run unit tests for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-sanity
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -72,6 +75,7 @@ presubmits:
       description: "Run sanity tests for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-integration
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -97,6 +101,7 @@ presubmits:
       description: "Run integration tests for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-windows-build
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -118,6 +123,7 @@ presubmits:
       description: "Run make smb-windows for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -164,6 +170,7 @@ presubmits:
       description: "Run E2E tests for SMB CSI driver on VMAS cluster."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-vmss
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -210,6 +217,7 @@ presubmits:
       description: "Run E2E tests for SMB CSI driver on VMSS cluster."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-windows
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -263,6 +271,7 @@ presubmits:
       description: "Run Windows E2E tests for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-windows-containerd
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb
@@ -316,6 +325,7 @@ presubmits:
       description: "Run Windows containerd E2E tests for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-capz
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -364,6 +374,7 @@ presubmits:
       description: "Run E2E tests on a capz cluster for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-capz-windows-2019
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -420,6 +431,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2019 cluster for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-external-e2e
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/csi-driver-smb

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-attacher-canary
+    cluster: default
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-provisioner-canary
+    cluster: default
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-resizer-canary
+    cluster: default
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-snapshotter-canary
+    cluster: default
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-livenessprobe-canary
+    cluster: default
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-node-driver-registrar-canary
+    cluster: default
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes-sigs/alibaba-cloud-csi-driver:
 
   - name: pull-alibaba-cloud-csi-driver-verify-fmt
+    cluster: default
     always_run: true
     decorate: true
     spec:
@@ -17,6 +18,7 @@ presubmits:
       description: Verifies the Golang sources have been formatted
 
   - name: pull-alibaba-cloud-csi-driver-verify-lint
+    cluster: default
     always_run: true
     decorate: true
     spec:
@@ -32,6 +34,7 @@ presubmits:
       description: Verifies the Golang sources are linted
 
   - name: pull-alibaba-cloud-csi-driver-verify-vet
+    cluster: default
     always_run: true
     decorate: true
     spec:
@@ -47,6 +50,7 @@ presubmits:
       description: Vets the Golang sources have been vetted
 
   - name: pull-alibaba-cloud-csi-driver-verify-unit
+    cluster: default
     always_run: true
     decorate: true
     spec:

--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/apiserver-network-proxy:
   - name: pull-apiserver-network-proxy-test
+    cluster: default
     always_run: true
     skip_report: false
     decorate: true
@@ -17,6 +18,7 @@ presubmits:
       testgrid-tab-name: pr-test
       description: Tests the apiserver-network-proxy
   - name: pull-apiserver-network-proxy-docker-build-amd64
+    cluster: default
     always_run: true
     skip_report: false
     decorate: true
@@ -39,6 +41,7 @@ presubmits:
       testgrid-tab-name: pr-docker-build-amd64
       description: Build amd64 image via Docker for the apiserver-network-proxy
   - name: pull-apiserver-network-proxy-docker-build-arm64
+    cluster: default
     always_run: true
     skip_report: false
     decorate: true
@@ -61,6 +64,7 @@ presubmits:
       testgrid-tab-name: pr-docker-build-arm64
       description: Build arm64 image via Docker for the apiserver-network-proxy
   - name: pull-apiserver-network-proxy-make-lint
+    cluster: default
     always_run: true
     skip_report: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-aws-ebs-csi-driver-unit-test
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 1h20m
@@ -28,6 +29,7 @@ periodics:
     description: aws ebs csi driver unit test, continuous
     testgrid-num-columns-recent: '30'
 - name: ci-aws-ebs-csi-driver-e2e-single-az
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 1h20m
@@ -56,6 +58,7 @@ periodics:
     description: aws ebs csi driver e2e test on single az, continuous
     testgrid-num-columns-recent: '30'
 - name: ci-aws-ebs-csi-driver-e2e-multi-az
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 1h20m
@@ -84,6 +87,7 @@ periodics:
     description: aws ebs csi driver e2e test on mutiple AZs, continuous
     testgrid-num-columns-recent: '30'
 - name: ci-aws-ebs-csi-driver-external-test
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 1h20m

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/aws-ebs-csi-driver:
   - name: pull-aws-ebs-csi-driver-test-e2e-external-eks-windows
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -25,6 +26,7 @@ presubmits:
       description: aws ebs csi driver External Storage tests for Windows on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-test-helm-chart
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -105,6 +107,7 @@ presubmits:
       description: aws ebs csi driver unit test on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-e2e-single-az
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -129,6 +132,7 @@ presubmits:
       description: aws ebs csi driver e2e test on single az on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-e2e-multi-az
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -153,6 +157,7 @@ presubmits:
       description: aws ebs csi driver e2e test on mutiple AZs on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -177,6 +182,7 @@ presubmits:
       description: kubernetes/kubernetes external test on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test-eks
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -201,6 +207,7 @@ presubmits:
       description: kubernetes/kubernetes external test on pull request on eks
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test-kustomize
+    cluster: default
     always_run: true
     optional: true
     decorate: true

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -57,6 +57,7 @@ presubmits:
       description: aws efs csi driver unit test
       testgrid-num-columns-recent: '30'
   - name: pull-aws-efs-csi-driver-e2e
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:
@@ -81,6 +82,7 @@ presubmits:
       description: aws efs csi driver e2e test
       testgrid-num-columns-recent: '30'
   - name: pull-aws-efs-csi-driver-external-test-eks
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -57,6 +57,7 @@ presubmits:
       description: aws fsx csi driver unit test
       testgrid-num-columns-recent: '30'
   - name: pull-aws-fsx-csi-driver-e2e
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:

--- a/config/jobs/kubernetes-sigs/aws-fsx-openzfs-csi-driver/aws-fsx-openzfs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-openzfs-csi-driver/aws-fsx-openzfs-csi-driver-presubmits.yaml
@@ -29,6 +29,7 @@ presubmits:
       description: aws fsx openzfs csi driver unit test
       testgrid-num-columns-recent: '30'
   - name: pull-aws-fsx-openzfs-csi-driver-sanity
+    cluster: default
     always_run: true
     decorate: true
     skip_branches:

--- a/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/aws-iam-authenticator:
   - name: pull-aws-iam-authenticator-unit
+    cluster: default
     always_run: true
     decorate: true
     labels:
@@ -19,6 +20,7 @@ presubmits:
       description: AWS IAM Authenticator unit test on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-iam-authenticator-integration
+    cluster: default
     always_run: true
     decorate: true
     labels:
@@ -38,6 +40,7 @@ presubmits:
       description: AWS IAM Authenticator integration test on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-iam-authenticator-e2e
+    cluster: default
     always_run: true
     decorate: true
     labels:
@@ -64,6 +67,7 @@ presubmits:
     - release-0.5
     - release-0.6
   - name: pull-aws-iam-authenticator-e2e-kind
+    cluster: default
     always_run: true
     decorate: true
     labels:

--- a/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -53,6 +53,7 @@ presubmits:
       description: aws load balancer controller unit tests
       testgrid-num-columns-recent: '30'
   - name: pull-aws-load-balancer-controller-e2e-test
+    cluster: default
     always_run: true
     decorate: true
     labels:

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/azuredisk-csi-driver:
   - name: pull-azuredisk-csi-driver-verify
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -24,6 +25,7 @@ presubmits:
       description: "Run code verification tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-unit
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -45,6 +47,7 @@ presubmits:
       description: "Run unit tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-sanity
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -69,6 +72,7 @@ presubmits:
       description: "Run sanity tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-integration
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -93,6 +97,7 @@ presubmits:
       description: "Run integration tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-single-az
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -144,6 +149,7 @@ presubmits:
       description: "Run E2E tests on a single-az cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-multi-az
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -196,6 +202,7 @@ presubmits:
       description: "Run E2E tests on a multi-az cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-migration
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -251,6 +258,7 @@ presubmits:
       description: "Run E2E tests on a cluster for Azure Disk CSI driver with CSI migration feature enabled on Linux nodes."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-migration-windows
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -306,6 +314,7 @@ presubmits:
       description: "Run E2E tests on a cluster for Azure Disk CSI driver with CSI migration feature enabled on Windows nodes."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-windows
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -362,6 +371,7 @@ presubmits:
       description: "Run E2E tests on a Windows cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-in-tree-azure-disk-e2e
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -412,6 +422,7 @@ presubmits:
       description: "Run Azure Disk e2e test with Azure Disk in-tree volume plugin."
       testgrid-num-columns-recent: '30'
   - name: pull-in-tree-azure-disk-e2e-vmss
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -464,6 +475,7 @@ presubmits:
       description: "Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-windows-build
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -485,6 +497,7 @@ presubmits:
       description: "Run make azuredisk-windows for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-in-tree-azure-disk-e2e-windows
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -537,6 +550,7 @@ presubmits:
       description: "Run Azure Disk e2e test on a Windows cluster with Azure Disk in-tree volume plugin."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-external-e2e-single-az
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -593,6 +607,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-azuredisk-csi-driver-external-e2e-windows is currently experimental and not yet stable
   - name: pull-azuredisk-csi-driver-external-e2e-windows
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -648,6 +663,7 @@ presubmits:
       description: "Run External E2E tests for Azure Disk CSI driver on Windows."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-windows-containerd
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -701,6 +717,7 @@ presubmits:
       description: "Run E2E tests on a Windows containerd cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2019
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -756,6 +773,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2019 cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2022
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -813,6 +831,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2022 cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -857,6 +876,7 @@ presubmits:
       description: "Run E2E tests on a capz cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-vmssflex
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -932,6 +952,7 @@ presubmits:
       description: "Run E2E tests on a capz cluster with vmssflex nodes for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2019-hostprocess
+    cluster: default
     decorate: true
     always_run: false
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -990,6 +1011,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2019 cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess
+    cluster: default
     decorate: true
     always_run: false
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/azuredisk-csi-driver:
   - name: pull-azuredisk-csi-driver-verify-mainv2
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -27,6 +28,7 @@ presubmits:
       description: "Run code verification tests for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-unit-mainv2
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -50,6 +52,7 @@ presubmits:
       description: "Run unit tests for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-sanity-mainv2
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -78,6 +81,7 @@ presubmits:
       description: "Run sanity tests for Azure Disk CSI V2 driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-integration-mainv2
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -106,6 +110,7 @@ presubmits:
       description: "Run integration tests for Azure Disk CSI V2 driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-single-az-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -160,6 +165,7 @@ presubmits:
       description: "Run E2E tests on a single-az cluster for Azure Disk CSI V2 driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-multi-az-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -215,6 +221,7 @@ presubmits:
       description: "Run E2E tests on a multi-az cluster for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-migration-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -271,6 +278,7 @@ presubmits:
       description: "Run E2E tests on a cluster for Azure Disk CSI V2 driver with CSI migration feature enabled on Linux nodes."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-migration-windows-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -331,6 +339,7 @@ presubmits:
       description: "Run E2E tests on a cluster for Azure Disk CSI V2 driver with CSI migration feature enabled on Windows nodes."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-windows-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -392,6 +401,7 @@ presubmits:
       description: "Run E2E tests on a Windows cluster for Azure Disk CSI V2 driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-windows-build-mainv2
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azuredisk-csi-driver
@@ -413,6 +423,7 @@ presubmits:
       description: "Run make azuredisk-windows for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-external-e2e-single-az-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -471,6 +482,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-azuredisk-csi-driver-external-e2e-windows-mainv2 is currently experimental and not yet stable
   - name: pull-azuredisk-csi-driver-external-e2e-windows-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -532,6 +544,7 @@ presubmits:
       description: "Run External E2E tests for Azure Disk CSI driver V2 on Windows."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-windows-containerd-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -591,6 +604,7 @@ presubmits:
       description: "Run E2E tests on a Windows containerd cluster for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2019-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h
@@ -655,6 +669,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2019 cluster for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2022-mainv2
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
@@ -721,6 +736,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2022 cluster for Azure Disk CSI driver V2."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-mainv2
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/azurefile-csi-driver:
   - name: pull-azurefile-csi-driver-verify
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -22,6 +23,7 @@ presubmits:
       description: "Run code verification tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-unit
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -43,6 +45,7 @@ presubmits:
       description: "Run unit tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-sanity
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -65,6 +68,7 @@ presubmits:
       description: "Run sanity tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-integration
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -87,6 +91,7 @@ presubmits:
       description: "Run integration tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -131,6 +136,7 @@ presubmits:
       description: "Run E2E tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-vmss
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -175,6 +181,7 @@ presubmits:
       description: "Run E2E tests on a VMSS-based cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-windows
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -226,6 +233,7 @@ presubmits:
       description: "Run E2E tests on a Windows cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-migration
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -280,6 +288,7 @@ presubmits:
       description: "Run E2E tests on a cluster for Azure File CSI driver with CSI migration feature enabled on Linux nodes."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-windows-build
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -299,6 +308,7 @@ presubmits:
       description: "Run make azurefile-windows for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-windows-containerd
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -350,6 +360,7 @@ presubmits:
       description: "Run E2E tests on a Windows containerd cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-migration-windows
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -413,6 +424,7 @@ presubmits:
       description: "Run E2E tests on a cluster for Azure File CSI driver with CSI migration feature enabled on Windows nodes."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-external-e2e-smb
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -460,6 +472,7 @@ presubmits:
       description: "Run External E2E tests for Azure File CSI driver using SMB protocol."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-external-e2e-smb-windows
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -513,6 +526,7 @@ presubmits:
       description: "Run External E2E tests for Azure File CSI driver using SMB protocol on Windows."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-external-e2e-nfs
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -560,6 +574,7 @@ presubmits:
       description: "Run External E2E tests for Azure File CSI driver using NFS protocol."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz-windows-2019
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -611,6 +626,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2019 cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz-windows-2022
+    cluster: default
     decorate: true
     always_run: false
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -666,6 +682,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2022 cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz-windows-2019-hostprocess
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -719,6 +736,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2019 Host-Process cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz-windows-2022-hostprocess
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver
@@ -776,6 +794,7 @@ presubmits:
       description: "Run E2E tests on a capz Windows 2022 Host-Process cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/azurefile-csi-driver

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/blob-csi-driver:
   - name: pull-blob-csi-driver-verify
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -22,6 +23,7 @@ presubmits:
       description: "Run code verification tests for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-unit
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -43,6 +45,7 @@ presubmits:
       description: "Run unit tests for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-sanity
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -66,6 +69,7 @@ presubmits:
       description: "Run sanity tests for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-integration
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -89,6 +93,7 @@ presubmits:
       description: "Run integration tests for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-e2e
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -135,6 +140,7 @@ presubmits:
       description: "Run E2E tests for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-e2e-vmss
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -179,6 +185,7 @@ presubmits:
       description: "Run E2E tests on a VMSS-based cluster for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-e2e-proxy
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -228,6 +235,7 @@ presubmits:
       description: "Run E2E tests for Azure Blob Storage CSI driver based on blobfuse-proxy"
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-external-e2e-blobfuse
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -277,6 +285,7 @@ presubmits:
       description: "Run External E2E tests for Azure Blob Storage CSI driver using blobfuse."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-external-e2e-blobfuse-v2
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -326,6 +335,7 @@ presubmits:
       description: "Run External E2E tests for Azure Blob Storage CSI driver using blobfuse v2."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-external-e2e-nfs
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver
@@ -375,6 +385,7 @@ presubmits:
       description: "Run External E2E tests for Azure Blob Storage CSI driver using nfs."
       testgrid-num-columns-recent: '30'
   - name: pull-blob-csi-driver-e2e-capz
+    cluster: default
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/blob-csi-driver

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -31,6 +31,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-ccm-vmss-capz runs Azure specific e2e tests on vmss.
   - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz
+    cluster: default
     skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     decoration_config:
@@ -83,6 +84,7 @@ presubmits:
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz
+    cluster: default
     always_run: false
     decorate: true
     decoration_config:
@@ -135,6 +137,7 @@ presubmits:
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz
+    cluster: default
     always_run: false
     decorate: true
     decoration_config:
@@ -188,6 +191,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-ccm-vmssflex-capz runs Azure specific e2e tests on vmssflex.
   - name: pull-cloud-provider-azure-e2e-ccm-vmssflex-capz
+    cluster: default
     skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     decoration_config:
@@ -255,6 +259,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-capz runs kubernetes conformance tests.
   - name: pull-cloud-provider-azure-e2e-capz
+    cluster: default
     skip_if_only_changed: "^docs/|^site/|^helm/|^tests/e2e/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     decoration_config:
@@ -316,6 +321,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-ccm-capz runs Azure specific e2e tests.
   - name: pull-cloud-provider-azure-e2e-ccm-capz
+    cluster: default
     skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     decoration_config:
@@ -367,6 +373,7 @@ presubmits:
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz
+    cluster: default
     always_run: false
     decorate: true
     decoration_config:
@@ -420,6 +427,7 @@ presubmits:
       description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz
+    cluster: default
     always_run: false
     decorate: true
     decoration_config:
@@ -474,6 +482,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz runs Azure specific e2e tests with cloud controller manager and IP-based load balancer backend pools.
   - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz
+    cluster: default
     always_run: false
     optional: true
     skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
@@ -543,6 +552,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz runs Azure specific e2e tests with cloud controller manager and multiple standard load balancers.
   - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz
+    cluster: default
     skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore"
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -31,6 +31,7 @@ presubmits:
         testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-25
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-25
+      cluster: default
       skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -84,6 +85,7 @@ presubmits:
         testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-capz-1-25 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-25
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -145,6 +147,7 @@ presubmits:
         testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-1-25
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-25
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -31,6 +31,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-26
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-26
+      cluster: default
       skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -84,6 +85,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-capz-1-26 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-26
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -145,6 +147,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-1-26
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-26
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -31,6 +31,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
+      cluster: default
       skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -84,6 +85,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-capz-1-27 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-27
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -145,6 +147,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-1-27
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-27
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -222,6 +225,7 @@ presubmits:
         description: "Run unit tests for cloud-provider-azure release-1.27."
         testgrid-num-columns-recent: "30"
     - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27
+      cluster: default
       always_run: false
       decorate: true
       decoration_config:
@@ -273,6 +277,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27
+      cluster: default
       always_run: false
       decorate: true
       decoration_config:
@@ -324,6 +329,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27
+      cluster: default
       always_run: false
       decorate: true
       decoration_config:
@@ -376,6 +382,7 @@ presubmits:
         description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27
+      cluster: default
       always_run: false
       decorate: true
       decoration_config:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -31,6 +31,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
+      cluster: default
       skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -84,6 +85,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-capz-1-28 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-28
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
@@ -145,6 +147,7 @@ presubmits:
         testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-1-28
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-28
+      cluster: default
       skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -136,6 +136,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-test-main
   - name: pull-cluster-api-operator-e2e-main
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-5.yaml
@@ -136,6 +136,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.5
       testgrid-tab-name: capi-operator-pr-test-release-0-5
   - name: pull-cluster-api-operator-e2e-release-0-5
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,6 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-25-1-26-main
+  cluster: default
   interval: 24h
   decorate: true
   labels:
@@ -46,6 +47,7 @@ periodics:
     testgrid-tab-name: capi-periodic-upgrade-main-1-25-1-26
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-26-1-27-main
+  cluster: default
   interval: 24h
   decorate: true
   labels:
@@ -91,6 +93,7 @@ periodics:
     testgrid-tab-name: capi-periodic-upgrade-main-1-26-1-27
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-27-1-28-main
+  cluster: default
   interval: 24h
   decorate: true
   labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-azure-conformance-main
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -34,6 +35,7 @@ periodics:
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with latest cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-main
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -78,6 +80,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests on latest kubernetes master with cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-capi-e2e-main
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -113,6 +116,7 @@ periodics:
     testgrid-tab-name: capz-periodic-capi-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-apiversion-upgrade-main
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -153,6 +157,7 @@ periodics:
     testgrid-tab-name: capz-periodic-apiversion-upgrade-main
     description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
 - name: periodic-cluster-api-provider-azure-coverage
+  cluster: default
   interval: 12h
   decorate: true
   path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -186,6 +191,7 @@ periodics:
       securityContext:
         privileged: true
 - name: periodic-cluster-api-provider-azure-e2e-main
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -221,6 +227,7 @@ periodics:
     testgrid-tab-name: capz-periodic-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-aks-main
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.10.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-10
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -34,6 +35,7 @@ periodics:
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.10 (v1beta1)
 - name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-10
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -78,6 +80,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.10 (v1beta1)
 - name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-10
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -113,6 +116,7 @@ periodics:
     testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-10
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-10
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -148,6 +152,7 @@ periodics:
     testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-10
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-10
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.9.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-9
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -34,6 +35,7 @@ periodics:
     testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-9
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-9
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -68,6 +70,7 @@ periodics:
     testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-9
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-9
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -69,6 +69,7 @@ presubmits:
       testgrid-tab-name: capz-pr-build-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -102,6 +103,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-optional
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -137,6 +139,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-optional-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-aks
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -172,6 +175,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-aks-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-e2e.sh|Makefile'
@@ -239,6 +243,7 @@ presubmits:
       testgrid-tab-name: capz-pr-verify-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-conformance
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -273,6 +278,7 @@ presubmits:
       testgrid-tab-name: capz-pr-conformance-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-conformance-with-ci-artifacts
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -314,6 +320,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-k8s-ci-main
   - name: pull-cluster-api-provider-azure-windows-containerd-upstream-with-ci-artifacts
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -362,6 +369,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-upstream-k8s-ci-windows-containerd-main
   - name: pull-cluster-api-provider-azure-windows-containerd-upstream-with-ci-artifacts-serial-slow
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -412,6 +420,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-upstream-k8s-ci-windows-containerd-serial-slow-main
   - name: pull-cluster-api-provider-azure-apidiff
+    cluster: default
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     always_run: true
@@ -430,6 +439,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main
   - name: pull-cluster-api-provider-azure-e2e-workload-upgrade
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -468,6 +478,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-upgrade
   - name: pull-cluster-api-provider-azure-apiversion-upgrade
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -510,6 +521,7 @@ presubmits:
       testgrid-tab-name: capz-pr-apiversion-upgrade-main
       description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
   - name: pull-cluster-api-provider-azure-ci-entrypoint
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -49,6 +49,7 @@ presubmits:
       testgrid-tab-name: capz-pr-build-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -82,6 +83,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-apiversion-upgrade-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -118,6 +120,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
       description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
   - name: pull-cluster-api-provider-azure-e2e-optional-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -153,6 +156,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-optional-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-aks-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -188,6 +192,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-aks-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-e2e.sh|Makefile'
@@ -255,6 +260,7 @@ presubmits:
       testgrid-tab-name: capz-pr-verify-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-conformance-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -288,6 +294,7 @@ presubmits:
       testgrid-tab-name: capz-pr-conformance-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-apidiff-v1beta1
+    cluster: default
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     always_run: true
@@ -307,6 +314,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-v1beta1
   - name: pull-cluster-api-provider-azure-ci-entrypoint-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -341,6 +349,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
       description: Creates a CAPZ cluster and exports KUBECONFIG. This job validates ci-entrypoint.sh used by other repositories for running tests on CAPZ clusters.
   - name: pull-cluster-api-provider-azure-conformance-with-ci-artifacts-v1beta1
+    cluster: default
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -381,6 +390,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-k8s-ci-v1beta1
   - name: pull-cluster-api-provider-azure-e2e-workload-upgrade-v1beta1
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -111,6 +111,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
   - name: capi-provider-cloudstack-presubmit-e2e-smoke-test
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
@@ -1,5 +1,6 @@
 periodics:
   - name: periodic-cluster-api-provider-digitalocean-janitor
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 1h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-1-2.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-digitalocean-conformance-release-1-2
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-1-3.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-digitalocean-conformance-release-1-3
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-digitalocean-conformance
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -32,6 +33,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-provider-digitalocean-conformance-ci-artifacts
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-2.yaml
@@ -97,6 +97,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-lint-release-1-2
   - name: pull-cluster-api-provider-digitalocean-e2e-release-1-2
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -126,6 +127,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-e2e-release-1-2
   - name: pull-cluster-api-provider-digitalocean-capi-e2e-release-1-2
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -160,6 +162,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-capi-e2e-release-1-2
   - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade-release-1-2
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -192,6 +195,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-e2e-upgrade-release-1-2
   - name: pull-cluster-api-provider-digitalocean-conformance-release-1-2
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -221,6 +225,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-conformance-release-1-2
   - name: pull-cluster-api-provider-digitalocean-conformance-ci-artifacts-release-1-2
+    cluster: default
     always_run: false
     optional: true
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-3.yaml
@@ -97,6 +97,7 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
         testgrid-tab-name: capdo-pr-lint-release-1-3
     - name: pull-cluster-api-provider-digitalocean-e2e-release-1-3
+      cluster: default
       always_run: true
       optional: false
       decorate: true
@@ -126,6 +127,7 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
         testgrid-tab-name: capdo-pr-e2e-release-1-3
     - name: pull-cluster-api-provider-digitalocean-capi-e2e-release-1-3
+      cluster: default
       always_run: false
       optional: true
       decorate: true
@@ -160,6 +162,7 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
         testgrid-tab-name: capdo-pr-capi-e2e-release-1-3
     - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade-release-1-3
+      cluster: default
       labels:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
@@ -192,6 +195,7 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
         testgrid-tab-name: capdo-pr-e2e-upgrade-release-1-3
     - name: pull-cluster-api-provider-digitalocean-conformance-release-1-3
+      cluster: default
       always_run: false
       optional: true
       decorate: true
@@ -221,6 +225,7 @@ presubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
         testgrid-tab-name: capdo-pr-conformance-release-1-3
     - name: pull-cluster-api-provider-digitalocean-conformance-ci-artifacts-release-1-3
+      cluster: default
       always_run: false
       optional: true
       decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -72,6 +72,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-verify
   - name: pull-cluster-api-provider-digitalocean-e2e
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -101,6 +102,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-e2e
   - name: pull-cluster-api-provider-digitalocean-capi-e2e
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -135,6 +137,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-capi-e2e
   - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -167,6 +170,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-e2e-upgrade
   - name: pull-cluster-api-provider-digitalocean-conformance
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -196,6 +200,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-conformance
   - name: pull-cluster-api-provider-digitalocean-conformance-ci-artifacts
+    cluster: default
     always_run: false
     optional: true
     decorate: true
@@ -228,6 +233,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-conformance-ci-artifacts
   - name: pull-cluster-api-provider-digitalocean-capi-e2e-experimental
+    cluster: default
     always_run: false
     optional: true
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -62,6 +62,7 @@ periodics:
       testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
       testgrid-num-failures-to-alert: "2"
   - name: periodic-cluster-api-provider-gcp-make-conformance-main
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -100,6 +101,7 @@ periodics:
       testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
       testgrid-num-failures-to-alert: "2"
   - name: periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-3.yaml
@@ -62,6 +62,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-gcp-make-conformance-release-1-3
+  cluster: default
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-4.yaml
@@ -62,6 +62,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-gcp-make-conformance-release-1-4
+  cluster: default
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -47,6 +47,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build
   - name: pull-cluster-api-provider-gcp-make
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -107,6 +108,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-verify
   - name: pull-cluster-api-provider-gcp-e2e-test
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -142,6 +144,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test
   - name: pull-cluster-api-provider-gcp-conformance-ci-artifacts
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -187,6 +190,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance-ci-artifacts
   - name: pull-cluster-api-provider-gcp-conformance
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -222,6 +226,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance
   - name: pull-cluster-api-provider-gcp-capi-e2e
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -257,6 +262,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-capi-e2e-test
   - name: pull-cluster-api-provider-gcp-e2e-workload-upgrade
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-3.yaml
@@ -47,6 +47,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build-release-1-3
   - name: pull-cluster-api-provider-gcp-make-release-1-3
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -107,6 +108,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-verify-release-1-3
   - name: pull-cluster-api-provider-gcp-e2e-test-release-1-3
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -142,6 +144,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test-release-1-3
   - name: pull-cluster-api-provider-gcp-conformance-release-1-3
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -177,6 +180,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance-release-1-3
   - name: pull-cluster-api-provider-gcp-capi-e2e-release-1-3
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -212,6 +216,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-capi-e2e-test-release-1-3
   - name: pull-cluster-api-provider-gcp-e2e-workload-upgrade-release-1-3
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-4.yaml
@@ -47,6 +47,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build-release-1-4
   - name: pull-cluster-api-provider-gcp-make-release-1-4
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -107,6 +108,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-verify-release-1-4
   - name: pull-cluster-api-provider-gcp-e2e-test-release-1-4
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -142,6 +144,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test-release-1-4
   - name: pull-cluster-api-provider-gcp-conformance-release-1-4
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -177,6 +180,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance-release-1-4
   - name: pull-cluster-api-provider-gcp-capi-e2e-release-1-4
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -212,6 +216,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-capi-e2e-test-release-1-4
   - name: pull-cluster-api-provider-gcp-e2e-workload-upgrade-release-1-4
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-ibmcloud-coverage
+  cluster: default
   interval: 12h
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-openstack-e2e-test-main
+  cluster: default
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -50,6 +51,7 @@ periodics:
       - error
       report_template: ':alert: Failed periodic job: {{.Status.State}}. <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-openstack|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
 - name: periodic-cluster-api-provider-openstack-conformance-test-main-with-k8s-ci-artifacts
+  cluster: default
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -93,6 +95,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "48"
 - name: periodic-cluster-api-provider-openstack-e2e-full-test-main
+  cluster: default
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubernetes-sigs/cluster-api-provider-openstack:
   - name: ci-cluster-api-provider-openstack-conformance-test
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -48,6 +48,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-test
   - name: pull-cluster-api-provider-openstack-e2e-test
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -88,6 +89,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-e2e-test
   - name: pull-cluster-api-provider-openstack-conformance-test
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -131,6 +133,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-conformance-test
   - name: pull-cluster-api-provider-openstack-e2e-full-test
+    cluster: default
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
@@ -78,6 +78,7 @@ periodics:
     description: Runs integration tests
 
 - name: periodic-cluster-api-provider-vsphere-e2e-full-main
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -121,6 +122,7 @@ periodics:
     description: Runs all e2e tests
 
 - name: periodic-cluster-api-provider-vsphere-conformance-main
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -164,6 +166,7 @@ periodics:
     description: Runs conformance tests for CAPV
 
 - name: periodic-cluster-api-provider-vsphere-coverage-main
+  cluster: default
   interval: 24h
   decorate: true
   rerun_auth_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.5.yaml
@@ -78,6 +78,7 @@ periodics:
     description: Runs integration tests
 
 - name: periodic-cluster-api-provider-vsphere-e2e-full-release-1-5
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -121,6 +122,7 @@ periodics:
     description: Runs all e2e tests
 
 - name: periodic-cluster-api-provider-vsphere-conformance-release-1-5
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.6.yaml
@@ -78,6 +78,7 @@ periodics:
     description: Runs integration tests
 
 - name: periodic-cluster-api-provider-vsphere-e2e-full-release-1-6
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -121,6 +122,7 @@ periodics:
     description: Runs all e2e tests
 
 - name: periodic-cluster-api-provider-vsphere-conformance-release-1-6
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.7.yaml
@@ -78,6 +78,7 @@ periodics:
     description: Runs integration tests
 
 - name: periodic-cluster-api-provider-vsphere-e2e-full-release-1-7
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -121,6 +122,7 @@ periodics:
     description: Runs all e2e tests
 
 - name: periodic-cluster-api-provider-vsphere-conformance-release-1-7
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-release-1.8.yaml
@@ -78,6 +78,7 @@ periodics:
     description: Runs integration tests
 
 - name: periodic-cluster-api-provider-vsphere-e2e-full-release-1-8
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
@@ -121,6 +122,7 @@ periodics:
     description: Runs all e2e tests
 
 - name: periodic-cluster-api-provider-vsphere-conformance-release-1-8
+  cluster: default
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
@@ -127,6 +127,7 @@ presubmits:
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-main
+    cluster: default
     branches:
     - ^main$
     labels:
@@ -165,6 +166,7 @@ presubmits:
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-main
+    cluster: default
     branches:
     - ^main$
     labels:
@@ -201,6 +203,7 @@ presubmits:
       description: Runs all e2e tests
 
   - name: pull-cluster-api-provider-vsphere-conformance-main
+    cluster: default
     branches:
     - ^main$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.5.yaml
@@ -129,6 +129,7 @@ presubmits:
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-5
+    cluster: default
     branches:
     - ^release-1.5$
     labels:
@@ -167,6 +168,7 @@ presubmits:
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-release-1-5
+    cluster: default
     branches:
     - ^release-1.5$
     labels:
@@ -203,6 +205,7 @@ presubmits:
       description: Runs all e2e tests
 
   - name: pull-cluster-api-provider-vsphere-conformance-release-1-5
+    cluster: default
     branches:
     - ^release-1.5$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.6.yaml
@@ -127,6 +127,7 @@ presubmits:
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-6
+    cluster: default
     branches:
     - ^release-1.6$
     labels:
@@ -165,6 +166,7 @@ presubmits:
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-release-1-6
+    cluster: default
     branches:
     - ^release-1.6$
     labels:
@@ -201,6 +203,7 @@ presubmits:
       description: Runs all e2e tests
 
   - name: pull-cluster-api-provider-vsphere-conformance-release-1-6
+    cluster: default
     branches:
     - ^release-1.6$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.7.yaml
@@ -127,6 +127,7 @@ presubmits:
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-7
+    cluster: default
     branches:
     - ^release-1.7$
     labels:
@@ -165,6 +166,7 @@ presubmits:
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-release-1-7
+    cluster: default
     branches:
     - ^release-1.7$
     labels:
@@ -201,6 +203,7 @@ presubmits:
       description: Runs all e2e tests
 
   - name: pull-cluster-api-provider-vsphere-conformance-release-1-7
+    cluster: default
     branches:
     - ^release-1.7$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-release-1.8.yaml
@@ -127,6 +127,7 @@ presubmits:
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-release-1-8
+    cluster: default
     branches:
     - ^release-1.8$
     labels:
@@ -165,6 +166,7 @@ presubmits:
       description: Runs only PR Blocking e2e tests
 
   - name: pull-cluster-api-provider-vsphere-e2e-full-release-1-8
+    cluster: default
     branches:
     - ^release-1.8$
     labels:
@@ -201,6 +203,7 @@ presubmits:
       description: Runs all e2e tests
 
   - name: pull-cluster-api-provider-vsphere-conformance-release-1-8
+    cluster: default
     branches:
     - ^release-1.8$
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -1,6 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-main
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -54,6 +55,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-main
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -107,6 +109,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-main
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -160,6 +163,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-main
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -213,6 +217,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-main
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -266,6 +271,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-28-latest-main
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-main
+  cluster: default
   interval: 2h
   decorate: true
   decoration_config:
@@ -29,6 +30,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-main
+  cluster: default
   interval: 2h
   decorate: true
   decoration_config:
@@ -68,6 +70,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-main
+  cluster: default
   interval: 2h
   decorate: true
   decoration_config:
@@ -110,6 +113,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-dualstack-and-ipv6-main
+  cluster: default
   interval: 2h
   decorate: true
   decoration_config:
@@ -155,6 +159,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-main
+  cluster: default
   interval: 2h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4-upgrades.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-4
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -53,6 +54,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-4
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -106,6 +108,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-4
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -159,6 +162,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-4
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -212,6 +216,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-4
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -265,6 +270,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-release-1-4
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-4.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-4
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -29,6 +30,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-release-1-4
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -66,6 +68,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-4
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -108,6 +111,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-4
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5-upgrades.yaml
@@ -1,6 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-5
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -54,6 +55,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-5
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -107,6 +109,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-5
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -160,6 +163,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-5
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -213,6 +217,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-release-1-5
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -266,6 +271,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-release-1-5
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-5
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -29,6 +30,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-release-1-5
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -68,6 +70,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-5
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -110,6 +113,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-dualstack-and-ipv6-release-1-5
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:
@@ -155,6 +159,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-5
+  cluster: default
   interval: 4h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-main
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -20,6 +21,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-build-main
   - name: pull-cluster-api-apidiff-main
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -40,6 +42,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-apidiff-main
   - name: pull-cluster-api-verify-main
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -66,6 +69,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-verify-main
   - name: pull-cluster-api-test-main
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -88,6 +92,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-test-main
   - name: pull-cluster-api-test-mink8s-main
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -121,6 +126,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-test-mink8s-main
   - name: pull-cluster-api-e2e-mink8s-main
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -159,6 +165,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-mink8s-main
   - name: pull-cluster-api-e2e-main
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -190,6 +197,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main
   - name: pull-cluster-api-e2e-full-dualstack-and-ipv6-main
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -228,6 +236,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-dualstack-and-ipv6-main
   - name: pull-cluster-api-e2e-full-main
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -263,6 +272,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
   - name: pull-cluster-api-e2e-workload-upgrade-1-28-latest-main
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -311,6 +321,7 @@ presubmits:
       testgrid-tab-name: capi-pr-e2e-main-1-28-latest
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-main-experimental
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-release-1-4
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -20,6 +21,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-build-release-1-4
   - name: pull-cluster-api-apidiff-release-1-4
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -40,6 +42,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-apidiff-release-1-4
   - name: pull-cluster-api-verify-release-1-4
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -66,6 +69,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-verify-release-1-4
   - name: pull-cluster-api-test-release-1-4
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -88,6 +92,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-test-release-1-4
   - name: pull-cluster-api-test-mink8s-release-1-4
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -118,6 +123,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-test-mink8s-release-1-4
   - name: pull-cluster-api-e2e-release-1-4
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -149,6 +155,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-e2e-release-1-4
   - name: pull-cluster-api-e2e-informing-release-1-4
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -183,6 +190,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-e2e-informing-release-1-4
   - name: pull-cluster-api-e2e-informing-ipv6-release-1-4
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -220,6 +228,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-e2e-informing-ipv6-release-1-4
   - name: pull-cluster-api-e2e-full-release-1-4
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -255,6 +264,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.4
       testgrid-tab-name: capi-pr-e2e-full-release-1-4
   - name: pull-cluster-api-e2e-workload-upgrade-1-26-1-27-release-1-4
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-release-1-5
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -20,6 +21,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-build-release-1-5
   - name: pull-cluster-api-apidiff-release-1-5
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -40,6 +42,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-apidiff-release-1-5
   - name: pull-cluster-api-verify-release-1-5
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -66,6 +69,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-verify-release-1-5
   - name: pull-cluster-api-test-release-1-5
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -88,6 +92,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-test-release-1-5
   - name: pull-cluster-api-test-mink8s-release-1-5
+    cluster: default
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
@@ -121,6 +126,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-test-mink8s-release-1-5
   - name: pull-cluster-api-e2e-mink8s-release-1-5
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -159,6 +165,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-5
   - name: pull-cluster-api-e2e-release-1-5
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -190,6 +197,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-release-1-5
   - name: pull-cluster-api-e2e-informing-release-1-5
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -222,6 +230,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-informing-release-1-5
   - name: pull-cluster-api-e2e-full-dualstack-and-ipv6-release-1-5
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -260,6 +269,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-full-dualstack-and-ipv6-release-1-5
   - name: pull-cluster-api-e2e-full-release-1-5
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -295,6 +305,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-full-release-1-5
   - name: pull-cluster-api-e2e-workload-upgrade-1-27-1-28-release-1-5
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -343,6 +354,7 @@ presubmits:
       testgrid-tab-name: capi-pr-e2e-release-1-5-1-27-1-28
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-release-1-5-experimental
+    cluster: default
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/controller-tools:
   - name: pull-controller-tools-test-master
+    cluster: default
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-tools

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - name: pull-gcp-compute-persistent-disk-csi-driver-e2e
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -25,6 +26,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e
       description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -45,6 +47,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-sanity
       description: Kubernetes sanity tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-unit
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -65,6 +68,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-unit
       description: Kubernetes unit tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-verify
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -95,6 +99,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-verify
       description: Kubernetes verify tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-kubernetes-integration
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-gcp-compute-persistent-disk-csi-driver-release-staging-k8s-master-integration
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -37,6 +38,7 @@ periodics:
     testgrid-alert-email: gke-managed-storage-alerts@google.com
     description: Kubernetes Integration tests for Kubernetes Master branch, Driver latest Release Candidate, and Stable Sidecars. Used to test release candidates when a new release is being cut.
 - name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -74,6 +76,7 @@ periodics:
     testgrid-alert-email: gke-managed-storage-alerts@google.com
     description: Kubernetes Integration tests for Kubernetes Master branch, Driver latest build, and Stable Sidecars
 - name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration-canary-sidecars
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-gce-pd-csi-driver-latest-k8s-master-windows-2019
+  cluster: default
   extra_refs:
   - org: kubernetes-sigs
     repo: gcp-compute-persistent-disk-csi-driver
@@ -48,6 +49,7 @@ periodics:
 presubmits:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - name: pull-gcp-compute-persistent-disk-csi-driver-e2e-windows-2019
+    cluster: default
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/gcp-filestore-csi-driver:
   - name: pull-gcp-filestore-csi-driver-e2e
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -21,6 +22,7 @@ presubmits:
         - name: ZONE
           value: us-central1-c
   - name: pull-gcp-filestore-csi-driver-sanity
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -37,6 +39,7 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "test/run_sanity.sh"
   - name: pull-gcp-filestore-csi-driver-unit
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -53,6 +56,7 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "test/run_unit.sh"
   - name: pull-gcp-filestore-csi-driver-verify
+    cluster: default
     always_run: true
     labels:
       preset-service-account: "true"
@@ -69,6 +73,7 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "hack/verify_all.sh"
   - name: pull-gcp-filestore-csi-driver-kubernetes-integration
+    cluster: default
     always_run: false
     run_if_changed: '^(pkg\/|cmd\/|test\/|hack\/|vendor\/)'
     labels:

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/image-builder:
     - name: pull-ova-all
+      cluster: default
       labels:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/image-builder:
   - name: pull-azure-vhds
+    cluster: default
     labels:
       preset-azure-cred: "true"
     decorate: true
@@ -22,6 +23,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-azure-vhds
   - name: pull-azure-sigs
+    cluster: default
     labels:
       preset-azure-cred: "true"
     decorate: true
@@ -95,6 +97,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-packer-validate
   - name: pull-image-builder-gcp-all
+    cluster: default
     path_alias: sigs.k8s.io/image-builder
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -2,6 +2,7 @@
 postsubmits:
   kubernetes-sigs/kind:
   - name: ci-kind-test
+    cluster: default
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/kind:
   - name: pull-kind-build
+    cluster: default
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -17,6 +18,7 @@ presubmits:
         securityContext:
           privileged: true
   - name: pull-kind-test
+    cluster: default
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -33,6 +35,7 @@ presubmits:
         securityContext:
           privileged: true
   - name: pull-kind-verify
+    cluster: default
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kind-unit-test
+  cluster: default
   interval: 6h
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes-sigs/krm-functions-registry/krm-functions-registry-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/krm-functions-registry/krm-functions-registry-presubmits-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/krm-functions-registry:
   - name: pull-krm-functions-registry-test-master
+    cluster: default
     decorate: true
     always_run: true
     labels:

--- a/config/jobs/kubernetes-sigs/kube-batch/kube-batch-config.yaml
+++ b/config/jobs/kubernetes-sigs/kube-batch/kube-batch-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-batch:
   - name: pull-kube-batch-verify
+    cluster: default
     branches:
     - master
     always_run: true

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-storage-version-migrator:
   - name: pull-kube-storage-version-migrator-disruptive
+    cluster: default
     decorate: true
     always_run: true
     labels:

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-storage-version-migrator:
   - name: pull-kube-storage-version-migrator-test
+    cluster: default
     decorate: true
     always_run: true
     spec:
@@ -14,6 +15,7 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-test
   - name: pull-kube-storage-version-migrator-manually-launched-e2e
+    cluster: default
     decorate: true
     always_run: true
     labels:
@@ -46,6 +48,7 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-manually-launched
   - name: pull-kube-storage-version-migrator-fully-automated-e2e
+    cluster: default
     decorate: true
     always_run: true
     labels:
@@ -79,6 +82,7 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-fully-automated
   - name: pull-kube-storage-version-migrator-ha-master
+    cluster: default
     path_alias: "sigs.k8s.io/kube-storage-version-migrator"
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: postsubmit-node-feature-discovery-verify-master
+    cluster: default
     branches:
     - ^main$
     - ^master
@@ -22,6 +23,7 @@ postsubmits:
               name: nfd-creds
               key: codecov-token
   - name: postsubmit-node-feature-discovery-e2e-test
+    cluster: default
     branches:
     - ^main$
     - ^master$

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-master
+    cluster: default
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^master

--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes-sigs/promo-tools:
   # Run promoter e2e tests.
   - name: pull-cip-e2e
+    cluster: default
     decorate: true
     path_alias: "sigs.k8s.io/promo-tools"
     skip_report: false
@@ -41,6 +42,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
   - name: pull-cip-auditor-e2e
+    cluster: default
     decorate: true
     path_alias: "sigs.k8s.io/promo-tools"
     skip_report: false

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -138,6 +138,7 @@ presubmits:
       description: "Run vulnerability scans for Secrets Store CSI driver images."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-vault
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -169,6 +170,7 @@ presubmits:
       description: "Run e2e test with vault provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-azure
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -206,6 +208,7 @@ presubmits:
       description: "Run e2e test with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-deploy-manifest-azure
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -243,6 +246,7 @@ presubmits:
       description: "Run e2e test using deploy manifest with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-windows
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 90m
@@ -301,6 +305,7 @@ presubmits:
       description: "Run E2E tests on a Windows cluster for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-gcp
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -337,6 +342,7 @@ presubmits:
       description: "Run e2e test with gcp provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-aws
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 1h
@@ -375,6 +381,7 @@ presubmits:
       description: "Run e2e test with aws provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-build
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 10m
@@ -402,6 +409,7 @@ presubmits:
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -442,6 +450,7 @@ presubmits:
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.7"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -482,6 +491,7 @@ presubmits:
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.25.3"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-26-0
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -522,6 +532,7 @@ presubmits:
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.26.0"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-27-1
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -562,6 +573,7 @@ presubmits:
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.27.0"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-akeyless
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 1h
@@ -602,6 +614,7 @@ presubmits:
 
   # release jobs
   - name: release-secrets-store-csi-driver-e2e-aws
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 1h
@@ -645,6 +658,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: release-secrets-store-csi-driver-e2e-vault
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -684,6 +698,7 @@ presubmits:
       description: "Run e2e test with vault provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
   - name: release-secrets-store-csi-driver-e2e-azure
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -725,6 +740,7 @@ presubmits:
       description: "Run e2e test with azure provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
   - name: release-secrets-store-csi-driver-e2e-gcp
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -768,6 +784,7 @@ presubmits:
 postsubmits:
   kubernetes-sigs/secrets-store-csi-driver:
   - name: secrets-store-csi-driver-e2e-vault-postsubmit
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -806,6 +823,7 @@ postsubmits:
       - aramase
       - ritazh
   - name: secrets-store-csi-driver-e2e-azure-postsubmit
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -846,6 +864,7 @@ postsubmits:
       - aramase
       - ritazh
   - name: secrets-store-csi-driver-e2e-gcp-postsubmit
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 25m
@@ -885,6 +904,7 @@ postsubmits:
       - aramase
       - ritazh
   - name: secrets-store-csi-driver-e2e-aws-postsubmit
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 1h

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -73,6 +73,7 @@ presubmits:
             memory: 4Gi
 
   - name: pull-sig-storage-local-static-provisioner-e2e
+    cluster: default
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
@@ -92,6 +93,7 @@ presubmits:
         securityContext:
           privileged: true
   - name: pull-sig-storage-local-static-provisioner-e2e-windows-2019
+    cluster: default
     always_run: false
     decorate: true
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
@@ -137,6 +139,7 @@ presubmits:
 
 periodics:
 - name: ci-sig-storage-local-static-provisioner-master-gce-latest
+  cluster: default
   interval: 4h
   decorate: true
   labels:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-containerd-1-25
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-containerd-windows-1-25
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -67,6 +68,7 @@ periodics:
     testgrid-dashboards: sig-release-1.25-informing, sig-windows-1.25-release, sig-windows-signal
     testgrid-tab-name: capz-e2e-windows-containerd-1.25
 - name: ci-kubernetes-e2e-capz-containerd-windows-serial-slow-1-25
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-containerd-1-26
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-1-26
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h0m0s
@@ -67,6 +68,7 @@ periodics:
     testgrid-dashboards: sig-release-1.26-informing, sig-windows-signal,  sig-windows-1.26-release
     testgrid-tab-name: capz-windows-containerd-1.26
 - name: ci-kubernetes-e2e-capz-1-26-windows-serial-slow
+  cluster: default
   interval: 48h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-1-27
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-windows-1-27
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h0m0s
@@ -63,6 +64,7 @@ periodics:
     testgrid-dashboards: sig-release-1.27-informing, sig-windows-signal,  sig-windows-1.27-release
     testgrid-tab-name: capz-windows-containerd-1.27
 - name: ci-kubernetes-e2e-capz-1-27-windows-serial-slow
+  cluster: default
   interval: 48h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-1-28
+    cluster: default
     always_run: false
     branches:
     - release-1.28

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-windows-1-28
+  cluster: default
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.28-informing, sig-windows-1.28-release, sig-windows-signal
@@ -65,6 +66,7 @@ periodics:
         - name: IMAGE_VERSION
           value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
 - name: ci-kubernetes-e2e-capz-1-28-windows-serial-slow
+  cluster: default
   interval: 48h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -12,6 +12,7 @@ presets:
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-master
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -58,6 +59,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-serial-slow-hpa
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -115,6 +117,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-serial-slow-hpa
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-alpha-features
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -171,6 +174,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-alpha-features
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-alpha-feature-vpa
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -229,6 +233,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubernetes-sigs/windows-testing:
   - name: pull-e2e-capz-windows-2022-extension
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -281,6 +286,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-extension
   - name: pull-e2e-run-capz-sh-windows-2022-hyperv
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -336,6 +342,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-run-capz-sh-windows-2022-hyperv
   - name: pull-e2e-capz-windows-2022-extension-gmsa
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -70,6 +70,7 @@ presets:
       value: "true"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-windows
+  cluster: default
   interval: 3h
   decorate: true
   decoration_config:
@@ -124,6 +125,7 @@ periodics:
     testgrid-dashboards: sig-release-master-informing, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -177,6 +179,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow-hpa
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -228,6 +231,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-master-serial-slow-hpa
 - name: ci-kubernetes-e2e-capz-master-windows-2022
+  cluster: default
   interval: 3h
   decorate: true
   decoration_config:
@@ -277,6 +281,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master
 - name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -332,6 +337,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow-hpa
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -386,6 +392,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master-serial-slow-hpa
 - name: ci-kubernetes-e2e-azuredisk-capz-windows-2019
+  cluster: default
   interval: 48h
   decorate: true
   decoration_config:
@@ -476,6 +483,7 @@ periodics:
 #     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
 #     description: Run Azure File e2e test in a CAPZ cluster on Windows 2019 nodes
 - name: ci-kubernetes-e2e-capz-master-containerd-nightly-windows
+  cluster: default
   interval: 24h
   decorate: true
   decoration_config:
@@ -525,6 +533,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master
 - name: ci-kubernetes-e2e-capz-master-windows-alpha
+  cluster: default
   interval: 3h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-misc.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-misc.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-aks-engine-gpu-windows-dockershim-1-23
+    cluster: default
     always_run: false
     optional: true
     decorate: true

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/perf-tests:
   - name: soak-tests-capz-windows-2019
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -81,6 +82,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 periodics:
   - name: hourly-soak-tests-capz-windows-2019
+    cluster: default
     cron: "0 * * * MON-SAT"
     decorate: true
     path_alias: k8s.io/perf-tests
@@ -145,6 +147,7 @@ periodics:
       description: "Run clusterloader2 tests every hour on a capz Windows 2019 cluster"
       testgrid-num-columns-recent: '30'
   - name: delete-win-soak-test-cluster
+    cluster: default
     cron: "0 0 * * SUN"
     decorate: true
     decoration_config:
@@ -182,6 +185,7 @@ periodics:
       testgrid-num-columns-recent: '30'
 
   - name: build-win-soak-test-cluster
+    cluster: default
     cron: "0 1 * * SUN"
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-capz-master-windows-service-proxy
+  cluster: default
   interval: 72h
   decorate: true
   decoration_config:
@@ -51,6 +52,7 @@ periodics:
     testgrid-dashboards: sig-windows-experimental
     testgrid-tab-name: capz-master-windows-service-proxy
 - name: ci-kubernetes-e2e-capz-master-windows-hyperv
+  cluster: default
   interval: 168h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/windows-operational-readiness:
   - name: operational-tests-capz-windows-2019
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-ci-kubernetes-unit-windows
+    cluster: default
     always_run: false
     optional: true
     decorate: true

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-unit-windows-master
+  cluster: default
   interval: 12h
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-alibaba-cloud:
   - name: pull-cloud-provider-alibaba-cloud-check
+    cluster: default
     always_run: true
     branches:
     - master
@@ -20,6 +21,7 @@ presubmits:
       description: alibaba cloud provider checks
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-alibaba-cloud-unit-test
+    cluster: default
     always_run: true
     branches:
     - master

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 6h
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   name: ci-cloud-provider-aws-e2e
   decorate: true
   decoration_config:
@@ -12,7 +12,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-aws-credential-aws-oss-testing: "true"
+    preset-aws-credential-aws-shared-testing: "true"
     preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes
@@ -43,7 +43,7 @@ periodics:
       securityContext:
         privileged: true
 - interval: 6h
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   name: ci-cloud-provider-aws-e2e-with-kubernetes-master
   decorate: true
   decoration_config:
@@ -55,7 +55,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-aws-credential-aws-oss-testing: "true"
+    preset-aws-credential-aws-shared-testing: "true"
     preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes
@@ -98,7 +98,7 @@ periodics:
     testgrid-dashboards: presubmits-ec2, amazon-ec2, amazon-ec2-provider, provider-aws-periodics
   labels:
     preset-dind-enabled: "true"
-    preset-aws-credential-aws-oss-testing: "true"
+    preset-aws-credential-aws-shared-testing: "true"
     preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes
@@ -178,7 +178,7 @@ periodics:
     testgrid-dashboards: presubmits-ec2, amazon-ec2, amazon-ec2-provider, provider-aws-periodics
   labels:
     preset-dind-enabled: "true"
-    preset-aws-credential-aws-oss-testing: "true"
+    preset-aws-credential-aws-shared-testing: "true"
     preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/cloud-provider-aws:
   - name: pull-cloud-provider-aws-e2e
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -9,10 +10,17 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-aws-credential-aws-oss-testing: "true"
+      preset-aws-credential-aws-shared-testing: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
         command:
         - runner.sh
         args:
@@ -28,6 +36,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: pull-cloud-provider-aws-e2e-kubetest2
+    cluster: eks-prow-build-cluster
     skip_branches:
       - release-\d+\.\d+  # per-release image
     annotations:
@@ -41,7 +50,6 @@ presubmits:
     path_alias: k8s.io/cloud-provider-aws
     always_run: true
     optional: true
-    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 4h
@@ -106,6 +114,7 @@ presubmits:
               memory: 10Gi
 
   - name: pull-cloud-provider-aws-e2e-kubetest2-quick
+    cluster: eks-prow-build-cluster
     skip_branches:
       - release-\d+\.\d+  # per-release image
     annotations:
@@ -119,7 +128,6 @@ presubmits:
     path_alias: k8s.io/cloud-provider-aws
     always_run: true
     optional: true
-    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 4h

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
@@ -253,6 +253,7 @@ presubmits:
 
   # Executes the e2e tests.
   - name: pull-cloud-provider-vsphere-e2e-test-1-26-minus
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -350,6 +350,7 @@ presubmits:
 
   # Executes the e2e tests.
   - name: pull-cloud-provider-vsphere-e2e-test
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -389,6 +390,7 @@ postsubmits:
 
   # Deploys the images and binaries after all merges to master
   - name: post-cloud-provider-vsphere-deploy
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -424,6 +426,7 @@ postsubmits:
 
   # Deploys images and binaries for tagged releases
   - name: post-cloud-provider-vsphere-release
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -25,6 +25,7 @@ presubmits:
       testgrid-dashboards: sig-contribex-community
       testgrid-tab-name: pull-verify
   - name: pull-community-tempelis-check
+    cluster: default
     decorate: true
     branches:
     - ^master$

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
 
   # kinder presubmits
   - name: pull-kubeadm-kinder-verify
+    cluster: default
     decorate: true
     optional: false
     path_alias: "k8s.io/kubeadm"
@@ -15,6 +16,7 @@ presubmits:
         - "./kinder/hack/verify-all.sh"
 
   - name: pull-kubeadm-kinder-upgrade-latest
+    cluster: default
     decorate: true
     optional: false
     run_if_changed: '^kinder\/.*$'

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/release:
   - name: pull-release-cluster-up
+    cluster: default
     run_if_changed: '^push-build.sh'
     labels:
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: check-dependency-stats
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 5m

--- a/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
+++ b/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-kind-kms
+    cluster: default
     decorate: true
     decoration_config:
       timeout: 150m

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-autoscaling-vpa-actuation
+  cluster: default
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -31,6 +32,7 @@ periodics:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-actuation
 - name: ci-kubernetes-e2e-autoscaling-vpa-admission-controller
+  cluster: default
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -62,6 +64,7 @@ periodics:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-admission-controller
 - name: ci-kubernetes-e2e-autoscaling-vpa-full
+  cluster: default
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -93,6 +96,7 @@ periodics:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-full
 - name: ci-kubernetes-e2e-autoscaling-vpa-recommender
+  cluster: default
   interval: 3h
   labels:
     preset-service-account: "true"
@@ -124,6 +128,7 @@ periodics:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-recommender
 - name: ci-kubernetes-e2e-autoscaling-vpa-updater
+  cluster: default
   interval: 2h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gci-gce-autoscaling
+    cluster: default
     annotations:
       testgrid-dashboards: sig-autoscaling-cluster-autoscaler
       testgrid-tab-name: gci-gce-autoscaling-pull
@@ -49,6 +50,7 @@ presubmits:
           privileged: true
 
   - name: pull-kubernetes-e2e-autoscaling-hpa-cpu
+    cluster: default
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
       testgrid-tab-name: gci-gce-autoscaling-hpa-cpu-pull
@@ -91,6 +93,7 @@ presubmits:
           privileged: true
 
   - name: pull-kubernetes-e2e-autoscaling-hpa-cm
+    cluster: default
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
       testgrid-tab-name: gci-gce-autoscaling-hpa-cm-pull

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-azure-disk
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -52,6 +53,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-disk-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -104,6 +106,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -155,6 +158,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -208,6 +212,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-conformance
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-azure-disk
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -52,6 +53,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-disk-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -104,6 +106,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -155,6 +158,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -208,6 +212,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-conformance
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-azure-disk
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -52,6 +53,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-disk-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -104,6 +106,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -155,6 +158,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -208,6 +212,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-conformance
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-azure-disk
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -52,6 +53,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-disk-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -104,6 +106,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -155,6 +158,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-azure-file-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -208,6 +212,7 @@ presubmits:
               memory: "4Gi"
 
   - name: pull-kubernetes-e2e-capz-conformance
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-azure-disk
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -57,6 +58,7 @@ presubmits:
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-azure-disk-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -114,6 +116,7 @@ presubmits:
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-azure-file
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -170,6 +173,7 @@ presubmits:
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-azure-file-vmss
+    cluster: default
     decorate: true
     always_run: false
     optional: true
@@ -228,6 +232,7 @@ presubmits:
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-conformance
+    cluster: default
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -103,6 +103,7 @@ presubmits:
         securityContext:
           privileged: true
   - name: pull-kubernetes-e2e-gce-cos-kubetest2
+    cluster: default
     # explicitly needs /test pull-kubernetes-e2e-gce to run
     always_run: false
     # if at all it is run and fails, don't block the PR
@@ -326,6 +327,7 @@ presubmits:
             privileged: true
 
   - name: pull-kubernetes-e2e-gce-cos-alpha-features
+    cluster: default
     optional: true
     run_if_changed: '^.*feature.*\.go'
     branches:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -10,6 +10,7 @@ presets:
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: default
     skip_branches:
     - release-\d+\.\d+
     annotations:

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-kind-json-logging
+    cluster: default
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:
@@ -68,6 +69,7 @@ presubmits:
             cpu: 7
 
   - name: pull-kubernetes-kind-text-logging
+    cluster: default
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:

--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
             memory: "4Gi"
   # Check that images to be promoted are free of fixable vulnerabilities
   - name: pull-k8sio-cip-vuln
+    cluster: default
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-k8s-infra-k8sio
@@ -57,6 +58,7 @@ presubmits:
         - --certificate-oidc-issuer=https://accounts.google.com
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
+    cluster: default
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-k8s-infra-k8sio
@@ -78,6 +80,7 @@ presubmits:
         - name: GOPATH
           value: /go
   - name: pull-k8sio-file-promo
+    cluster: default
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
@@ -102,6 +105,7 @@ presubmits:
   # Adds two extra containers to dry-run miroring for staging and production mirrors.
   # TODO(justinsb): merge with pull-k8sio-file-promo once we are happy with it
   - name: pull-k8sio-file-promo-with-mirroring
+    cluster: default
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -85,6 +85,7 @@ presets:
 presubmits:
   kubernetes/ingress-gce:
   - name: pull-ingress-gce-test
+    cluster: default
     always_run: true
     decorate: true
     labels:
@@ -106,6 +107,7 @@ presubmits:
       testgrid-tab-name: pull-ingress-gce-test
 
   - name: pull-ingress-gce-verify
+    cluster: default
     always_run: true
     decorate: true
     branches:
@@ -129,6 +131,7 @@ presubmits:
       testgrid-tab-name: pull-ingress-gce-verify
 
   - name: pull-ingress-gce-e2e
+    cluster: default
     always_run: true
     optional: false
     decorate: true
@@ -160,6 +163,7 @@ presubmits:
 
 periodics:
 - name: ci-ingress-gce-e2e
+  cluster: default
   interval: 6h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -4,6 +4,7 @@ presubmits:
   kubernetes/kubernetes:
 
   - name: pull-kubernetes-e2e-gci-gce-ingress
+    cluster: default
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
     - master
@@ -72,6 +73,7 @@ presubmits:
       description: Uses kubetest to run e2e Conformance, SIG-Network or Network Ingress tests against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
 
   - name: pull-kubernetes-e2e-ubuntu-gce-network-policies
+    cluster: default
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
     - master
@@ -140,6 +142,7 @@ presubmits:
       description: Uses kubetest to run e2e Conformance, SIG-Network or Network Policy tests against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
 
   - name: pull-kubernetes-e2e-gci-gce-ipvs
+    cluster: default
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
     - master

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -37,6 +37,7 @@ presets:
 periodics:
 # containerd build PERIODICS have been moved to the config/jobs/containerd/containerd folder. Please don't add any in here.
 - name: ci-containerd-e2e-ubuntu-gce
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -66,6 +67,7 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
 - name: ci-cos-cgroupv1-containerd-node-e2e
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -353,6 +355,7 @@ periodics:
 #    testgrid-tab-name: soak-cos-gce
 
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
+  cluster: default
   cron: "30 1-23/3 * * *"
   labels:
     preset-service-account: "true"
@@ -879,6 +882,7 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv2-containerd-node-e2e
 - name: ci-cgroup-systemd-containerd-node-e2e
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -1041,6 +1045,7 @@ periodics:
     testgrid-tab-name: gce-containerd
     description: node gce e2e tests for master branch using containerd
 - name: ci-kubernetes-node-kubelet-containerd-resource-managers
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -1072,6 +1077,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes CPU, Memory and Topology manager e2e tests"
 - name: ci-kubernetes-node-kubelet-containerd-hugepages
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -1104,6 +1110,7 @@ periodics:
     description: "Executes hugepages e2e tests"
 
 - name: ci-kubernetes-node-swap-ubuntu
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -1177,6 +1184,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes performance e2e tests"
 - name: ci-kubernetes-node-kubelet-lock-contention
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -1206,6 +1214,7 @@ periodics:
     testgrid-tab-name: kubelet-gce-e2e-lock-contention
     description: "Contains disruptive tests for the Lock Contention feature."
 - name: ci-kubernetes-node-kubelet-credential-provider
+  cluster: default
   interval: 6h
   labels:
     preset-service-account: "true"
@@ -1235,6 +1244,7 @@ periodics:
     testgrid-tab-name: kubelet-credential-provider
     description: "tests feature kubelet image credential provider"
 - name: ci-kubernetes-e2e-gcp-credential-provider
+  cluster: default
   interval: 24h
   labels:
     preset-service-account: "true"
@@ -1263,6 +1273,7 @@ periodics:
     testgrid-tab-name: gcp-kubelet-credential-provider
     description: "tests feature gcp kubelet image credential provider"
 - name: ci-cos-cgroupv2-inplace-pod-resize-containerd-main-e2e-gce-serial
+  cluster: default
   interval: 24h
   labels:
     preset-service-account: "true"
@@ -1301,6 +1312,7 @@ periodics:
     testgrid-tab-name: cos-cgroupv2-inplace-pod-resize-containerd-e2e-serial
     description: Runs cluster e2e pod resize tests in serial with FOCUS=[Feature:InPlacePodVerticalScaling] with cgroup v2
 - name: ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce-serial
+  cluster: default
   interval: 48h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-crio-cgroupv1-node-e2e-conformance
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -66,6 +67,7 @@ periodics:
 #     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 #     description: "OWNER: sig-node; runs NodeConformance and alpha e2e tests with crio master and cgroup v1"
 - name: ci-crio-cgroupv1-node-e2e-features
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -98,6 +100,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs NodeFeatures e2e tests with crio master and cgroup v1"
 - name: ci-crio-cgroupv1-node-e2e-flaky
+  cluster: default
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -130,6 +133,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs NodeFeatures e2e tests with crio master and cgroup v1"
 - name: ci-crio-cgroupv1-node-e2e-unlabelled
+  cluster: default
   interval: 12h
   labels:
     preset-service-account: "true"
@@ -162,6 +166,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [NodeFeature] or [NodeSpecialFeature] or [NodeAlphaFeature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
 - name: ci-crio-cgroupv1-node-e2e-eviction
+  cluster: default
   interval: 4h30m
   labels:
     preset-service-account: "true"
@@ -194,6 +199,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v1"
 - name: ci-crio-cgroupv2-node-e2e-conformance
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -226,6 +232,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
 - name: ci-crio-cgroupv1-node-e2e-resource-managers
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -258,6 +265,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes CPU, Memory and Topology manager e2e tests"
 - name: ci-crio-cgroupv1-node-e2e-hugepages
+  cluster: default
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -290,6 +298,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
 - name: ci-crio-cgroupv1-evented-pleg
+  cluster: default
   interval: 3h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -47,6 +47,7 @@ periodics:
 
   # This job runs e2e_node.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
   - name: ci-node-e2e-crio-dra
+    cluster: default
     interval: 6h
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
@@ -82,6 +83,7 @@ periodics:
 
   # This job runs the same tests as ci-node-e2e-crio-dra with Containerd 1.7 runtime
   - name: ci-node-e2e-containerd-1-7-dra
+    cluster: default
     interval: 6h
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation

--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-node-release-branch-1-25
+  cluster: default
   interval: 24h
   labels:
     preset-service-account: "true"
@@ -34,6 +35,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.25
 - name: ci-kubernetes-node-release-branch-1-26
+  cluster: default
   interval: 24h
   labels:
     preset-service-account: "true"
@@ -68,6 +70,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.26
 - name: ci-kubernetes-node-release-branch-1-27
+  cluster: default
   interval: 24h
   labels:
     preset-service-account: "true"
@@ -102,6 +105,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.27
 - name: ci-kubernetes-node-release-branch-1-28
+  cluster: default
   interval: 24h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-containerd-gce
+    cluster: default
     always_run: false
     optional: true
     skip_branches:
@@ -240,6 +241,7 @@ presubmits:
               cpu: 8
               memory: 10Gi
   - name: pull-kubernetes-node-arm64-ubuntu-serial-gce
+    cluster: default
     # this is functional duplicated with `pull-kubernetes-node-arm64-e2e-containerd-serial-ec2`, consider to remove one of them when either of them is green
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -295,6 +297,7 @@ presubmits:
             cpu: 4
             memory: 6Gi
   - name: pull-kubernetes-node-e2e-containerd-kubetest2
+    cluster: default
     always_run: false
     optional: true
     branches:
@@ -491,6 +494,7 @@ presubmits:
             memory: 6Gi
 
   - name: pull-kubernetes-node-kubelet-serial-containerd
+    cluster: default
     always_run: false
     optional: true
     skip_report: false
@@ -531,6 +535,7 @@ presubmits:
               cpu: 4
               memory: 6Gi
   - name: pull-kubernetes-node-kubelet-serial-containerd-alpha-features
+    cluster: default
     always_run: false
     optional: true
     skip_report: false
@@ -573,6 +578,7 @@ presubmits:
   # TODO(gjkim42, SidecarContainers): Remove this once SidecarContainers
   # graduates to beta.
   - name: pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers
+    cluster: default
     always_run: false
     optional: true
     skip_report: false
@@ -613,6 +619,7 @@ presubmits:
               cpu: 4
               memory: 6Gi
   - name: pull-kubernetes-node-kubelet-serial-containerd-kubetest2
+    cluster: default
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-containerd-kubetest2 to run
     always_run: false
     # if at all it is run and fails, don't block the PR
@@ -1526,6 +1533,7 @@ presubmits:
   # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
   # on a kind cluster with containerd updated to a version with CDI support.
   - name: pull-kubernetes-kind-dra
+    cluster: default
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:
@@ -1894,6 +1902,7 @@ presubmits:
   #     Until then, this job complements pull-kubernetes-e2e-gce-cos-alpha-features by running inplace pod resize e2e tests
   #     full-spectrum against containerd/main which has the necessary CRI support.
   - name: pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
+    cluster: default
     optional: true
     always_run: false
     run_if_changed: 'test/e2e/node/pod_resize.go|pkg/kubelet/kubelet.go|pkg/kubelet/kubelet_pods.go|pkg/kubelet/kuberuntime/kuberuntime_manager.go'

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
@@ -9,6 +9,7 @@
 presubmits:
   kubernetes/perf-tests:
   - name: pull-perf-tests-100-adhoc
+    cluster: default
     always_run: false # This test needs to be triggered manually via `/test pull-perf-tests-100-adhoc`
     max_concurrency: 1 # Keep at 1 until we figure out a proper reservation system.
     skip_report: false # Report the status on github.

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-storage-scalability
+  cluster: default
   tags:
     - "perfDashPrefix: storage"
     - "perfDashJobType: storage"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -278,6 +278,7 @@ periodics:
           memory: "2Gi"
 
 - name: ci-kubernetes-kubemark-100-gce-scheduler-highqps
+  cluster: default
   tags:
   - "perfDashPrefix: kubemark-100Nodes-scheduler-highqps"
   - "perfDashJobType: performance"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -88,6 +88,7 @@ presubmits:
           privileged: true
 
   - name: pull-kubernetes-e2e-gce-big-performance
+    cluster: default
     always_run: false
     max_concurrency: 1
     branches:
@@ -221,6 +222,7 @@ presubmits:
           privileged: true
 
   - name: pull-kubernetes-e2e-gce-scale-performance-manual
+    cluster: default
     always_run: false
     max_concurrency: 1
     branches:
@@ -493,6 +495,7 @@ presubmits:
 
   kubernetes/perf-tests:
   - name: pull-perf-tests-benchmark-kube-dns
+    cluster: default
     always_run: false
     skip_report: false
     max_concurrency: 3
@@ -536,6 +539,7 @@ presubmits:
         - --timeout=120m
 
   - name: pull-perf-tests-clusterloader2
+    cluster: default
     always_run: false
     skip_report: false
     max_concurrency: 3
@@ -606,6 +610,7 @@ presubmits:
             memory: "6Gi"
 
   - name: pull-perf-tests-clusterloader2-kubemark
+    cluster: default
     always_run: false
     skip_report: false
     max_concurrency: 3
@@ -682,6 +687,7 @@ presubmits:
 
   # Fork of kubernetes/kubernetes: pull-kubernetes-e2e-gce-scale-performance-manual
   - name: pull-perf-tests-clusterloader2-e2e-gce-scale-performance-manual
+    cluster: default
     always_run: false
     max_concurrency: 1
     branches:
@@ -772,6 +778,7 @@ presubmits:
           privileged: true
 
   - name: pull-perf-tests-util-images
+    cluster: default
     always_run: false
     skip_report: false
     max_concurrency: 10
@@ -807,6 +814,7 @@ presubmits:
             memory: "2Gi"
 
   - name: pull-perf-tests-verify-all-python
+    cluster: default
     decorate: true
     always_run: true
     skip_branches:
@@ -831,6 +839,7 @@ presubmits:
               memory: "2Gi"
 
   - name: pull-perf-tests-verify-test
+    cluster: default
     decorate: true
     always_run: true
     skip_branches:
@@ -853,6 +862,7 @@ presubmits:
             memory: "2Gi"
 
   - name: pull-perf-tests-verify-dashboard
+    cluster: default
     decorate: true
     run_if_changed: ^clusterloader2/pkg/prometheus/manifests/dashboards/.*\.json$
     skip_branches:
@@ -877,6 +887,7 @@ presubmits:
             memory: "2Gi"
 
   - name: pull-perf-tests-verify-lint
+    cluster: default
     decorate: true
     always_run: true
     skip_branches:

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gce-storage-slow
+    cluster: default
     always_run: false
     optional: true
     # All the files owned by sig-storage. Keep in sync across
@@ -52,6 +53,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
   - name: pull-kubernetes-e2e-gce-storage-snapshot
+    cluster: default
     always_run: false
     optional: true
     # All the files owned by sig-storage. Keep in sync across
@@ -102,6 +104,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
   - name: pull-kubernetes-e2e-gce-csi-serial
+    cluster: default
     always_run: false
     optional: true
     # All the files owned by sig-storage. Keep in sync across
@@ -152,6 +155,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
   - name: pull-kubernetes-e2e-gce-storage-disruptive
+    cluster: default
     always_run: false
     optional: true
     branches:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-prow-canary
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -55,6 +56,7 @@ periodics:
     testgrid-tab-name: gce
 
 - name: ci-kubernetes-e2e-node-canary
+  cluster: default
   interval: 1h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -50,6 +50,7 @@ presets:
 
 periodics:
 - name: ci-kubernetes-e2e-windows-containerd-gce-master
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h
@@ -99,6 +100,7 @@ periodics:
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 - name: ci-kubernetes-e2e-windows-win2022-containerd-gce-master
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-test-infra-benchmark-demo
+  cluster: default
   interval: 24h
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-test-infra-continuous-test
+  cluster: default
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -28,6 +29,7 @@ periodics:
     description: Runs `make test verify` on the test-infra repo every hour
 
 - name: metrics-kettle
+  cluster: default
   interval: 1h
   decorate: true
   extra_refs:
@@ -54,6 +56,7 @@ periodics:
     description: Monitors Kettle's BigQuery database freshness.
 
 - name: test-infra-fuzz
+  cluster: default
   labels:
     preset-dind-enabled: "true"
   decorate: true
@@ -94,6 +97,7 @@ periodics:
     description: Runs clusterfuzzlite every hour
 
 - name: test-infra-cfl-coverage-report
+  cluster: default
   labels:
     preset-dind-enabled: "true"
   decorate: true
@@ -135,6 +139,7 @@ periodics:
     description: Runs clusterfuzzlite coverage report every day
 
 - name: test-infra-cfl-prune
+  cluster: default
   labels:
     preset-dind-enabled: "true"
   decorate: true


### PR DESCRIPTION
Adds `cluster: default` to all jobs that do not currently have a cluster defined. 

/hold do not merge