### PR TITLE
CAPZ: add dual stack ci test and fix ipv6 variables

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -346,6 +346,8 @@ presubmits:
               value: "-kubetest.use-ci-artifacts"
             - name: IP_FAMILY
               value: "IPv6"
+            - name: KUBERNETES_VERSION
+              value: "latest-1.27" # workaround for https://github.com/kubernetes/kubernetes/issues/120999
           securityContext:
             privileged: true
           resources:
@@ -355,6 +357,48 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-ipv6-k8s-ci-main
+  - name: pull-cluster-api-provider-azure-conformance-dual-stack-with-ci-artifacts
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    branches:
+    - ^main$
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-1.27
+          command:
+            - runner.sh
+          args:
+            - ./scripts/ci-conformance.sh
+          env:
+            - name: E2E_ARGS
+              value: "-kubetest.use-ci-artifacts"
+            - name: IP_FAMILY
+              value: "dual"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: capz-pr-conformance-dual-stack-k8s-ci-main
   - name: pull-cluster-api-provider-azure-windows-containerd-upstream-with-ci-artifacts
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false


### PR DESCRIPTION
adds optional job for testing https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4086/files, will eventually become a periodic job