### PR TITLE
CAPZ: use main branch for dual stack jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -375,7 +375,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: ${capz_periodic_branch_name}
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -424,7 +424,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: ${capz_periodic_branch_name}
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.25.yaml
@@ -311,7 +311,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -360,7 +360,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
@@ -311,7 +311,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -360,7 +360,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
@@ -311,7 +311,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -360,7 +360,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
@@ -311,7 +311,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -360,7 +360,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.11
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -336,7 +336,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: main
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs
@@ -385,7 +385,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: main
+    base_ref: main # TODO: switch back to capz_periodic_branch_name once capz release-1.12 exists
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: true
   - org: kubernetes-sigs


### PR DESCRIPTION
This PR temporarily sets the CAPZ branch to main for ipv6 and dual stack jobs that were recently added since https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4086 is not yet part of a CAPZ release branch.