### PR TITLE
Bump docker images for kueue jobs so they use go 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -73,7 +73,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
         env:
         - name: E2E_KIND_VERSION
           value: kindest/node:v1.25.11
@@ -111,7 +111,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
         env:
         - name: E2E_KIND_VERSION
           value: kindest/node:v1.26.6
@@ -149,7 +149,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
         env:
         - name: E2E_KIND_VERSION
           value: kindest/node:v1.27.3
@@ -187,7 +187,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.28.0
@@ -253,7 +253,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
         securityContext:
           privileged: true
         command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -94,7 +94,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.25.11
@@ -138,7 +138,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.26.6
@@ -182,7 +182,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.27.3
@@ -226,7 +226,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230918-570a399623-master
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.28.0


### PR DESCRIPTION
Those changes are needed in order to bump go version to 1.21 for kueue:
https://github.com/kubernetes-sigs/kueue/pull/1153