### PR TITLE
prow: query github organization add node_id support

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -1155,8 +1155,9 @@ type Membership struct {
 type Organization struct {
 	// Login has the same meaning as Name, but it's more reliable to use as Name can sometimes be empty,
 	// see https://developer.github.com/v3/orgs/#list-organizations
-	Login string `json:"login"`
-	Id    int    `json:"id"`
+	Login  string `json:"login"`
+	Id     int    `json:"id"`
+	NodeId string `json:"node_id"`
 	// BillingEmail holds private billing address
 	BillingEmail string `json:"billing_email"`
 	Company      string `json:"company"`


### PR DESCRIPTION
node_id can be used for github projectv2