### PR TITLE
fix release 1.25 cloning issues

### DIFF
--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -9,8 +9,8 @@ periodics:
     timeout: 240m
   extra_refs:
   - org: kubernetes
-    repo: release-1.25
-    base_ref: master
+    repo: kubernetes
+    base_ref: release-1.25
     path_alias: k8s.io/kubernetes
     workdir: true
   - org: kubernetes


### PR DESCRIPTION
There was a typo in the migration to drop bootstrap for these jobs.  

/cc @dims 