### PR TITLE
Optionally use Moonraker for Sub, Tide, and Gerrit

### DIFF
--- a/prow/cmd/gangway/main.go
+++ b/prow/cmd/gangway/main.go
@@ -164,7 +164,7 @@ func main() {
 
 	// InRepoConfig getter.
 	if o.config.MoonrakerAddress != "" {
-		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second)
+		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second, configAgent)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Moonraker client.")
 		}

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/test-infra/greenhouse/diskutil"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/metrics"
+	"k8s.io/test-infra/prow/moonraker"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -178,20 +179,30 @@ func main() {
 		persist = true
 	}
 
-	gitClient, err := (&prowflagutil.GitHubOptions{}).GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun, persist)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error creating git client.")
-	}
+	var ircg config.InRepoConfigGetter
+	if o.config.MoonrakerAddress != "" {
+		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second, ca)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error getting Moonraker client.")
+		}
+		ircg = moonrakerClient
+	} else {
+		gitClient, err := (&prowflagutil.GitHubOptions{}).GitClientFactory(o.cookiefilePath, &o.config.InRepoConfigCacheDirBase, o.dryRun, persist)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error creating git client.")
+		}
 
-	if o.config.InRepoConfigCacheDirBase != "" {
-		go diskMonitor(o.pushGatewayInterval, o.config.InRepoConfigCacheDirBase)
-	}
+		if o.config.InRepoConfigCacheDirBase != "" {
+			go diskMonitor(o.pushGatewayInterval, o.config.InRepoConfigCacheDirBase)
+		}
 
-	cacheGetter, err := config.NewInRepoConfigCache(o.config.InRepoConfigCacheSize, ca, gitClient)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error creating InRepoConfigCacheGetter.")
+		ircc, err := config.NewInRepoConfigCache(o.config.InRepoConfigCacheSize, ca, gitClient)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error creating InRepoConfigCache.")
+		}
+		ircg = ircc
 	}
