### PR TITLE
GeneralizeComment function - github client

### DIFF
--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -238,4 +238,6 @@ func GeneralizeComment[E CommentLikeEventTypes](event E) (*GenericCommentEvent, 
 			IssueHTMLURL: t.PullRequest.HTMLURL,
 		}, nil
 	}
+
+	return nil, fmt.Errorf("we were unable to generalize comment, unknown type encountered")
 }

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -105,3 +105,137 @@ func PermissionsFromTeamPermission(permission TeamPermission) RepoPermissions {
 		return RepoPermissions{}
 	}
 }
+
+// CommentLikeEventTypes are various event types that can be coerced into
+// a GenericCommentEvent.
+type CommentLikeEventTypes interface {
+	IssueEvent | IssueCommentEvent | PullRequestEvent | ReviewEvent | ReviewCommentEvent
+}
+
+// GeneralizeComment takes an event that can be coerced into a GenericCommentEvent
+// and returns a populated GenericCommentEvent.
+func GeneralizeComment[E CommentLikeEventTypes](event E) (*GenericCommentEvent, error) {
+	switch t := any(event).(type) {
+
+	case IssueEvent:
+		action := GeneralizeCommentAction(string(t.Action))
+		if action == "" {
+			return nil, fmt.Errorf("failed to determine events action [%v]", string(t.Action))
+		}
+
+		return &GenericCommentEvent{
+			ID:           t.Issue.ID,
+			NodeID:       t.Issue.NodeID,
+			GUID:         t.GUID,
+			IsPR:         t.Issue.IsPullRequest(),
+			Action:       action,
+			Body:         t.Issue.Body,
+			HTMLURL:      t.Issue.HTMLURL,
+			Number:       t.Issue.Number,
+			Repo:         t.Repo,
+			User:         t.Issue.User,
+			IssueAuthor:  t.Issue.User,
+			Assignees:    t.Issue.Assignees,
+			IssueState:   t.Issue.State,
+			IssueTitle:   t.Issue.Title,
+			IssueBody:    t.Issue.Body,
+			IssueHTMLURL: t.Issue.HTMLURL,
+		}, nil
+	case IssueCommentEvent:
+		action := GeneralizeCommentAction(string(t.Action))
+		if action == "" {
+			return nil, fmt.Errorf("failed to determine events action [%v]", string(t.Action))
+		}
+
+		return &GenericCommentEvent{
+			ID:           t.Issue.ID,
+			NodeID:       t.Issue.NodeID,
+			CommentID:    &t.Comment.ID,
+			GUID:         t.GUID,
+			IsPR:         t.Issue.IsPullRequest(),
+			Action:       action,
+			Body:         t.Comment.Body,
+			HTMLURL:      t.Comment.HTMLURL,
+			Number:       t.Issue.Number,
+			Repo:         t.Repo,
+			User:         t.Comment.User,
+			IssueAuthor:  t.Issue.User,
+			Assignees:    t.Issue.Assignees,
+			IssueState:   t.Issue.State,
+			IssueTitle:   t.Issue.Title,
+			IssueBody:    t.Issue.Body,
+			IssueHTMLURL: t.Issue.HTMLURL,
+		}, nil
+	case PullRequestEvent:
+		action := GeneralizeCommentAction(string(t.Action))
+		if action == "" {
+			return nil, fmt.Errorf("failed to determine events action [%v]", string(t.Action))
+		}
+
+		return &GenericCommentEvent{
+			ID:           t.PullRequest.ID,
+			NodeID:       t.PullRequest.NodeID,
+			GUID:         t.GUID,
+			IsPR:         true,
+			Action:       action,
+			Body:         t.PullRequest.Body,
+			HTMLURL:      t.PullRequest.HTMLURL,
+			Number:       t.PullRequest.Number,
+			Repo:         t.Repo,
+			User:         t.PullRequest.User,
+			IssueAuthor:  t.PullRequest.User,
+			Assignees:    t.PullRequest.Assignees,
+			IssueState:   t.PullRequest.State,
+			IssueTitle:   t.PullRequest.Title,
+			IssueBody:    t.PullRequest.Body,
+			IssueHTMLURL: t.PullRequest.HTMLURL,
+		}, nil
+	case ReviewEvent:
+		action := GeneralizeCommentAction(string(t.Action))
+		if action == "" {
+			return nil, fmt.Errorf("failed to determine events action [%v]", string(t.Action))
+		}
+
+		return &GenericCommentEvent{
+			GUID:         t.GUID,
+			NodeID:       t.Review.NodeID,
+			IsPR:         true,
+			Action:       action,
+			Body:         t.Review.Body,
+			HTMLURL:      t.Review.HTMLURL,
+			Number:       t.PullRequest.Number,
+			Repo:         t.Repo,
+			User:         t.Review.User,
+			IssueAuthor:  t.PullRequest.User,
+			Assignees:    t.PullRequest.Assignees,
+			IssueState:   t.PullRequest.State,
+			IssueTitle:   t.PullRequest.Title,
+			IssueBody:    t.PullRequest.Body,
+			IssueHTMLURL: t.PullRequest.HTMLURL,
+		}, nil
+	case ReviewCommentEvent:
+		action := GeneralizeCommentAction(string(t.Action))
+		if action == "" {
+			return nil, fmt.Errorf("failed to determine events action [%v]", string(t.Action))
+		}
+
+		return &GenericCommentEvent{
+			GUID:         t.GUID,
+			NodeID:       t.Comment.NodeID,
+			IsPR:         true,
+			CommentID:    &t.Comment.ID,
+			Action:       action,
+			Body:         t.Comment.Body,
+			HTMLURL:      t.Comment.HTMLURL,
+			Number:       t.PullRequest.Number,
+			Repo:         t.Repo,
+			User:         t.Comment.User,
+			IssueAuthor:  t.PullRequest.User,
+			Assignees:    t.PullRequest.Assignees,
+			IssueState:   t.PullRequest.State,
+			IssueTitle:   t.PullRequest.Title,
+			IssueBody:    t.PullRequest.Body,
+			IssueHTMLURL: t.PullRequest.HTMLURL,
+		}, nil
+	}
+}

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -105,26 +105,14 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 		l.Errorf(FailedCommentCoerceFmt, "pull_request_review", string(re.Action))
 		return
 	}
