### PR TITLE
Work around bug in gcloud when downloading logs

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -317,7 +317,10 @@ function copy-logs-from-node() {
     if [[ "${gcloud_supported_providers}" =~ ${KUBERNETES_PROVIDER} ]]; then
       # get-serial-port-output lets you ask for ports 1-4, but currently (11/21/2016) only port 1 contains useful information
       gcloud compute instances get-serial-port-output --project "${PROJECT}" --zone "${ZONE}" --port 1 "${node}" > "${dir}/serial-1.log" || true
-      gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${scp_files}" "${dir}" > /dev/null || true
+      # FIXME(dims): bug in gcloud prevents multiple source files specified using curly braces, so we just loop through for now
+      for single_file in "${files[@]}"; do
+        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" > /dev/null || true
+      done
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
       local ip
       ip=$(get_ssh_hostname "${node}")


### PR DESCRIPTION
Context: see https://kubernetes.slack.com/archives/C09QZ4DQB/p1697396526944759

TLDR; `"instance-1:{/var/log/kern.log,/var/log/auth.log}"` format is not supported in latest gcloud and fails miserably with the following error. (this gcloud is the one packaged in `https://gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-master`
```
root@27ca4db1fd04:/workspace# gcloud --version
Google Cloud SDK 450.0.0
alpha 2023.10.06
beta 2023.10.06
bq 2.0.98
bundled-python3-unix 3.9.16
core 2023.10.06
gcloud-crc32c 1.0.0
gke-gcloud-auth-plugin 0.5.6
gsutil 5.26
kubectl 1.27.5
root@27ca4db1fd04:/workspace# gcloud compute scp --recurse --project "cri-containerd-pr-node-e2e" --zone "us-central1-a" "instance-1:{/var/log/kern.log,/var/log/auth.log}" "."
/usr/bin/scp: {/var/log/kern.log,/var/log/auth.log}: No such file or directory
ERROR: (gcloud.compute.scp) [/usr/bin/scp] exited with return code [1].
```
