### PR TITLE
Update kubekins-e2e to Go 1.20.10 and 1.21.3

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,14 +1,14 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.21.2
+    GO_VERSION: 1.21.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.21.2
+    GO_VERSION: 1.21.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -21,37 +21,37 @@ variants:
     KIND_VERSION: 0.17.0
   master:
     CONFIG: master
-    GO_VERSION: 1.21.2
+    GO_VERSION: 1.21.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.21.2
+    GO_VERSION: 1.21.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.28':
     CONFIG: '1.28'
-    GO_VERSION: 1.20.9
+    GO_VERSION: 1.20.10
     K8S_RELEASE: latest-1.28
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: 1.20.9
+    GO_VERSION: 1.20.10
     K8S_RELEASE: stable-1.27
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.26':
     CONFIG: '1.26'
-    GO_VERSION: 1.20.9
+    GO_VERSION: 1.20.10
     K8S_RELEASE: stable-1.26
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: 1.20.9
+    GO_VERSION: 1.20.10
     K8S_RELEASE: stable-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
- Update kubekins-e2e to Go 1.20.10 and 1.21.3

xref: https://github.com/kubernetes/release/issues/3311

/assign @saschagrunert @aojea @Verolop  @xmudrii 
cc @kubernetes/release-engineering 