### PR TITLE
typo in branch name for containerd

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -296,7 +296,7 @@ periodics:
     workdir: true
   - org: containerd
     repo: containerd
-    base_ref: release-1.7
+    base_ref: release/1.7
     path_alias: github.com/containerd/containerd
   - org: kubernetes
     repo: test-infra


### PR DESCRIPTION
Test is failing to clone containerd release/1.7.  

https://testgrid.k8s.io/sig-node-containerd#containerd-node-e2e-1.7

This is because containerd uses nonsensical naming for branches. ;)

release-1.7 should be changed to release/1.7. 

Only place I could see where this was set like this.