### PR TITLE
capv: extend external secret to split credentials per project

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -11,12 +11,12 @@ presets:
     valueFrom:
       secretKeyRef:
         name: cluster-api-provider-vsphere-ci
-        key: vmc-vcenter-user
+        key: vmc-vcenter-cluster-api-provider-vsphere-user
   - name: GOVC_PASSWORD
     valueFrom:
       secretKeyRef:
         name: cluster-api-provider-vsphere-ci
-        key: vmc-vcenter-password
+        key: vmc-vcenter-cluster-api-provider-vsphere-password
   - name: VSPHERE_TLS_THUMBPRINT
     valueFrom:
       secretKeyRef:

--- a/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build/build_kubernetes-external-secrets_customresource.yaml
@@ -84,17 +84,29 @@ spec:
   - key: vmc-e2e-vm-ssh_pubkey
     name: vmc-e2e-vm-ssh.pubkey
     version: latest
-  - key: vmc-vcenter-password
-    name: vmc-vcenter-password
-    version: latest
   - key: vmc-vcenter-thumbprint
     name: vmc-vcenter-thumbprint
     version: latest
   - key: vmc-vcenter-url
     name: vmc-vcenter-url
     version: latest
-  - key: vmc-vcenter-user
-    name: vmc-vcenter-user
+  - key: vmc-vcenter-cluster-api-provider-vsphere-user
+    name: vmc-vcenter-cluster-api-provider-vsphere-user
+    version: latest
+  - key: vmc-vcenter-cluster-api-provider-vsphere-password
+    name: vmc-vcenter-cluster-api-provider-vsphere-password
+    version: latest
+  - key: vmc-vcenter-cloud-provider-vsphere-user
+    name: vmc-vcenter-cloud-provider-vsphere-user
+    version: latest
+  - key: vmc-vcenter-cloud-provider-vsphere-password
+    name: vmc-vcenter-cloud-provider-vsphere-password
+    version: latest
+  - key: vmc-vcenter-image-builder-user
+    name: vmc-vcenter-image-builder-user
+    version: latest
+  - key: vmc-vcenter-image-builder-password
+    name: vmc-vcenter-image-builder-password
     version: latest
   - key: vmc-vpn-ca_crt
     name: vmc-vpn-ca.crt


### PR DESCRIPTION
/assign @sbueringer 
/assign @killianmuldoon 

Note: new secrets in SecretManager exist and should already have the required permissions for the prow service accounts.