-	s.handleGenericComment(
-		l,
-		&github.GenericCommentEvent{
-			GUID:         re.GUID,
-			NodeID:       re.Review.NodeID,
-			IsPR:         true,
-			Action:       action,
-			Body:         re.Review.Body,
-			HTMLURL:      re.Review.HTMLURL,
-			Number:       re.PullRequest.Number,
-			Repo:         re.Repo,
-			User:         re.Review.User,
-			IssueAuthor:  re.PullRequest.User,
-			Assignees:    re.PullRequest.Assignees,
-			IssueState:   re.PullRequest.State,
-			IssueTitle:   re.PullRequest.Title,
-			IssueBody:    re.PullRequest.Body,
-			IssueHTMLURL: re.PullRequest.HTMLURL,
-		},
-	)
+
+	gce, err := github.GeneralizeComment(re)
+	if err != nil {
+		l.Errorln(err)
+		return
+	}
+
+	s.handleGenericComment(l, gce)
 }
 
 func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewCommentEvent) {
@@ -163,27 +151,14 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 		l.Errorf(FailedCommentCoerceFmt, "pull_request_review_comment", string(rce.Action))
 		return
 	}
-	s.handleGenericComment(
-		l,
-		&github.GenericCommentEvent{
-			GUID:         rce.GUID,
-			NodeID:       rce.Comment.NodeID,
-			IsPR:         true,
-			CommentID:    intPtr(rce.Comment.ID),
-			Action:       action,
-			Body:         rce.Comment.Body,
-			HTMLURL:      rce.Comment.HTMLURL,
-			Number:       rce.PullRequest.Number,
-			Repo:         rce.Repo,
-			User:         rce.Comment.User,
-			IssueAuthor:  rce.PullRequest.User,
-			Assignees:    rce.PullRequest.Assignees,
-			IssueState:   rce.PullRequest.State,
-			IssueTitle:   rce.PullRequest.Title,
-			IssueBody:    rce.PullRequest.Body,
-			IssueHTMLURL: rce.PullRequest.HTMLURL,
-		},
-	)
+
+	gce, err := github.GeneralizeComment(rce)
+	if err != nil {
+		l.Errorln(err)
+		return
+	}
+
+	s.handleGenericComment(l, gce)
 }
 
 func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEvent) {
@@ -223,27 +198,14 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 		}
 		return
 	}
