### PR TITLE
ci-kubernetes-e2e-kind-rootless: Fix `/root/.ssh/google_compute_engine.pub: no such file or directory`

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -625,6 +625,7 @@ periodics:
           --instance-image=ubuntu-os-cloud/ubuntu-2204-lts \
           --instance-type=n2-standard-4 \
           --kind-rootless \
+          --user=rootless \
           --build \
           --up \
           --down \

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -615,6 +615,9 @@ periodics:
         set -eux
         # kindinv: Kubernetes in (Rootless) Docker in (GCE) VM
         # See https://github.com/rootless-containers/kubetest2-kindinv
+        #
+        # GCE VM is used for setting up cgroup v2 and systemd.
+        # (k8s-infra-prow-build lacks cgroup v2, and the kubekins-e2e container lacks systemd)
         (cd ; GO111MODULE=on go install github.com/rootless-containers/kubetest2-kindinv@master)
         mkdir -p -m 0700 ~/.ssh
         cp -f "${GCE_SSH_PRIVATE_KEY_FILE}" ~/.ssh/google_compute_engine

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -616,6 +616,9 @@ periodics:
         # kindinv: Kubernetes in (Rootless) Docker in (GCE) VM
         # See https://github.com/rootless-containers/kubetest2-kindinv
         (cd ; GO111MODULE=on go install github.com/rootless-containers/kubetest2-kindinv@master)
+        mkdir -p -m 0700 ~/.ssh
+        cp -f "${GCE_SSH_PRIVATE_KEY_FILE}" ~/.ssh/google_compute_engine
+        cp -f "${GCE_SSH_PUBLIC_KEY_FILE}" ~/.ssh/google_compute_engine.pub
         exec kubetest2 kindinv \
           --gcp-project=k8s-prow-builds \
           --gcp-zone=us-west1-b \

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -634,7 +634,6 @@ periodics:
           --down \
           --test=ginkgo \
           -- \
-          --use-built-binaries \
           --focus-regex='\[NodeConformance\]' \
           --skip-regex='\[Environment:NotInUserNS\]|\[Slow\]' \
           --parallel=8


### PR DESCRIPTION
### Commit 1: `ci-kubernetes-e2e-kind-rootless: Fix "/root/.ssh/google_compute_engine.pub: no such file or directory"`
Should fix #31296

### Commit 2: `ci-kubernetes-e2e-kind-rootless: specify remote user name`

For testing rootless, the remote user name mustn't be "root"

### Commit 3: `ci-kubernetes-e2e-kind-rootless: add a comment to explain the background`

`ci-kubernetes-e2e-kind-rootless` launches a GCE VM because `k8s-infra-prow-build` lacks cgroup v2, and the `kubekins-e2e` container lacks systemd.

### Commit 4: `ci-kubernetes-e2e-kind-rootless: use prebuilt ginkgo binaries`