### PR TITLE
move back pull-gcp-compute-persistent-disk-csi-driver-e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -1,7 +1,6 @@
 presubmits:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - name: pull-gcp-compute-persistent-disk-csi-driver-e2e
-    cluster: k8s-infra-prow-build
     always_run: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/test-infra/pull/30757

Some E2E tests related to disk encryption with a custom CMEK key fails to run successfully on k8s-infra. moving back the job until we identify the root cause.