### PR TITLE
csi: move alpha and canary to community cluster

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -1589,6 +1589,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-26
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1642,6 +1643,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-27
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1695,6 +1697,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-28
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1748,6 +1751,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-master
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1801,6 +1805,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-on-kubernetes-master
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1854,6 +1859,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-26
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1907,6 +1913,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-27
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1960,6 +1967,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-28
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -2013,6 +2021,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-master
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -2066,6 +2075,7 @@ periodics:
           cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-test-on-kubernetes-master
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -726,6 +726,7 @@ for deployment_suffix in "" "-test"; do
             cat >>"$base/csi-driver-host-path/csi-driver-host-path-config.yaml" <<EOF
 - interval: 6h
   name: $(job_name "ci" "" "$tests" "canary$deployment_suffix" "$kubernetes")
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi


### PR DESCRIPTION
Related to:
 - https://github.com/kubernetes/test-infra/issues/30277

Move alpha and canary prowjobs to GKE cluster k8s-infra-prow-build