### PR TITLE
Validate N/w programming latency slo, In cluster N/w latency, DNS lookup Latency

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1440,7 +1440,12 @@ def generate_presubmits_scale():
                 'CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD': "99.5",
                 'CL2_ALLOWED_SLOW_API_CALLS': "1",
                 'ENABLE_PROMETHEUS_SERVER': "true",
-                'PROMETHEUS_PVC_STORAGE_CLASS': "gp2"
+                'PROMETHEUS_PVC_STORAGE_CLASS': "gp2",
+                'CL2_NETWORK_LATENCY_THRESHOLD': "0.5s",
+                'CL2_ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES': "true",
+                'CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD': "20s",
+                'CL2_ENABLE_DNSTESTS': "true",
+                'CL2_USE_ADVANCED_DNSTEST': "true"
             }
         ),
         presubmit_test(

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -144,6 +144,16 @@ presubmits:
           value: "true"
         - name: PROMETHEUS_PVC_STORAGE_CLASS
           value: "gp2"
+        - name: CL2_NETWORK_LATENCY_THRESHOLD
+          value: "0.5s"
+        - name: CL2_ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES
+          value: "true"
+        - name: CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD
+          value: "20s"
+        - name: CL2_ENABLE_DNSTESTS
+          value: "true"
+        - name: CL2_USE_ADVANCED_DNSTEST
+          value: "true"
         - name: CLOUD_PROVIDER
           value: "aws"
         - name: CLUSTER_NAME


### PR DESCRIPTION
Added ability to measure [N/w Programming Latency ](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/network_programming_latency.md )and [In Cluster N/w Latency SLOs](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/network_latency.md) in CL2 :- 
-  https://github.com/kubernetes/perf-tests/issues/2407
-  https://github.com/kubernetes/perf-tests/issues/2417