### PR TITLE
Revert "migrate `sig-cloud-provider` jobs to community cluster"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -671,7 +671,6 @@ periodics:
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
-  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -698,13 +697,6 @@ periodics:
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
       - --timeout=70m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-alpha-enabled-default
@@ -933,7 +925,6 @@ periodics:
 
 - interval: 12h
   name: ci-kubernetes-soak-gce-gci
-  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -960,20 +951,12 @@ periodics:
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gce-gci
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-beta
-  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -1000,20 +983,12 @@ periodics:
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.15
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable1
-  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -1039,20 +1014,12 @@ periodics:
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.14
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable2
-  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -1078,20 +1045,12 @@ periodics:
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.13
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable3
-  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -1117,13 +1076,6 @@ periodics:
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.12


### PR DESCRIPTION
This reverts commit ddb3d08a8310129b76467f3dd7ba979d963bfb72.

- https://github.com/kubernetes/test-infra/pull/30731/

Fixes https://github.com/kubernetes/kubernetes/issues/120899