### PR TITLE
[ci-containerd-e2e-ubuntu-gce] Switch to newer LTS for ubuntu

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -72,7 +72,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=ubuntu-2004-lts
+      - --image-family=ubuntu-2204-lts
       - --image-project=ubuntu-os-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/31003 we fixed the master image, in this we fix the ubuntu worker node image