### PR TITLE
update BOM jobs to use Go1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -61,7 +61,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
needed for https://github.com/kubernetes-sigs/bom/pull/350


/assign @saschagrunert @puerco @ameukam 
cc @kubernetes-sigs/release-engineering 