### PR TITLE
build moonraker images for production

### DIFF
--- a/prow/.prow-images.yaml
+++ b/prow/.prow-images.yaml
@@ -18,6 +18,7 @@ images:
   - dir: prow/cmd/jenkins-operator
   - dir: prow/cmd/mkpj
   - dir: prow/cmd/mkpod
+  - dir: prow/cmd/moonraker
   - dir: prow/cmd/peribolos
   - dir: prow/cmd/sinker
   - dir: prow/cmd/status-reconciler


### PR DESCRIPTION
We already build moonraker in CI since
https://github.com/kubernetes/test-infra/pull/30294.

Add the configuration for production images that are pushed to gcr.io/k8s-prow.

/cc @cjwagner @airbornepony @timwangmusic