### PR TITLE
update release branches job pull-kubernetes-node-e2e-containerd to add extra repo checkout

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -1021,6 +1021,11 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1089,6 +1089,11 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -1043,6 +1043,11 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1040,6 +1040,11 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - command:


### PR DESCRIPTION
we are seeing some errors in the `pull-kubernetes-node-e2e-containerd` job

```
F1012 07:30:36.917511    8964 gce_runner.go:407] Failed to read metadata file "/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml": open /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml: no such file or directory
exit status 255
```

PRs: https://github.com/kubernetes/kubernetes/pull/121150 / https://github.com/kubernetes/kubernetes/pull/121128

that looks like is related to the change made in https://github.com/kubernetes/test-infra/pull/30797


applying the same changes made in the original job to the release branch jobs as well

/assign @ameukam @dims 
