### PR TITLE
skip alpha serviceCIDR tests for kind cloud provider

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
@@ -26,7 +26,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
       command:
         - wrapper.sh
         - bash
@@ -80,7 +80,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|loadbalancer.source.ranges|Internet.connection.for.containers
+        value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|loadbalancer.source.ranges|Internet.connection.for.containers
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+          value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
         command:
         - wrapper.sh
         - bash
@@ -87,7 +87,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|loadbalancer.source.ranges|Internet.connection.for.containers
+          value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|loadbalancer.source.ranges|Internet.connection.for.containers
         command:
         - wrapper.sh
         - bash
@@ -139,7 +139,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|GCE|NetworkPolicy|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+          value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
         - name: PARALLEL
           value: "true"
         - name: IP_FAMILY


### PR DESCRIPTION
This feature is alpha and causes all the test to permanently fail

https://testgrid.k8s.io/sig-testing-kind#cloud-provider-kind%20conformance,%20master%20(dev)%20%5Bnon-serial%5D