### PR TITLE
migrate `sig-autoscaling` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-autoscaling-vpa-actuation
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -33,11 +34,19 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-actuation
 - name: ci-kubernetes-e2e-autoscaling-vpa-admission-controller
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -71,11 +80,19 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-admission-controller
 - name: ci-kubernetes-e2e-autoscaling-vpa-full
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -109,11 +126,19 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-full
 - name: ci-kubernetes-e2e-autoscaling-vpa-recommender
+  cluster: k8s-infra-prow-build
   interval: 3h
   labels:
     preset-service-account: "true"
@@ -147,11 +172,19 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-recommender
 - name: ci-kubernetes-e2e-autoscaling-vpa-updater
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-service-account: "true"
@@ -185,6 +218,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
@@ -215,19 +255,26 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=3
-      - --gcp-project=k8s-jkns-gci-autoscaling
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
     testgrid-tab-name: gci-gce-autoscaling
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa-cm
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -243,7 +290,6 @@ periodics:
       - --cluster=hpa
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-project=k8s-jkns-gci-autoscaling
       - --gcp-zone=us-west1-b
       - --provider=gce
       # Enable HPAContainerMetrics and HPAScaleToZero. Required for container metrics and scale to zero tests.
@@ -251,6 +297,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -281,19 +334,26 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=3
-      - --gcp-project=k8s-jkns-gci-autoscaling-migs
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
     testgrid-tab-name: gci-gce-autoscaling-migs
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -309,7 +369,6 @@ periodics:
       - --cluster=hpa
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-project=k8s-jkns-gci-autoscaling-migs
       - --gcp-zone=us-west1-b
       - --provider=gce
       # Enable HPAContainerMetrics and HPAScaleToZero. Required for container metrics and scale to zero tests.
@@ -317,12 +376,20 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gce-autoscaling-migs-hpa
 - interval: 30m
   name: ci-kubernetes-e2e-autoscaling-hpa-cpu
+  cluster: k8s-infra-prow-build
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -347,6 +414,13 @@ periodics:
         --minStartupPods=8
       - --ginkgo-parallel=1
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
 
   annotations:
     # TODO: add to release blocking dashboards once run is successful

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gci-gce-autoscaling
+    cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-cluster-autoscaler
       testgrid-tab-name: gci-gce-autoscaling-pull
@@ -40,7 +41,6 @@ presubmits:
         - --extract=local
         - --gcp-node-image=gci
         - --gcp-nodes=3
-        - --gcp-project=k8s-jkns-gci-autoscaling
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-autoscaling
@@ -50,8 +50,16 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
 
   - name: pull-kubernetes-e2e-autoscaling-hpa-cpu
+    cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
       testgrid-tab-name: gci-gce-autoscaling-hpa-cpu-pull
@@ -92,8 +100,16 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
 
   - name: pull-kubernetes-e2e-autoscaling-hpa-cm
+    cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
       testgrid-tab-name: gci-gce-autoscaling-hpa-cm-pull
@@ -134,3 +150,10 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi


### PR DESCRIPTION
This PR moves sig-cloud-provider jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @mwielgus @maciekpytel @bskiba
/cc @ameukam @dims 