### PR TITLE
Rolling back image used for Gateway API verify presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
@@ -14,7 +14,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231009-5a9a0d4990-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh


### PR DESCRIPTION
The image upgrade broke pip3 install which broke verify-yamllint for us. That should be fixed by the work @BenTheElder is doing in https://github.com/kubernetes/test-infra/pull/30998 and corresponding follow ups. Rolling back so we can get back up and running sooner, but the next auto-upgrade of this image should include venv so should not break Gateway API next time.