### PR TITLE
Unify memory for kubemark-100 jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -272,10 +272,10 @@ periodics:
       resources:
         requests:
           cpu: 2
-          memory: "2Gi"
+          memory: "6Gi"
         limits:
           cpu: 2
-          memory: "2Gi"
+          memory: "6Gi"
 
 - name: ci-kubernetes-kubemark-100-gce-scheduler-highqps
   tags:
@@ -349,10 +349,10 @@ periodics:
       resources:
         requests:
           cpu: 2
-          memory: "2Gi"
+          memory: "6Gi"
         limits:
           cpu: 2
-          memory: "2Gi"
+          memory: "6Gi"
 
 - name: ci-kubernetes-kubemark-500-gce
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
It seem to be the most obvious difference between failing kubemark-100-scheduler and kubemark-100. We seem to use ~2Gi of memory around the time when test fails, so worth trying.

Also it looks like at that time we try to run ~50 concurrent gclouds to translate image family to specific image, which indeed may be quite memory consuming.

![image](https://github.com/kubernetes/test-infra/assets/2559168/ee513cb8-290f-403c-949f-2d409bb64421)


/assign @wojtek-t 