### PR TITLE
Remove simplelru dep from prow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/klauspost/pgzip v1.2.1
 	github.com/mattn/go-zglob v0.0.2
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1

--- a/prow/cache/cache_test.go
+++ b/prow/cache/cache_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	"k8s.io/utils/lru"
 )
 
 // TestGetOrAddSimple is a basic check that the underlying LRU cache
@@ -150,7 +152,7 @@ func TestGetOrAddSimple(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset test state.
 			valConstructorCalls = 0
-			simpleCache.Purge()
+			simpleCache.Clear()
 
 			for k, v := range tc.cacheInitialState {
 				if tc.cache != nil {
@@ -282,7 +284,7 @@ func TestGetOrAddBurst(t *testing.T) {
 	}
 
 	valConstructorCalls = 0
-	lruCache.Purge()
+	lruCache.Clear()
 
 	// Consider the case where all threads perform one of 5 different cache lookups.
 	wg.Add(maxConcurrentRequests)
@@ -354,7 +356,7 @@ func TestCallbacks(t *testing.T) {
 	lookupsCallback := mkCallback(&lookupsCounter)
 	hitsCallback := mkCallback(&hitsCounter)
 	missesCallback := mkCallback(&missesCounter)
-	forcedEvictionsCallback := func(key interface{}, _ interface{}) {
+	forcedEvictionsCallback := func(key lru.Key, _ interface{}) {
 		forcedEvictionsCounter++
 	}
 	manualEvictionsCallback := mkCallback(&manualEvictionsCounter)

--- a/prow/config/cache_test.go
+++ b/prow/config/cache_test.go
@@ -390,7 +390,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 			// Simulate storing a value of the wrong type in the cache (a string
 			// instead of a *ProwYAML).
 			if tc.cacheCorrupted {
-				cache.Purge()
+				cache.Clear()
 
 				for _, kp := range tc.cacheInitialState {
 					k, err := kp.CacheKey()


### PR DESCRIPTION
We are still using the hashicorp simple-lru package in prow Cache. For several weeks the race detector non blocking job (https://testgrid.k8s.io/presubmits-test-infra#unit-test-race-detector-nonblocking) has been flaky and is often faling the `TestGetProwYAMLCached` test on calling simplelru. This failure is documented in https://github.com/kubernetes/test-infra/issues/31052.

This PR takes the opportunity to remove the simplelru dependency and simultaniously stabilize the `TestGetProwYAMLCached` test through moving to the community package. 
