### PR TITLE
k8s-infra: Add ExternalSecret for kOps build cluster

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig:/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -74,6 +74,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -124,6 +127,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       # AWS IAM token needed to assume role to access the prow-build-cluster EKS cluster.
       - name: aws-iam-token
         projected:

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -63,7 +63,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -92,6 +92,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -152,6 +155,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       - name: config
         configMap:
           name: config

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -51,7 +51,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -102,6 +102,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         # AWS IAM token needed to assume role to access the prow-build-cluster EKS cluster.
         - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
@@ -165,6 +168,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       # AWS IAM token needed to assume role to access the prow-build-cluster EKS cluster.
       - name: aws-iam-token
         projected:

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -74,6 +74,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -118,6 +121,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       - name: config
         configMap:
           name: config

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -52,6 +52,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -84,6 +87,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Add the kubeconfig of the EKS cluster k8s-infra-kops-prow-build.