### PR TITLE
make moonraker client default the retrieved jobs against central config

### DIFF
--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -65,6 +65,7 @@ in_repo_config:
    "fakegitserver.default/repo/repo3": true
    "fakegitserver.default/repo/org1/repo4": true
    "fakegitserver.default/repo/org1/repo5": true
+   "fakegitserver.default/repo/org1/repo6": true
    "fakegitserver.default/repo/some/org/gangway-test-repo-1": true
    "fakegitserver.default/repo/moonraker-burst": true
 

--- a/prow/test/integration/test/sub_test.go
+++ b/prow/test/integration/test/sub_test.go
@@ -93,6 +93,7 @@ func TestPubSubSubscriptions(t *testing.T) {
 		Repo3HEADsha       = "97b866610ecdee8b90a7808b176c1fb3a859fa00"
 		Repo4HEADsha       = "4c028549d727a9deebf69b68b640837844222632"
 		Repo5HEADsha       = "c0ea4b30f3d9dc0bf1d3391d8e3a6bee39ad4de6"
+		Repo6HEADsha       = "907254e19d6138e3c62e4da1a23318aae6869f46"
 		CreateRepoRepo1    = `
 echo this-is-from-repo1 > README.txt
 git add README.txt
@@ -113,6 +114,32 @@ presubmits:
         - |
           set -eu
           echo "hello from trigger-inrepoconfig-presubmit-via-pubsub-repo%s"
+          cat README.txt
+`
+
+		// The Brancher field in the job config has an unexported 're' field.
+		// This job will fail if we are (1) fetching jobs through moonraker and (2)
+		// we are not defaulting the jobs. This is because some of the exported
+		// fields for Brancher will still come through to us client-side, which
+		// will trigger a "ShouldRun" check which will in turn try to use the
+		// unexported 're' field.
+		ProwJobDecoratedBrancher = `
+postsubmits:
+  - name: trigger-inrepoconfig-postsubmit-via-pubsub-repo%s
+    always_run: false
+    decorate: true
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: localhost:5001/alpine
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -eu
+          echo "hello from trigger-inrepoconfig-postsubmit-via-pubsub-repo%s"
           cat README.txt
 `
 		ProwJobDecoratedCloneURI = `
@@ -140,6 +167,7 @@ presubmits:
 	CreateRepo3 := createGerritRepo("3", fmt.Sprintf(ProwJobDecorated, "3", "3"))
 	CreateRepo4 := createGerritRepo("4", fmt.Sprintf(ProwJobDecorated, "4", "4"))
 	CreateRepo5 := createGerritRepo("5", fmt.Sprintf(ProwJobDecoratedCloneURI, "5", "https://fakegitserver.default/repo/org1/repo5", "5"))
+	CreateRepo6 := createGerritRepo("6", fmt.Sprintf(ProwJobDecoratedBrancher, "6", "6"))
 
 	tests := []struct {
 		name       string
@@ -393,6 +421,39 @@ this-is-from-repo4
 			},
 			expected: `hello from trigger-inrepoconfig-presubmit-via-pubsub-repo5
 this-is-from-repo5
+`,
+		},
+		{
+			name: "inrepoconfig-postsubmit6-with-branch-regex",
+			repoSetups: []fakegitserver.RepoSetup{
+				{
+					Name:      "org1/repo6",
+					Script:    CreateRepo6,
+					Overwrite: true,
+				},
+			},
+			msg: fakepubsub.PubSubMessageForSub{
+				Attributes: map[string]string{
+					subscriber.ProwEventType: subscriber.PostsubmitProwJobEvent,
+				},
+				Data: subscriber.ProwJobEvent{
+					Name: "trigger-inrepoconfig-postsubmit-via-pubsub-repo6",
+					Refs: &prowjobv1.Refs{
+						Org:      "https://fakegitserver.default/repo/org1",
+						Repo:     "repo6",
+						RepoLink: "https://fakegitserver.default/repo/org1/repo6",
+						BaseSHA:  Repo6HEADsha,
+						BaseRef:  "master",
+						CloneURI: "https://fakegitserver.default/repo/org1/repo6",
+						Pulls:    []prowjobv1.Pull{},
+					},
+					Labels: map[string]string{
+						kube.GerritRevision: "123",
+					},
+				},
+			},
+			expected: `hello from trigger-inrepoconfig-postsubmit-via-pubsub-repo6
+this-is-from-repo6
 `,
 		},
 	}


### PR DESCRIPTION
This adds a new integration test case to check cases where we are not properly defaulting the retrieved jobs from Moonraker on the client. This test was able to locally reproduce an error (see below) we were seeing while trying to get sub to use moonraker:

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b06d18]

goroutine 95 [running]:
k8s.io/test-infra/prow/config.Brancher.ShouldRun({{0x0, 0x0, 0x0}, {0xc0007e6210, 0x1, 0x1}, 0x0, 0x0}, {0xc000952110, 0x6})
        k8s.io/test-infra/prow/config/jobs.go:370 +0x118
k8s.io/test-infra/prow/config.Postsubmit.CouldRun(...)
        k8s.io/test-infra/prow/config/jobs.go:441
k8s.io/test-infra/prow/gangway.(*postsubmitJobHandler).getProwJobSpec(0x362e240?, {0x25391f0, 0xc0004e6700}, {0x252a398, 0xc000a127e0}, 0xc000a08050)
        k8s.io/test-infra/prow/gangway/gangway.go:770 +0xaf4
k8s.io/test-infra/prow/gangway.HandleProwJob(0x2d?, 0xc0008ab960, 0xc000a08050, {0x7faaa22b4bb8, 0xc00097d040}, {0x25391f0, 0xc0004e6700}, {0x252a398, 0xc000a127e0}, 0x0, ...)
        k8s.io/test-infra/prow/gangway/gangway.go:466 +0xc8
k8s.io/test-infra/prow/pubsub/subscriber.(*Subscriber).handleMessage(0xc00097ef80, {0x253a230, 0xc000808000}, {0xc00081fb30, 0x2d}, {0xc0008e75a0, 0x1, 0x1})
        k8s.io/test-infra/prow/pubsub/subscriber/subscriber.go:169 +0x2e5
k8s.io/test-infra/prow/pubsub/subscriber.(*PullServer).handlePulls.func1.1({0x0?, 0x0?}, {0x253a230, 0xc000808000})
        k8s.io/test-infra/prow/pubsub/subscriber/server.go:129 +0xa8
k8s.io/test-infra/prow/pubsub/subscriber.(*pubSubSubscription).receive.func1({0x2538f70, 0xc0009d26e0}, 0xc0003300e0)
        k8s.io/test-infra/prow/pubsub/subscriber/server.go:79 +0x9c
cloud.google.com/go/pubsub.(*Subscription).Receive.func2.2({0x1e9b7e0?, 0xc0003300e0?})
        cloud.google.com/go/pubsub@v1.30.0/subscription.go:1184 +0x7b
cloud.google.com/go/pubsub/internal/scheduler.(*ReceiveScheduler).Add.func1()
        cloud.google.com/go/pubsub@v1.30.0/internal/scheduler/receive_scheduler.go:84 +0x2b
created by cloud.google.com/go/pubsub/internal/scheduler.(*ReceiveScheduler).Add in goroutine 209
        cloud.google.com/go/pubsub@v1.30.0/internal/scheduler/receive_scheduler.go:82 +0x353```