### PR TITLE
Add S3 support in gcsweb

### DIFF
--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -473,16 +473,6 @@ func providerPrefix(provider string) string {
 	return "/" + provider
 }
 
-func providerName(provider string) string {
-	switch provider {
-	case providers.GS:
-		return "GCS"
-	case providers.S3:
-		return "S3"
-	}
-	return provider
-}
-
 func pathPrefix(prowPath *prowv1.ProwPath) string {
 	return joinPath(providerPrefix(prowPath.StorageProvider()), prowPath.Bucket())
 }
@@ -537,7 +527,7 @@ type gcsDir struct {
 
 // Render writes HTML representing this gcsDir to the provided output.
 func (dir *gcsDir) Render(out http.ResponseWriter, inPath string) {
-	htmlPageHeader(out, providerName(dir.ProwPath.StorageProvider()), dir.ProwPath.Bucket())
+	htmlPageHeader(out, providers.DisplayName(dir.ProwPath.StorageProvider()), dir.ProwPath.Bucket())
 
 	if !strings.HasSuffix(inPath, "/") {
 		inPath += "/"

--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -27,6 +27,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -513,16 +514,15 @@ func joinPath(paths ...string) string {
 	return strings.Join(paths, "/")
 }
 
-// getParent returns the logical parent directory of the path.  This is different
-// than path.Split() in that we want getParent("/gcs/foo/bar/") -> "/gcs/foo/", whereas
-// path.Split() returns "/gcs/foo/bar/".
-// As a special case, getParent returns the empty string for the bucket root, e.g.
-// getParent("/gcs/foo") -> "".
-func getParent(path string) string {
-	parts := strings.Split(strings.Trim(path, "/"), "/")
-	if len(parts) > 2 {
-		return "/" + strings.Join(parts[0:len(parts)-1], "/") + "/"
+// getParent is basically path.Dir but handles two special cases for gcsweb:
+// - it treats paths with and without trailing slash equally, e.g.: /gcs/foo/bar/ -> /gcs/foo/ and /gcs/foo/bar -> /gcs/foo/
+// - it returns the empty string for the bucket root, e.g.: /gcs/foo -> ""
+func getParent(inPath string) string {
+	parent := path.Dir(strings.TrimSuffix(inPath, "/"))
+	if strings.Count(parent, "/") >= 2 {
+		return parent + "/"
 	}
+	// inPath is bucket root
 	return ""
 }
 

--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -63,7 +62,7 @@ func (f *fakeOpener) Iterator(ctx context.Context, prefix string, delimiter stri
 	if err != nil {
 		return nil, err
 	}
-	bucket := bucketWithScheme(prowPath)
+	bucket := prowPath.BucketWithScheme()
 
 	var objects []pkgio.ObjectAttributes
 
@@ -477,7 +476,7 @@ func TestHandleDirectory(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := s.handleDirectory(w, prowPath, strings.Trim(prowPath.Path, "/"), tc.path); err != nil {
+			if err := s.handleDirectory(w, prowPath, tc.path); err != nil {
 				t.Fatalf("error not expected: %v", err)
 			}
 

--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -621,11 +621,6 @@ func TestGetParent(t *testing.T) {
 			expected: "/gcs/foo/",
 		},
 		{
-			id:       "without leading slash",
-			path:     "gcs/foo/bar",
-			expected: "/gcs/foo/",
-		},
-		{
 			id:       "bucket root with trailing slash",
 			path:     "/gcs/foo/",
 			expected: "",

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -979,8 +979,16 @@ func (pp ProwPath) Bucket() string {
 	return pp.Host
 }
 
+func (pp ProwPath) BucketWithScheme() string {
+	return fmt.Sprintf("%s://%s", pp.StorageProvider(), pp.Bucket())
+}
+
 func (pp ProwPath) FullPath() string {
 	return pp.Host + pp.Path
+}
+
+func (pp *ProwPath) String() string {
+	return (*url.URL)(pp).String()
 }
 
 // ParsePath tries to extract the ProwPath from, e.g.:

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1044,7 +1044,7 @@ lensesLoop:
 
 	artifactsLink := ""
 	bucket := ""
-	if jobPath != "" && strings.HasPrefix(jobPath, providers.GS) {
+	if jobPath != "" && (strings.HasPrefix(jobPath, providers.GS) || strings.HasPrefix(jobPath, providers.S3)) {
 		bucket = strings.Split(jobPath, "/")[1] // The provider (gs) will be in index 0, followed by the bucket name
 	}
 	gcswebPrefix := cfg().Deck.Spyglass.GetGCSBrowserPrefix(org, repo, bucket)

--- a/prow/io/iterator.go
+++ b/prow/io/iterator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
@@ -33,6 +34,10 @@ type ObjectAttributes struct {
 	ObjName string
 	// IsDir is true if the object is a directory
 	IsDir bool
+	// Size is the size of the blob's content in bytes in case of an object.
+	Size int64
+	// Updated is the creation or modification time in case of the object.
+	Updated time.Time
 }
 
 // ObjectIterator iterates through storage objects
@@ -62,6 +67,8 @@ func (g gcsObjectIterator) Next(_ context.Context) (ObjectAttributes, error) {
 		attr.Name = oAttrs.Name
 		nameSplit := strings.Split(oAttrs.Name, "/")
 		attr.ObjName = nameSplit[len(nameSplit)-1]
+		attr.Size = oAttrs.Size
+		attr.Updated = oAttrs.Updated
 	} else {
 		// directory
 		attr.Name = oAttrs.Prefix
@@ -91,6 +98,8 @@ func (g openerObjectIterator) Next(ctx context.Context) (ObjectAttributes, error
 		// object
 		nameSplit := strings.Split(oAttrs.Key, "/")
 		attr.ObjName = nameSplit[len(nameSplit)-1]
+		attr.Size = oAttrs.Size
+		attr.Updated = oAttrs.ModTime
 	}
 	return attr, nil
 }

--- a/prow/io/opener.go
+++ b/prow/io/opener.go
@@ -489,7 +489,8 @@ func (o *opener) Iterator(ctx context.Context, prefix, delimiter string) (Object
 	if err != nil {
 		return nil, err
 	}
-	if !strings.HasSuffix(relativePath, "/") {
+	// listing a directory requires the "/" suffix except if we try to list the bucket's root directory
+	if relativePath != "" && !strings.HasSuffix(relativePath, "/") {
 		relativePath += "/"
 	}
 	return openerObjectIterator{

--- a/prow/io/opener.go
+++ b/prow/io/opener.go
@@ -62,6 +62,15 @@ type Attributes struct {
 	// ContentEncoding specifies the encoding used for the blob's content, if any.
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
 	ContentEncoding string
+	// ContentType is the MIME type of the blob, if any.
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+	ContentType string
+	// ContentDisposition specifies whether the blob content is expected to be displayed inline or as an attachment.
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+	ContentDisposition string
+	// ContentLanguage specifies the language used in the blob's content, if any.
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Language
+	ContentLanguage string
 	// Size is the size of the blob's content in bytes.
 	Size int64
 	// Metadata includes user-metadata associated with the file
@@ -326,9 +335,12 @@ func (o *opener) Attributes(ctx context.Context, path string) (Attributes, error
 			return Attributes{}, err
 		}
 		return Attributes{
-			ContentEncoding: attr.ContentEncoding,
-			Size:            attr.Size,
-			Metadata:        attr.Metadata,
+			ContentEncoding:    attr.ContentEncoding,
+			ContentType:        attr.ContentType,
+			ContentDisposition: attr.ContentDisposition,
+			ContentLanguage:    attr.ContentLanguage,
+			Size:               attr.Size,
+			Metadata:           attr.Metadata,
 		}, nil
 	}
 
@@ -342,9 +354,12 @@ func (o *opener) Attributes(ctx context.Context, path string) (Attributes, error
 		return Attributes{}, err
 	}
 	return Attributes{
-		ContentEncoding: attr.ContentEncoding,
-		Size:            attr.Size,
-		Metadata:        attr.Metadata,
+		ContentEncoding:    attr.ContentEncoding,
+		ContentType:        attr.ContentType,
+		ContentDisposition: attr.ContentDisposition,
+		ContentLanguage:    attr.ContentLanguage,
+		Size:               attr.Size,
+		Metadata:           attr.Metadata,
 	}, nil
 }
 

--- a/prow/io/providers/providers.go
+++ b/prow/io/providers/providers.go
@@ -41,6 +41,19 @@ const (
 	File = "file"
 )
 
+// DisplayName turns canonical provider IDs into displayable names.
+func DisplayName(provider string) string {
+	switch provider {
+	case GS:
+		return "GCS"
+	case S3:
+		return "S3"
+	case File:
+		return "File"
+	}
+	return provider
+}
+
 // GetBucket opens and returns a gocloud blob.Bucket based on credentials and a path.
 // The path is used to discover which storageProvider should be used.
 //


### PR DESCRIPTION
/kind feature
/sig testing
/area prow

This PR adds support for S3 directory listings in gcsweb by implementing the proposal from https://github.com/kubernetes/test-infra/issues/31240.

TL;DR: Simply pass your bucket name with the `s3://` prefix to `-b`, configure your credentials like on other prow components, set `deck.spyglass.gcs_browser_prefix`, and you're good to go! (see https://github.com/kubernetes/k8s.io/tree/main/apps/gcsweb for example manifests)

Fixes https://github.com/kubernetes/test-infra/issues/31240

I hope the dedicated commits help ease the review. Can be squashed afterwards.
/label tide/merge-method-squash