### PR TITLE
migrate `perf-test` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml
@@ -1739,6 +1739,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -1791,6 +1792,7 @@ presubmits:
     branches:
     - release-1.25
     context: pull-perf-tests-clusterloader2-kubemark
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 2h0m0s


### PR DESCRIPTION
This PR moves perf-test jobs to the community owned cluster gke cluster. Only 1.25 jobs are being moved now. All other releases will be moved after 1.25 is verified ok. 

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @cici37 @cpanato @jeremyrickard @justaugustus @palnabarun