### PR TITLE
Make gangway optionally use Moonraker

### DIFF
--- a/prow/cmd/gangway/main.go
+++ b/prow/cmd/gangway/main.go
@@ -164,7 +164,11 @@ func main() {
 
 	// InRepoConfig getter.
 	if o.config.MoonrakerAddress != "" {
-		gw.InRepoConfigGetter = moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second)
+		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error getting Moonraker client.")
+		}
+		gw.InRepoConfigGetter = moonrakerClient
 	} else {
 		gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun, false)
 		if err != nil {

--- a/prow/cmd/gangway/main.go
+++ b/prow/cmd/gangway/main.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
+	"k8s.io/test-infra/prow/moonraker"
 	"k8s.io/test-infra/prow/pjutil"
 )
 
@@ -156,25 +157,30 @@ func main() {
 		}
 	}
 
-	gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun, false)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error getting Git client.")
+	gw := gangway.Gangway{
+		ConfigAgent:   configAgent,
+		ProwJobClient: prowjobClient,
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCache(o.config.InRepoConfigCacheSize, configAgent, gitClient)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
+	// InRepoConfig getter.
+	if o.config.MoonrakerAddress != "" {
+		gw.InRepoConfigGetter = moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second)
+	} else {
+		gitClient, err := o.github.GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun, false)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error getting Git client.")
+		}
+		ircc, err := config.NewInRepoConfigCache(o.config.InRepoConfigCacheSize, configAgent, gitClient)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error creating InRepoConfigCache.")
+		}
+		gw.InRepoConfigGetter = ircc
 	}
+
 	metrics.ExposeMetrics("gangway", configAgent.Config().PushGateway, o.instrumentationOptions.MetricsPort)
 
 	// Start serving liveness endpoint /healthz.
 	healthHTTP := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
