### PR TITLE
Remove capg-conformance-main-ci-artifacts from sig-release-master-informing dashboard

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -150,7 +150,10 @@ periodics:
               # during the tests more like 3-20m is used
               cpu: 2000m
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp, sig-release-master-informing
+      # TODO: promote to sig-release-master-informing, once fix PR is merged
+      # https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1018.
+      # Also, add back release-team@kubernetes.io to testgrid-alert-email
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: capg-conformance-main-ci-artifacts
-      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io, release-team@kubernetes.io
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
       testgrid-num-failures-to-alert: "2"


### PR DESCRIPTION
The [capg-conformance-main-ci-artifacts](https://testgrid.k8s.io/sig-release-master-informing#capg-conformance-main-ci-artifacts) job has been failing for approx a month now.

There is work ongoing on the fix with PR kubernetes-sigs/cluster-api-provider-gcp#1018, but it's taking some time to get merged.

Since, the 1.29 Release Team is approaching the `1.29.0-alpha.2` cut tomorrow (Oct 10, 2023).

After our latest discussion, we're proposing temporarily removing the `capg-conformance-main-ci-artifacts` job from the `sig-release-master-informing` dashboard until the fix is in and  the job is running successfully again for a few iterations.

#### Related slack discussions on k8s slack:

- https://kubernetes.slack.com/archives/C01D1RFEN9G/p1694671751153029 (#cluster-api-gcp)
- https://kubernetes.slack.com/archives/C8TSNPY4T/p1694166186381649 (#cluster-api)
- https://kubernetes.slack.com/archives/C2C40FMNF/p1694672335486569 (#sig-release)
- https://kubernetes.slack.com/archives/CJH2GBF7Y/p1696857419785299 (#release-management)

cc: @cpanato  @justinsb @richardcase @vincepri 
cc: @kubernetes/release-team-leads 