### PR TITLE
conformance e2e jobs run already fro kubernetes folder

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -29,11 +29,10 @@ presubmits:
         command:
         - runner.sh
         args:
-        # the script must run from kubernetes, but we're checking out kind
         - "bash"
         - "--"
         - "-c"
-        - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+        - "source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -126,11 +125,10 @@ periodics:
       command:
       - runner.sh
       args:
-      # the script must run from kubernetes, but we're checking out kind
       - "bash"
       - "--"
       - "-c"
-      - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+      - "source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
I think that this is correct and the jobs are already in the kubernetes folder, but I'm always confused about this, worst case we keep trying, those jobs are already broken for more than a month


Ref: https://kubernetes.slack.com/archives/C09QZ4DQB/p1697668820069519