### PR TITLE
Bump CRI-O to cgroups v1 tests to `297d07c1`

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1.ign
@@ -84,7 +84,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=0f501d4a7c33157e9662f2729c72f8c33baffe84\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=7cb9a19ff190abb04fa627b904fc7d352c250912\"\nEnvironment=\"CRIO_COMMIT=297d07c1c86f251fcb9c8c491a56508e6835cccb\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign
@@ -92,7 +92,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"COMMIT=0f501d4a7c33157e9662f2729c72f8c33baffe84\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\\\n      bash -s -- -t $COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=7cb9a19ff190abb04fa627b904fc7d352c250912\"\nEnvironment=\"CRIO_COMMIT=297d07c1c86f251fcb9c8c491a56508e6835cccb\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv1.yaml
@@ -92,15 +92,16 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=0f501d4a7c33157e9662f2729c72f8c33baffe84"
+        Environment="SCRIPT_COMMIT=7cb9a19ff190abb04fa627b904fc7d352c250912"
+        Environment="CRIO_COMMIT=297d07c1c86f251fcb9c8c491a56508e6835cccb"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /usr
         ExecStartPre=rm -f /usr/bin/runc
         ExecStartPre=bash -c '\
           curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
+            https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\
+              bash -s -- -t $CRIO_COMMIT'
         ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
         ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
         ExecStart=systemctl enable --now crio.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv1_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv1_eventedpleg.yaml
@@ -96,15 +96,16 @@ systemd:
 
         [Service]
         Type=oneshot
-        Environment="COMMIT=0f501d4a7c33157e9662f2729c72f8c33baffe84"
+        Environment="SCRIPT_COMMIT=7cb9a19ff190abb04fa627b904fc7d352c250912"
+        Environment="CRIO_COMMIT=297d07c1c86f251fcb9c8c491a56508e6835cccb"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /usr
         ExecStartPre=rm -f /usr/bin/runc
         ExecStartPre=bash -c '\
           curl --fail --retry 5 --retry-delay 3 --silent --show-error \
-            https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT/scripts/get |\
-              bash -s -- -t $COMMIT'
+            https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\
+              bash -s -- -t $CRIO_COMMIT'
         ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
         ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf
         ExecStart=systemctl enable --now crio.service

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -25,8 +25,8 @@ fi
 
 # Change the following configurations to adapt the resulting ignitions files.
 declare -A CONFIGURATIONS=(
-    ["crio_cgroupsv1"]="root cgroups-v1"
-    ["crio_cgroupsv1_eventedpleg"]="root cgroups-v1 eventedpleg"
+    ["crio_cgroupsv1"]="root_v2 cgroups-v1"
+    ["crio_cgroupsv1_eventedpleg"]="root_v2 cgroups-v1 eventedpleg"
     ["crio_cgroupsv1_hugepages"]="root_v2 cgroups-v1 hugepages"
     ["crio_cgroupsv2"]="root"
     ["crio_cgroupsv2_swap1g"]="root swap-1G"


### PR DESCRIPTION
Update the other cgroups v1 tests to the new root config after successful merge of https://github.com/kubernetes/test-infra/pull/31102 and green runs in https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-hugepages.

cc @haircommander @kannon92 @harche @sairameshv 

