### PR TITLE
migrate `promo-tools` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes-sigs/promo-tools:
   # Run promoter e2e tests.
   - name: pull-cip-e2e
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "sigs.k8s.io/promo-tools"
     skip_report: false
@@ -32,6 +33,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 1Gi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
       volumes:
       - name: k8s-cip-test-prod-service-account-creds
         secret:
@@ -41,6 +49,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
   - name: pull-cip-auditor-e2e
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "sigs.k8s.io/promo-tools"
     skip_report: false
@@ -71,6 +80,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 1Gi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
       volumes:
       - name: k8s-gcr-audit-test-prod-service-account-creds
         secret:


### PR DESCRIPTION
This PR moves promo-tools jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @cpanato @jeremyrickard @justaugustus @listx @puerco @saschagrunert
/cc @ameukam 