### PR TITLE
Do not checkout repo as we use ci/latest

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -178,7 +178,7 @@ presubmits:
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.6-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
 
-  - name: pull-containerd-sandboxed-node-e2e
+  - name: pull-containerd-legacy-cri-node-e2e
     always_run: false
     max_concurrency: 8
     decorate: true
@@ -209,8 +209,8 @@ presubmits:
         env:
         - name: USE_TEST_INFRA_LOG_DUMPING
           value: "true"
-        - name: ENABLE_CRI_SANDBOXES
-          value: "sandboxed"
+        - name: DISABLE_CRI_SANDBOXES
+          value: "1"
         command:
         - sh
         - -c

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -63,12 +63,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master


### PR DESCRIPTION
originally the args looked like this. my bad adding an extra repo and workdir, causing failures:

https://github.com/kubernetes/test-infra/blob/7627101a17a5d04f4306f0ae56469f135a7bfa3b/config/jobs/kubernetes/sig-testing/local-e2e.yaml#L72-L75
