### PR TITLE
Bootstrap etcd jobs on prow

### DIFF
--- a/config/jobs/etcd/OWNERS
+++ b/config/jobs/etcd/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - ahrtr
+  - jmhbnz
+  - serathius
+  - wenjiaswe
+
+approvers:
+  - ahrtr
+  - jmhbnz
+  - serathius
+  - wenjiaswe
+
+labels:
+  - sig/etcd

--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -1,0 +1,32 @@
+periodics:
+- name: ci-etcd-e2e-amd64
+  interval: 4h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-e2e-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231103-fd8df63b1a-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"

--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -1,0 +1,25 @@
+postsubmits:
+  etcd-io/etcd:
+  - name: post-etcd-build
+    cluster: eks-prow-build-cluster
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-postsubmits
+      testgrid-tab-name: post-etcd-build
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231103-fd8df63b1a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - build
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -1,0 +1,79 @@
+presubmits:
+  etcd-io/etcd:
+  - name: pull-etcd-build
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-build
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231103-fd8df63b1a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - build
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
+
+  - name: pull-etcd-unit-test
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-unit-test
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231103-fd8df63b1a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-unit
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
+
+  - name: pull-etcd-verify-lint
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-verify-lint
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231103-fd8df63b1a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify-lint
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -208,6 +208,8 @@ managed_webhooks:
       token_created_after: 2020-09-17T00:00:00Z
     cncf/apisnoop:
       token_created_after: 2020-09-22T00:00:00Z
+    etcd-io:
+      token_created_after: 2023-11-13T00:00:00Z
 
 slack_reporter_configs:
   '*':

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -28,6 +28,10 @@ triggers:
   join_org_url: "https://github.com/containerd/project/blob/main/MAINTAINERS"
   trigger_github_workflows: true
 - repos:
+  - etcd-io
+  join_org_url: "https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md"
+  trigger_github_workflows: true
+- repos:
   - bazelbuild
 - repos:
   - kubernetes/utils
@@ -1559,6 +1563,17 @@ plugins:
     - lifecycle
     - size
     - trigger
+
+  etcd-io:
+    plugins:
+    - assign
+    - trigger
+    - label
+    - pony
+    - retitle
+    - skip
+    - wip
+    - yuks
 
   containerd/containerd:
     plugins:

--- a/config/testgrids/kubernetes/sig-etcd/OWNERS
+++ b/config/testgrids/kubernetes/sig-etcd/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - ahrtr
+  - jmhbnz
+  - serathius
+  - wenjiaswe
+
+approvers:
+  - ahrtr
+  - jmhbnz
+  - serathius
+  - wenjiaswe
+
+labels:
+  - sig/etcd

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -1,0 +1,11 @@
+dashboard_groups:
+- name: sig-etcd
+  dashboard_names:
+  - sig-etcd-presubmits
+  - sig-etcd-periodics
+  - sig-etcd-postsubmits
+
+dashboards:
+  - name: sig-etcd-presubmits
+  - name: sig-etcd-periodics
+  - name: sig-etcd-postsubmits


### PR DESCRIPTION
etcd maintainers want to start using testgrid to track flakes which means running prow jobs. I have bootstrapped the initial set of unit/build/lint jobs to get going.

/cc @dims @BenTheElder 

/cc @wenjiaswe @serathius @ahrtr
Once this PR is merged, a sig-etcd entry will appear in https://testgrid.k8s.io

/hold for comments