### PR TITLE
use 109 for release 1.28 rather than beta

### DIFF
--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.28.yaml
@@ -1,6 +1,5 @@
 images:
-    # TODO(mmiranda96): update to cos-109-lts once COS beta promotes to stable
   cos-dev:
-    image_family: cos-beta
+    image_family: cos-109-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
Fix the TODO.  

/assign @mmiranda96 

This PR will use the cos-109-lts rather than cos-beta.  Its nice to have this as we can have stable images for these tests.