### PR TITLE
Adding support for retrieving Jira Project Versions

### DIFF
--- a/prow/jira/fakejira/fake.go
+++ b/prow/jira/fakejira/fake.go
@@ -41,6 +41,7 @@ type FakeClient struct {
 	Transitions      []jira.Transition
 	Users            []*jira.User
 	SearchResponses  map[SearchRequest]SearchResponse
+	ProjectVersions  map[string][]*jira.Version
 }
 
 func (f *FakeClient) ListProjects() (*jira.ProjectList, error) {
@@ -369,4 +370,11 @@ func (f *FakeClient) SearchWithContext(ctx context.Context, jql string, options 
 		return nil, nil, fmt.Errorf("the query: %s is not registered", jql)
 	}
 	return resp.issues, resp.response, resp.error
+}
+
+func (f *FakeClient) GetProjectVersions(project string) ([]*jira.Version, error) {
+	if versions, ok := f.ProjectVersions[project]; ok {
+		return versions, nil
+	}
+	return []*jira.Version{}, nil
 }

--- a/prow/jira/fakejira/fake_test.go
+++ b/prow/jira/fakejira/fake_test.go
@@ -72,3 +72,31 @@ func TestFakeClient_SearchWithContext(t *testing.T) {
 		t.Fatal("expected invalid query to fail, but got no error")
 	}
 }
+
+func TestFakeClient_GetProjectVersions(t *testing.T) {
+	fakeClient := &FakeClient{
+		ProjectVersions: map[string][]*jira.Version{
+			"ABC": {
+				{
+					Name: "Version1",
+				},
+				{
+					Name: "Version2",
+				},
+				{
+					Name: "Version3",
+				},
+			},
+		},
+	}
+
+	for _, project := range []string{"ABC", "FOO"} {
+		versions, err := fakeClient.GetProjectVersions(project)
+		if len(versions) != len(fakeClient.ProjectVersions[project]) {
+			t.Fatalf("expected: %d results, but got: %d", len(fakeClient.ProjectVersions[project]), len(versions))
+		}
+		if err != nil {
+			t.Fatalf("Error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Every Jira project can be configured with a list of `Version` objects that correspond to the "Releases" in the Jira UI.  This PR introduces an API to retrieve the list of versions associated with a project.  This will allow users the ability to interrogate and select an appropriate pre-populated version, if one exists.

The API relies on the following Jira REST Endpoint: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-versions/#api-rest-api-3-project-projectidorkey-versions-get