### PR TITLE
[ci-containerd-e2e-ubuntu-gce] add missing extra-refs for k8s.io/test-infra

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -52,6 +52,10 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
     workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
   - org: containerd
     repo: containerd
     base_ref: main


### PR DESCRIPTION
fixing error in [log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-containerd-e2e-ubuntu-gce/1705530812612481024/build-log.txt)
```
ERROR: (gcloud.compute.instances.create) Unable to read file [/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env]: [Errno 2] No such file or directory: '/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env'
Failed to create master instance due to non-retryable error
```