### PR TITLE
Add presbumit/periodic jobs to test conformance using AL2 images

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -526,6 +526,70 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-eks-conformance-canary
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/provider-aws-test-infra
+    always_run: false
+    optional: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231117-8a628a317a-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              cd kubetest2-ec2 && GOPROXY=direct go install .
+              AMI_ID=$(aws ssm get-parameters --names \
+                       /aws/service/eks/optimized-ami/1.28/amazon-linux-2/recommended/image_id \
+                       --query 'Parameters[0].[Value]' --output text)
+              kubetest2 ec2 \
+               --build \
+               --instance-type=m6a.large  \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --worker-image "$AMI_ID" \
+               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
+               --stage provider-aws-test-infra \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --use-built-binaries true \
+               --focus-regex='\[Conformance\]'
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
 periodics:
 - interval: 6h
   cluster: eks-prow-build-cluster
@@ -564,6 +628,68 @@ periodics:
             kubetest2 ec2 \
              --build \
              --target-build-arch linux/amd64 \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --focus-regex='\[Conformance\]'
+        env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 6h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-ec2-eks-conformance-latest
+  annotations:
+    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-tab-name: Conformance - EC2/EKS - master
+    description: Runs conformance tests using kubetest against kubernetes master on EC2 using EKS worker nodes
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231117-8a628a317a-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            AMI_ID=$(aws ssm get-parameters --names \
+                     /aws/service/eks/optimized-ami/1.28/amazon-linux-2/recommended/image_id \
+                     --query 'Parameters[0].[Value]' --output text)
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/amd64 \
+             --worker-image "$AMI_ID" \
+             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
              --stage provider-aws-test-infra \
              --up \
              --down \


### PR DESCRIPTION
- `pull-kubernetes-e2e-ec2-eks-conformance-canary` is the same as `pull-kubernetes-e2e-ec2-conformance-canary` except using AL2 images
- `ci-kubernetes-ec2-eks-conformance-latest` is the same as `ci-kubernetes-ec2-conformance-latest` except using AL2 images

Pick a recent EKS image that has AL2 as it has a bunch of things built in already (like containerd/run etc!). We use an alternative userdata file that uses `kubadm join` with the community maintainerd `kubelet` service spec etc (see https://github.com/kubernetes-sigs/provider-aws-test-infra/blob/main/kubetest2-ec2/config/al2.sh for details)