### PR TITLE
kOps: Increase post-submit job memory

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -547,10 +547,10 @@ postsubmits:
         - "UPLOAD_DEST=gs://k8s-release-dev/kops/ci"
         resources:
           requests:
-            memory: "4Gi"
+            memory: "6Gi"
             cpu: 4
           limits:
-            memory: "4Gi"
+            memory: "6Gi"
             cpu: 4
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, kops-presubmits


### PR DESCRIPTION
The job fails quite often: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/kops-postsubmit
```
github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network:
  /usr/local/go/pkg/tool/linux_amd64/compile: signal: killed
make: *** [Makefile:215: nodeup-arm64] Error 1
```

/cc @upodroid @ameukam @olemarkus 