### PR TITLE
enable dind for kops/kube build job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -486,6 +486,7 @@ presubmits:
     skip_report: false
     labels:
       preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
     decorate: true
     extra_refs:
     - org: kubernetes


### PR DESCRIPTION
Forgot this in https://github.com/kubernetes/test-infra/pull/31023