### PR TITLE
update tejolote jobs to use go1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
needed for https://github.com/kubernetes-sigs/tejolote/pull/169

/assign @saschagrunert @xmudrii @Verolop
cc @kubernetes/release-engineering 