### PR TITLE
Revert "conformance e2e jobs run already fro kubernetes folder"

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -29,9 +29,10 @@ presubmits:
         command:
         - runner.sh
         args:
+        # the script must run from kubernetes, but we're checking out kind
         - "bash"
         - "-c"
-        - "source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+        - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -124,9 +125,10 @@ periodics:
       command:
       - runner.sh
       args:
+      # the script must run from kubernetes, but we're checking out kind
       - "bash"
       - "-c"
-      - "source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+      - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
This reverts commit e86640bba2df118b49506837691a8d4087833077.

The problem seems to be this one https://github.com/kubernetes/test-infra/pull/31084, and we need to cd into kubernetes