### PR TITLE
Use shlex instead of pipes

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -99,7 +99,7 @@ def terminate(end, proc, kill):
 
 def _call(end, cmd, stdin=None, check=True, output=None, log_failures=True, env=None):  # pylint: disable=too-many-locals
     """Start a subprocess."""
-    logging.info('Call:  %s', ' '.join(pipes.quote(c) for c in cmd))
+    logging.info('Call:  %s', ' '.join(shlex.quote(c) for c in cmd))
     begin = time.time()
     if end:
         end = max(end, time.time() + 60)  # Allow at least 60s per command


### PR DESCRIPTION
missed a spot in 06bb395e573874c0eb2fb53d7e75280acf3b6972

just started to fail in https://prow.k8s.io/log?container=test&id=1705029307161645056&job=pull-kubernetes-e2e-gce