### PR TITLE
k8s-infra: Add secret for kOps build cluster

### DIFF
--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -143,3 +143,16 @@ spec:
   - key: eks-prow-build-cluster-kubeconfig
     name: kubeconfig
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-k8s-infra-kops-prow-build
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build-trusted
+  data:
+  - key: k8s-infra-kops-prow-build-kubeconfig
+    name: kubeconfig
+    version: latest


### PR DESCRIPTION
Related to:
 - https://github.com/kubernetes/k8s.io/issues/5127

Add an ExternelSecret that will sync the kubeconfig for the cluster k8s-infra-kops-prow-build to the k8s-prow cluster.