### PR TITLE
CAPZ: shorten job names for windows custom builds

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -399,7 +399,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-dual-stack-k8s-ci-main
-  - name: pull-cluster-api-provider-azure-windows-containerd-upstream-with-ci-artifacts
+  - name: pull-cluster-api-provider-azure-windows-with-ci-artifacts
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -674,7 +674,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-custom-k8s-main
-  - name: pull-cluster-api-provider-azure-windows-containerd-upstream-custom-builds
+  - name: pull-cluster-api-provider-azure-windows--custom-builds
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true


### PR DESCRIPTION
Workaround for https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3673

/assign @marosset 