### PR TITLE
migrate `containerd` jobs to community cluster

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -1,6 +1,7 @@
 presubmits:
   containerd/containerd:
   - name: pull-containerd-build
+    cluster: k8s-infra-prow-build
     always_run: true
     branches:
     - main
@@ -24,8 +25,16 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e
+    cluster: k8s-infra-prow-build
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -75,8 +84,16 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e-1-7
+    cluster: k8s-infra-prow-build
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -126,8 +143,16 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e-1-6
+    cluster: k8s-infra-prow-build
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -177,3 +202,10 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.6-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi


### PR DESCRIPTION
This PR moves containerd jobs to the community owned cluster gke cluster

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @mrunalp @klueska @SergeyKanzhelev @endocrimes