### PR TITLE
verify: enable verify-golangci-lint in separate job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -44,12 +44,17 @@ presubmits:
           requests:
             cpu: 7
             memory: 12Gi
-  - name: pull-kubernetes-linter-strict
+  - name: pull-kubernetes-verify-lint
     cluster: eks-prow-build-cluster
     decorate: true
-    # This entire job is currently experimental. If it turns out to be useful,
-    # the job can be removed and the same check can run as part of pull-kubernetes-verify
-    # by removing the exclusion of verify-golangci-lint-pr.sh in hack/make-rules/verify.sh.
+    # This job is running all required linter checks:
+    # - baseline for all code
+    # - stricter configuration for new or modified code in a pull request
+    #
+    # Both run in the same job to reuse the build and (to some extend)
+    # golangci-lint cache. Testing the baseline is necessary because,
+    # for example, a linter config change or tool update might cause
+    # failures in existing, unmodified code.
     always_run: true
     optional: true
     skip_branches:
@@ -68,7 +73,7 @@ presubmits:
         - make
         args:
         - verify
-        - WHAT=golangci-lint-pr
+        - WHAT=golangci-lint golangci-lint-pr
         resources:
           # It peaks at around 7 cores of the EKS cluster. We can fit more jobs onto
           # a node without much slowdown by requesting one third of a node

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -35,11 +35,11 @@ jobs:
   - pull-kubernetes-integration
   - pull-kubernetes-integration-go-compatibility
   - pull-kubernetes-linter-hints
-  - pull-kubernetes-linter-strict
   - pull-kubernetes-node-e2e-containerd
   - pull-kubernetes-typecheck
   - pull-kubernetes-unit
   - pull-kubernetes-unit-go-compatibility
   - pull-kubernetes-verify
   - pull-kubernetes-verify-govet-levee
+  - pull-kubernetes-verify-lint
 recursive_artifacts: false


### PR DESCRIPTION
The goal is to move verify-golangci-lint from pull-kubernetes-verify into the same job that also runs verify-golangci-lint-pr, to take better advantage of caching.

Because this is more like pull-kubernetes-verify than the not merge-blocking pull-kubernetes-linter-hints, the job is now called pull-kubernetes-verify-lint.

Follow-up to today's SIG Testing meeting. The next PRs after it will be
- make  pull-kubernetes-verify-lint merge-blocking after https://github.com/kubernetes/test-infra/pull/30514 is merged
- remove verify-golangci-lint from "make verify" and thus pull-kubernetes-verify, after pull-kubernetes-verify-lint is merge-blocking

/cc @BenTheElder @alculquicondor 