### PR TITLE
peribolos: bump ci jobs timeout to 150m

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -3,6 +3,8 @@ postsubmits:
   - name: post-org-peribolos
     cluster: test-infra-trusted
     decorate: true
+    decoration_config:
+      timeout: 150m
     branches:
     - ^main$
     max_concurrency: 1
@@ -548,6 +550,8 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   cluster: test-infra-trusted
   decorate: true
+  decoration_config:
+    timeout: 150m
   max_concurrency: 1
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
Part of fix for the failing Peribolos CI jobs: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1708291567845904384 

Above job is currently failing with the following error:

```
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:169","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h0m0s timeout","severity":"error","time":"2023-10-01T01:23:23Z"} 
```

The PR bumps the timeout to `150 min` to test the job behaviour (temporary change).

/sig contributor-experience
cc: @cblecker 