### PR TITLE
prow: cosi: use dind for build test

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -1,5 +1,6 @@
 presubmits:
   kubernetes-sigs/container-object-storage-interface-controller:
+
   - name: pull-container-object-storage-interface-controller-build
     cluster: eks-prow-build-cluster
     always_run: true
@@ -9,14 +10,22 @@ presubmits:
       testgrid-dashboards: sig-storage-container-object-storage-interface-controller
       testgrid-tab-name: build
       description: Build test in container-object-storage-interface-controller repo.
+    labels:
+      # running a docker-based build requires docker-in-docker (DinD)
+      preset-dind-enabled: "true"  # see config/prow/config.yaml - 'presets' section
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
+      # specified tags are periodically updated in bulk for all prow jobs
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         command:
-        - /buildx-entrypoint
+        - runner.sh
         args:
-        - build
-        - .
+        - bash
+        - -c
+        - |
+          make build
+        securityContext:
+          privileged: true # docker-in-docker needs privileged mode
         resources:
           limits:
             cpu: 2


### PR DESCRIPTION
Use Docker-in-Docker (DinD) for docker-based build. Many projects use this pattern, which is identifiable by the label `preset-dind-enabled: "true"`.