### PR TITLE
Clone containerd for ci-cos-cgroupv2-containerd-node-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -862,6 +862,10 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
+  - org: containerd
+    repo: containerd
+    base_ref: main
+    path_alias: github.com/containerd/containerd
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231010-50b212c4fa-master


### PR DESCRIPTION
This job is failing because we actually need the containerd repo cloned.  

All other containerd jobs have this YAML it seems.  Must have been an oversight.  

Merging this should fix https://testgrid.k8s.io/sig-node-containerd#cos-cgroupv2-containerd-node-e2e

I found this failure because the logs of build show an error on parsing containerd data.

```
I1017 14:28:20.520363    9008 gce_runner.go:364] parsing instance metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"
F1017 14:28:20.520411    9008 gce_runner.go:407] Failed to read metadata file "/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml": open /home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml: no such file or directory
exit status 255
```