### PR TITLE
Add missing extra-refs for ci-kubernetes-local-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -63,6 +63,12 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 240m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master


### PR DESCRIPTION
not so obvious, but we are missing checking out of the k/k repo :)

```
2023/09/26 12:39:54 process.go:155: Step 'bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"' finished in 16.313253ms
2023/09/26 12:39:54 main.go:328: Something went wrong: starting e2e cluster: error during /workspace/kubernetes/hack/local-up-cluster.sh: exit status 1
```