### PR TITLE
prow: cosi: re-enable build test with docker build

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -13,9 +13,10 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
         command:
-        - make
+        - /buildx-entrypoint
         args:
         - build
+        - .
         resources:
           limits:
             cpu: 2


### PR DESCRIPTION
Test for building COSI was previously disabled. COSI builds using docker multi-stage build.