### PR TITLE
log-dump: switch to gcloud ssh --command tar.

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -319,7 +319,8 @@ function copy-logs-from-node() {
       gcloud compute instances get-serial-port-output --project "${PROJECT}" --zone "${ZONE}" --port 1 "${node}" > "${dir}/serial-1.log" || true
       # FIXME(dims): bug in gcloud prevents multiple source files specified using curly braces, so we just loop through for now
       for single_file in "${files[@]}"; do
-        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${single_file}" "${dir}" > /dev/null || true
+        # gcloud scp doesn't work very well when trying to fetch constantly changing files such as logs, as it blocks forever sometimes.
+        gcloud compute ssh --project "${PROJECT}" --zone "${ZONE}" "${node}" --command "tar -zcvf - ${single_file}" | tar -zxf - --strip-components=2 -C "${dir}" || true
       done
     elif  [[ "${KUBERNETES_PROVIDER}" == "aws" ]]; then
       local ip


### PR DESCRIPTION
gcloud scp tries to copy entire file, which is hard to achieve with constantly changing files as logs.

This leads to locking our tests for a long time.

I'm not really sure why it sometimes work, but after reading scp (sftp specifically implementation [1]) it looks like it uses dynamic chunk size that adjusts to the minimum received chunk of data. This likely mean that when we reach end of initial file range, it determines a chunk size of future reads and if we get value large enough we should be able to keep up and read entire data, but otherwise we will be still catching.

Refs https://github.com/kubernetes/kubernetes/issues/121320

[1] https://github.com/openssh/openssh-portable/blob/26f3f3bbc69196d908cad6558c8c7dc5beb8d74a/sftp-client.c#L1792-L1794

Tested on my dev instance (by running command below for sample paths).

/assign @wojtek-t 