### PR TITLE
Assign more resources to pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -657,11 +657,11 @@ presubmits:
             value: /go
           resources:
             limits:
-              cpu: 4
-              memory: 6Gi
+              cpu: 8
+              memory: 10Gi
             requests:
-              cpu: 4
-              memory: 6Gi
+              cpu: 8
+              memory: 10Gi
   - name: pull-kubernetes-node-kubelet-serial-containerd-kubetest2
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-containerd-kubetest2 to run
     always_run: false


### PR DESCRIPTION
This allows more resources to pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers.

This is needed to test
- https://github.com/kubernetes/kubernetes/pull/120718
- https://github.com/kubernetes/kubernetes/pull/119447