### PR TITLE
npd: Switch pull-npd-e2e-test to cos-stable

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -230,9 +230,7 @@ presubmits:
         - name: ZONE
           value: us-central1-a
         - name: IMAGE_FAMILY
-        # TODO: update to `cos-stable` once NPD dependencies have been upgraded.
-        # See https://github.com/kubernetes/test-infra/issues/29308#issuecomment-1522523412
-          value: cos-97-lts
+          value: cos-stable
         - name: IMAGE_PROJECT
           value: cos-cloud
         - name: BOSKOS_PROJECT_TYPE


### PR DESCRIPTION
https://github.com/kubernetes/node-problem-detector/pull/825#issuecomment-1786429416

Tests are failing now due to:
```
Oct 31 04:03:58 systemd[1]: Started Node problem detector.
 node-problem-detector[723]: /home/kubernetes/bin/node-problem-detector: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /home/kubernetes/bin/node-problem-detector)
Oct 31 04:03:58 systemd[1]: node-problem-detector.service: Main process exited, code=exited, status=1/FAILURE
Oct 31 04:03:58 systemd[1]: node-problem-detector.service: Failed with result 'exit-code'.
Oct 31 04:04:08 systemd[1]: node-problem-detector.service: Scheduled restart job, restart counter is at 1.
Oct 31 04:04:08 systemd[1]: Stopped Node problem detector.
```

Ref: https://github.com/kubernetes/test-infra/issues/29308#issuecomment-1522523412