### PR TITLE
Add missing extra-ref for test-infra repo

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -450,6 +450,11 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
     workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+    workdir: true
   - org: containerd
     repo: containerd
     base_ref: main


### PR DESCRIPTION
fixing a problem seeing in [logs](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-device-plugin-gpu/1706617346254180352/build-log.txt):
```
Creating firewall...
ERROR: (gcloud.compute.instances.create) Unable to read file [/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env]: [Errno 2] No such file or directory: '/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env'
Failed to create master instance due to non-retryable error
```