### PR TITLE
Drop the old preset-service-account from cloud-provider-aws jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -10,7 +10,6 @@ periodics:
     testgrid-dashboards: presubmits-ec2, amazon-ec2, amazon-ec2-provider, provider-aws-periodics
     description: Runs e2e against cloud-provider-aws master on AWS
   labels:
-    preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-aws-credential-aws-shared-testing: "true"
     preset-k8s-ssh: "true"
@@ -54,7 +53,6 @@ periodics:
     testgrid-dashboards: presubmits-ec2, amazon-ec2, amazon-ec2-provider, provider-aws-periodics
     description: Runs e2e against cloud-provider-aws master on AWS using latest k8s.io/kubernetes libraries
   labels:
-    preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-aws-credential-aws-shared-testing: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -8,7 +8,6 @@ presubmits:
     - gh-pages
     path_alias: k8s.io/cloud-provider-aws
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-aws-credential-aws-shared-testing: "true"
     spec:
@@ -48,6 +47,7 @@ presubmits:
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
+      preset-aws-credential-aws-shared-testing: "true"
     path_alias: k8s.io/cloud-provider-aws
     always_run: true
     optional: true
@@ -126,6 +126,7 @@ presubmits:
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
+      preset-aws-credential-aws-shared-testing: "true"
     path_alias: k8s.io/cloud-provider-aws
     always_run: true
     optional: true


### PR DESCRIPTION
All jobs needing to access AWS services should:

- Run in `cluster: eks-prow-build-cluster`
- Should have `serviceAccountName: aws-shared-testing-role` in `spec`
- Should have `preset-aws-credential-aws-shared-testing: "true"` in `label`
- Should not have `preset-service-account: "true"`