### PR TITLE
Increase logging around log-dump

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -326,7 +326,7 @@ function copy-logs-from-node() {
       done 
 
       for single_file in "${files[@]}"; do
-        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
+        strace --trace-path "${dir}/${single_file}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
       done
       set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then


### PR DESCRIPTION
Even more observability attempts for kubernetes/kubernetes#121320 Strace syscalls touching the target file of the scp, this should allow us to see if any progress is made.