### PR TITLE
[sig-windows-networking] Update CAPZ Flannel Prowjobs

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -33,12 +33,12 @@ dashboards:
       test_group_name: sig-windows-soak-tests
 - name: sig-windows-networking
   dashboard_tab:
-  - name: ltsc2019-containerd-flannel-sdnbridge-master
-    description: Runs Windows (LTSC 2019 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
-    test_group_name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
-  - name: ltsc2019-containerd-flannel-sdnoverlay-master
-    description: Runs Windows (LTSC 2019 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in overlay network mode.
-    test_group_name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
+  - name: ltsc2022-containerd-flannel-sdnbridge-master
+    description: Runs Windows (LTSC 2022 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
+    test_group_name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master
+  - name: ltsc2022-containerd-flannel-sdnoverlay-master
+    description: Runs Windows (LTSC 2022 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in overlay network mode.
+    test_group_name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-master
   - name: ltsc2019-containerd-flannel-sdnbridge-stable
     description: Runs Windows (LTSC 2019 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
@@ -81,10 +81,10 @@ dashboards:
 
 test_groups:
 # Flannel CNI on Windows test groups
-- name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
-- name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
+- name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master
+  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master
+- name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-master
+  gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-master
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable


### PR DESCRIPTION
Use Windows Server 2022 instead of Windows Server 2019 for the `sig-windows-networking` Prowjobs using latest Kubernetes `master` branch code.

The Prow system was updated via the PR https://github.com/e2e-win/k8s-e2e-runner/pull/230.