### PR TITLE
Spyglass: use UTF-8 character encoding on JUnit Logs page

### DIFF
--- a/prow/spyglass/lenses/junit/lens.ts
+++ b/prow/spyglass/lenses/junit/lens.ts
@@ -42,6 +42,7 @@ const addStdoutStderrOpeners = (): void => {
       const text = (link.nextElementSibling as HTMLElement).innerHTML;
       const blob = new Blob([`
       <head>
+        <meta charset="UTF-8">
         <title>Logs</title>
       </head>
       <body style="background-color: #303030; color: white; font-family: monospace; white-space: pre-wrap;">${text}</body>`], {type: 'text/html'});


### PR DESCRIPTION
Related to: #31174 