### PR TITLE
migrate `depstat` job to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: check-dependency-stats
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 5m
@@ -31,6 +32,13 @@ presubmits:
           git checkout -b base "${PULL_BASE_SHA}"
           depstat stats -m "k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')" -v > "${WORKDIR}/stats-base.txt"
           diff -s -u --ignore-all-space "${WORKDIR}"/stats-base.txt "${WORKDIR}"/stats.txt || true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-testing-misc


### PR DESCRIPTION
This PR moves vsphere-csi-driver jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @cheftako @johnbelamaric @hh