### PR TITLE
verify: simplify and rename golangci-lint PR jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -1760,36 +1760,6 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: false
-    branches:
-    - release-1.27
-    cluster: k8s-infra-prow-build
-    context: pull-kubernetes-verify-strict-lint
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-verify-strict-lint
-    optional: true
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - /bin/sh
-        - -c
-        - if [ -x hack/verify-golangci-lint-pr.sh ]; then hack/verify-golangci-lint-pr.sh; fi
-        command:
-        - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-1.27
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          limits:
-            cpu: "7"
-            memory: 12Gi
-          requests:
-            cpu: "7"
-            memory: 12Gi
   kubernetes/perf-tests:
   - always_run: false
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1987,36 +1987,6 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: false
-    branches:
-    - release-1.28
-    cluster: k8s-infra-prow-build
-    context: pull-kubernetes-verify-strict-lint
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-verify-strict-lint
-    optional: true
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - /bin/sh
-        - -c
-        - if [ -x hack/verify-golangci-lint-pr.sh ]; then hack/verify-golangci-lint-pr.sh; fi
-        command:
-        - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-1.28
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          limits:
-            cpu: "7"
-            memory: 12Gi
-          requests:
-            cpu: "7"
-            memory: 12Gi
   kubernetes/perf-tests:
   - always_run: false
     branches:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -44,7 +44,7 @@ presubmits:
           requests:
             cpu: 7
             memory: 12Gi
-  - name: pull-kubernetes-verify-strict-lint
+  - name: pull-kubernetes-linter-strict
     cluster: eks-prow-build-cluster
     decorate: true
     # This entire job is currently experimental. If it turns out to be useful,
@@ -64,14 +64,15 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-master
-        imagePullPolicy: Always
         command:
-        - runner.sh
+        - make
         args:
-        - /bin/sh
-        - "-c"
-        - "hack/verify-golangci-lint.sh -r ${PULL_BASE_SHA} -s"
+        - verify
+        - WHAT=golangci-lint-pr
         resources:
+          # It peaks at around 7 cores of the EKS cluster. We can fit more jobs onto
+          # a node without much slowdown by requesting one third of a node
+          # (= 3 * 5 + 1 for kubelet).
           limits:
             cpu: 5
             memory: 12Gi
@@ -98,13 +99,11 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-master
-        imagePullPolicy: Always
         command:
-        - runner.sh
+        - make
         args:
-        - /bin/sh
-        - "-c"
-        - "hack/verify-golangci-lint.sh -r ${PULL_BASE_SHA} -n"
+        - verify
+        - WHAT=golangci-lint-pr-hints
         resources:
           # It peaks at around 7 cores of the EKS cluster. We can fit more jobs onto
           # a node without much slowdown by requesting one third of a node

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -35,11 +35,11 @@ jobs:
   - pull-kubernetes-integration
   - pull-kubernetes-integration-go-compatibility
   - pull-kubernetes-linter-hints
+  - pull-kubernetes-linter-strict
   - pull-kubernetes-node-e2e-containerd
   - pull-kubernetes-typecheck
   - pull-kubernetes-unit
   - pull-kubernetes-unit-go-compatibility
   - pull-kubernetes-verify
   - pull-kubernetes-verify-govet-levee
-  - pull-kubernetes-verify-strict-lint
 recursive_artifacts: false


### PR DESCRIPTION
"make verify WHAT=..." gets enabled in
https://github.com/kubernetes/kubernetes/pull/121086. It's easier than direct invocations and includes producing JUnit files, which has some advantages (doesn't rely on syntax highlighting of job output, better integration into testgrid).

Strict linting might remain as a separate job, so the name gets simplified to better describe the intent and to match pull-kubernetes-linter-hints.

/hold

For https://github.com/kubernetes/kubernetes/pull/121086.