### PR TITLE
bump cos version to 109 due to libgc issue

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -659,7 +659,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-101-lts
+      - --image-family=cos-109-lts
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.25.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.25.yaml
@@ -1,5 +1,5 @@
 images:
   cos-101:
-    image_family: cos-101-lts
+    image_family: cos-109-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
@@ -1,5 +1,5 @@
 images:
   cos-101:
-    image_family: cos-101-lts
+    image_family: cos-109-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.27.yaml
@@ -1,5 +1,5 @@
 images:
   cos-105:
-    image_family: cos-105-lts
+    image_family: cos-109-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
Node release branches tests were failing due to a libgc compilation issue.  

Bumping the OS version has been shown to fix this.

Failing tests:

- https://testgrid.k8s.io/sig-node-release-blocking#node-conformance-release-1.25
- https://testgrid.k8s.io/sig-node-release-blocking#node-conformance-release-1.26
- https://testgrid.k8s.io/sig-node-release-blocking#node-conformance-release-1.27

- https://testgrid.k8s.io/sig-node-containerd#cos-cgroupv1-containerd-e2e