### PR TITLE
The prow-controller-manager role is missing get permissions 

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -1080,6 +1080,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -1082,6 +1082,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -1122,6 +1122,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -1080,6 +1080,7 @@ rules:
       - watch
       - create
       - patch
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The prow-controller-manager role is missing get permissions in the test-pods namespace.

fixes #29286