### PR TITLE
Explicitly checkout test-infra and run kubernetes_janitor.py

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -85,11 +85,17 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 30m
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+    workdir: true
   spec:
     containers:
     - command:
       - runner.sh
-      - /workspace/scenarios/kubernetes_janitor.py
+      - /home/prow/go/src/k8s.io/test-infra/scenarios/kubernetes_janitor.py
       args:
       - --mode=pr
       env:


### PR DESCRIPTION
the bootstrap version of this job made too many assumptions!! 

see https://storage.googleapis.com/kubernetes-jenkins/logs/maintenance-pull-janitor/1706294855593889792/build-log.txt