### PR TITLE
Move controlplane instances to amd arch

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1301,7 +1301,7 @@ def generate_presubmits_scale():
                 'RUN_CL2_TEST': "true",
                 'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "20",
                 'CONTROL_PLANE_COUNT': "3",
-                'CONTROL_PLANE_SIZE': "c6g.16xlarge",
+                'CONTROL_PLANE_SIZE': "c7a.16xlarge",
                 'CL2_LOAD_TEST_THROUGHPUT': "50",
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -208,7 +208,7 @@ presubmits:
         - name: CONTROL_PLANE_COUNT
           value: "3"
         - name: CONTROL_PLANE_SIZE
-          value: "c6g.16xlarge"
+          value: "c7a.16xlarge"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT


### PR DESCRIPTION
- Move controlplane instances to amd arch because current we have kops create cluster uses same arch for control-plane and dataplane and for dataplane we need amd ; More details on this PR  changes here - https://github.com/kubernetes/kops/pull/15963
