### PR TITLE
Enforce 1.29 code freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -680,6 +680,32 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+      - master
+      - release-1.29
+    labels:
+      - lgtm
+      - approved
+      - "cncf-cla: yes"
+    missingLabels:
+      - do-not-merge
+      - do-not-merge/blocked-paths
+      - do-not-merge/cherry-pick-not-approved
+      - do-not-merge/contains-merge-commits
+      - do-not-merge/hold
+      - do-not-merge/invalid-commit-message
+      - do-not-merge/invalid-owners-file
+      - do-not-merge/needs-kind
+      - do-not-merge/needs-sig
+      - do-not-merge/release-note-label-needed
+      - do-not-merge/work-in-progress
+      - needs-rebase
+  - repos:
+      - kubernetes/kubernetes
+    milestone: v1.29
+    includedBranches:
+      - master
+      - release-1.29
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes 1.29 Code Freeze is scheduled to start at [01:00 UTC Wednesday 1st November 2023 / 18:00 PDT Tuesday 31st October 2023](https://everytimezone.com/s/24b27b03)

/hold
The hold should ONLY be cancelled by the Release Team Leads when the 1.29 Release Team is ready around the Code Freeze deadline.

/priority critical-urgent
/cc https://github.com/orgs/kubernetes/teams/release-team-leads https://github.com/orgs/kubernetes/teams/release-engineering