### PR TITLE
Try a single gcloud command for scp-ing all files

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -321,13 +321,15 @@ function copy-logs-from-node() {
       set +e
 
       # TODO(argh4k): remove it once https://github.com/kubernetes/kubernetes/issues/121320 is solved
+      source_file_args=()
+      trace_paths=()
       for single_file in "${files[@]}"; do
-        gcloud compute scp --dry-run --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug 
-      done 
-
-      for single_file in "${files[@]}"; do
-        strace --trace-path "${dir}/${single_file}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
+        source_file_args+=( "${node}:${single_file}" )
+        trace_paths+=( "--trace-path ${dir}/${single_file}" )
       done
+      gcloud compute scp --dry-run --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug
+
+      strace "${trace_paths[@]}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug --scp-flag="-v"
       set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
       local ip


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/commit/11b0eed9e7fc3b3211426aa42f55ab62f2c62e27 we tried to adapt to new `gcloud` behavior by emitting one gcloud command per file. Here we are combining this back into a new syntax used in gcloud where you can specify multiple files explicitly (unlink the previous way we did where the syntax was to use commas the way `scp` works).