### PR TITLE
migrate `sig-insturmentation` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-kind-json-logging
+    cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:
@@ -68,6 +69,7 @@ presubmits:
             cpu: 7
 
   - name: pull-kubernetes-kind-text-logging
+    cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:


### PR DESCRIPTION
This PR moves sig-insturmentation jobs to the community owned cluster.

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @dashpole @dgrisonnet @ehashman @logicalhan