### PR TITLE
migrate `k-csi` canary job to community cluster

### DIFF
--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-attacher-canary
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-provisioner-canary
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-resizer-canary
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-external-snapshotter-canary
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -493,6 +493,7 @@ EOF
       cat >>"$base/$repo/$repo-config.yaml" <<EOF
 
   - name: $(job_name "pull" "$repo" "canary")
+    cluster: $(job_cluster "$repo")
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-livenessprobe-canary
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -381,6 +381,7 @@ presubmits:
             cpu: 4
 
   - name: pull-kubernetes-csi-node-driver-registrar-canary
+    cluster: eks-prow-build-cluster
     optional: true
     decorate: true
     skip_report: false


### PR DESCRIPTION
This PR updates `gen-jobs.sh` and migrates canary jobs to the community clusters. This was missed in previous iterations of k-csi migrations. 

ref: https://github.com/kubernetes/test-infra/issues/29722

/cc @pohly @xing-yang @jsafrane