### PR TITLE
Update versions to be compatible with k8s 1.25+

### DIFF
--- a/config/prow/cluster/kube-state-metrics_deployment.yaml
+++ b/config/prow/cluster/kube-state-metrics_deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.6.0
+    app.kubernetes.io/version: 2.10.0
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.6.0
+        app.kubernetes.io/version: 2.10.0
     spec:
       containers:
-      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
+      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
         args:
         - --metric-allowlist="kube_pod_container_status_restarts_total"
         livenessProbe:

--- a/config/prow/cluster/kube-state-metrics_rbac.yaml
+++ b/config/prow/cluster/kube-state-metrics_rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.6.0
+    app.kubernetes.io/version: 2.10.0
   name: kube-state-metrics
   namespace: kube-system
 ---
@@ -12,7 +12,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.6.0
+    app.kubernetes.io/version: 2.10.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28,7 +28,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.6.0
+    app.kubernetes.io/version: 2.10.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/config/prow/cluster/kube-state-metrics_service.yaml
+++ b/config/prow/cluster/kube-state-metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.6.0
+    app.kubernetes.io/version: 2.10.0
   name: kube-state-metrics
   namespace: kube-system
 spec:

--- a/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.6.0
+    app.kubernetes.io/version: 2.10.0
     app: kube-state-metrics
   name: kube-state-metrics
   namespace: prow-monitoring

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: label-sync


### PR DESCRIPTION
CronJob is no longer served at v1beta1 in v1.25 (https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-25?_ga=2.252078157.-538276868.1698275423#cronjob-v125), so updating to the v1 API. Also updating kube-state-metrics to a more recent version (https://github.com/kubernetes/kube-state-metrics#compatibility-matrix)