### PR TITLE
Bump up golang version to test boskos project

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.18.3
+          - image: public.ecr.aws/docker/library/golang:1.19.12
             imagePullPolicy: Always
             command:
               - make


### PR DESCRIPTION
Combine with https://github.com/kubernetes-sigs/boskos/pull/174 to bump up the controller-runtime version since newer controller-runtime requires at least golang 1.19