### PR TITLE
Configure disabled clusters

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -163,6 +164,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 	cfg := configAgent.Config
+	o.client.SetDisabledClusters(sets.New[string](cfg().DisabledClusters...))
 
 	restCfg, err := o.client.InfrastructureClusterConfig(o.dryrun)
 	if err != nil {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -284,6 +285,8 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 	cfg := configAgent.Config
+	disableClustersSet := sets.New[string](cfg().DisabledClusters...)
+	o.kubernetes.SetDisabledClusters(disableClustersSet)
 
 	var pluginAgent *plugins.ConfigAgent
 	if o.pluginsConfig.PluginConfigPath != "" {
@@ -1451,8 +1454,21 @@ func handleSerialize(w http.ResponseWriter, name string, data interface{}, l *lo
 
 func handleConfig(cfg config.Getter, log *logrus.Entry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// TODO: add the ability to query for portions of the config?
-		handleSerialize(w, "config.yaml", cfg(), log)
+		// TODO: add the ability to query for any portions of the config?
+		k := r.URL.Query().Get("key")
+		switch k {
+		case "disabled-clusters":
+			l := sets.New[string](cfg().DisabledClusters...).UnsortedList()
+			sort.Strings(l)
+			handleSerialize(w, "disabled-clusters.yaml", l, log)
+		case "":
+			handleSerialize(w, "config.yaml", cfg(), log)
+		default:
+			msg := fmt.Sprintf("getting config for key %s is not supported", k)
+			log.Error(msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 
 	"k8s.io/test-infra/pkg/flagutil"
@@ -115,6 +116,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
+	o.kubernetes.SetDisabledClusters(sets.New[string](configAgent.Config().DisabledClusters...))
 
 	var tokens []string
 

--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -124,7 +124,8 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 	cfg := configAgent.Config
-
+	o.kubernetes.SetDisabledClusters(sets.New[string](cfg().DisabledClusters...))
+	
 	var logOpts []zap.Opts
 	if cfg().LogLevel == "debug" {
 		logOpts = append(logOpts, func(o *zap.Options) {

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -108,6 +108,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 	cfg := configAgent.Config
+	o.kubernetes.SetDisabledClusters(sets.New[string](cfg().DisabledClusters...))
 
 	metrics.ExposeMetrics("sinker", cfg().PushGateway, o.instrumentationOptions.MetricsPort)
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -222,6 +222,10 @@ type ProwConfig struct {
 	// match a job are used. Later matching entries override the fields of earlier
 	// matching entires.
 	ProwJobDefaultEntries []*ProwJobDefaultEntry `json:"prowjob_default_entries,omitempty"`
+
+	// DisabledClusters holds a list of disabled build cluster names. The same context names will be ignored while
+	// Prow components load the kubeconfig files.
+	DisabledClusters []string `json:"disabled_clusters,omitempty"`
 }
 
 type InRepoConfig struct {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -426,6 +426,10 @@ deck:
 # DefaultJobTimeout this is default deadline for prow jobs. This value is used when
 # no timeout is configured at the job level. This value is set to 24 hours.
 default_job_timeout: 0s
+# DisabledClusters holds a list of disabled build cluster names. The same context names will be ignored while
+# Prow components load the kubeconfig files.
+disabled_clusters:
+    - ""
 # Gangway contains configurations needed by the the Prow API server of the
 # same name. It encodes an allowlist of API clients and what kinds of Prow
 # Jobs they are authorized to trigger.


### PR DESCRIPTION
Following up https://github.com/kubernetes/test-infra/pull/30808#issuecomment-1733683830

```console
$ oc -n ci extract secret/config-updater --to=/tmp/
error: sa.config-updater.app.ci.config: file exists, pass --confirm to overwrite
error: sa.config-updater.build01.config: file exists, pass --confirm to overwrite
error: sa.config-updater.build02.config: file exists, pass --confirm to overwrite
...

```

In Prow deployment for OpenShift CI, Prow connects build farms with the secret above providing kubeconfigs.
There are other secrets, with the same names as the Prow components, for the corresponding component.
We have to manually modify the contents of all the secrets to remove a build cluster from the component.

We expect the field in Prow's configuration file introduced by this PR to become the ONLY one place we need to modify if some build cluster is down.

/cc @droslean @smg247 
