### PR TITLE
add jobset 1.28 release test

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
@@ -187,6 +187,39 @@ presubmits:
           requests:
             cpu: 2
             memory: 8Gi
+  - name: pull-jobset-test-e2e-main-1-28
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-jobset-test-e2e-main-1-28
+      description: "Run jobset end to end tests for Kubernetes 1.28"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.28.0
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 8Gi
+          requests:
+            cpu: 2
+            memory: 8Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
With jobset supporting 1.28, we should have e2e tests for it.  