### PR TITLE
log-dump.sh: use value(name) in detect-node-names

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -197,7 +197,7 @@ function detect-node-names() {
     for group in "${INSTANCE_GROUPS[@]}"; do
       NODE_NAMES+=($(gcloud compute instance-groups managed list-instances \
         "${group}" --zone "${ZONE}" --project "${PROJECT}" \
-        --format='value(instance)'))
+        --format='value(name)'))
     done
   fi
   # Add heapster node name to the list too (if it exists).
@@ -208,7 +208,7 @@ function detect-node-names() {
     for group in "${WINDOWS_INSTANCE_GROUPS[@]}"; do
       WINDOWS_NODE_NAMES+=($(gcloud compute instance-groups managed \
         list-instances "${group}" --zone "${ZONE}" --project "${PROJECT}" \
-        --format='value(instance)'))
+        --format='value(name)'))
     done
   fi
 


### PR DESCRIPTION
Populates https://github.com/kubernetes/kubernetes/pull/121875 to log-dump.sh's copy of detect-node-names.

Refs https://github.com/kubernetes/kubernetes/issues/121320

/assign @wojtek-t