### PR TITLE
Fix presubmit for K8s-sigs/ANP.

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -40,6 +40,9 @@ presubmits:
         args:
         - make
         - docker-build/proxy-agent-amd64
+        env:
+        - name: REGISTRY
+          value: testlocal.io
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -70,6 +73,9 @@ presubmits:
         args:
         - make
         - docker-build/proxy-agent-arm64
+        env:
+        - name: REGISTRY
+          value: testlocal.io
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Fixing kubernetes-sigs/apiserver-network-proxy/issues/538 
Issue is REGISTRY is not set.
We used to pull the registry using gcloud.
This breaks when not running on GCP.
Registry is not actually needed for the presubmit. However we still need a non-empty string.
Setting a placeholder value for the test.