### PR TITLE
fix: sigs.k8s.io/kubernetes-sigs => sigs.k8s.io

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -8,7 +8,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 30m
-    path_alias: sigs.k8s.io/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
@@ -121,7 +121,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
-    path_alias: sigs.k8s.io/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -63,7 +63,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 180m
-    path_alias: sigs.k8s.io/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master


### PR DESCRIPTION
sigs.k8s.io/$repo is an alias for github.com/kubernetes-sigs/$repo

cc @dims @sunnylovestiramisu 