### PR TITLE
sig-windows: add job to test NodeLogQuery

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -491,3 +491,58 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-master-alpha-features
+- name: ci-kubernetes-e2e-capz-master-windows-alpha-nodelogquery
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2022: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231117-8a628a317a-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: \[Feature:NodeLogQuery\] # run the NodeLogQuery tests
+          - name: GINKGO_SKIP
+            value: ""
+          - name: NODE_FEATURE_GATES
+            value: "NodeLogQuery=true"
+          - name: WINDOWS_CONTAINERD_URL
+            value: "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz"
+  annotations:
+    testgrid-alert-email: sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: capz-master-windows-alpha-nodelogquery


### PR DESCRIPTION
Add a temporary job to see if the NodeLogQuery tests have been wired up correctly. Once the tests have been updated to also run against Windows nodes, this job can be removed.