### PR TITLE
chore: remove preset-azure-capz-sa-cred: "true" label for ip lb v1.27 test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -441,7 +441,6 @@ presubmits:
         preset-kind-volume-mounts: "true"
         preset-azure-cred-only: "true"
         preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure


### PR DESCRIPTION
chore: remove preset-azure-capz-sa-cred: "true" label for ip lb v1.27 test

/area provider/azure
/kind failing-test