### PR TITLE
Add Prow repo sparse checkout metrics

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -35,6 +35,7 @@ var gitMetrics = struct {
 	ensureFreshPrimaryDuration *prometheus.HistogramVec
 	fetchByShaDuration         *prometheus.HistogramVec
 	secondaryCloneDuration     *prometheus.HistogramVec
+	sparseCheckoutDuration     prometheus.Histogram
 }{
 	ensureFreshPrimaryDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "git_ensure_fresh_primary_duration",
@@ -53,9 +54,14 @@ var gitMetrics = struct {
 	secondaryCloneDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "git_secondary_clone_duration",
 		Help:    "Histogram of seconds spent creating the secondary clone, by org and repo.",
-		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60},
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90},
 	}, []string{
 		"org", "repo",
+	}),
+	sparseCheckoutDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "sparse_checkout_duration",
+		Help:    "Histogram of seconds spent performing sparse checkout for a repository",
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90},
 	}),
 }
 
@@ -63,6 +69,7 @@ func init() {
 	prometheus.MustRegister(gitMetrics.ensureFreshPrimaryDuration)
 	prometheus.MustRegister(gitMetrics.fetchByShaDuration)
 	prometheus.MustRegister(gitMetrics.secondaryCloneDuration)
+	prometheus.MustRegister(gitMetrics.sparseCheckoutDuration)
 }
 
 // ClientFactory knows how to create clientFactory for repos

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -21,10 +21,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
-
-	"github.com/sirupsen/logrus"
+	"time"
 )
 
 // Interactor knows how to operate on a git repository cloned from GitHub
@@ -179,9 +179,12 @@ func (i *interactor) CloneWithRepoOpts(from string, repoOpts RepoOpts) error {
 		}
 		sparseCheckoutArgs := []string{"-C", i.dir, "sparse-checkout", "set"}
 		sparseCheckoutArgs = append(sparseCheckoutArgs, repoOpts.SparseCheckoutDirs...)
+
+		timeBeforeSparseCheckout := time.Now()
 		if out, err := i.executor.Run(sparseCheckoutArgs...); err != nil {
 			return fmt.Errorf("error setting it to a sparse checkout: %w %v", err, string(out))
 		}
+		gitMetrics.sparseCheckoutDuration.Observe(time.Since(timeBeforeSparseCheckout).Seconds())
 	}
 	return nil
 }

--- a/prow/git/v2/interactor_test.go
+++ b/prow/git/v2/interactor_test.go
@@ -124,7 +124,7 @@ func TestInteractor_CloneWithRepoOpts(t *testing.T) {
 			dir:  "/secondaryclone",
 			from: "/mirrorclone",
 			repoOpts: RepoOpts{
-				SparseCheckoutDirs:         nil,
+				SparseCheckoutDirs:           nil,
 				ShareObjectsWithPrimaryClone: true,
 			},
 			responses: map[string]execResponse{
@@ -142,7 +142,7 @@ func TestInteractor_CloneWithRepoOpts(t *testing.T) {
 			dir:  "/secondaryclone",
 			from: "/mirrorclone",
 			repoOpts: RepoOpts{
-				SparseCheckoutDirs:         []string{},
+				SparseCheckoutDirs:           []string{},
 				ShareObjectsWithPrimaryClone: true,
 			},
 			responses: map[string]execResponse{
@@ -160,7 +160,7 @@ func TestInteractor_CloneWithRepoOpts(t *testing.T) {
 			dir:  "/secondaryclone",
 			from: "/mirrorclone",
 			repoOpts: RepoOpts{
-				SparseCheckoutDirs:         []string{"a", "b"},
+				SparseCheckoutDirs:           []string{"a", "b"},
 				ShareObjectsWithPrimaryClone: true,
 			},
 			responses: map[string]execResponse{


### PR DESCRIPTION
We need additional metrics to debug secondary clone slowness issue for Gerrit repositories. Therefore we are breaking up the timing of secondary clone to the clone itself and the git sparse-checkout.

cc: @cjwagner @airbornepony 