### PR TITLE
fix failure(s) in ci-kubernetes-node-arm64-e2e-containerd-ec2

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -308,7 +308,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-arm64.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=cgroupfs"'
+              value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
tests are borked in:
https://testgrid.k8s.io/amazon-ec2-node#ci-kubernetes-node-arm64-e2e-containerd-ec2&width=20

need to switch from `cgroups` to `systemd` for this to work! See `ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2` which works fine