### PR TITLE
add a periodic kind job to get signal on alpha features

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -329,3 +329,56 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+
+periodics:
+- interval: 24h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-alpha-beta-features
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-master-alpha-beta
+    description: Uses kubetest to run e2e tests against a latest kubernetes master and all features enabled cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20231009-5a9a0d4990-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: FEATURE_GATES
+        value: '{"AllAlpha":true,"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/all":"true"}'
+      - name: FOCUS
+        value: "."
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7


### PR DESCRIPTION
We don't have signal if an alpha feature breaks some deployments, the only one that I found is the presubmit but it run last time in Oct % https://testgrid.k8s.io/presubmits-kubernetes-nonblocking#pull-kubernetes-e2e-kind-alpha-features&width=90