### PR TITLE
migrate `sig-windows` jobs to community gcp cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows-presubmits.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-containerd-1-25
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -38,6 +39,9 @@ presubmits:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.25-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-containerd-windows-1-25
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -57,6 +58,9 @@ periodics:
         requests:
           cpu: "2"
           memory: 9Gi
+        limits:
+          cpu: 2
+          memory: "9Gi"
       securityContext:
         privileged: true
       env:
@@ -67,6 +71,7 @@ periodics:
     testgrid-dashboards: sig-release-1.25-informing, sig-windows-1.25-release, sig-windows-signal
     testgrid-tab-name: capz-e2e-windows-containerd-1.25
 - name: ci-kubernetes-e2e-capz-containerd-windows-serial-slow-1-25
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -111,6 +116,9 @@ periodics:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
         env:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-containerd-1-26
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -38,6 +39,9 @@ presubmits:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-containerd-windows-1-26
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 4h0m0s
@@ -57,6 +58,9 @@ periodics:
         requests:
           cpu: "2"
           memory: 9Gi
+        limits:
+          cpu: 2
+          memory: "9Gi"
       securityContext:
         privileged: true
       env:
@@ -67,6 +71,7 @@ periodics:
     testgrid-dashboards: sig-release-1.26-informing, sig-windows-signal,  sig-windows-1.26-release
     testgrid-tab-name: capz-windows-containerd-1.26
 - name: ci-kubernetes-e2e-capz-1-26-windows-serial-slow
+  cluster: k8s-infra-prow-build
   interval: 48h
   decorate: true
   decoration_config:
@@ -110,6 +115,9 @@ periodics:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
         env:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-1-27
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -45,8 +46,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 2
-            memory: "9Gi"
+            cpu: "2"
+            memory: 9Gi
+          limits:
+            cpu: "2"
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-1.27

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.27-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-windows-1-27
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 4h0m0s
@@ -56,6 +57,9 @@ periodics:
         requests:
           cpu: "2"
           memory: 9Gi
+        limits:
+          cpu: "2"
+          memory: 9Gi
       securityContext:
         privileged: true
   annotations:
@@ -63,6 +67,7 @@ periodics:
     testgrid-dashboards: sig-release-1.27-informing, sig-windows-signal,  sig-windows-1.27-release
     testgrid-tab-name: capz-windows-containerd-1.27
 - name: ci-kubernetes-e2e-capz-1-27-windows-serial-slow
+  cluster: k8s-infra-prow-build
   interval: 48h
   decorate: true
   decoration_config:
@@ -106,8 +111,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
-            memory: "9Gi"
+            cpu: "2"
+            memory: 9Gi
+          limits:
+            cpu: "2"
+            memory: 9Gi
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-1-28
+    cluster: k8s-infra-prow-build
     always_run: false
     branches:
     - release-1.28
@@ -43,6 +44,9 @@ presubmits:
         name: ""
         resources:
           requests:
+            cpu: "2"
+            memory: 9Gi
+          limits:
             cpu: "2"
             memory: 9Gi
         securityContext:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -14,6 +14,7 @@ presets:
     value: "Standard_D4s_v3"
 periodics:
 - name: ci-kubernetes-e2e-capz-windows-1-28
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-release-1.28-informing, sig-windows-1.28-release, sig-windows-signal
@@ -59,12 +60,16 @@ periodics:
         requests:
           cpu: "2"
           memory: 9Gi
+        limits:
+          cpu: "2"
+          memory: 9Gi
       securityContext:
         privileged: true
       env:
         - name: IMAGE_VERSION
           value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
 - name: ci-kubernetes-e2e-capz-1-28-windows-serial-slow
+  cluster: k8s-infra-prow-build
   interval: 48h
   decorate: true
   decoration_config:
@@ -109,6 +114,9 @@ periodics:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
         env:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -12,6 +12,7 @@ presets:
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-master
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -52,12 +53,16 @@ presubmits:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-serial-slow-hpa
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -105,6 +110,9 @@ presubmits:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -115,6 +123,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-serial-slow-hpa
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-alpha-features
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -161,6 +170,9 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
             - name: NODE_FEATURE_GATES
               value: "PodAndContainerStatsFromCRI=true"
@@ -171,6 +183,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-alpha-features
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-alpha-feature-vpa
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -218,6 +231,9 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
             - name: API_SERVER_FEATURE_GATES
               value: "InPlacePodVerticalScaling=true"
@@ -233,6 +249,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubernetes-sigs/windows-testing:
   - name: pull-e2e-capz-windows-2022-extension
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -276,6 +293,9 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
@@ -285,6 +305,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-extension
   - name: pull-e2e-run-capz-sh-windows-2022-hyperv
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -327,6 +348,9 @@ presubmits:
             requests:
               cpu: 2
               memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
@@ -340,6 +364,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-run-capz-sh-windows-2022-hyperv
   - name: pull-e2e-capz-windows-2022-extension-gmsa
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -380,6 +405,9 @@ presubmits:
             privileged: true
           resources:
             requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
               cpu: 2
               memory: "9Gi"
           env:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -70,6 +70,7 @@ presets:
       value: "true"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-windows
+  cluster: k8s-infra-prow-build
   interval: 3h
   decorate: true
   decoration_config:
