### PR TITLE
CRI-O: pin fedora-coreos images to v38

### DIFF
--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-evented-pleg.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-evented-pleg.yaml
@@ -1,5 +1,7 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-hugepages.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-hugepages.yaml
@@ -3,7 +3,9 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign"
     # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-resource-managers.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-resource-managers.yaml
@@ -1,6 +1,8 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
@@ -1,6 +1,8 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: n1-standard-2
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv1.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1.yaml
@@ -1,5 +1,7 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv1.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-imagefs.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-imagefs.yaml
@@ -1,6 +1,8 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: n1-standard-2
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2_imagefs.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
@@ -1,6 +1,8 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: n1-standard-2
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
@@ -1,5 +1,7 @@
 images:
   fedora:
-    image_family: fedora-coreos-stable
+    # TODO: use image_family when the test setup is fixed on fedora-coreos-39
+    image: fedora-coreos-38-20231027-3-2-gcp-x86-64
+    # image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2.ign"


### PR DESCRIPTION
Tests are failing all over the place when using Fedora 39, which is the new version in the image_family. We now pin the tests to 38 until they run with 39.

cc @pacoxu @sairameshv @harche @haircommander @kannon92 