### PR TITLE
support triggering only failed jobs in a github workflow

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -1193,6 +1193,10 @@ func (f *FakeClient) TriggerGitHubWorkflow(org, repo string, id int) error {
 	return nil
 }
 
+func (f *FakeClient) TriggerFailedGitHubWorkflow(org, repo string, id int) error {
+	return nil
+}
+
 func (f *FakeClient) RequestReview(org, repo string, number int, logins []string) error {
 	f.ReviewersRequested = logins
 	return nil

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -157,7 +157,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 					})
 					runID := run.ID
 					go func() {
-						if err := c.GitHubClient.TriggerGitHubWorkflow(org, repo, runID); err != nil {
+						if err := c.GitHubClient.TriggerFailedGitHubWorkflow(org, repo, runID); err != nil {
 							log.Errorf("attempt to trigger github run failed: %v", err)
 						} else {
 							log.Infof("successfully triggered action run")

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -160,6 +160,7 @@ type githubClient interface {
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 	RemoveLabel(org, repo string, number int, label string) error
 	TriggerGitHubWorkflow(org, repo string, id int) error
+	TriggerFailedGitHubWorkflow(org, repo string, id int) error
 	DeleteStaleComments(org, repo string, number int, comments []github.IssueComment, isStale func(github.IssueComment) bool) error
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }


### PR DESCRIPTION
Add support to trigger only the failed jobs and its dependents in a workflow run. This will make sure that all the jobs are not retriggered on a /retest command, and only the failed jobs will be rerun

Ref: https://docs.github.com/en/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run

Fix: #30713 