### PR TITLE
Bump `ci-k8sio-audit` job timeout

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
@@ -1,10 +1,10 @@
 periodics:
 - name: ci-k8sio-audit
-  interval: 3h
+  interval: 4h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   decoration_config:
-    timeout: 3h
+    timeout: 4h
   max_concurrency: 1
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
This job has been timing out and causing unnecessary notifications.

https://testgrid.k8s.io/sig-k8s-infra-k8sio#ci-k8sio-audit

/cc @BenTheElder @dims 