### PR TITLE
Revert "Merge pull request #30642 from lzhecheng/cpa-master-k8s-ver-1.28"

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -70,7 +70,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.28"
+              value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
@@ -229,7 +229,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.28"
+              value: "latest"
             - name: ORCHESTRATION_MODE # CAPZ config
               value: "Flexible"
             - name: CLUSTER_TEMPLATE # CAPZ config
@@ -300,7 +300,7 @@ presubmits:
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "standard"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.28"
+              value: "latest"
             - name: GINKGO_ARGS # cloud-provider-azure config
               value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
@@ -358,7 +358,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.28"
+              value: "latest"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
     annotations:
@@ -513,7 +513,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.28"
+              value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
@@ -579,7 +579,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.28"
+              value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
@@ -898,7 +898,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
+          value: "latest"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
   annotations:
@@ -950,7 +950,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
+          value: "latest"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
   annotations:
@@ -1004,7 +1004,7 @@ periodics:
         - name: TEST_WINDOWS # CAPZ config
           value: "true"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
+          value: "latest"
         - name: WORKER_MACHINE_COUNT # CAPZ config
           value: "0"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -1063,7 +1063,7 @@ periodics:
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "standard"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
@@ -1125,7 +1125,7 @@ periodics:
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "standard"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\] --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
@@ -1194,7 +1194,7 @@ periodics:
       - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
         value: "standard"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
@@ -1251,7 +1251,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
+          value: "latest"
         - name: CLUSTER_TEMPLATE # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
         - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
@@ -1371,7 +1371,7 @@ periodics:
       - name: TEST_CCM # CAPZ config
         value: "true"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
@@ -1436,7 +1436,7 @@ periodics:
       - name: TEST_CCM # CAPZ config
         value: "true"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular.resource.usage.tracking.resource.tracking.for|validates.MaxPods.limit.number.of.pods.that.are.allowed.to.run|In-tree.Volumes|RuntimeClass.should.run.a.Pod.requesting.a.RuntimeClass.with.scheduling.with.taints|Multi-AZ.Clusters.should.spread.the.pods.of.a.replication.controller.across.zones|Multi-AZ.Clusters.should.spread.the.pods.of.a.service.across.zones|Should.test.that.pv.used.in.a.pod.that.is.deleted.while.the.kubelet.is.down.cleans.up.when.the.kubelet.returns|Should.test.that.pv.used.in.a.pod.that.is.force.deleted.while.the.kubelet.is.down.cleans.up.when.the.kubelet.returns|Should.test.that.pv.written.before.kubelet.restart.is.readable.after.restart|subPath.should.unmount.if.pod.is.force.deleted.while.kubelet.is.down|subPath.should.unmount.if.pod.is.gracefully.deleted.while.kubelet.is.down|Should.test.that.pv.written.before.kubelet.restart.is.readable.after.restart --report-dir=/logs/artifacts --disable-log-dump=true
@@ -1504,7 +1504,7 @@ periodics:
       - name: TEST_CCM # CAPZ config
         value: "true"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs --report-dir=/logs/artifacts --disable-log-dump=true
@@ -1570,7 +1570,7 @@ periodics:
       - name: TEST_CCM # CAPZ config
         value: "true"
       - name: KUBERNETES_VERSION # CAPZ config
-        value: "latest-1.28"
+        value: "latest"
       - name: GINKGO_ARGS # cloud-provider-azure config
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config


### PR DESCRIPTION
Running k8s master branch test against k8s cluster last-1.28 fails consistently for the following change in merged for now only in master k8s branch.
https://github.com/kubernetes/kubernetes/commit/0cda42af7ab8b9b63d3b6ce1bf1c3766f15a2b00

Keep k8s cluster and test version synced to fix this and future possible test failures.

revert https://github.com/kubernetes/test-infra/pull/30642