### PR TITLE
Missed a bunch of PathAlias for presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
@@ -20,6 +20,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 75m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -101,6 +101,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -152,6 +153,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -15,6 +15,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 450m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -124,6 +124,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 80m # hard cap, based on original pre-kubetest2 job but moved to a prow-level timeout
+    path_alias: k8s.io/kubernetes
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1813,6 +1813,7 @@ presubmits:
       testgrid-dashboards: sig-node-presubmits
       testgrid-tab-name: pr-crio-dra
     decorate: true
+    path_alias: k8s.io/kubernetes
     # Not relevant for most PRs.
     always_run: false
     # This covers most of the code related to dynamic resource allocation.

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -6,6 +6,7 @@ presubmits:
     run_if_changed: '(^.go-version)|(^build/build-image/)|(^hack/lib/golang.sh)|(^build/common.sh)'
     cluster: eks-prow-build-cluster
     decorate: true
+    path_alias: k8s.io/kubernetes
     labels:
       preset-dind-enabled: "true"
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -556,6 +556,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 75m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -606,6 +607,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -657,6 +659,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -708,6 +711,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -765,6 +769,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -824,6 +829,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 520m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -883,6 +889,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -970,6 +977,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -1012,6 +1020,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -553,6 +553,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 75m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -604,6 +605,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -654,6 +656,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -710,6 +713,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -772,6 +776,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -836,6 +841,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 520m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -895,6 +901,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 120m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -948,6 +955,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -1037,6 +1045,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -1079,6 +1088,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -563,6 +563,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 75m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -614,6 +615,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -664,6 +666,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -715,6 +718,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -772,6 +776,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -831,6 +836,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 520m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -890,6 +896,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 120m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -943,6 +950,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -991,6 +999,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -1033,6 +1042,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -563,6 +563,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 75m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -614,6 +615,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -664,6 +666,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -715,6 +718,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -772,6 +776,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -831,6 +836,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 520m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -890,6 +896,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 120m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -943,6 +950,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -988,6 +996,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 105m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -1030,6 +1039,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -26,6 +26,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 150m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -81,6 +82,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 150m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -135,6 +137,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 170m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release
@@ -179,6 +182,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 300m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: release

--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    path_alias: k8s.io/kubernetes
     cluster: eks-prow-build-cluster
     # All the files owned by sig-storage. Keep in sync across
     # all sig-storage-jobs

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -17,6 +17,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 60m
+    path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
       repo: test-infra

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -18,6 +18,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 240m
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -951,6 +951,14 @@ func checkScenarioArgs(jobName, imageName string, args []string) error {
 	return nil
 }
 
+func TestPreSubmitPathAlias(t *testing.T) {
+	for _, job := range c.AllStaticPresubmits([]string{"kubernetes/kubernetes"}) {
+		if job.PathAlias != "k8s.io/kubernetes" {
+			t.Errorf("Invalid PathAlias (%s) in job %s for kubernetes/kubernetes repository", job.Name, job.PathAlias)
+		}
+	}
+}
+
 // TestValidScenarioArgs makes sure all scenario args in job configs are valid
 func TestValidScenarioArgs(t *testing.T) {
 	for _, job := range c.AllStaticPresubmits(nil) {


### PR DESCRIPTION
Added a test to ensure we correctly add PathAlias in the job itself (not extra-refs) for presubmit jobs (especially for k/k)