### PR TITLE
[Kueue] Add a Job for K8s v1.28 E2E and remove one for K8s v1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -210,6 +210,44 @@ presubmits:
           limits:
             cpu: "10"
             memory: "40Gi"
+  - name: pull-kueue-test-e2e-main-1-28
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^main
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-main-1-28
+      description: "Run kueue end to end tests for Kubernetes 1.28"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.28.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.20
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "40Gi"
+            limits:
+              cpu: "10"
+              memory: "40Gi"
   - name: pull-kueue-verify-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -58,44 +58,6 @@ presubmits:
           limits:
             cpu: "4"
             memory: "16Gi"
-  - name: pull-kueue-test-e2e-main-1-24
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-24
-      description: "Run kueue end to end tests for Kubernetes 1.24"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.24.15
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.20
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "40Gi"
-          limits:
-            cpu: "10"
-            memory: "40Gi"
   - name: pull-kueue-test-e2e-main-1-25
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -74,50 +74,6 @@ periodics:
               cpu: "4"
               memory: "16Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-24
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-24
-      description: "Run periodic kueue end to end tests for Kubernetes 1.24"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.24.15
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.20
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "40Gi"
-            limits:
-              cpu: "10"
-              memory: "40Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-main-1-25
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -249,3 +249,47 @@ periodics:
             limits:
               cpu: "10"
               memory: "40Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-main-1-28
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-main-1-28
+      description: "Run periodic kueue end to end tests for Kubernetes 1.28"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.28.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.20
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "40Gi"
+            limits:
+              cpu: "10"
+              memory: "40Gi"


### PR DESCRIPTION
I added a Job for K8s v1.28 E2E. Also, I removed a Job for K8s v1.24.

/hold for https://github.com/kubernetes-sigs/kueue/pull/1133
