### PR TITLE
Add missing extra ref for containerd

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -801,6 +801,10 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
+  - org: containerd
+    repo: containerd
+    base_ref: main
+    path_alias: github.com/containerd/containerd
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master


### PR DESCRIPTION
missed adding an entry for the repo causing this! (from [log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cos-cgroupv2-containerd-node-e2e-features/1705415552819793920/build-log.txt))

```
I0923 02:59:48.497986    8997 gce_runner.go:364] parsing instance metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"
F0923 02:59:48.498052    8997 gce_runner.go:407] Failed to read metadata file "/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml": open /home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml: no such file or directory
exit status 255
```