### PR TITLE
kubeadm: update OWNERS for 1.29

### DIFF
--- a/config/jobs/kubernetes/kubeadm/OWNERS
+++ b/config/jobs/kubernetes/kubeadm/OWNERS
@@ -1,6 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
-- fabriziopandini
 - neolit123
 - SataQiu
 - pacoxu
@@ -9,8 +8,8 @@ reviewers:
 - neolit123
 - SataQiu
 - pacoxu
-- RA489
 emeritus_approvers:
+- fabriziopandini
 - luxas
 - timothysc
 labels:


### PR DESCRIPTION
/cc @SataQiu @pacoxu 

side cleanup PR to:
https://github.com/kubernetes/kubeadm/pull/2930
https://github.com/kubernetes/kubernetes/pull/120598

- remove `@RA489` from reviewers
- move `@fabriziopandini` to emeritus

~leaving `@fabriziopandini` as approver since he is a SIG CL lead.~
actually, this is the k/kubeadm path OWNERS file, thus the cleanup can be done here.
continues to be present in kubernetes/sig-cluster-lifecycle/OWNERS as a SIG lead.
