### PR TITLE
node: resource-mgrs: Run resource manager tests on multi-NUMA

### DIFF
--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -15,5 +15,5 @@ images:
     image_family: cos-beta
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
-    # Using `n1-standard-4` to enable resource managers node e2e tests.
-    machine: n1-standard-4
+    # Using `n2d-standard-32` that has 2 numa nodes to enable resource managers node e2e tests.
+    machine: n2d-standard-32


### PR DESCRIPTION
Currently in `image-config-serial-resource-managers.yaml` we have config with images that point to GCP node with multi-numa support (n2d-standard-32) as well as without it (n1-standard-4).

This results in the jobs that refer to this config to be executed twice, once on a node with multi-numa support and another time without it which explain the flaky topology manager tests and tests being skipped when they are executed on nodes that don't provide this support with the following message:

```
 [SKIPPED] this test is intended to be run on a multi-node NUMA system
```

Let's ensure that we use ubuntu and cos based images such that they both have multi-numa numa support for execution of resource manager tests.

~~Potential fix for  https://github.com/kubernetes/kubernetes/issues/120725.~~ 
[EDIT: On carefully looking at the logs, this inconsistent config does not appear to be the reason behind kubernetes/kubernetes/issues/120725 as we see failure on multi-NUMA nodes as well. More details captured [here](https://github.com/kubernetes/kubernetes/issues/120725#issuecomment-1768935761) but irrespective of that this update is still beneficial to ensure consistent config].