### PR TITLE
Add kubeconfigIgnoredFile into KubernetesOptions

### DIFF
--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -110,6 +111,10 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 				logrus.WithField("filename", filename).WithField("suffix", opts.suffix).Info("Ignored file without suffix")
 				continue
 			}
+			if opts.ignoredFiles.Has(filename) {
+				logrus.WithField("filename", filename).Info("Ignored file")
+				continue
+			}
 			candidates = append(candidates, filepath.Join(opts.dir, filename))
 		}
 	}
@@ -149,6 +154,7 @@ type Options struct {
 	file               string
 	dir                string
 	suffix             string
+	ignoredFiles       sets.Set[string]
 	projectedTokenFile string
 	noInClusterConfig  bool
 }
@@ -159,6 +165,13 @@ type ConfigOptions func(*Options)
 func ConfigDir(dir string) ConfigOptions {
 	return func(kc *Options) {
 		kc.dir = dir
+	}
+}
+
+// IgnoredFiles configure the names of the files to ignore in directory containing kubeconfig files
+func IgnoredFiles(ignoredFiles sets.Set[string]) ConfigOptions {
+	return func(kc *Options) {
+		kc.ignoredFiles = ignoredFiles
 	}
 }
 


### PR DESCRIPTION
```console
$ oc -n ci extract secret/config-updater --to=/tmp/
error: sa.config-updater.app.ci.config: file exists, pass --confirm to overwrite
error: sa.config-updater.build01.config: file exists, pass --confirm to overwrite
error: sa.config-updater.build02.config: file exists, pass --confirm to overwrite
...

```

In Prow deployment for OpenShift CI, Prow connects build farms with the secret above providing kubeconfigs.
There are other secrets, with the same names as the Prow components, for the corresponding component.
We have to manually modify the contents of all the secrets to remove a build cluster from the component.

We expect the flag introduced by this PR to be more efficient if some build cluster is down:
Modify the flags in the deployment manifests for the Prow component, instead of modifying the mounted secrets.