@@ -114,6 +115,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: IMAGE_VERSION
             value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
@@ -124,6 +128,7 @@ periodics:
     testgrid-dashboards: sig-release-master-informing, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -167,6 +172,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -177,6 +185,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow-hpa
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -218,6 +227,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -228,6 +240,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-master-serial-slow-hpa
 - name: ci-kubernetes-e2e-capz-master-windows-2022
+  cluster: k8s-infra-prow-build
   interval: 3h
   decorate: true
   decoration_config:
@@ -269,6 +282,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
@@ -277,6 +293,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master
 - name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -320,6 +337,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
@@ -332,6 +352,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow-hpa
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -374,6 +395,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
@@ -386,6 +410,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master-serial-slow-hpa
 - name: ci-kubernetes-e2e-azuredisk-capz-windows-2019
+  cluster: k8s-infra-prow-build
   interval: 48h
   decorate: true
   decoration_config:
@@ -426,6 +451,13 @@ periodics:
             make e2e-test
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-azuredisk-windows-2019
@@ -476,6 +508,7 @@ periodics:
 #     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
 #     description: Run Azure File e2e test in a CAPZ cluster on Windows 2019 nodes
 - name: ci-kubernetes-e2e-capz-master-containerd-nightly-windows
+  cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
   decoration_config:
@@ -520,11 +553,15 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master
 - name: ci-kubernetes-e2e-capz-master-windows-alpha
+  cluster: k8s-infra-prow-build
   interval: 3h
   decorate: true
   decoration_config:
@@ -564,6 +601,9 @@ periodics:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
         env:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-misc.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-misc.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-aks-engine-gpu-windows-dockershim-1-23
+    cluster: k8s-infra-prow-build
     always_run: false
     optional: true
     decorate: true
@@ -51,6 +52,13 @@ presubmits:
         - --ginkgo-parallel=1
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-aks-engine-gpu-windows-dockershim-1.23

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes/perf-tests:
   - name: soak-tests-capz-windows-2019
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -40,6 +41,13 @@ presubmits:
               --v=2
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
             # CAPZ variables
             - name: NODE_MACHINE_TYPE
@@ -81,6 +89,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 periodics:
   - name: hourly-soak-tests-capz-windows-2019
+    cluster: k8s-infra-prow-build
     cron: "0 * * * MON-SAT"
     decorate: true
     path_alias: k8s.io/perf-tests
@@ -123,6 +132,13 @@ periodics:
               --provider=aks
               --report-dir=${ARTIFACTS}
               --v=2
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
             # clusterloader2 variables
             - name: ENABLE_PROMETHEUS_SERVER
@@ -145,6 +161,7 @@ periodics:
       description: "Run clusterloader2 tests every hour on a capz Windows 2019 cluster"
       testgrid-num-columns-recent: '30'
   - name: delete-win-soak-test-cluster
+    cluster: k8s-infra-prow-build
     cron: "0 0 * * SUN"
     decorate: true
     decoration_config:
@@ -175,6 +192,13 @@ periodics:
               --resource-group
               win-soak-test
               -y
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-windows-soak-tests
       testgrid-tab-name: delete-win-soak-test-cluster
@@ -182,6 +206,7 @@ periodics:
       testgrid-num-columns-recent: '30'
 
   - name: build-win-soak-test-cluster
+    cluster: k8s-infra-prow-build
     cron: "0 1 * * SUN"
     decorate: true
     decoration_config:
@@ -224,6 +249,13 @@ periodics:
               -n win-soak-test
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
             # CAPZ variables
             - name: CLUSTER_NAME

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-experimental.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-capz-master-windows-service-proxy
+  cluster: k8s-infra-prow-build
   interval: 72h
   decorate: true
   decoration_config:
@@ -43,6 +44,9 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
         env:
           - name: WINDOWS_KPNG
             value: "true"
@@ -51,6 +55,7 @@ periodics:
     testgrid-dashboards: sig-windows-experimental
     testgrid-tab-name: capz-master-windows-service-proxy
 - name: ci-kubernetes-e2e-capz-master-windows-hyperv
+  cluster: k8s-infra-prow-build
   interval: 168h
   decorate: true
   decoration_config:
@@ -92,6 +97,9 @@ periodics:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
             cpu: 2
             memory: "9Gi"
         env:

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-op-tests.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/windows-operational-readiness:
   - name: operational-tests-capz-windows-2019
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -40,6 +41,13 @@ presubmits:
               ./hack/run-tests.sh
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
           env:
             # CAPZ variables
             - name: NODE_MACHINE_TYPE

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-ci-kubernetes-unit-windows
+    cluster: k8s-infra-prow-build
     always_run: false
     optional: true
     decorate: true
@@ -29,6 +30,9 @@ presubmits:
             privileged: true
           resources:
             requests:
+              cpu: 2
+              memory: "4Gi"
+            limits:
               cpu: 2
               memory: "4Gi"
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-unit-windows-master
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   decoration_config:
@@ -22,6 +23,9 @@ periodics:
           privileged: true
         resources:
           requests:
+            cpu: 2
+            memory: "4Gi"
+          limits:
             cpu: 2
             memory: "4Gi"
   annotations:


### PR DESCRIPTION
This PR moves sig-windows jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @adelina-t @andyzhangx @benmoss @feiskyer @marosset
/cc @ameukam 