### PR TITLE
Move references used by e2e-node jobs to new directory

### DIFF
--- a/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
@@ -2,4 +2,4 @@ images:
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2-serial.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2-serial.yaml
@@ -3,4 +3,4 @@ images:
     image_family: cos-beta
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
@@ -3,4 +3,4 @@ images:
     # Using cos-beta to pick up cgroupv2 enabled by default as of cos-beta-97-16919-0-3.
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/image-config.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
@@ -3,11 +3,11 @@ images:
     image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
     machine: n1-standard-16  # node performance tests will be skipped on smaller machines
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
     machine: n1-standard-16 # node performance tests will be skipped on smaller machines
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"
 
 # The only difference of this file from the image-config.yaml supposed to be the machine size

--- a/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
@@ -2,4 +2,4 @@ images:
   cos-stable:
     image_family: cos-stable
     project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env"
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.7/env"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7/env"
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.7/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/image-cadvisor.yaml
+++ b/jobs/e2e_node/containerd/image-cadvisor.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"

--- a/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
@@ -3,4 +3,4 @@ images:
     image_family: cos-beta
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init-eviction.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init-eviction.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
@@ -5,6 +5,6 @@ images:
   ubuntu:
     image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"
     # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation
     machine: n1-standard-2

--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -10,10 +10,10 @@ images:
     image_regex: ".*[^-cgroupsv1]$"
     # Using `n2d-standard-32` that has 2 numa nodes to enable resource managers node e2e tests.
     machine: n2d-standard-32
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable1:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
     # Using `n1-standard-4` to enable resource managers node e2e tests.
     machine: n1-standard-4

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -6,12 +6,12 @@ images:
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
     image_regex: ".*[^-cgroupsv1]$"
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable2:
     image_family: cos-stable
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
     resources:
       accelerators:
         - type: nvidia-tesla-k80
@@ -20,4 +20,4 @@ images:
     image_family: cos-stable
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/image-config-systemd.yaml
+++ b/jobs/e2e_node/containerd/image-config-systemd.yaml
@@ -5,8 +5,8 @@ images:
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
     image_regex: ".*[^-cgroupsv1]$"
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:
     image_family: cos-stable
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.25.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.25.yaml
@@ -2,4 +2,4 @@ images:
   cos-101:
     image_family: cos-101-lts
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
@@ -2,4 +2,4 @@ images:
   cos-101:
     image_family: cos-101-lts
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
@@ -2,4 +2,4 @@ images:
   cos-105:
     image_family: cos-105-lts
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
@@ -3,4 +3,4 @@ images:
   cos-dev:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-evented-pleg.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-evented-pleg.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud 
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_evented_pleg.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_evented_pleg.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-hugepages.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-hugepages.yaml
@@ -5,6 +5,6 @@ images:
   ubuntu:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio-with-1G-hugepages.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio-with-1G-hugepages.ign"
     # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation
     machine: n1-standard-2

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-k8s-infra-prow-build.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-k8s-infra-prow-build.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_k8s_infra_prow_build.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-resource-managers.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-resource-managers.yaml
@@ -4,4 +4,4 @@ images:
     project: fedora-coreos-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
@@ -3,4 +3,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: n1-standard-2
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_serial.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_serial.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud 
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-k8s-infra-prow-build.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-k8s-infra-prow-build.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgrpv2_k8s_infra_prow_build.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
@@ -3,4 +3,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: n1-standard-2
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_cgrpv2_serial.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgrpv2_serial.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-swap1g.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-swap1g.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud 
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_swap1g.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_swap1g.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud 
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_cgrpv2.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgrpv2.ign"

--- a/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image_family: pipeline-1-25
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"
   cos:
     image_family: cos-stable
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"

--- a/jobs/e2e_node/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/image-config-serial-hugepages.yaml
@@ -5,6 +5,6 @@ images:
   ubuntu:
     image: ubuntu-gke-2204-1-24-v20220623
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml"
     # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation
     machine: n1-standard-2

--- a/jobs/e2e_node/swap/image-config-swap-fedora.yaml
+++ b/jobs/e2e_node/swap/image-config-swap-fedora.yaml
@@ -6,4 +6,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud 
     machine: n1-standard-2
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_swap1g.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_swap1g.ign"

--- a/jobs/e2e_node/swap/image-config-swap.yaml
+++ b/jobs/e2e_node/swap/image-config-swap.yaml
@@ -5,5 +5,5 @@ images:
   ubuntu:
     image_family: pipeline-1-24
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"
     machine: n1-standard-2


### PR DESCRIPTION
`/workspace/test-infra` should be `/home/prow/go/src/k8s.io/test-infra`