### PR TITLE
don't use custom projects for sig-network jobs

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -180,7 +180,6 @@ periodics:
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/latest
-      - --gcp-project-type=ingress-project
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
       - --provider=gce

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -253,7 +253,6 @@ periodics:
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-project=k8s-e2e-gce-alpha-api-access
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce
@@ -566,7 +565,6 @@ periodics:
       - --env=CREATE_CUSTOM_NETWORK=true
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-project-type=ingress-project
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
@@ -603,7 +601,6 @@ periodics:
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-project=k8s-jenkins-gce-gci-ip-aliases
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce


### PR DESCRIPTION
After moving to the community projects, jobs started to fail because the custom projects does not exist there https://github.com/kubernetes/test-infra/pull/30761/files