### PR TITLE
add path_alias to pull-gcp-filestore-csi-driver-e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml
@@ -9,6 +9,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 60m
+    path_alias: sigs.k8s.io/gcp-filestore-csi-driver
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_gcp-filestore-csi-driver/599/pull-gcp-filestore-csi-driver-e2e/1707170660809183232

```
  Expected
      <*errors.errorString | 0xc0004d3200>: {
          s: "failed to setup test package \"/tmp/driver-temp-archive2426426928\": Failed to make at /home/prow/go/src/sigs.k8s.io/gcp-filestore-csi-driver: make: *** /home/prow/go/src/sigs.k8s.io/gcp-filestore-csi-driver: No such file or directory.  Stop.\n: exit status 2",
      }
```

ref: https://github.com/kubernetes/test-infra/issues/30898