### PR TITLE
use central config for moonraker client-side timeout

### DIFF
--- a/prow/cmd/gangway/main.go
+++ b/prow/cmd/gangway/main.go
@@ -164,7 +164,7 @@ func main() {
 
 	// InRepoConfig getter.
 	if o.config.MoonrakerAddress != "" {
-		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second, configAgent)
+		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, configAgent)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Moonraker client.")
 		}

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -181,7 +181,7 @@ func main() {
 
 	var ircg config.InRepoConfigGetter
 	if o.config.MoonrakerAddress != "" {
-		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second, ca)
+		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, ca)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Moonraker client.")
 		}

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -123,7 +123,7 @@ func main() {
 	}
 
 	if o.config.MoonrakerAddress != "" {
-		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, 10*time.Second, configAgent)
+		moonrakerClient, err := moonraker.NewClient(o.config.MoonrakerAddress, configAgent)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Moonraker client.")
 		}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -8201,6 +8201,8 @@ log_level: info
 managed_webhooks:
   auto_accept_invitation: false
   respect_legacy_global_token: false
+moonraker:
+  client_timeout: 10m0s
 plank:
   max_goroutines: 20
   pod_pending_timeout: 10m0s
@@ -8282,6 +8284,8 @@ log_level: info
 managed_webhooks:
   auto_accept_invitation: false
   respect_legacy_global_token: false
+moonraker:
+  client_timeout: 10m0s
 plank:
   max_goroutines: 20
   pod_pending_timeout: 10m0s
@@ -8356,6 +8360,8 @@ log_level: info
 managed_webhooks:
   auto_accept_invitation: false
   respect_legacy_global_token: false
+moonraker:
+  client_timeout: 10m0s
 plank:
   max_goroutines: 20
   pod_pending_timeout: 10m0s
@@ -8435,6 +8441,8 @@ log_level: info
 managed_webhooks:
   auto_accept_invitation: false
   respect_legacy_global_token: false
+moonraker:
+  client_timeout: 10m0s
 plank:
   max_goroutines: 20
   pod_pending_timeout: 10m0s

--- a/prow/config/moonraker.go
+++ b/prow/config/moonraker.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Moonraker struct {
+	ClientTimeout *metav1.Duration `json:"client_timeout,omitempty"`
+}
+
+func (m *Moonraker) Validate() error {
+	return nil
+}

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -534,6 +534,11 @@ managed_webhooks:
         "":
             token_created_after: "0001-01-01T00:00:00Z"
     respect_legacy_global_token: false
+# Moonraker contains configurations for Moonraker, such as the client
+# timeout to use for all Prow services that need to send requests to
+# Moonraker.
+moonraker:
+    client_timeout: 0s
 # OwnersDirDenylist is used to configure regular expressions matching directories
 # to ignore when searching for OWNERS{,_ALIAS} files in a repo.
 owners_dir_denylist:

--- a/prow/moonraker/client.go
+++ b/prow/moonraker/client.go
@@ -50,11 +50,11 @@ type Client struct {
 	configAgent prowConfigAgentClient
 }
 
-func NewClient(host string, timeout time.Duration, configAgent prowConfigAgentClient) (*Client, error) {
+func NewClient(host string, configAgent prowConfigAgentClient) (*Client, error) {
 	c := Client{
 		host: host,
 		httpClient: &http.Client{
-			Timeout: timeout,
+			Timeout: configAgent.Config().Moonraker.ClientTimeout.Duration,
 		},
 		configAgent: configAgent,
 	}

--- a/prow/test/integration/test/moonraker_test.go
+++ b/prow/test/integration/test/moonraker_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
@@ -185,8 +186,16 @@ git commit -m "add inrepoconfig for my-presubmit"
 	// address here uses localhost, because we're initiating the request from
 	// outside the KIND cluster (this file you are reading is executed outside
 	// the cluster).
-	fca := &fakeConfigAgent{}
-	moonrakerClient, err := moonraker.NewClient("http://localhost/moonraker", 5*time.Second, fca)
+	fca := &fakeConfigAgent{
+		c: &config.Config{
+			ProwConfig: config.ProwConfig{
+				Moonraker: config.Moonraker{
+					ClientTimeout: &metav1.Duration{Duration: 5 * time.Second},
+				},
+			},
+		},
+	}
+	moonrakerClient, err := moonraker.NewClient("http://localhost/moonraker", fca)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -124,7 +124,7 @@ func NewGerritController(
 
 	var ircg config.InRepoConfigGetter
 	if configOptions.MoonrakerAddress != "" {
-		moonrakerClient, err := moonraker.NewClient(configOptions.MoonrakerAddress, 10*time.Second, cfgAgent)
+		moonrakerClient, err := moonraker.NewClient(configOptions.MoonrakerAddress, cfgAgent)
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Moonraker client.")
 		}


### PR DESCRIPTION
Instead of hardcoding the client-side timeout into each binary that
needs to use Moonraker, put it into the main config. This way we don't
need to restart the services to pick up changes to this setting (it will
be auto-mounted already into the Config via the Config Agent, which
listens to the ConfigMap for the main config).

/hold