### PR TITLE
migrate `sig-autoscaling` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -231,6 +231,7 @@ periodics:
     testgrid-tab-name: autoscaling-vpa-updater
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -310,6 +311,7 @@ periodics:
     testgrid-tab-name: gci-gce-autoscaling-hpa-cm
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
This PR moves vsphere-csi-driver jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @mwielgus @maciekpytel @bskiba