### PR TITLE
Add service account to pull-aws-ebs-csi-driver-test-helm-chart

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-aws-credential-shared-oss-testing: "true"
     spec:
+      serviceAccountName: aws-shared-testing-role
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         command:


### PR DESCRIPTION
related to:
https://github.com/kubernetes/k8s.io/issues/5194

looks like we need to add service account explicitly because the error looks like this:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/1745/pull-aws-ebs-csi-driver-test-helm-chart/1703020309822574592/build-log.txt

```
An error occurred (AccessDeniedException) when calling the GetParameters operation: User: arn:aws:sts::468814281478:assumed-role/build-managed-green-eks-node-group-20230710085529221600000001/i-077eb03bcc672ff59 is not authorized to perform: ssm:GetParameters on resource: arn:aws:ssm:us-west-2::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 because no identity-based policy allows the ssm:GetParameters action
```