### PR TITLE
migrate `sig-auth` kms jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
+++ b/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-kind-kms
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 150m
@@ -37,10 +38,18 @@ presubmits:
         - "/bin/bash"
         - "-c"
         - ./test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
 
 periodics:
 - interval: 6h
   name: periodic-kubernetes-e2e-kind-kms
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 150m
@@ -70,3 +79,10 @@ periodics:
       - "/bin/bash"
       - "-c"
       - ./test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi


### PR DESCRIPTION
This PR moves sig-auth jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @deads2k @enj @liggitt @mikedanese @ritazh