### PR TITLE
cloud-provider-openstack: Add OVN provider testing

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -37,6 +37,45 @@ presubmits:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test
 
+  - name: openstack-cloud-controller-manager-ovn-e2e-test
+    cluster: k8s-infra-prow-build
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "k8s.io/cloud-provider-openstack"
+    always_run: false
+    branches:
+    - ^master$
+    run_if_changed: '^(pkg\/util\/|pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/|Dockerfile)'
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        env:
+        - name: "BOSKOS_HOST"
+          value: "boskos.test-pods.svc.cluster.local"
+        - name: "OCTAVIA_PROVIDER"
+          value: "ovn"
+        command:
+        - "runner.sh"
+        - "./tests/ci-occm-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
+      testgrid-tab-name: presubmit-ovn-e2e-test
+
   # - name: openstack-cloud-controller-manager-e2e-conformance-test
   #   labels:
   #     preset-service-account: "true"


### PR DESCRIPTION
This adds a job testing against OCCM configured to use ovn-octavia-provider.