### PR TITLE
Respect terminated_pod_ttl for periodic ProwJobs

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -367,15 +367,15 @@ func (c *controller) clean() {
 			continue
 		}
 
+		if !prowJob.Complete() {
+			continue
+		}
+		isFinished.Insert(prowJob.ObjectMeta.Name)
 		latestPJ := latestPeriodics[prowJob.Spec.Job]
 		if isActivePeriodic[prowJob.Spec.Job] && prowJob.ObjectMeta.Name == latestPJ.ObjectMeta.Name {
 			// Ignore deleting this one.
 			continue
 		}
-		if !prowJob.Complete() {
-			continue
-		}
-		isFinished.Insert(prowJob.ObjectMeta.Name)
 		if time.Since(prowJob.Status.StartTime.Time) <= maxProwJobAge {
 			continue
 		}


### PR DESCRIPTION
We need to clean Pods for periodic ProwJobs so they don't block node pool scaling when they complete.

At the same time we need to keep the periodic ProwJobs alive for horologium because they contain information about the last time it was triggered.

Fixes #31041 