### PR TITLE
decode the urlopen output

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -589,7 +589,7 @@ def node():
             # metadata server.
             os.environ[NODE_ENV] = urllib.request.urlopen(urllib.request.Request(
                 'http://169.254.169.254/computeMetadata/v1/instance/name',
-                headers={'Metadata-Flavor': 'Google'})).read()
+                headers={'Metadata-Flavor': 'Google'})).read().decode('utf-8')
             os.environ[POD_ENV] = host  # We also want to log this.
         except IOError:  # Fallback.
             os.environ[NODE_ENV] = host


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/30759 reported an issue with the image bump. This PR decodes the metadata bytes to a string.

There could be more code locations this impacts; reverting https://github.com/kubernetes/test-infra/pull/30695 might make sense.