### PR TITLE
Set a higher timeout for pull-aws-load-balancer-controller-e2e-test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -56,6 +56,8 @@ presubmits:
     cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 4h
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
looks like this job is a bit flaky. let's try bumping the timeout
https://testgrid.k8s.io/provider-aws-load-balancer-controller#e2e%20test&width=20