### PR TITLE
create 1.26 instead of 1.25 for capz cluster tests

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -612,7 +612,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.25
+        base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -637,7 +637,7 @@ presubmits:
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.25"
+              value: "latest-1.26"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
             - name: EXTERNAL_E2E_TEST # azuredisk-csi-driver config
@@ -775,7 +775,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.25
+        base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -804,7 +804,7 @@ presubmits:
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.25"
+              value: "latest-1.26"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -629,7 +629,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.25
+        base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -658,7 +658,7 @@ presubmits:
             - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.25"
+              value: "latest-1.26"
             - name: WORKER_MACHINE_COUNT
               value: "0" # Don't create any linux worker nodes
     annotations:

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -297,7 +297,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.25
+        base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -318,7 +318,7 @@ presubmits:
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D2s_v3"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.25"
+              value: "latest-1.26"
             - name: EXTERNAL_E2E_TEST_NFS
               value: "true"
     annotations:


### PR DESCRIPTION
create 1.26 instead of 1.25 for capz cluster tests since 1.25 is not supported on capz