### PR TITLE
Fix image-builder `base_ref` to be `main`

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.0.yaml
@@ -153,7 +153,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.0.yaml
@@ -128,7 +128,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
-      base_ref: master
+      base_ref: main
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes


### PR DESCRIPTION
Image builder project has switched to `main` as base ref. So this periodic conformance test was failing: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-aws-2.0#periodic-conformance-release-2-0-k8s-main