-	s.handleGenericComment(
-		l,
-		&github.GenericCommentEvent{
-			ID:           pr.PullRequest.ID,
-			NodeID:       pr.PullRequest.NodeID,
-			GUID:         pr.GUID,
-			IsPR:         true,
-			Action:       action,
-			Body:         pr.PullRequest.Body,
-			HTMLURL:      pr.PullRequest.HTMLURL,
-			Number:       pr.PullRequest.Number,
-			Repo:         pr.Repo,
-			User:         pr.PullRequest.User,
-			IssueAuthor:  pr.PullRequest.User,
-			Assignees:    pr.PullRequest.Assignees,
-			IssueState:   pr.PullRequest.State,
-			IssueTitle:   pr.PullRequest.Title,
-			IssueBody:    pr.PullRequest.Body,
-			IssueHTMLURL: pr.PullRequest.HTMLURL,
-		},
-	)
+
+	gce, err := github.GeneralizeComment(pr)
+	if err != nil {
+		l.Errorln(err)
+		return
+	}
+
+	s.handleGenericComment(l, gce)
 }
 
 func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
@@ -309,27 +271,14 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 		}
 		return
 	}
-	s.handleGenericComment(
-		l,
-		&github.GenericCommentEvent{
-			ID:           i.Issue.ID,
-			NodeID:       i.Issue.NodeID,
-			GUID:         i.GUID,
-			IsPR:         i.Issue.IsPullRequest(),
-			Action:       action,
-			Body:         i.Issue.Body,
-			HTMLURL:      i.Issue.HTMLURL,
-			Number:       i.Issue.Number,
-			Repo:         i.Repo,
-			User:         i.Issue.User,
-			IssueAuthor:  i.Issue.User,
-			Assignees:    i.Issue.Assignees,
-			IssueState:   i.Issue.State,
-			IssueTitle:   i.Issue.Title,
-			IssueBody:    i.Issue.Body,
-			IssueHTMLURL: i.Issue.HTMLURL,
-		},
-	)
+
+	gce, err := github.GeneralizeComment(i)
+	if err != nil {
+		l.Errorln(err)
+		return
+	}
+
+	s.handleGenericComment(l, gce)
 }
 
 func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueCommentEvent) {
@@ -367,28 +316,14 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 		l.Errorf(FailedCommentCoerceFmt, "issue_comment", string(ic.Action))
 		return
 	}
-	s.handleGenericComment(
-		l,
-		&github.GenericCommentEvent{
-			ID:           ic.Issue.ID,
-			NodeID:       ic.Issue.NodeID,
-			CommentID:    intPtr(ic.Comment.ID),
-			GUID:         ic.GUID,
-			IsPR:         ic.Issue.IsPullRequest(),
-			Action:       action,
-			Body:         ic.Comment.Body,
-			HTMLURL:      ic.Comment.HTMLURL,
-			Number:       ic.Issue.Number,
-			Repo:         ic.Repo,
-			User:         ic.Comment.User,
-			IssueAuthor:  ic.Issue.User,
-			Assignees:    ic.Issue.Assignees,
-			IssueState:   ic.Issue.State,
-			IssueTitle:   ic.Issue.Title,
-			IssueBody:    ic.Issue.Body,
-			IssueHTMLURL: ic.Issue.HTMLURL,
-		},
-	)
+
+	gce, err := github.GeneralizeComment(ic)
+	if err != nil {
+		l.Errorln(err)
+		return
+	}
+
+	s.handleGenericComment(l, gce)
 }
 
 func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -377,10 +377,6 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericComment
 	}
 }
 
-func intPtr(i int) *int {
-	return &i
-}
-
 func errorOnPanic(f func() error) (err error) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Moving some of the generic comment logic in hook out in the github client, so it's easier to share and use in external plugins.