### PR TITLE
Cleanup bootstrap and kubernetes e2e scripts

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -43,10 +43,10 @@ import contextlib
 import json
 import logging
 import os
-import pipes
 import random
 import re
 import select
+import shlex
 import signal
 import socket
 import subprocess
@@ -1066,7 +1066,7 @@ def bootstrap(args):
     )
 
     if len(sys.argv) > 1:
-        logging.info('Args: %s', ' '.join(pipes.quote(a)
+        logging.info('Args: %s', ' '.join(shlex.quote(a)
                                           for a in sys.argv[1:]))
     logging.info('Bootstrap %s...', job)
     logging.info('Builder: %s', node())


### PR DESCRIPTION
- drop deprecated method that will be dropped in upcoming python versions
```
bootstrap.py:46: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
```
- remove unused options related to aws/kops/federation