### PR TITLE
image-builder: move to new personalized credentials for the build environment

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -81,3 +81,40 @@ presets:
       - key: capv-gcs-keyfile.json
         path: keyfile.json
         mode: 288
+- labels:
+    preset-image-builder-vsphere-e2e-config: "true"
+  env:
+  - name: GOVC_URL
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-url
+  - name: GOVC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-image-builder-user
+  - name: GOVC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-image-builder-password
+  volumeMounts:
+  - name: vmc-vpn
+    mountPath: /root/.openvpn
+  volumes:
+  - name: vmc-vpn
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-vpn-config.ovpn
+        path: prow.ovpn
+      - key: vmc-vpn-client.crt
+        path: client.crt
+      - key: vmc-vpn-client.key
+        path: client.key
+      - key: vmc-vpn-ca.crt
+        path: ca.crt
+      - key: vmc-vpn-tls.key
+        path: tls.key

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
-        preset-cluster-api-provider-vsphere-e2e-config: "true"
+        preset-image-builder-vsphere-e2e-config: "true"
       decorate: true
       decoration_config:
         timeout: 1h


### PR DESCRIPTION
This creates a specified preset for image-builder to configure CI credentials specialised for the image-builder project.

I tested the credentials in the target CI environment with the following make targets which succeeded:

```sh
make build-node-ova-vsphere-base-${target}
make build-node-ova-vsphere-clone-${target}
```

The user is setup with the following `image-builder` role for vshpere permissions:
```
Cryptographer.Access
Cryptographer.Clone
Datastore.AllocateSpace
Datastore.Browse
Datastore.FileManagement
Network.Assign
Resource.AssignVMToPool
System.Anonymous
System.Read
System.View
VirtualMachine.Config.AddNewDisk
VirtualMachine.Config.AddRemoveDevice
VirtualMachine.Config.AdvancedConfig
VirtualMachine.Config.Annotation
VirtualMachine.Config.CPUCount
VirtualMachine.Config.EditDevice
VirtualMachine.Config.Memory
VirtualMachine.Config.Resource
VirtualMachine.Config.Settings
VirtualMachine.Interact.ConsoleInteract
VirtualMachine.Interact.DeviceConnection
VirtualMachine.Interact.PowerOff
VirtualMachine.Interact.PowerOn
VirtualMachine.Interact.PutUsbScanCodes
VirtualMachine.Interact.SetCDMedia
VirtualMachine.Interact.SetFloppyMedia
VirtualMachine.Inventory.Create
VirtualMachine.Inventory.CreateFromExisting
VirtualMachine.Inventory.Delete
VirtualMachine.Provisioning.Clone
VirtualMachine.Provisioning.CloneTemplate
VirtualMachine.Provisioning.CreateTemplateFromVM
VirtualMachine.Provisioning.DeployTemplate
VirtualMachine.Provisioning.MarkAsTemplate
VirtualMachine.Provisioning.MarkAsVM
VirtualMachine.State.CreateSnapshot
```

The permissions are assigned with the following script to grant permissions on the resource pool + folder for image-builder:

```sh
USER="<redacted>"
GOVC_DATACENTER="<datacenter>"
GOVC_DATASTORE="<datastore>"
GOVC_CLUSTER="<cluster>"
GOVC_RESOURCE_POOL="<resource/pool>"
GOVC_NETWORK="<network>"
GOVC_HOSTSWITCH="<hostswitch>"
GOVC_FOLDER="<folder>"
HOST_IPS=("x.x.x.x" "y.y.y.y")


govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=false "/"
govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=false "/${GOVC_DATACENTER}"
govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=false "/${GOVC_DATACENTER}/datastore/${GOVC_DATASTORE}"
govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=true "/${GOVC_DATACENTER}/host/${GOVC_CLUSTER}/Resources/${GOVC_RESOURCE_POOL}"
govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=false "/${GOVC_DATACENTER}/network/${GOVC_NETWORK}"
govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=true "/${GOVC_DATACENTER}/vm/${GOVC_FOLDER}"
for HOST_IP in ${HOST_IPS}; do
  govc permissions.set -principal prow-image-builder@ldap.local -role image-builder -propagate=false "/${GOVC_DATACENTER}/host/${GOVC_CLUSTER}/${HOST_IP}"
done
govc permissions.set -principal prow-image-builder@ldap.local -role ReadOnly -propagate=false "/${GOVC_DATACENTER}/network/${GOVC_HOSTSWITCH}"
```

cc @killianmuldoon @sbueringer 