### PR TITLE
add python3-venv to bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-distutils \
     python3-gflags \
     python3-pip \
+    python3-venv \
     python3-yaml \
     rsync \
     unzip \


### PR DESCRIPTION
we should encourage kubekins-e2e users to use venvs, but venv apparently requires this package on debian/ubuntu

cc @robscott, next we'll have to bump this image and then kubekins when this is built.

at some point we shoudl flatten these built OTOH this base needs touching less often and it's a huge build between the two ...