### PR TITLE
add containerd to huge pages for containerd job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -968,8 +968,8 @@ presubmits:
           args:
             - --deployment=node
             - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config-serial-hugepages.yaml
-            - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
+            - '--node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}'
             - --node-tests=true
             - --provider=gce
             - --test_args=--nodes=1 --skip="" --focus="\[Feature:HugePages\]"


### PR DESCRIPTION
#Fixes https://github.com/kubernetes/kubernetes/issues/120929

This fixes the above issue because we were using the wrong image-config for containerd.  

I notice that the periodic job was working fine but the presubmit was wrong.  

Added some more logs so we can get the containerd logs also.  