### PR TITLE
make k8s version consistent in Azure CSI driver e2e test

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -720,7 +720,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.26
+        base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -775,7 +775,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.26
+        base_ref: release-1.25
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -952,7 +952,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.26
+        base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -577,7 +577,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.26
+        base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -628,7 +628,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.26
+        base_ref: release-1.25
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:


### PR DESCRIPTION
this PR makes k8s version consistent in Azure CSI driver e2e test, trying to fix the windows image pulling failure