### PR TITLE
run kind alpha presubmit with all tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -310,7 +310,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"true"}'
         - name: FOCUS
-          value: \[Alpha\]
+          value: "."
         - name: SKIP
           value: \[Slow\]|\[Disruptive\]|\[Flaky\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
         - name: PARALLEL


### PR DESCRIPTION
The current regex does not match anything, and we want to check not only the alpha tests, also the interaction of the enabled features with the current existing tests