### PR TITLE
capg: migrate prowjobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -62,6 +62,7 @@ periodics:
       testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
       testgrid-num-failures-to-alert: "2"
   - name: periodic-cluster-api-provider-gcp-make-conformance-main
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -88,6 +89,9 @@ periodics:
           securityContext:
             privileged: true
           resources:
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
             requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
@@ -100,6 +104,7 @@ periodics:
       testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
       testgrid-num-failures-to-alert: "2"
   - name: periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -135,6 +140,9 @@ periodics:
           securityContext:
             privileged: true
           resources:
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
             requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -47,6 +47,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build
   - name: pull-cluster-api-provider-gcp-make
+    cluster: k8s-infra-prow-build
     always_run: true
     optional: false
     decorate: true
@@ -107,6 +108,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-verify
   - name: pull-cluster-api-provider-gcp-e2e-test
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -138,10 +140,14 @@ presubmits:
               memory: "9000Mi"
               # during the tests more like 3-20m is used
               cpu: 2000m
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test
   - name: pull-cluster-api-provider-gcp-conformance-ci-artifacts
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -183,10 +189,14 @@ presubmits:
               memory: "9000Mi"
               # during the tests more like 3-20m is used
               cpu: 2000m
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance-ci-artifacts
   - name: pull-cluster-api-provider-gcp-conformance
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -218,10 +228,14 @@ presubmits:
               memory: "9000Mi"
               # during the tests more like 3-20m is used
               cpu: 2000m
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance
   - name: pull-cluster-api-provider-gcp-capi-e2e
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -253,10 +267,14 @@ presubmits:
             requests:
               memory: "9000Mi"
               cpu: 2000m
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-capi-e2e-test
   - name: pull-cluster-api-provider-gcp-e2e-workload-upgrade
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -284,6 +302,9 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              memory: "9000Mi"
+              cpu: 2000m
             requests:
               memory: "9000Mi"
               cpu: 2000m


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/test-infra/issues/30277

Move some prowjobs to k8s-infra-prow-build