### PR TITLE
Reduce curl calls to GH by eliminating duplicate CVEs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -44,7 +44,7 @@ periodics:
         RESULT=$(echo $RESULT_UNFILTERED | jq \
         '{vulnerabilities: .vulnerabilities | map(select((.type != "license") and (.version !=  "0.0.0"))) | select(length > 0) }')
         if [[ ${RESULT} ]]; then
-          CVE_IDs=$(echo $RESULT | jq '.vulnerabilities[].identifiers.CVE')
+          CVE_IDs=$(echo $RESULT | jq '.vulnerabilities[].identifiers.CVE | unique[]' | sort -u)
           #convert string to array
           CVE_IDs_array=(`echo ${CVE_IDs}`)
           #TODO:Implement deduplication of CVE IDs in future


### PR DESCRIPTION
Prow job may see HTTP rate limits due to repeated, unnecessary queries for the same CVE due to duplicates in the scan results.  Reducing list to unique CVE values only.

In local testing this dropped the queries from 476 to 3