### PR TITLE
[releng] 1.29: Update kubekins-e2e variants.yaml with 1.29 config

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -31,6 +31,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.29':
+    CONFIG: '1.29'
+    GO_VERSION: 1.21.4
+    K8S_RELEASE: latest-1.29
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.28':
     CONFIG: '1.28'
     GO_VERSION: 1.20.11


### PR DESCRIPTION
Update kubekins-e2e variant with 1.29 config, following [this 1.28 example](https://github.com/kubernetes/test-infra/pull/30215).

/sig release
/area release-eng

cc @kubernetes/release-engineering