### PR TITLE
convert unlabeled job to community cluster for crio

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -187,6 +187,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs NodeFeatures e2e tests with crio master and cgroup v1"
 - name: ci-crio-cgroupv1-node-e2e-unlabelled
+  cluster: k8s-infra-prow-build
   interval: 12h
   labels:
     preset-service-account: "true"
@@ -213,7 +214,6 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true


### PR DESCRIPTION
1) convert e2e-unlabelled job to use the community cluster.
2) drop gcp-project-type 