### PR TITLE
add e2e etcd presubmit

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   etcd-io/etcd:
   - name: pull-etcd-build
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -28,7 +27,6 @@ presubmits:
 
   - name: pull-etcd-unit-test
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -54,7 +52,6 @@ presubmits:
 
   - name: pull-etcd-verify-lint
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -77,3 +74,32 @@ presubmits:
           limits:
             cpu: "4"
             memory: "4Gi"
+
+  - name: pull-etcd-e2e-amd64
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-e2e-amd64
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231114-c7aaf965de-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"


### PR DESCRIPTION
/cc @serathius @ahrtr 
@etsrpl

The presubmit jobs I introduced in #31218 are stable now and I made them required now.

I also introduced an e2e presubmit for someone to fix the bugs in the ci-etcd-e2e-amd64 job.

https://testgrid.k8s.io/sig-etcd-periodics#ci-etcd-e2e-amd64