### PR TITLE
migrate `kind` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -2,6 +2,7 @@
 postsubmits:
   kubernetes-sigs/kind:
   - name: ci-kind-test
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -17,6 +18,13 @@ postsubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-testing-kind
       testgrid-tab-name: ci unit test

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -2,6 +2,7 @@
 presubmits:
   kubernetes-sigs/kind:
   - name: pull-kind-build
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -16,7 +17,15 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-kind-test
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -32,7 +41,15 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   - name: pull-kind-verify
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -48,6 +65,13 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   # GA-only variant

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kind-unit-test
+  cluster: k8s-infra-prow-build
   interval: 6h
   decorate: true
   extra_refs:
@@ -19,6 +20,13 @@ periodics:
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-testing-kind
     testgrid-tab-name: kind-ci-unit-test


### PR DESCRIPTION
This PR moves promo-tools jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @bentheelder @munnerz @neolit123 @aojea
/cc @ameukam 