### PR TITLE
Increase CPU limits for k/test-infra jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -158,10 +158,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "4"
+            cpu: "8"
             memory: "8Gi"
           limits:
-            cpu: "4"
+            cpu: "8"
             memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
@@ -188,10 +188,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "4"
+            cpu: "8"
             memory: "8Gi"
           limits:
-            cpu: "4"
+            cpu: "8"
             memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
@@ -252,10 +252,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "4"
+            cpu: "8"
             memory: "8Gi"
           limits:
-            cpu: "4"
+            cpu: "8"
             memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra


### PR DESCRIPTION
This PR increases CPU limits for k/test-infra jobs that are being throttled:

- pull-test-infra-unit-test-race-detector-nonblocking
- pull-test-infra-unit-test
- pull-test-infra-verify-lint

The new values are based on data from our monitoring stack: https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=kubernetes&var-repo=test-infra&var-job=ci-test-infra-prow-checkconfig&orgId=1&from=now-7d&to=now&refresh=30s&var-build=All

/assign @BenTheElder @dims @ameukam 