### PR TITLE
CAPI: Make most presubmits blocking

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -92,7 +92,6 @@ presubmits:
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -128,7 +127,6 @@ presubmits:
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -196,7 +194,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
       # The script this job runs is not in all branches.
@@ -234,7 +231,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -269,7 +265,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-3.yaml
@@ -239,7 +239,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    optional: true
     always_run: false
     branches:
     - ^release-1.3$
@@ -275,7 +274,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    optional: true
     always_run: false
     branches:
     - ^release-1.3$

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-4.yaml
@@ -226,7 +226,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
       # The script this job runs is not in all branches.
@@ -261,7 +260,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
       # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
@@ -92,7 +92,6 @@ presubmits:
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -128,7 +127,6 @@ presubmits:
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -228,7 +226,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
       # The script this job runs is not in all branches.
@@ -266,7 +263,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -301,7 +297,6 @@ presubmits:
     decorate: true
     decoration_config:
       gcs_credentials_secret: "" # Use workload identity for uploading artifacts
-    optional: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.


### PR DESCRIPTION
Make most of the presubmit jobs for Cluster API blocking on PRs by making them non-optional. The jobs which are still optional are:

- `pull-cluster-api-e2e-scale-main-experimental` which is experimental and should not block.
- `pull-cluster-api-apidiff-main` which needs to be optional to allow api changes in PRs.
- `pull-cluster-api-e2e-informing-release-1-5` which is explicitly optional - i.e. pr informing rather than blocking.
- `pull-cluster-api-e2e-informing-ipv6-release-1-4` which is explicitly optional - i.e. pr informing rather than blocking
- `pull-cluster-api-e2e-informing-ipv6-release-1-3` which is explicitly optional - i.e. pr informing rather than blocking