### PR TITLE
Disable enhancements project board job for 1.29 Enhancement Freeze

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,8 +1,8 @@
 periodics:
 - name: periodic-sync-enhancements-github-project-1-29
 # temporarily disable job by with an impossible cron date instead of deleting it
-  # cron: '0 0 31 2 *'
-  interval: 6h
+  cron: '0 0 31 2 *'
+  # interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
PR bump the 6 hrs frequency of `periodic-sync-enhancements-github-project-1-29` to enforce 1.29 Enhancements Freeze.