### PR TITLE
Rolling Gateway API forward to kubekins-e2e image with venv

### DIFF
--- a/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
@@ -14,7 +14,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231009-5a9a0d4990-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh


### PR DESCRIPTION
This should supersede #30999.

/cc @BenTheElder 