### PR TITLE
CAPI: Update milestone applier config for v1.7

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -498,7 +498,8 @@ milestone_applier:
     release-1.17: v1.17
     release-1.16: v1.16
   kubernetes-sigs/cluster-api:
-    main: v1.6
+    main: v1.7
+    release-1.6: v1.6
     release-1.5: v1.5
     release-1.4: v1.4
     release-1.3: v1.3


### PR DESCRIPTION
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/9094 and addresses: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#create-a-release-branch:

```
Update the [milestone applier config](https://github.com/kubernetes/test-infra/blob/0b17ef5ffd6c7aa7d8ca1372d837acfb85f7bec6/config/prow/plugins.yaml#L371) accordingly (e.g. release-1.4: v1.4 and main: v1.5)
Prior art: https://github.com/kubernetes/test-infra/pull/266315
```

/hold until release-1.6 branch is created

