### PR TITLE
containerd: enable additional plugins

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1579,6 +1579,10 @@ plugins:
     plugins:
     - assign  # Allow /assign and /cc
     - trigger # Allow people to configure CI jobs to /test
+    - label   # Allow people to label issues and PRs
+    - mergecommitblocker # Mark PRs with merge commits
+    - size    # Mark size of PRs
+    - wip     # Mark draft PRs
 
   GoogleCloudPlatform/k8s-multicluster-ingress:
     plugins:
@@ -1871,3 +1875,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  containerd/containerd:
+  - name: needs-rebase
+    events:
+    - issue_comment
+    - pull_request
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request


### PR DESCRIPTION
In discussion with @dmcgowan.  I'm not sure if the external plugins need any additional configuration in the org. 

(cc @akhilerm)