### PR TITLE
Add troubleshooting output for CVE search failures

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -36,7 +36,7 @@ periodics:
         fi
         echo "Running snyk scan .."
         EXIT_CODE=0
-        RESULT_UNFILTERED=$(snyk test -d --json-file-outout=${ARTIFACTS}/snyk-test-unfiltered.json --json) || EXIT_CODE=$?
+        RESULT_UNFILTERED=$(snyk test -d --json-file-output=${ARTIFACTS}/snyk-test-unfiltered.json --json) || EXIT_CODE=$?
         if [ $EXIT_CODE -gt 1 ]; then
           echo "Failed to run snyk scan with exit code $EXIT_CODE "
           exit 1

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -36,7 +36,7 @@ periodics:
         fi
         echo "Running snyk scan .."
         EXIT_CODE=0
-        RESULT_UNFILTERED=$(snyk test -d --json) || EXIT_CODE=$?
+        RESULT_UNFILTERED=$(snyk test -d --json-file-outout=${ARTIFACTS}/snyk-test-unfiltered.json --json) || EXIT_CODE=$?
         if [ $EXIT_CODE -gt 1 ]; then
           echo "Failed to run snyk scan with exit code $EXIT_CODE "
           exit 1
@@ -54,7 +54,14 @@ periodics:
                   #Look for presence of GitHub Issues for detected CVEs. If no issues are present, this CVE needs triage
                   #Once the job fails, CVE is triaged by SIG Security and a tracking issue is created.
                   #This will allow in the next run for the job to pass again
-                  TOTAL_COUNT=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/search/issues?q=repo:kubernetes/kubernetes+${i}" | jq .total_count)
+                  echo "Searching for ${i} in Kubernetes issues..."
+                  SEARCH_URL="https://api.github.com/search/issues?q=repo:kubernetes/kubernetes+${i}"
+                  TOTAL_COUNT=$(curl -s -H "Accept: application/vnd.github.v3+json" $SEARCH_URL | jq .total_count) || EXIT_CODE=$?
+                  if [ $EXIT_CODE -gt 1 ]; then
+                    echo "Failed to search via $CURL_URL , curl exited with exit code $EXIT_CODE "
+                    exit 1
+                  fi
+
                   if [[ $TOTAL_COUNT -eq 0 ]]; then
                     echo "Vulnerability filtering failed"
                     exit 1


### PR DESCRIPTION
We are having failures in prow runs due to an unknown value being curl'ed against the k/k issues
These changes will output troubleshooting data, reduce noise in the logs, and, hopefully, better handle the error in the future.

UPDATE: This may be by design - see comments below...
Slack thread discussion: https://kubernetes.slack.com/archives/C01CUSVMHPY/p1697720914354159