### PR TITLE
pull-kubernetes-e2e-kind-alpha-features: enable also beta features

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -306,9 +306,9 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: FEATURE_GATES
-          value: '{"AllAlpha":true}'
+          value: '{"AllAlpha":true,"AllBeta":true}'
         - name: RUNTIME_CONFIG
-          value: '{"api/alpha":"true"}'
+          value: '{"api/all":"true"}'
         - name: FOCUS
           value: \[Alpha\]
         - name: SKIP


### PR DESCRIPTION
This PR enables beta features and apis for `pull-kubernetes-e2e-kind-alpha-features`, to
- test alpha features that conditionally require beta features;
- help with feature graduation
- deal with edge cases where a feature is beta but disabled by default