-	c := adapter.NewController(ctx, prowJobClient, op, ca, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback, o.changeWorkerPoolSize, o.gerrit.MaxQPS, o.gerrit.MaxBurst, cacheGetter)
+	c := adapter.NewController(ctx, prowJobClient, op, ca, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback, o.changeWorkerPoolSize, o.gerrit.MaxQPS, o.gerrit.MaxBurst, ircg)
 
 	logrus.Infof("Starting gerrit fetcher")
 

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -124,6 +124,8 @@ var _ ProwYAMLGetter = prowYAMLGetter
 // InRepoConfigCache (LRU cache)).
 type InRepoConfigGetter interface {
 	GetInRepoConfig(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error)
+	GetPresubmits(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error)
+	GetPostsubmits(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error)
 }
 
 // prowYAMLGetter is like prowYAMLGetterWithDefaults, but without default values

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -3170,7 +3170,7 @@ func TestTriggerJobs(t *testing.T) {
 				prowJobClient:               fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
 				gc:                          &gc,
 				tracker:                     &fakeSync{val: fakeLastSync},
-				inRepoConfigCache:           cache,
+				inRepoConfigGetter:          cache,
 				inRepoConfigFailuresTracker: make(map[string]bool),
 			}
 

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -82,11 +82,11 @@ func (pe *ProwJobEvent) ToMessageOfType(t string) (*pubsub.Message, error) {
 // validates them using Prow Configuration and
 // use a ProwJobClient to create Prow Jobs.
 type Subscriber struct {
-	ConfigAgent       *config.Agent
-	Metrics           *Metrics
-	ProwJobClient     gangway.ProwJobClient
-	Reporter          reportClient
-	InRepoConfigCache *config.InRepoConfigCache
+	ConfigAgent        *config.Agent
+	Metrics            *Metrics
+	ProwJobClient      gangway.ProwJobClient
+	Reporter           reportClient
+	InRepoConfigGetter config.InRepoConfigGetter
 }
 
 type messageInterface interface {
@@ -166,7 +166,7 @@ func (s *Subscriber) handleMessage(msg messageInterface, subscription string, al
 	var allowedApiClient *config.AllowedApiClient = nil
 	var requireTenantID bool = false
 
-	if _, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigCache, allowedApiClient, requireTenantID, allowedClusters); err != nil {
+	if _, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigGetter, allowedApiClient, requireTenantID, allowedClusters); err != nil {
 		l.WithError(err).Info("failed to create Prow Job")
 		s.Metrics.ErrorCounter.With(prometheus.Labels{
 			subscriptionLabel: subscription,

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -340,11 +340,11 @@ func TestHandleMessage(t *testing.T) {
 			gitClient, _ := (&flagutil.GitHubOptions{}).GitClientFactory("abc", nil, true, false)
 			cache, _ := config.NewInRepoConfigCache(100, ca, gitClient)
 			s := Subscriber{
-				Metrics:           NewMetrics(),
-				ProwJobClient:     fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),
-				ConfigAgent:       ca,
-				Reporter:          &fr,
-				InRepoConfigCache: cache,
+				Metrics:            NewMetrics(),
+				ProwJobClient:      fakeProwJobClient.ProwV1().ProwJobs(tc.config.ProwJobNamespace),
+				ConfigAgent:        ca,
+				Reporter:           &fr,
+				InRepoConfigGetter: cache,
 			}
 			if tc.pe != nil {
 				m, err := tc.pe.ToMessageOfType(tc.eventType)
@@ -586,11 +586,11 @@ func TestHandlePeriodicJob(t *testing.T) {
 			gitClient, _ := (&flagutil.GitHubOptions{}).GitClientFactory("abc", nil, true, false)
 			cache, _ := config.NewInRepoConfigCache(100, ca, gitClient)
 			s := Subscriber{
-				Metrics:           NewMetrics(),
-				ProwJobClient:     fakeProwJobClient.ProwV1().ProwJobs(ca.Config().ProwJobNamespace),
-				ConfigAgent:       ca,
-				InRepoConfigCache: cache,
-				Reporter:          &fr,
+				Metrics:            NewMetrics(),
+				ProwJobClient:      fakeProwJobClient.ProwV1().ProwJobs(ca.Config().ProwJobNamespace),
+				ConfigAgent:        ca,
+				InRepoConfigGetter: cache,
+				Reporter:           &fr,
 			}
 			l := logrus.NewEntry(logrus.New())
 
@@ -599,7 +599,7 @@ func TestHandlePeriodicJob(t *testing.T) {
 				t1.Error("programmer error: could not convert ProwJobEvent to CreateJobExecutionRequest")
 			}
 
-			_, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigCache, nil, false, tc.allowedClusters)
+			_, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigGetter, nil, false, tc.allowedClusters)
 			if err != nil {
 				if err.Error() != tc.err {
 					t1.Errorf("Expected error '%v' got '%v'", tc.err, err.Error())

--- a/prow/test/integration/config/prow/cluster/gerrit.yaml
+++ b/prow/test/integration/config/prow/cluster/gerrit.yaml
@@ -26,8 +26,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --last-sync-fallback=/etc/last-sync-fallback/last-sync-fallback
-        - --cache-dir-base=/etc/cache
-        - --cookiefile=/etc/cookies/cookies
+        - --moonraker-address=http://moonraker.default
         ports:
         - name: metrics
           containerPort: 9090
@@ -42,9 +41,6 @@ spec:
           mountPath: /etc/last-sync-fallback
         - name: cache
           mountPath: /etc/cache
-        - name: cookies
-          mountPath: /etc/cookies
-          readOnly: true
         resources:
           requests:
             cpu: "1"
@@ -64,10 +60,6 @@ spec:
         emptyDir: {}
       - name: cache
         emptyDir: {}
-      - name: cookies
-        secret:
-          defaultMode: 420
-          secretName: http-cookiefile
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/test/integration/config/prow/cluster/sub.yaml
+++ b/prow/test/integration/config/prow/cluster/sub.yaml
@@ -24,26 +24,14 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --grace-period=110s
-        # This cookie file is only here to trigger the creation of a
-        # Gerrit-flavored Git client factory. So this makes this sub deployment
-        # "tied" to Gerrit.
-        #
-        # TODO (listx): Allow sub to be deployed with access to multiple
-        # GitHub/Gerrit credentials (and make it know which one to use based on
-        # the org/repo name). We can't simply deploy a 2nd sub deployment
-        # configured with GitHub creds to test that codepath because currently
-        # sub will always choose one or the other.
-        - --cookiefile=/etc/cookies/cookies
         - --dry-run=false
+        - --moonraker-address=http://moonraker.default
         ports:
         - name: http
           containerPort: 80
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - name: cookies
-          mountPath: /etc/cookies
-          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -58,15 +46,7 @@ spec:
         # Make sub use the Pub/Sub emulator running in the fakepubsub service.
         - name: PUBSUB_EMULATOR_HOST
           value: fakepubsub.default:80
-        # When cloning from an inrepoconfig repo, don't bother verifying certs.
-        # This allows us to use "https://..." addresses to fakegitserver.
-        - name: GIT_SSL_NO_VERIFY
-          value: "1"
       volumes:
-      - name: cookies
-        secret:
-          defaultMode: 420
-          secretName: http-cookiefile
       - name: config
         configMap:
           name: config

--- a/prow/test/integration/config/prow/cluster/tide_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/tide_deployment.yaml
@@ -43,6 +43,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --history-uri=/tmp/tide-history.json
         - --status-path=/tmp/tide-status-checkpoint.yaml
+        - --moonraker-address=http://moonraker.default
         ports:
         - name: http
           containerPort: 8888

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/io"
 	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/moonraker"
 	"k8s.io/test-infra/prow/tide/blockers"
 	"k8s.io/test-infra/prow/tide/history"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,11 +122,22 @@ func NewGerritController(
 		newPoolPending:   make(chan bool),
 	}
 
-	cacheGetter, err := config.NewInRepoConfigCache(configOptions.InRepoConfigCacheSize, cfgAgent, gc)
-	if err != nil {
-		return nil, fmt.Errorf("failed creating inrepoconfig cache getter: %v", err)
+	var ircg config.InRepoConfigGetter
+	if configOptions.MoonrakerAddress != "" {
+		moonrakerClient, err := moonraker.NewClient(configOptions.MoonrakerAddress, 10*time.Second, cfgAgent)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error getting Moonraker client.")
+		}
+		ircg = moonrakerClient
+	} else {
+		var err error
+		ircg, err = config.NewInRepoConfigCache(configOptions.InRepoConfigCacheSize, cfgAgent, gc)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating inrepoconfig cache: %v", err)
+		}
 	}
-	provider := newGerritProvider(logger, cfgAgent.Config, mgr.GetClient(), cacheGetter, cookieFilePath, "", maxQPS, maxBurst)
+
+	provider := newGerritProvider(logger, cfgAgent.Config, mgr.GetClient(), ircg, cookieFilePath, "", maxQPS, maxBurst)
 	syncCtrl, err := newSyncController(ctx, logger, mgr, provider, cfgAgent.Config, gc, hist, false, statusUpdate)
 	if err != nil {
 		return nil, err
@@ -145,9 +157,9 @@ type GerritProvider struct {
 	gc          gerritClient
 	pjclientset ctrlruntimeclient.Client
 
-	cookiefilePath    string
-	inRepoConfigCache *config.InRepoConfigCache
-	tokenPathOverride string
+	cookiefilePath     string
+	inRepoConfigGetter config.InRepoConfigGetter
+	tokenPathOverride  string
 
 	logger *logrus.Entry
 }
@@ -156,7 +168,7 @@ func newGerritProvider(
 	logger *logrus.Entry,
 	cfg config.Getter,
 	pjclientset ctrlruntimeclient.Client,
-	inRepoConfigCache *config.InRepoConfigCache,
+	ircg config.InRepoConfigGetter,
 	cookiefilePath string,
 	tokenPathOverride string,
 	maxQPS, maxBurst int,
@@ -171,13 +183,13 @@ func newGerritProvider(
 	gerritClient.ApplyGlobalConfig(orgRepoConfigGetter, nil, cookiefilePath, tokenPathOverride, nil)
 
 	return &GerritProvider{
-		logger:            logger,
-		cfg:               cfg,
-		pjclientset:       pjclientset,
-		gc:                gerritClient,
-		inRepoConfigCache: inRepoConfigCache,
-		cookiefilePath:    cookiefilePath,
-		tokenPathOverride: tokenPathOverride,
+		logger:             logger,
+		cfg:                cfg,
+		pjclientset:        pjclientset,
+		gc:                 gerritClient,
+		inRepoConfigGetter: ircg,
+		cookiefilePath:     cookiefilePath,
+		tokenPathOverride:  tokenPathOverride,
 	}
 }
 
@@ -384,12 +396,12 @@ func (p *GerritProvider) GetPresubmits(identifier string, baseSHAGetter config.R
 	presubmits := p.cfg().GetPresubmitsStatic(identifier)
 	// If InRepoConfigCache is provided, then it means that we also want to fetch
 	// from an inrepoconfig.
-	if p.inRepoConfigCache != nil {
-		presubmitsFromCache, err := p.inRepoConfigCache.GetPresubmits(identifier, baseSHAGetter, headSHAGetters...)
+	if p.inRepoConfigGetter != nil {
+		prowYAML, err := p.inRepoConfigGetter.GetInRepoConfig(identifier, baseSHAGetter, headSHAGetters...)
 		if err != nil {
-			return nil, fmt.Errorf("faled to get presubmits from cache: %v", err)
+			return nil, fmt.Errorf("faled to get presubmits from inrepoconfig: %v", err)
 		}
-		presubmits = append(presubmits, presubmitsFromCache...)
+		presubmits = append(presubmits, prowYAML.Presubmits...)
 	}
 	return presubmits, nil
 }


### PR DESCRIPTION
This builds on https://github.com/kubernetes/test-infra/pull/30765 and makes Sub, Tide, and Gerrit (our adapter) all optionally use Moonraker to handle inrepoconfig caching.

This was not a simple copy/paste of #30765 because some code needed refactoring (namely, dropping "GetPresubmits" and "GetPostsubmits" methods on the inrepoconfig cache and replacing them with the "GetInRepoConfig" interface function). Please take a look, thanks!

NOTE: Merging this PR should be a NOP for the k8s-prow cluster, because none of the components are being configured here to actually use Moonraker (we haven't even deployed it to k8s-prow). If we want to make k8s-prow use Moonraker, that'll have to come in a separate PR.

/cc @cjwagner @airbornepony @timwangmusic 

/hold