### PR TITLE
move gcp jobs for vSphere CSI Driver to default cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -219,7 +219,7 @@ postsubmits:
 
   # Deploys the CSI image after all merges to master
   - name: post-vsphere-csi-driver-deploy
-    cluster: k8s-infra-prow-build
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -253,7 +253,7 @@ postsubmits:
 
   # Deploys the CSI image for tagged releases
   - name: post-vsphere-csi-driver-release
-    cluster: k8s-infra-prow-build
+    cluster: default
     decorate: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Jobs started failing with following error after moving to community cluster

```
The pod could not start because it could not mount the volume "cloud-provider-vsphere-e2e-config": secret "cloud-provider-vsphere-e2e-config" not found
```

Ref: https://github.com/kubernetes/test-infra/pull/31060#issuecomment-1778069997 

/cc @xing-yang @rjsadow 
/cc @ameukam