### PR TITLE
Enable dind for aws-iam-authenticator integration

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-iam-authenticator/aws-iam-authenticator-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
+      preset-dind-enabled: "true"
       preset-aws-credential-aws-shared-testing: "true"
     spec:
       containers:


### PR DESCRIPTION
Integration tests now require docker in docker due to use of `./hack/update-codegen.sh`.