### PR TITLE
remove gcp-project-type from crio jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -27,7 +27,6 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
@@ -112,7 +111,6 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
@@ -163,7 +161,6 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
@@ -315,7 +312,6 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
@@ -366,7 +362,6 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
@@ -417,7 +412,6 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
@@ -468,7 +462,6 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock
             --container-runtime-process-name=/usr/local/bin/crio


### PR DESCRIPTION
#Fixes https://github.com/kubernetes/kubernetes/issues/120886

All the CRIO jobs I migrated were failing due to this.  

Community clusters do not have the boskos project type.