### PR TITLE
Add presbumit/periodic jobs to test conformance using AL2023 images

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -590,6 +590,84 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-eks-al2023-conformance-canary
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/provider-aws-test-infra
+    always_run: false
+    optional: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231117-8a628a317a-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              KUBE_MINOR_VERSION="v1.29"
+              TODAYS_DATE=$(date -u +'%Y%m%d')
+              AMI_NAME="amazon-eks-al2023-node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+              ami_id=$(aws ec2 describe-images --region=us-west-2 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+
+              if [ -z "${ami_id}" ] ; then
+                export AMI_NAME
+                $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
+                ami_id=$(aws ec2 describe-images --region=us-west-2 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+              else
+                echo "found existing ami : ${ami_id} skipping building a new AMI..."
+              fi
+
+              cd kubetest2-ec2 && GOPROXY=direct go install .
+              kubetest2 ec2 \
+               --build \
+               --instance-type=m6a.large  \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --worker-image "${ami_id}" \
+               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
+               --stage provider-aws-test-infra \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --use-built-binaries true \
+               --focus-regex='\[Conformance\]'
+          env:
+            - name: BUILD_EKS_AMI_OS
+              value: "al2023"
+            - name: BUILD_EKS_AMI_ARCH
+              value: "x86_64"
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
 periodics:
 - interval: 6h
   cluster: eks-prow-build-cluster
@@ -698,6 +776,82 @@ periodics:
              --use-built-binaries true \
              --focus-regex='\[Conformance\]'
         env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 6h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-ec2-eks-al2023-conformance-latest
+  annotations:
+    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-tab-name: Conformance - EC2/EKS/AL2023 - master
+    description: Runs conformance tests using kubetest against kubernetes master on EC2 using EKS worker nodes
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231117-8a628a317a-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            KUBE_MINOR_VERSION="v1.29"
+            TODAYS_DATE=$(date -u +'%Y%m%d')
+            AMI_NAME="amazon-eks-al2023-node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+            ami_id=$(aws ec2 describe-images --region=us-west-2 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+
+            if [ -z "${ami_id}" ] ; then
+              export AMI_NAME
+              $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
+              ami_id=$(aws ec2 describe-images --region=us-west-2 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+            else
+              echo "found existing ami : ${ami_id} skipping building a new AMI..."
+            fi
+
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/amd64 \
+             --worker-image "${ami_id}" \
+             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --focus-regex='\[Conformance\]'
+        env:
+          - name: BUILD_EKS_AMI_OS
+            value: "al2023"
+          - name: BUILD_EKS_AMI_ARCH
+            value: "x86_64"
           - name: USE_DOCKERIZED_BUILD
             value: "true"
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Similar to https://github.com/kubernetes/test-infra/pull/31277

However we use al2023 images. We need to ensure we build them from scratch as they are not available (al2 EKS images can be picked up from SSM).