### PR TITLE
cloud-provider-vsphere: move to new personalized credentials for the build environment

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -82,6 +82,73 @@ presets:
         path: keyfile.json
         mode: 288
 - labels:
+    # For kubernetes/cloud-provider-vsphere
+    preset-cloud-provider-vsphere-e2e-config-capv: "true"
+  env:
+  - name: GOVC_URL
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-url
+  - name: GOVC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-cloud-provider-vsphere-user
+  - name: GOVC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-cloud-provider-vsphere-password
+  - name: VSPHERE_TLS_THUMBPRINT
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-thumbprint
+  - name: VM_SSH_PUB_KEY
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-e2e-vm-ssh.pubkey
+  volumeMounts:
+  - name: vmc-e2e-vm-ssh-key
+    mountPath: /root/ssh/.private-key
+  - name: vmc-vpn
+    mountPath: /root/.openvpn
+  - name: vmc-capv-services-kubeconfig
+    mountPath: /root/ipam-conf
+  volumes:
+  - name: vmc-e2e-vm-ssh-key
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-e2e-vm-ssh.key
+        path: private-key
+  - name: vmc-vpn
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-vpn-config.ovpn
+        path: prow.ovpn
+      - key: vmc-vpn-client.crt
+        path: client.crt
+      - key: vmc-vpn-client.key
+        path: client.key
+      - key: vmc-vpn-ca.crt
+        path: ca.crt
+      - key: vmc-vpn-tls.key
+        path: tls.key
+  - name: vmc-capv-services-kubeconfig
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-capv-services.kubeconfig
+        path: capv-services.conf
+- labels:
+    # For kubernetes-sigs/image-builder
     preset-image-builder-vsphere-e2e-config: "true"
   env:
   - name: GOVC_URL

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config-1.26-minus.yaml
@@ -257,7 +257,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       # Borrows CAPV credentials for cloud provider e2e testing
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cloud-provider-vsphere-e2e-config-capv: "true"
       preset-cloud-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     branches:

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -354,7 +354,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       # Borrows CAPV credentials for cloud provider e2e testing
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cloud-provider-vsphere-e2e-config-capv: "true"
       preset-cloud-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     branches:


### PR DESCRIPTION
CAPV maintainer here.

This creates a specified preset for cloud-provider-vsphere to configure CI credentials specialised for the cloud-provider-vsphere project.

I tested the credentials in the target CI environment via cluster-api-provider-vsphere e2e tests. cloud-provider-vsphere does  run similar tests so this should require the same permissions

Similar to #30784

The user is setup with the following `capv-ci` role for vshpere permissions:

```
Cns.Searchable
Datastore.AllocateSpace
Datastore.Browse
Datastore.FileManagement
Network.Assign
Resource.AssignVMToPool
Sessions.GlobalMessage
Sessions.ValidateSession
StorageProfile.View
System.Anonymous
System.Read
System.View
VApp.ApplicationConfig
VApp.Import
VApp.InstanceConfig
VirtualMachine.Config.AddExistingDisk
VirtualMachine.Config.AddNewDisk
VirtualMachine.Config.AddRemoveDevice
VirtualMachine.Config.AdvancedConfig
VirtualMachine.Config.Annotation
VirtualMachine.Config.CPUCount
VirtualMachine.Config.ChangeTracking
VirtualMachine.Config.DiskExtend
VirtualMachine.Config.EditDevice
VirtualMachine.Config.Memory
VirtualMachine.Config.RawDevice
VirtualMachine.Config.RemoveDisk
VirtualMachine.Config.Resource
VirtualMachine.Config.Settings
VirtualMachine.Config.UpgradeVirtualHardware
VirtualMachine.Interact.ConsoleInteract
VirtualMachine.Interact.DeviceConnection
VirtualMachine.Interact.PowerOff
VirtualMachine.Interact.PowerOn
VirtualMachine.Interact.SetCDMedia
VirtualMachine.Interact.SetFloppyMedia
VirtualMachine.Inventory.CreateFromExisting
VirtualMachine.Inventory.Delete
VirtualMachine.Provisioning.Clone
VirtualMachine.Provisioning.CloneTemplate
VirtualMachine.Provisioning.CreateTemplateFromVM
VirtualMachine.Provisioning.DeployTemplate
VirtualMachine.Provisioning.DiskRandomRead
VirtualMachine.Provisioning.GetVmFiles
VirtualMachine.State.CreateSnapshot
VirtualMachine.State.RemoveSnapshot
```

The permissions are assigned with the following script to grant permissions on the resource pools + folders for cloud-provider-vsphere:

```
function govcpermissionsset {
  govc permissions.set -principal "${1}@ldap.local" \
    -propagate="${2}" \
    -role "${3}" \
    "${4}"
}

govcpermissionsset "${USER}" "false" "capv-ci" "/"
govcpermissionsset "${USER}" "false" "capv-ci" "/${GOVC_DATACENTER}"
govcpermissionsset "${USER}" "false" "capv-ci" "/${GOVC_DATACENTER}/datastore/${GOVC_DATASTORE}"
govcpermissionsset "${USER}" "false" "capv-ci" "/${GOVC_DATACENTER}/host/${GOVC_CLUSTER}"
govcpermissionsset "${USER}" "true" "capv-ci" "/${GOVC_DATACENTER}/network/${GOVC_NETWORK}"
govcpermissionsset "${USER}" "false" "ReadOnly" "/${GOVC_DATACENTER}/network/${GOVC_HOSTSWITCH}"

# access to hosts
for HOST_IP in ${HOST_IPS}; do
  govcpermissionsset "${USER}" "false" "capv-ci" "/${GOVC_DATACENTER}/host/${GOVC_CLUSTER}/${HOST_IP}"
done

# access to folders
for GOVC_FOLDER in ${GOVC_FODLERS}; do
  govcpermissionsset "${USER}" "true" "capv-ci" "/${GOVC_DATACENTER}/vm/${GOVC_FOLDER}"
done

# access to resource pools
for GOVC_RESOURE_POOL in ${GOVC_RESOURE_POOLS}; do
  govcpermissionsset "${USER}" "true" "capv-ci" "/${GOVC_DATACENTER}/host/${GOVC_CLUSTER}/Resources/${GOVC_RESOURE_POOL}"
done
```

cc @killianmuldoon @lubronzhan @wyike 

/hold

After merging this I'd start relevant CI jobs to verify everything is still green. If we run into issues I'll file a PR which reverts the user and password to the currently used credentials (so it should work again) and investigate further.