-
-	gw := gangway.Gangway{
-		ConfigAgent:       configAgent,
-		ProwJobClient:     prowjobClient,
-		InRepoConfigCache: cacheGetter,
-	}
 
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(o.port))
 	if err != nil {

--- a/prow/cmd/moonraker/main.go
+++ b/prow/cmd/moonraker/main.go
@@ -170,6 +170,7 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/%s", moonraker.PathPing), mr.ServePing)
 	mux.HandleFunc(fmt.Sprintf("/%s", moonraker.PathGetInrepoconfig), mr.ServeGetInrepoconfig)
 	server := &http.Server{
 		Addr:    ":" + strconv.Itoa(o.port),

--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -354,6 +354,11 @@ func (cache *InRepoConfigCache) GetProwYAML(identifier string, baseSHAGetter Ref
 	return newProwYAML, nil
 }
 
+// GetInRepoConfig just wraps around GetProwYAML().
+func (cache *InRepoConfigCache) GetInRepoConfig(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+	return cache.GetProwYAML(identifier, baseSHAGetter, headSHAGetters...)
+}
+
 // getProwYAML performs a lookup of previously-calculated *ProwYAML objects. The
 // 'valConstructorHelper' is used in two ways. First it is used by the caching
 // mechanism to lazily generate the value only when it is required (otherwise,

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -115,6 +115,17 @@ type ProwYAMLGetter func(c *Config, gc git.ClientFactory, identifier, baseSHA st
 var _ ProwYAMLGetter = prowYAMLGetterWithDefaults
 var _ ProwYAMLGetter = prowYAMLGetter
 
+// InRepoConfigGetter defines a common interface that both the Moonraker client
+// and raw InRepoConfigCache can implement. This way, Prow components like Sub
+// and Gerrit can choose either one (based on runtime flags), but regardless of
+// the choice the surrounding code can still just call this GetProwYAML()
+// interface method (without being aware whether the underlying implementation
+// is going over the network to Moonraker or is done locally with the local
+// InRepoConfigCache (LRU cache)).
+type InRepoConfigGetter interface {
+	GetInRepoConfig(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error)
+}
+
 // prowYAMLGetter is like prowYAMLGetterWithDefaults, but without default values
 // (it does not call DefaultAndValidateProwYAML()). Its sole purpose is to allow
 // caching of ProwYAMLs that are retrieved purely from the inrepoconfig's repo,

--- a/prow/flagutil/config/config.go
+++ b/prow/flagutil/config/config.go
@@ -43,6 +43,9 @@ type ConfigOptions struct {
 	// Inrepoconfig related flags
 	InRepoConfigCacheSize    int
 	InRepoConfigCacheDirBase string
+	// Moonraker is the centralized Inrepconfig Caching Service. Using this flag
+	// overrides the use of the local InRepoConfigCache.
+	MoonrakerAddress string
 }
 
 func (o *ConfigOptions) AddFlags(fs *flag.FlagSet) {
@@ -59,6 +62,7 @@ func (o *ConfigOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.SupplementalProwConfigsFileNameSuffix, "supplemental-prow-configs-filename-suffix", "_prowconfig.yaml", "Suffix for additional prow configs. Only files with this name will be considered")
 	fs.IntVar(&o.InRepoConfigCacheSize, "in-repo-config-cache-size", 200, "Cache size for ProwYAMLs read from in-repo configs.")
 	fs.StringVar(&o.InRepoConfigCacheDirBase, "cache-dir-base", "", "Directory where the repo cache should be mounted.")
+	fs.StringVar(&o.MoonrakerAddress, "moonraker-address", "", "full HTTP address (domain and port) of moonraker service")
 }
 
 func (o *ConfigOptions) Validate(_ bool) error {

--- a/prow/gangway/gangway.go
+++ b/prow/gangway/gangway.go
@@ -668,12 +668,6 @@ func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *con
 	var presubmitJob *config.Presubmit
 	org, repo, branch := refs.Org, refs.Repo, refs.BaseRef
 	orgRepo := org + "/" + repo
-	// Add "https://" prefix to orgRepo if this is a gerrit job.
-	// (Unfortunately gerrit jobs use the full repo URL as the identifier.)
-	prefix := "https://"
-	if cjer.GetPodSpecOptions() != nil && cjer.GetPodSpecOptions().Labels[kube.GerritRevision] != "" && !strings.HasPrefix(orgRepo, prefix) {
-		orgRepo = prefix + orgRepo
-	}
 	baseSHAGetter := func() (string, error) {
 		return refs.BaseSHA, nil
 	}

--- a/prow/gangway/gangway.go
+++ b/prow/gangway/gangway.go
@@ -46,7 +46,7 @@ type Gangway struct {
 	UnimplementedProwServer
 	ConfigAgent       *config.Agent
 	ProwJobClient     ProwJobClient
-	InRepoConfigCache *config.InRepoConfigCache
+	InRepoConfigGetter config.InRepoConfigGetter
 }
 
 // ProwJobClient describes a Kubernetes client for the Prow Job CR. Unlike a
@@ -95,7 +95,7 @@ func (gw *Gangway) CreateJobExecution(ctx context.Context, cjer *CreateJobExecut
 	var reporterFunc ReporterFunc = nil
 	requireTenantID := true
 
-	jobExec, err := HandleProwJob(l, reporterFunc, cjer, gw.ProwJobClient, mainConfig, gw.InRepoConfigCache, allowedApiClient, requireTenantID, allowedClusters)
+	jobExec, err := HandleProwJob(l, reporterFunc, cjer, gw.ProwJobClient, mainConfig, gw.InRepoConfigGetter, allowedApiClient, requireTenantID, allowedClusters)
 	if err != nil {
 		logrus.WithError(err).Debugf("failed to create job %q", cjer.GetJobName())
 		return nil, err
@@ -450,7 +450,7 @@ func HandleProwJob(l *logrus.Entry,
 	cjer *CreateJobExecutionRequest,
 	pjc ProwJobClient,
 	mainConfig prowCfgClient,
-	pc *config.InRepoConfigCache,
+	ircg config.InRepoConfigGetter,
 	allowedApiClient *config.AllowedApiClient,
 	requireTenantID bool,
 	allowedClusters []string) (*JobExecution, error) {
@@ -463,7 +463,7 @@ func HandleProwJob(l *logrus.Entry,
 	if err != nil {
 		return nil, err
 	}
-	prowJobSpec, labels, annotations, err := jh.getProwJobSpec(mainConfig, pc, cjer)
+	prowJobSpec, labels, annotations, err := jh.getProwJobSpec(mainConfig, ircg, cjer)
 	if err != nil {
 		// These are user errors, i.e. missing fields, requested prowjob doesn't exist etc.
 		// These errors are already surfaced to user via pubsub two lines below.
@@ -587,13 +587,13 @@ func HandleProwJob(l *logrus.Entry,
 
 // jobHandler handles job type specific logic
 type jobHandler interface {
-	getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCache, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error)
+	getProwJobSpec(mainConfig prowCfgClient, ircg config.InRepoConfigGetter, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error)
 }
 
 // periodicJobHandler implements jobHandler
 type periodicJobHandler struct{}
 
-func (peh *periodicJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCache, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
+func (peh *periodicJobHandler) getProwJobSpec(mainConfig prowCfgClient, ircg config.InRepoConfigGetter, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
 	var periodicJob *config.Periodic
 	// TODO(chaodaiG): do we want to support inrepoconfig when
 	// https://github.com/kubernetes/test-infra/issues/21729 is done?
@@ -655,7 +655,7 @@ func validateRefs(jobType JobExecutionType, refs *prowcrd.Refs) error {
 	return nil
 }
 
-func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCache, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
+func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, ircg config.InRepoConfigGetter, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
 	// presubmit jobs require Refs and Refs.Pulls to be set
 	refs, err := ToCrdRefs(cjer.GetRefs())
 	if err != nil {
@@ -682,21 +682,18 @@ func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *con
 	logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch, "orgRepo": orgRepo})
 	// Get presubmits from Config alone.
 	presubmits := mainConfig.GetPresubmitsStatic(orgRepo)
-	// If InRepoConfigCache is provided, then it means that we also want to fetch
+	// If InRepoConfigGetter is provided, then it means that we also want to fetch
 	// from an inrepoconfig.
-	if pc != nil {
+	if ircg != nil {
 		logger.Debug("Getting prow jobs.")
 		var presubmitsWithInrepoconfig []config.Presubmit
 		var err error
-		presubmitsWithInrepoconfig, err = pc.GetPresubmits(orgRepo, baseSHAGetter, headSHAGetters...)
+		prowYAML, err := ircg.GetInRepoConfig(orgRepo, baseSHAGetter, headSHAGetters...)
 		if err != nil {
 			logger.WithError(err).Info("Failed to get presubmits")
 		} else {
 			logger.WithField("static-jobs", len(presubmits)).WithField("jobs-with-inrepoconfig", len(presubmitsWithInrepoconfig)).Debug("Jobs found.")
-			// Overwrite presubmits. This is safe because pc.GetPresubmits()
-			// itself calls mainConfig.GetPresubmitsStatic() and adds to it all the
-			// presubmits found in the inrepoconfig.
-			presubmits = presubmitsWithInrepoconfig
+			presubmits = append(presubmits, prowYAML.Presubmits...)
 		}
 	}
 
@@ -729,7 +726,7 @@ func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *con
 type postsubmitJobHandler struct {
 }
 
-func (poh *postsubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *config.InRepoConfigCache, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
+func (poh *postsubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, ircg config.InRepoConfigGetter, cjer *CreateJobExecutionRequest) (prowJobSpec *prowcrd.ProwJobSpec, labels map[string]string, annotations map[string]string, err error) {
 	// postsubmit jobs require Refs to be set
 	refs, err := ToCrdRefs(cjer.GetRefs())
 	if err != nil {
@@ -755,16 +752,16 @@ func (poh *postsubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, pc *co
 
 	logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "branch": branch, "orgRepo": orgRepo})
 	postsubmits := mainConfig.GetPostsubmitsStatic(orgRepo)
-	if pc != nil {
+	if ircg != nil {
 		logger.Debug("Getting prow jobs.")
 		var postsubmitsWithInrepoconfig []config.Postsubmit
 		var err error
-		postsubmitsWithInrepoconfig, err = pc.GetPostsubmits(orgRepo, baseSHAGetter)
+		prowYAML, err := ircg.GetInRepoConfig(orgRepo, baseSHAGetter)
 		if err != nil {
 			logger.WithError(err).Info("Failed to get postsubmits from inrepoconfig")
 		} else {
 			logger.WithField("static-jobs", len(postsubmits)).WithField("jobs-with-inrepoconfig", len(postsubmitsWithInrepoconfig)).Debug("Jobs found.")
-			postsubmits = postsubmitsWithInrepoconfig
+			postsubmits = append(postsubmits, prowYAML.Postsubmits...)
 		}
 	}
 

--- a/prow/moonraker/client.go
+++ b/prow/moonraker/client.go
@@ -19,6 +19,7 @@ package moonraker
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/version"
@@ -37,13 +39,31 @@ type Client struct {
 	httpClient *http.Client
 }
 
-func NewClient(host string, timeout time.Duration) *Client {
-	return &Client{
+func NewClient(host string, timeout time.Duration) (*Client, error) {
+	c := Client{
 		host: host,
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
 	}
+
+	// isMoonrakerUp is a ConditionFunc (see
+	// https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#ConditionFunc).
+	isMoonrakerUp := func() (bool, error) {
+		if err := c.Ping(); err != nil {
+			return false, nil
+		} else {
+			return true, nil
+		}
+	}
+
+	pollLoopTimeout := 15 * time.Second
+	pollInterval := 500 * time.Millisecond
+	if err := wait.Poll(pollInterval, pollLoopTimeout, isMoonrakerUp); err != nil {
+		return nil, errors.New("timed out waiting for Moonraker to be available")
+	}
+
+	return &c, nil
 }
 
 func (c *Client) do(method, path string, payload []byte, params map[string]string) (*http.Response, error) {
@@ -64,6 +84,18 @@ func (c *Client) do(method, path string, payload []byte, params map[string]strin
 	}
 	req.URL.RawQuery = q.Encode()
 	return c.httpClient.Do(req)
+}
+
+func (c *Client) Ping() error {
+	resp, err := c.do(http.MethodGet, PathPing, nil, nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == 200 {
+		return nil
+	}
+
+	return fmt.Errorf("invalid status code %d", resp.StatusCode)
 }
 
 // GetProwYAML returns the inrepoconfig contents for a repo, based on the Refs

--- a/prow/moonraker/moonraker.go
+++ b/prow/moonraker/moonraker.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	PathGetInrepoconfig = "inrepoconfig"
+	PathPing            = "ping"
 )
 
 type Moonraker struct {
@@ -45,6 +46,12 @@ type payload struct {
 
 type ProwYAMLGetter interface {
 	GetProwYAML(payload *payload) (*config.ProwYAML, error)
+}
+
+// ServePing responds with "pong". It's meant to be used by clients to check if
+// the service is up.
+func (mr *Moonraker) ServePing(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "pong")
 }
 
 // serveGetInrepoconfig returns a ProwYAML object marshaled into JSON.

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -29,6 +29,7 @@ import (
 	prowcrd "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gangway"
+	"k8s.io/test-infra/prow/kube"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -265,6 +266,13 @@ func (s *Subscriber) peToCjer(l *logrus.Entry, pe *ProwJobEvent, eType, subscrip
 		cjer.Refs, err = gangway.FromCrdRefs(pe.Refs)
 		if err != nil {
 			return nil, err
+		}
+
+		// Add "https://" prefix to orgRepo if this is a gerrit job.
+		// (Unfortunately gerrit jobs use the full repo URL as the identifier.)
+		prefix := "https://"
+		if pso.Labels[kube.GerritRevision] != "" && !strings.HasPrefix(cjer.Refs.Org, prefix) {
+			cjer.Refs.Org = prefix + cjer.Refs.Org
 		}
 	}
 

--- a/prow/test/integration/config/prow/cluster/gangway_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/gangway_deployment.yaml
@@ -24,26 +24,14 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --grace-period=110s
-        # This cookie file is only here to trigger the creation of a
-        # Gerrit-flavored Git client factory. So this makes this gangway deployment
-        # "tied" to Gerrit.
-        #
-        # TODO (listx): Allow gangway to be deployed with access to multiple
-        # GitHub/Gerrit credentials (and make it know which one to use based on
-        # the org/repo name). We can't simply deploy a 2nd gangway deployment
-        # configured with GitHub creds to test that codepath because currently
-        # gangway will always choose one or the other.
-        - --cookiefile=/etc/cookies/cookies
         - --dry-run=false
+        - --moonraker-address=http://moonraker.default
         ports:
         - name: grpc
           containerPort: 32000
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - name: cookies
-          mountPath: /etc/cookies
-          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -67,16 +55,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 3
           timeoutSeconds: 600
-        env:
-        # When cloning from an inrepoconfig repo, don't bother verifying certs.
-        # This allows us to use "https://..." addresses to fakegitserver.
-        - name: GIT_SSL_NO_VERIFY
-          value: "1"
       volumes:
-      - name: cookies
-        secret:
-          defaultMode: 420
-          secretName: http-cookiefile
       - name: config
         configMap:
           name: config

--- a/prow/test/integration/test/moonraker_test.go
+++ b/prow/test/integration/test/moonraker_test.go
@@ -173,7 +173,10 @@ git commit -m "add inrepoconfig for my-presubmit"
 	// address here uses localhost, because we're initiating the request from
 	// outside the KIND cluster (this file you are reading is executed outside
 	// the cluster).
-	moonrakerClient := moonraker.NewClient("http://localhost/moonraker", 5*time.Second)
+	moonrakerClient, err := moonraker.NewClient("http://localhost/moonraker", 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var want = config.Presubmit{
 		JobBase: config.JobBase{


### PR DESCRIPTION
This builds on https://github.com/kubernetes/test-infra/pull/30294 (this is blocked by that PR). Specifically, it addresses the concern in https://github.com/kubernetes/test-infra/pull/30294#pullrequestreview-1573799442 where we didn't want to force existing Prow users to deploy Moonraker into their cluster. This PR uses a new interface, `InRepoConfigGetter`, and adds implementations for the existing `InRepoConfigCache` (in-memory LRU cache) and the new Moonraker client. If a Prow components wants to use Moonraker, they can use the InRepoConfigGetter along with the Moonraker client instance.

This PR only enhances Gangway to be able to optionally use Moonraker (via a new CLI flag, `--moonraker-address`). In the future, we will migrate over the other components to do the same (in particular, Sub, Tide, and Gerrit).

Marking as WIP while working out any unforeseen CI failures.
/hold