### PR TITLE
Revert logdump changes

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -322,12 +322,14 @@ function copy-logs-from-node() {
 
       # TODO(argh4k): remove it once https://github.com/kubernetes/kubernetes/issues/121320 is solved
       source_file_args=()
+      trace_paths=()
       for single_file in "${files[@]}"; do
         source_file_args+=( "${node}:${single_file}" )
+        trace_paths+=( "--trace-path ${dir}/${single_file}" )
       done
       gcloud compute scp --dry-run --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug
 
-      gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug --scp-flag="-v"
+      strace "${trace_paths[@]}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug --scp-flag="-v"
       set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
       local ip

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -321,15 +321,13 @@ function copy-logs-from-node() {
       set +e
 
       # TODO(argh4k): remove it once https://github.com/kubernetes/kubernetes/issues/121320 is solved
-      source_file_args=()
-      trace_paths=()
       for single_file in "${files[@]}"; do
-        source_file_args+=( "${node}:${single_file}" )
-        trace_paths+=( "--trace-path ${dir}/${single_file}" )
-      done
-      gcloud compute scp --dry-run --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug
+        gcloud compute scp --dry-run --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug 
+      done 
 
-      strace "${trace_paths[@]}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${source_file_args[@]}" "${dir}" --verbosity debug --scp-flag="-v"
+      for single_file in "${files[@]}"; do
+        strace --trace-path "${dir}/${single_file}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
+      done
       set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
       local ip

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -326,7 +326,7 @@ function copy-logs-from-node() {
       done 
 
       for single_file in "${files[@]}"; do
-        strace --trace-path "${dir}/${single_file}" gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
+        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
       done
       set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -326,7 +326,7 @@ function copy-logs-from-node() {
       done 
 
       for single_file in "${files[@]}"; do
-        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug --scp-flag="-v"
+        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug
       done
       set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -318,11 +318,9 @@ function copy-logs-from-node() {
       # get-serial-port-output lets you ask for ports 1-4, but currently (11/21/2016) only port 1 contains useful information
       gcloud compute instances get-serial-port-output --project "${PROJECT}" --zone "${ZONE}" --port 1 "${node}" > "${dir}/serial-1.log" || true
       # FIXME(dims): bug in gcloud prevents multiple source files specified using curly braces, so we just loop through for now
-      set +e
       for single_file in "${files[@]}"; do
-        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug
+        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" > /dev/null || true
       done
-      set -e
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
       local ip
       ip=$(get_ssh_hostname "${node}")

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -319,12 +319,6 @@ function copy-logs-from-node() {
       gcloud compute instances get-serial-port-output --project "${PROJECT}" --zone "${ZONE}" --port 1 "${node}" > "${dir}/serial-1.log" || true
       # FIXME(dims): bug in gcloud prevents multiple source files specified using curly braces, so we just loop through for now
       set +e
-
-      # TODO(argh4k): remove it once https://github.com/kubernetes/kubernetes/issues/121320 is solved
-      for single_file in "${files[@]}"; do
-        gcloud compute scp --dry-run --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug 
-      done 
-
       for single_file in "${files[@]}"; do
         gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" --verbosity debug
       done


### PR DESCRIPTION
Get back to a well known state and remove all the changes that were added to debug the the performance problem, since we should be able to debug these problems outside of this script and these has caused a release job to constantily fail