### PR TITLE
swap fedora jobs use crio so should display in crio testgrid tab

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -255,7 +255,7 @@ periodics:
             cpu: 4
             memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-node-kubelet
+    testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
     testgrid-tab-name: kubelet-gce-e2e-swap-fedora
     testgrid-alert-email: ehashman@redhat.com, ikema@google.com
     description: Executes E2E suite with swap enabled on Fedora
@@ -313,7 +313,7 @@ periodics:
   interval: 4h
   cluster: k8s-infra-prow-build
   annotations:
-    testgrid-dashboards: sig-node-kubelet
+    testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
     testgrid-tab-name: kubelet-gce-e2e-swap-fedora-serial
     description: "Run serial node e2e tests with swap environment on Fedora"
   labels:


### PR DESCRIPTION
Both the fedora swap jobs use crio so we should add these jobs to our crio dashboard.

