### PR TITLE
kOps: Switch from c6g to c5 instances for periodic scale test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -94,7 +94,7 @@ periodics:
       - name: CONTROL_PLANE_COUNT
         value: "3"
       - name: CONTROL_PLANE_SIZE
-        value: "c6g.16xlarge"
+        value: "c5.18xlarge"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-infra-kops-scale-tests"
       - name: CLOUD_PROVIDER


### PR DESCRIPTION
https://testgrid.k8s.io/kops-misc#ec2-master-scale-performance