### PR TITLE
deck: fix reading loglines from S3 buckets

### DIFF
--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -478,12 +478,12 @@ func logLinesAll(artifact api.Artifact) ([]string, error) {
 func logLines(artifact api.Artifact, offset, length int64) ([]string, error) {
 	b := make([]byte, length)
 	_, err := artifact.ReadAt(b, offset)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		if err != lenses.ErrGzipOffsetRead {
 			return nil, fmt.Errorf("couldn't read requested bytes: %w", err)
 		}
 		moreBytes, err := artifact.ReadAtMost(offset + length)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, fmt.Errorf("couldn't handle reading gzipped file: %w", err)
 		}
 		b = moreBytes[offset:]


### PR DESCRIPTION
The EOF error for Storage Artifacts can be wrapped via `fmt.Errorf("error reading from artifact: %w", err)`, which broke this error check. The effect is that when using S3 with Prow, clicking on "NNN skipped lines…" on a Spyglass page resulted in 

> Failed to retrieve log lines: couldn't read requested bytes: error reading from artifact: EOF

The "show all hidden lines" function was not affected by this bug.

The same bug did not occur in another Prow setup where GCS is used, so I presume it's related to that?