### PR TITLE
Allow Configuring Spyglass Lens Buildlog Max Line Length

### DIFF
--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -40,18 +40,20 @@ import (
 )
 
 const (
-	name               = "buildlog"
-	title              = "Build Log"
-	priority           = 10
-	neighborLines      = 5 // number of "important" lines to be displayed in either direction
-	minLinesSkipped    = 5
-	maxHighlightLength = 10000 // Maximum length of a line worth highlighting
+	name            = "buildlog"
+	title           = "Build Log"
+	priority        = 10
+	neighborLines   = 5 // number of "important" lines to be displayed in either direction
+	minLinesSkipped = 5
 )
 
+var defaultHighlightLineLengthMax = 10000 // Default maximum length of a line worth highlighting
+
 type config struct {
-	HighlightRegexes []string         `json:"highlight_regexes"`
-	HideRawLog       bool             `json:"hide_raw_log,omitempty"`
-	Highlighter      *highlightConfig `json:"highlighter,omitempty"`
+	HighlightRegexes   []string         `json:"highlight_regexes"`
+	HideRawLog         bool             `json:"hide_raw_log,omitempty"`
+	Highlighter        *highlightConfig `json:"highlighter,omitempty"`
+	HighlightLengthMax *int             `json:"highlight_line_length_max,omitempty"`
 }
 
 type highlightConfig struct {
@@ -66,9 +68,10 @@ type highlightConfig struct {
 }
 
 type parsedConfig struct {
-	highlightRegex *regexp.Regexp
-	showRawLog     bool
-	highlighter    *highlightConfig
+	highlightRegex     *regexp.Regexp
+	showRawLog         bool
+	highlighter        *highlightConfig
+	highlightLengthMax *int
 }
 
 var _ api.Lens = Lens{}
@@ -188,6 +191,9 @@ func getConfig(rawConfig json.RawMessage) parsedConfig {
 	conf.showRawLog = !c.HideRawLog
 	if len(c.HighlightRegexes) == 0 {
 		return conf
+	}
+	if conf.highlightLengthMax == nil {
+		conf.highlightLengthMax = &defaultHighlightLineLengthMax
 	}
 
 	re, err := regexp.Compile(strings.Join(c.HighlightRegexes, "|"))

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -270,7 +270,7 @@ func TestGroupLines(t *testing.T) {
 	art := "fake-artifact"
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := groupLines(&art, test.start, test.end, highlightLines(test.lines, 0, &art, defaultErrRE)...)
+			got := groupLines(&art, test.start, test.end, highlightLines(test.lines, 0, &art, defaultErrRE, defaultHighlightLineLengthMax)...)
 			if len(got) != len(test.groups) {
 				t.Fatalf("Expected %d groups, got %d", len(test.groups), len(got))
 			}
@@ -1146,6 +1146,6 @@ func BenchmarkHighlightLines(b *testing.B) {
 	}
 	art := "fake-artifact"
 	b.Run("HighlightLines", func(b *testing.B) {
-		_ = highlightLines(lorem, 0, &art, defaultErrRE)
+		_ = highlightLines(lorem, 0, &art, defaultErrRE, defaultHighlightLineLengthMax)
 	})
 }


### PR DESCRIPTION
Sometimes people would like to highlight longer or shorter lines than the default.