### PR TITLE
[ci-kubernetes-e2e-node-canary] switch to cos-beta from cos-105-lts

### DIFF
--- a/jobs/e2e_node/image-config-canary.yaml
+++ b/jobs/e2e_node/image-config-canary.yaml
@@ -1,5 +1,5 @@
 images:
   cos-stable:
-    image_family: cos-105-lts
+    image_family: cos-beta
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
GLIBC issue, let's move to newer cos

```
Sep 27 07:03:28 tmp-node-e2e-ad604391-cos-105-17412-156-63 systemd[1]: Created slice runtime.slice.
Sep 27 07:03:28 tmp-node-e2e-ad604391-cos-105-17412-156-63 systemd[1]: Started kubelet-20230927T070215.service.
Sep 27 07:03:28 tmp-node-e2e-ad604391-cos-105-17412-156-63 systemd[1]: kubelet-20230927T070215.service: Main process exited, code=exited, status=1/FAILURE
Sep 27 07:03:28 tmp-node-e2e-ad604391-cos-105-17412-156-63 systemd[1]: kubelet-20230927T070215.service: Failed with result 'exit
```