### PR TITLE
Cleanup and also run controlplane on amd instance types for cl2

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1424,10 +1424,9 @@ def generate_presubmits_scale():
             env={
                 'CNI_PLUGIN': "amazonvpc",
                 'KUBE_NODE_COUNT': "100",
-                'RUN_CL2_TEST': "true",
                 'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "20",
                 'CONTROL_PLANE_COUNT': "3",
-                'CONTROL_PLANE_SIZE': "c6g.4xlarge",
+                'CONTROL_PLANE_SIZE': "c5.4xlarge",
                 'CL2_LOAD_TEST_THROUGHPUT': "50",
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -201,14 +201,12 @@ presubmits:
           value: "amazonvpc"
         - name: KUBE_NODE_COUNT
           value: "100"
-        - name: RUN_CL2_TEST
-          value: "true"
         - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
           value: "20"
         - name: CONTROL_PLANE_COUNT
           value: "3"
         - name: CONTROL_PLANE_SIZE
-          value: "c6g.4xlarge"
+          value: "c5.4xlarge"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT


### PR DESCRIPTION
- To be in sync with fixes for issues in this PR - https://github.com/kubernetes/kops/pull/15963

### Testing
Was able to successfully test with attached PR changes here - https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/15963/presubmit-kops-aws-small-scale-amazonvpc-using-cl2/1714377536231706624 