### PR TITLE
WIP: Assign a bigger machine to pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -646,7 +646,7 @@ presubmits:
           args:
           - --deployment=node
           - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--feature-gates=SidecarContainers=true --service-feature-gates=SidecarContainers=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
@@ -657,11 +657,11 @@ presubmits:
             value: /go
           resources:
             limits:
-              cpu: 8
-              memory: 10Gi
+              cpu: 4
+              memory: 6Gi
             requests:
-              cpu: 8
-              memory: 10Gi
+              cpu: 4
+              memory: 6Gi
   - name: pull-kubernetes-node-kubelet-serial-containerd-kubetest2
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-containerd-kubetest2 to run
     always_run: false


### PR DESCRIPTION
This assigns a bigger machine to `pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers` and reverts the resource requirements.

reverts: https://github.com/kubernetes/test-infra/pull/30844