### PR TITLE
migrate `kube-batch` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-batch/kube-batch-config.yaml
+++ b/config/jobs/kubernetes-sigs/kube-batch/kube-batch-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/kube-batch:
   - name: pull-kube-batch-verify
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: true
@@ -19,6 +20,13 @@ presubmits:
         - --
         - make
         - verify
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: presubmits-kube-batch
       testgrid-tab-name: verify


### PR DESCRIPTION
This PR moves the `kube-batch` jobs from the GCP cluster to the community owned EKS cluster.

Ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @hex108 @hzxuzhonghu @k82cn 