### PR TITLE
Bump CRI-O to `297d07c1` and adapt get-script location

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign
@@ -84,7 +84,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=0f501d4a7c33157e9662f2729c72f8c33baffe84\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=7cb9a19ff190abb04fa627b904fc7d352c250912\"\nEnvironment=\"CRIO_COMMIT=297d07c1c86f251fcb9c8c491a56508e6835cccb\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/templates/base/root_v2.yaml
+++ b/jobs/e2e_node/crio/templates/base/root_v2.yaml
@@ -46,6 +46,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: tools-install.service
       enabled: true
       contents: |
@@ -65,6 +66,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: selinux-install.service
       enabled: true
       contents: |
@@ -83,6 +85,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: crio-install.service
       enabled: true
       contents: |
@@ -108,6 +111,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: authorized-key.service
       enabled: true
       contents: |
@@ -127,20 +131,3 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    - name: allocate-1G-hugepages.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Allocate 1G hugepages.
-        After=network-online.target
-
-        [Service]
-        Type=oneshot
-        ExecStart=/bin/sh -c '/usr/bin/echo 1 > \
-          /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages'
-
-        [Install]
-        WantedBy=multi-user.target
-kernel_arguments:
-  should_exist:
-    - systemd.unified_cgroup_hierarchy=0

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -27,7 +27,7 @@ fi
 declare -A CONFIGURATIONS=(
     ["crio_cgroupsv1"]="root cgroups-v1"
     ["crio_cgroupsv1_eventedpleg"]="root cgroups-v1 eventedpleg"
-    ["crio_cgroupsv1_hugepages"]="root cgroups-v1 hugepages"
+    ["crio_cgroupsv1_hugepages"]="root_v2 cgroups-v1 hugepages"
     ["crio_cgroupsv2"]="root"
     ["crio_cgroupsv2_swap1g"]="root swap-1G"
 )


### PR DESCRIPTION
Fixing the script location as well as bumping CRI-O to the latest available `main` commit.

cc @haircommander @harche @sairameshv @kannon92 