### PR TITLE
Move plugin config tests to config/tests/plugins directory

### DIFF
--- a/config/tests/plugins/plugins_test.go
+++ b/config/tests/plugins/plugins_test.go
@@ -1,0 +1,81 @@
+package plugins
+
+import (
+	"k8s.io/test-infra/prow/plugins"
+	"os"
+	"sigs.k8s.io/yaml"
+	"strings"
+	"testing"
+)
+
+// TestApprovePluginConfig validates that there are no duplicate repos in the approve plugin config.
+func TestApprovePluginConfig(t *testing.T) {
+	pa := &plugins.ConfigAgent{}
+
+	b, err := os.ReadFile("../../prow/plugins.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read plugin config: %v.", err)
+	}
+	np := &plugins.Configuration{}
+	if err := yaml.Unmarshal(b, np); err != nil {
+		t.Fatalf("Failed to unmarshal plugin config: %v.", err)
+	}
+	pa.Set(np)
+
+	orgs := map[string]bool{}
+	repos := map[string]bool{}
+	for _, config := range pa.Config().Approve {
+		for _, entry := range config.Repos {
+			if strings.Contains(entry, "/") {
+				if repos[entry] {
+					t.Errorf("The repo %q is duplicated in the 'approve' plugin configuration.", entry)
+				}
+				repos[entry] = true
+			} else {
+				if orgs[entry] {
+					t.Errorf("The org %q is duplicated in the 'approve' plugin configuration.", entry)
+				}
+				orgs[entry] = true
+			}
+		}
+	}
+}
+
+// TestWelcomePluginConfig validates that there are no duplicate repos in the welcome plugin config.
+func TestWelcomePluginConfig(t *testing.T) {
+	pa := &plugins.ConfigAgent{}
+
+	b, err := os.ReadFile("../../prow/plugins.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read plugin config: %v.", err)
+	}
+	np := &plugins.Configuration{}
+	if err := yaml.Unmarshal(b, np); err != nil {
+		t.Fatalf("Failed to unmarshal plugin config: %v.", err)
+	}
+	pa.Set(np)
+
+	orgs := map[string]bool{}
+	repos := map[string]bool{}
+	for _, config := range pa.Config().Welcome {
+		for _, entry := range config.Repos {
+			if strings.Contains(entry, "/") {
+				if repos[entry] {
+					t.Errorf("The repo %q is duplicated in the 'welcome' plugin configuration.", entry)
+				}
+				repos[entry] = true
+			} else {
+				if orgs[entry] {
+					t.Errorf("The org %q is duplicated in the 'welcome' plugin configuration.", entry)
+				}
+				orgs[entry] = true
+			}
+		}
+	}
+	for repo := range repos {
+		org := strings.Split(repo, "/")[0]
+		if orgs[org] {
+			t.Errorf("The repo %q is duplicated with %q in the 'welcome' plugin configuration.", repo, org)
+		}
+	}
+}

--- a/config/tests/plugins/plugins_test.go
+++ b/config/tests/plugins/plugins_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package plugins
 
 import (

--- a/config/tests/plugins/plugins_test.go
+++ b/config/tests/plugins/plugins_test.go
@@ -1,11 +1,12 @@
 package plugins
 
 import (
-	"k8s.io/test-infra/prow/plugins"
 	"os"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"testing"
+
+	"k8s.io/test-infra/prow/plugins"
+	"sigs.k8s.io/yaml"
 )
 
 // TestApprovePluginConfig validates that there are no duplicate repos in the approve plugin config.

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -46,39 +46,6 @@ import (
 
 const prNumber = 1
 
-// TestPluginConfig validates that there are no duplicate repos in the approve plugin config.
-func TestPluginConfig(t *testing.T) {
-	pa := &plugins.ConfigAgent{}
-
-	b, err := os.ReadFile("../../../config/prow/plugins.yaml")
-	if err != nil {
-		t.Fatalf("Failed to read plugin config: %v.", err)
-	}
-	np := &plugins.Configuration{}
-	if err := yaml.Unmarshal(b, np); err != nil {
-		t.Fatalf("Failed to unmarshal plugin config: %v.", err)
-	}
-	pa.Set(np)
-
-	orgs := map[string]bool{}
-	repos := map[string]bool{}
-	for _, config := range pa.Config().Approve {
-		for _, entry := range config.Repos {
-			if strings.Contains(entry, "/") {
-				if repos[entry] {
-					t.Errorf("The repo %q is duplicated in the 'approve' plugin configuration.", entry)
-				}
-				repos[entry] = true
-			} else {
-				if orgs[entry] {
-					t.Errorf("The org %q is duplicated in the 'approve' plugin configuration.", entry)
-				}
-				orgs[entry] = true
-			}
-		}
-	}
-}
-
 func newTestComment(user, body string) github.IssueComment {
 	return github.IssueComment{User: github.User{Login: user}, Body: body}
 }

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -19,14 +19,10 @@ package welcome
 import (
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
-
-	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
@@ -444,45 +440,6 @@ func TestWelcomeConfig(t *testing.T) {
 		receivedMessage := welcomeMessageForRepo(optionsForRepo(config, tc.org, tc.repo))
 		if receivedMessage != tc.expectedMessage {
 			t.Fatalf("%s: expected to get '%s' and received '%s'", tc.name, tc.expectedMessage, receivedMessage)
-		}
-	}
-}
-
-// TestPluginConfig validates that there are no duplicate repos in the welcome plugin config.
-func TestPluginConfig(t *testing.T) {
-	pa := &plugins.ConfigAgent{}
-
-	b, err := os.ReadFile("../../../config/prow/plugins.yaml")
-	if err != nil {
-		t.Fatalf("Failed to read plugin config: %v.", err)
-	}
-	np := &plugins.Configuration{}
-	if err := yaml.Unmarshal(b, np); err != nil {
-		t.Fatalf("Failed to unmarshal plugin config: %v.", err)
-	}
-	pa.Set(np)
-
-	orgs := map[string]bool{}
-	repos := map[string]bool{}
-	for _, config := range pa.Config().Welcome {
-		for _, entry := range config.Repos {
-			if strings.Contains(entry, "/") {
-				if repos[entry] {
-					t.Errorf("The repo %q is duplicated in the 'welcome' plugin configuration.", entry)
-				}
-				repos[entry] = true
-			} else {
-				if orgs[entry] {
-					t.Errorf("The org %q is duplicated in the 'welcome' plugin configuration.", entry)
-				}
-				orgs[entry] = true
-			}
-		}
-	}
-	for repo := range repos {
-		org := strings.Split(repo, "/")[0]
-		if orgs[org] {
-			t.Errorf("The repo %q is duplicated with %q in the 'welcome' plugin configuration.", repo, org)
 		}
 	}
 }


### PR DESCRIPTION
These tests require `config/prow/plugins.yaml` file. To support forking Prow effort, we need to move these tests out of the Prow directory so we can adjust the dependent package to the new Prow repository once it is available. 

/assign @cjwagner @listx @airbornepony 