### PR TITLE
integration test: add missing preset file

### DIFF
--- a/prow/test/integration/config/prow/jobs/presets.yaml
+++ b/prow/test/integration/config/prow/jobs/presets.yaml
@@ -1,0 +1,6 @@
+presets:
+  - labels:
+      preset-foo: "true"
+    env:
+      - name: FOO_FILE
+        value: /etc/foo

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1554,7 +1554,7 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 		log := c.logger.WithField("base-sha", sp.sha).WithFields(pr.logFields())
 		presubmitsForPull, err := c.provider.GetPresubmits(sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(pr.HeadRefOID))
 		if err != nil {
-			c.logger.WithError(err).Debug("Failed to get presubmits for PR, excluding from subpool")
+			log.WithError(err).Debug("Failed to get presubmits for PR, excluding from subpool")
 			continue
 		}
 		filteredPRs = append(filteredPRs, pr)


### PR DESCRIPTION
We forgot to add this file for the integration test case that was added in 958b032e58 (integration test: add env var duplication test case, 2023-09-23), which was part of 2d7622ba27 (Merge pull request #30833 from airbornepony/moonraker-defaulting-fix, 2023-09-23).

Adding this file is a NOP for now, but is a stronger guarantee that the defaulting property was fixed properly in that PR.

/cc @cjwagner @airbornepony @timwangmusic 