### PR TITLE
inrepoconfig: advance the base branch HEAD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,6 +177,7 @@ require (
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,7 @@ github.com/djherbis/atime v1.0.0 h1:ySLvBAM0EvOGaX7TI4dAM5lWj+RdJUCKtGSEHN8SGBg=
 github.com/djherbis/atime v1.0.0/go.mod h1:5W+KBIuTwVGcqjIfaTwt+KSYX1o6uep8dtevevQP/f8=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
@@ -439,6 +440,7 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=
 github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -552,6 +554,8 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1/go.mod h1:DK1Cjkc0E49ShgRVs5jy5A
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mmcloughlin/avo v0.5.0/go.mod h1:ChHFdoV7ql95Wi7vuq2YT1bwCJqiWdZrQ1im3VujLYM=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/prow/cmd/deck/pr_history.go
+++ b/prow/cmd/deck/pr_history.go
@@ -217,7 +217,7 @@ func getStorageDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitCli
 		return nil, nil
 	}
 	prRefGetter := config.NewRefGetterForGitHubPullRequest(gitHubClient, org, repo, prNumber)
-	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, prRefGetter.BaseSHA, prRefGetter.HeadSHA)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, "", prRefGetter.BaseSHA, prRefGetter.HeadSHA)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Presubmits for pull request %s/%s#%d: %w", org, repo, prNumber, err)
 	}

--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -303,8 +303,8 @@ func keyToOrgRepo(key interface{}) (string, string, error) {
 // GetPresubmits uses a cache lookup to get the *ProwYAML value (cache hit),
 // instead of computing it from scratch (cache miss). It also stores the
 // *ProwYAML into the cache if there is a cache miss.
-func (cache *InRepoConfigCache) GetPresubmits(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
-	prowYAML, err := cache.GetProwYAML(identifier, baseSHAGetter, headSHAGetters...)
+func (cache *InRepoConfigCache) GetPresubmits(identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
+	prowYAML, err := cache.GetProwYAML(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -317,8 +317,8 @@ func (cache *InRepoConfigCache) GetPresubmits(identifier string, baseSHAGetter R
 // lookup to get the *ProwYAML value (cache hit), instead of computing it from
 // scratch (cache miss). It also stores the *ProwYAML into the cache if there is
 // a cache miss.
-func (cache *InRepoConfigCache) GetPostsubmits(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error) {
-	prowYAML, err := cache.GetProwYAML(identifier, baseSHAGetter, headSHAGetters...)
+func (cache *InRepoConfigCache) GetPostsubmits(identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error) {
+	prowYAML, err := cache.GetProwYAML(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -328,8 +328,8 @@ func (cache *InRepoConfigCache) GetPostsubmits(identifier string, baseSHAGetter 
 }
 
 // GetProwYAML returns the ProwYAML value stored in the InRepoConfigCache.
-func (cache *InRepoConfigCache) GetProwYAML(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
-	prowYAML, err := cache.GetProwYAMLWithoutDefaults(identifier, baseSHAGetter, headSHAGetters...)
+func (cache *InRepoConfigCache) GetProwYAML(identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+	prowYAML, err := cache.GetProwYAMLWithoutDefaults(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (cache *InRepoConfigCache) GetProwYAML(identifier string, baseSHAGetter Ref
 	return newProwYAML, nil
 }
 
-func (cache *InRepoConfigCache) GetProwYAMLWithoutDefaults(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+func (cache *InRepoConfigCache) GetProwYAMLWithoutDefaults(identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 	timeGetProwYAML := time.Now()
 	defer func() {
 		orgRepo := NewOrgRepo(identifier)
@@ -359,7 +359,7 @@ func (cache *InRepoConfigCache) GetProwYAMLWithoutDefaults(identifier string, ba
 
 	c := cache.configAgent.Config()
 
-	prowYAML, err := cache.getProwYAML(c.getProwYAML, identifier, baseSHAGetter, headSHAGetters...)
+	prowYAML, err := cache.getProwYAML(c.getProwYAML, identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -368,9 +368,18 @@ func (cache *InRepoConfigCache) GetProwYAMLWithoutDefaults(identifier string, ba
 }
 
 // GetInRepoConfig just wraps around GetProwYAML().
-func (cache *InRepoConfigCache) GetInRepoConfig(identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
-	return cache.GetProwYAML(identifier, baseSHAGetter, headSHAGetters...)
+func (cache *InRepoConfigCache) GetInRepoConfig(identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+	return cache.GetProwYAML(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 }
+
+// valConstructorHelper is called to construct ProwYAML values inside the cache.
+type valConstructorHelper func(
+	gitClient git.ClientFactory,
+	identifier string,
+	baseBranch string,
+	baseSHAGetter RefGetter,
+	headSHAGetters ...RefGetter,
+) (*ProwYAML, error)
 
 // getProwYAML performs a lookup of previously-calculated *ProwYAML objects. The
 // 'valConstructorHelper' is used in two ways. First it is used by the caching
@@ -380,8 +389,9 @@ func (cache *InRepoConfigCache) GetInRepoConfig(identifier string, baseSHAGetter
 // because unit tests can just provide its own function for constructing a
 // *ProwYAML object (instead of needing to create an actual Git repo, etc.).
 func (cache *InRepoConfigCache) getProwYAML(
-	valConstructorHelper func(git.ClientFactory, string, RefGetter, ...RefGetter) (*ProwYAML, error),
+	valConstructorHelper valConstructorHelper,
 	identifier string,
+	baseBranch string,
 	baseSHAGetter RefGetter,
 	headSHAGetters ...RefGetter) (*ProwYAML, error) {
 
@@ -407,7 +417,7 @@ func (cache *InRepoConfigCache) getProwYAML(
 	}
 
 	valConstructor := func() (interface{}, error) {
-		return valConstructorHelper(cache.gitClient, identifier, baseSHAGetter, headSHAGetters...)
+		return valConstructorHelper(cache.gitClient, identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	}
 
 	got, err := cache.get(CacheKeyParts{Identifier: identifier, BaseSHA: baseSHA, HeadSHAs: headSHAs}, valConstructor)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -438,7 +438,7 @@ func GetAndCheckRefs(
 // does a call to GitHub and who also need the result of that GitHub call just
 // keep a pointer to its result, but must nilcheck that pointer before accessing
 // it.
-func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 	if identifier == "" {
 		return nil, errors.New("no identifier for repo given")
 	}
@@ -451,7 +451,7 @@ func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier string
 		return nil, err
 	}
 
-	prowYAML, err := c.ProwYAMLGetterWithDefaults(c, gc, identifier, baseSHA, headSHAs...)
+	prowYAML, err := c.ProwYAMLGetterWithDefaults(c, gc, identifier, baseBranch, baseSHA, headSHAs...)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +460,7 @@ func (c *Config) getProwYAMLWithDefaults(gc git.ClientFactory, identifier string
 }
 
 // getProwYAML is like getProwYAMLWithDefaults, minus the defaulting logic.
-func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
+func (c *Config) getProwYAML(gc git.ClientFactory, identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) (*ProwYAML, error) {
 	if identifier == "" {
 		return nil, errors.New("no identifier for repo given")
 	}
@@ -473,7 +473,7 @@ func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGet
 		return nil, err
 	}
 
-	prowYAML, err := c.ProwYAMLGetter(c, gc, identifier, baseSHA, headSHAs...)
+	prowYAML, err := c.ProwYAMLGetter(c, gc, identifier, baseBranch, baseSHA, headSHAs...)
 	if err != nil {
 		return nil, err
 	}
@@ -487,8 +487,8 @@ func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGet
 // Consumers that pass in a RefGetter implementation that does a call to GitHub and who
 // also need the result of that GitHub call just keep a pointer to its result, but must
 // nilcheck that pointer before accessing it.
-func (c *Config) GetPresubmits(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
-	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, baseSHAGetter, headSHAGetters...)
+func (c *Config) GetPresubmits(gc git.ClientFactory, identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
+	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -517,8 +517,8 @@ func (c *Config) GetPresubmitsStatic(identifier string) []Presubmit {
 // Consumers that pass in a RefGetter implementation that does a call to GitHub and who
 // also need the result of that GitHub call just keep a pointer to its result, but must
 // nilcheck that pointer before accessing it.
-func (c *Config) GetPostsubmits(gc git.ClientFactory, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error) {
-	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, baseSHAGetter, headSHAGetters...)
+func (c *Config) GetPostsubmits(gc git.ClientFactory, identifier, baseBranch string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Postsubmit, error) {
+	prowYAML, err := c.getProwYAMLWithDefaults(gc, identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -7526,7 +7526,7 @@ func TestGetProwYAMLDoesNotCallRefGettersWhenInrepoconfigIsDisabled(t *testing.T
 	}
 
 	c := &Config{}
-	if _, err := c.getProwYAMLWithDefaults(nil, "test", baseSHAGetter, headSHAGetter); err != nil {
+	if _, err := c.getProwYAMLWithDefaults(nil, "test", "main", baseSHAGetter, headSHAGetter); err != nil {
 		t.Fatalf("error calling GetProwYAML: %v", err)
 	}
 	if baseSHAGetterCalled {
@@ -7563,7 +7563,7 @@ func TestGetPresubmitsReturnsStaticAndInrepoconfigPresubmits(t *testing.T) {
 		},
 	}
 
-	presubmits, err := c.GetPresubmits(nil, org+"/"+repo, func() (string, error) { return "", nil })
+	presubmits, err := c.GetPresubmits(nil, org+"/"+repo, "main", func() (string, error) { return "", nil })
 	if err != nil {
 		t.Fatalf("Error calling GetPresubmits: %v", err)
 	}
@@ -7601,7 +7601,7 @@ func TestGetPostsubmitsReturnsStaticAndInrepoconfigPostsubmits(t *testing.T) {
 		},
 	}
 
-	postsubmits, err := c.GetPostsubmits(nil, org+"/"+repo, func() (string, error) { return "", nil })
+	postsubmits, err := c.GetPostsubmits(nil, org+"/"+repo, "main", func() (string, error) { return "", nil })
 	if err != nil {
 		t.Fatalf("Error calling GetPostsubmits: %v", err)
 	}

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -613,14 +613,26 @@ postsubmits: [{"name": "oli", "spec": {"containers": [{}]}}]`),
 
 			var p *ProwYAML
 			if headSHA == baseSHA {
-				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, baseSHA)
+				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, "main", baseSHA)
 			} else {
-				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, baseSHA, headSHA)
+				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, "main", baseSHA, headSHA)
 			}
 
 			if err := tc.validate(p, err); err != nil {
 				t.Fatal(err)
 			}
+
+			// Empty base branch string shouldn't affect how we can fetch the configs.
+			if headSHA == baseSHA {
+				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, "", baseSHA)
+			} else {
+				p, err = prowYAMLGetterWithDefaults(tc.config, testGC, org+"/"+repo, "", baseSHA, headSHA)
+			}
+
+			if err := tc.validate(p, err); err != nil {
+				t.Fatal(err)
+			}
+
 		})
 	}
 }

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -885,7 +885,7 @@ func (c Config) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, bra
 	headSHAGetter := func() (string, error) {
 		return headSHA, nil
 	}
-	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, branch, baseSHAGetter, headSHAGetter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get presubmits: %w", err)
 	}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -2025,7 +2025,7 @@ func TestTideContextPolicy_MissingRequiredContexts(t *testing.T) {
 }
 
 func fakeProwYAMLGetterFactory(presubmits []Presubmit, postsubmits []Postsubmit) ProwYAMLGetter {
-	return func(_ *Config, _ git.ClientFactory, _, _ string, _ ...string) (*ProwYAML, error) {
+	return func(_ *Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*ProwYAML, error) {
 		return &ProwYAML{
 			Presubmits:  presubmits,
 			Postsubmits: postsubmits,

--- a/prow/gangway/gangway.go
+++ b/prow/gangway/gangway.go
@@ -44,8 +44,8 @@ const (
 
 type Gangway struct {
 	UnimplementedProwServer
-	ConfigAgent       *config.Agent
-	ProwJobClient     ProwJobClient
+	ConfigAgent        *config.Agent
+	ProwJobClient      ProwJobClient
 	InRepoConfigGetter config.InRepoConfigGetter
 }
 
@@ -688,7 +688,7 @@ func (prh *presubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, ircg co
 		logger.Debug("Getting prow jobs.")
 		var presubmitsWithInrepoconfig []config.Presubmit
 		var err error
-		prowYAML, err := ircg.GetInRepoConfig(orgRepo, baseSHAGetter, headSHAGetters...)
+		prowYAML, err := ircg.GetInRepoConfig(orgRepo, branch, baseSHAGetter, headSHAGetters...)
 		if err != nil {
 			logger.WithError(err).Info("Failed to get presubmits")
 		} else {
@@ -756,7 +756,7 @@ func (poh *postsubmitJobHandler) getProwJobSpec(mainConfig prowCfgClient, ircg c
 		logger.Debug("Getting prow jobs.")
 		var postsubmitsWithInrepoconfig []config.Postsubmit
 		var err error
-		prowYAML, err := ircg.GetInRepoConfig(orgRepo, baseSHAGetter)
+		prowYAML, err := ircg.GetInRepoConfig(orgRepo, branch, baseSHAGetter)
 		if err != nil {
 			logger.WithError(err).Info("Failed to get postsubmits from inrepoconfig")
 		} else {

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -629,7 +629,7 @@ func (c *Controller) triggerJobs(logger logrus.FieldLogger, instance string, cha
 		// Gerrit server might be unavailable intermittently, retry inrepoconfig
 		// processing for increased reliability.
 		for attempt := 0; attempt < inRepoConfigRetries; attempt++ {
-			postsubmits, err = c.inRepoConfigGetter.GetPostsubmits(cloneURI, baseSHAGetter, headSHAGetter)
+			postsubmits, err = c.inRepoConfigGetter.GetPostsubmits(cloneURI, change.Branch, baseSHAGetter, headSHAGetter)
 			// Break if there was no error, or if there was a merge conflict
 			if err == nil {
 				gerritMetrics.inrepoconfigResults.WithLabelValues(instance, change.Project, client.ResultSuccess).Inc()
@@ -675,7 +675,7 @@ func (c *Controller) triggerJobs(logger logrus.FieldLogger, instance string, cha
 		// Gerrit server might be unavailable intermittently, retry inrepoconfig
 		// processing for increased reliability.
 		for attempt := 0; attempt < inRepoConfigRetries; attempt++ {
-			presubmits, err = c.inRepoConfigGetter.GetPresubmits(cloneURI, baseSHAGetter, headSHAGetter)
+			presubmits, err = c.inRepoConfigGetter.GetPresubmits(cloneURI, change.Branch, baseSHAGetter, headSHAGetter)
 			if err == nil {
 				break
 			}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -114,6 +114,7 @@ func fakeProwYAMLGetter(
 	c *config.Config,
 	gc git.ClientFactory,
 	identifier string,
+	baseBranch string,
 	baseSHA string,
 	headSHAs ...string) (*config.ProwYAML, error) {
 

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -85,6 +85,8 @@ type cacher interface {
 	RemoteUpdate() error
 	// FetchCommits fetches only the given commits.
 	FetchCommits([]string) error
+	// RetargetBranch moves the given branch to an already-existing commit.
+	RetargetBranch(string, string) error
 }
 
 // cloner knows how to clone repositories from a central cache
@@ -454,6 +456,16 @@ func (i *interactor) FetchCommits(commitSHAs []string) error {
 
 	if err := i.Fetch(fetchArgs...); err != nil {
 		return fmt.Errorf("failed to fetch %s: %v", fetchArgs, err)
+	}
+
+	return nil
+}
+
+// RetargetBranch moves the given branch to an already-existing commit.
+func (i *interactor) RetargetBranch(branch, sha string) error {
+	args := []string{"branch", "-f", branch, sha}
+	if out, err := i.executor.Run(args...); err != nil {
+		return fmt.Errorf("error retargeting branch: %w %v", err, string(out))
 	}
 
 	return nil

--- a/prow/moonraker/client.go
+++ b/prow/moonraker/client.go
@@ -171,7 +171,7 @@ func (c *Client) GetProwYAML(refs *prowapi.Refs) (*config.ProwYAML, error) {
 // required because the Presubmit and Postsubmit job types have private fields
 // in them that would not be serialized into JSON when sent over from the
 // server. So the defaulting has to be done client-side.
-func (c *Client) GetInRepoConfig(identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) (*config.ProwYAML, error) {
+func (c *Client) GetInRepoConfig(identifier, baseBranch string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) (*config.ProwYAML, error) {
 	refs := prowapi.Refs{}
 
 	orgRepo := config.NewOrgRepo(identifier)
@@ -183,6 +183,8 @@ func (c *Client) GetInRepoConfig(identifier string, baseSHAGetter config.RefGett
 	if err != nil {
 		return nil, err
 	}
+
+	refs.BaseRef = baseBranch
 
 	pulls := []prowapi.Pull{}
 	for _, headSHAGetter := range headSHAGetters {
@@ -209,8 +211,8 @@ func (c *Client) GetInRepoConfig(identifier string, baseSHAGetter config.RefGett
 	return prowYAML, nil
 }
 
-func (c *Client) GetPresubmits(identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error) {
-	prowYAML, err := c.GetInRepoConfig(identifier, baseSHAGetter, headSHAGetters...)
+func (c *Client) GetPresubmits(identifier, baseBranch string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error) {
+	prowYAML, err := c.GetInRepoConfig(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}
@@ -219,8 +221,8 @@ func (c *Client) GetPresubmits(identifier string, baseSHAGetter config.RefGetter
 	return append(config.GetPresubmitsStatic(identifier), prowYAML.Presubmits...), nil
 }
 
-func (c *Client) GetPostsubmits(identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Postsubmit, error) {
-	prowYAML, err := c.GetInRepoConfig(identifier, baseSHAGetter, headSHAGetters...)
+func (c *Client) GetPostsubmits(identifier, baseBranch string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Postsubmit, error) {
+	prowYAML, err := c.GetInRepoConfig(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/moonraker/moonraker.go
+++ b/prow/moonraker/moonraker.go
@@ -89,7 +89,7 @@ func (mr *Moonraker) ServeGetInrepoconfig(w http.ResponseWriter, r *http.Request
 	}
 	identifier := payload.Refs.Org + "/" + payload.Refs.Repo
 
-	prowYAML, err := mr.InRepoConfigCache.GetProwYAMLWithoutDefaults(identifier, baseSHAGetter, headSHAGetters...)
+	prowYAML, err := mr.InRepoConfigCache.GetProwYAMLWithoutDefaults(identifier, payload.Refs.BaseRef, baseSHAGetter, headSHAGetters...)
 	if err != nil {
 		logrus.WithError(err).Error("unable to retrieve inrepoconfig ProwYAML")
 		http.Error(w, fmt.Sprintf("unable to retrieve inrepoconfig ProwYAML: %v", err), http.StatusBadRequest)

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -137,7 +137,7 @@ func (c client) presubmits(org, repo string, baseSHAGetter config.RefGetter, hea
 	headSHAGetter := func() (string, error) {
 		return headSHA, nil
 	}
-	presubmits, err := c.config.GetPresubmits(c.gc, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	presubmits, err := c.config.GetPresubmits(c.gc, org+"/"+repo, "", baseSHAGetter, headSHAGetter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get presubmits: %w", err)
 	}

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -98,7 +98,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 	headSHAGetter := func() (string, error) {
 		return pr.Head.SHA, nil
 	}
-	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, pr.Base.Ref, baseSHAGetter, headSHAGetter)
 	if err != nil {
 		return fmt.Errorf("failed to get presubmits: %w", err)
 	}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -340,7 +340,7 @@ func runRequested(c Client, pr *github.PullRequest, baseSHA string, requestedJob
 }
 
 func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, orgRepo string, baseSHAGetter, headSHAGetter config.RefGetter) []config.Presubmit {
-	presubmits, err := cfg.GetPresubmits(gc, orgRepo, baseSHAGetter, headSHAGetter)
+	presubmits, err := cfg.GetPresubmits(gc, orgRepo, "", baseSHAGetter, headSHAGetter)
 	if err != nil {
 		// Fall back to static presubmits to avoid deadlocking when a presubmit is used to verify
 		// inrepoconfig. Tide will still respect errors here and not merge.
@@ -351,7 +351,7 @@ func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, 
 }
 
 func getPostsubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, orgRepo string, baseSHAGetter config.RefGetter) []config.Postsubmit {
-	postsubmits, err := cfg.GetPostsubmits(gc, orgRepo, baseSHAGetter)
+	postsubmits, err := cfg.GetPostsubmits(gc, orgRepo, "", baseSHAGetter)
 	if err != nil {
 		// Fall back to static postsubmits, loading inrepoconfig returned an error.
 		log.WithError(err).Error("Failed to get postsubmits")

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -472,7 +472,7 @@ func TestGetPresubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-presubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Presubmits: []config.Presubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-presubmit"},
@@ -496,7 +496,7 @@ func TestGetPresubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-presubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Presubmits: []config.Presubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-presubmit"},
@@ -550,7 +550,7 @@ func TestGetPostsubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-postsubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Postsubmits: []config.Postsubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-postsubmit"},
@@ -574,7 +574,7 @@ func TestGetPostsubmits(t *testing.T) {
 							JobBase: config.JobBase{Name: "my-static-postsubmit"},
 						}},
 					},
-					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _ string, _ ...string) (*config.ProwYAML, error) {
+					ProwYAMLGetterWithDefaults: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, _ ...string) (*config.ProwYAML, error) {
 						return &config.ProwYAML{
 							Postsubmits: []config.Postsubmit{{
 								JobBase: config.JobBase{Name: "my-inrepoconfig-postsubmit"},

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -855,6 +855,7 @@ func fakeProwYAMLGetter(
 	c *config.Config,
 	gc git.ClientFactory,
 	identifier string,
+	baseBranch string,
 	baseSHA string,
 	headSHAs ...string) (*config.ProwYAML, error) {
 

--- a/prow/test/integration/config/prow/cluster/moonraker_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/moonraker_deployment.yaml
@@ -29,6 +29,8 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        # Use a static, predictable folder for storing primary clones.
+        - --cache-dir-base=/etc/moonraker-inrepoconfig-pv
         # This cookie file is only here to trigger the creation of a
         # Gerrit-flavored Git client factory. So this makes this moonraker deployment
         # "tied" to Gerrit.

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -69,6 +69,7 @@ in_repo_config:
    "fakegitserver.default/repo/org1/repo7": true
    "fakegitserver.default/repo/some/org/gangway-test-repo-1": true
    "fakegitserver.default/repo/moonraker-burst": true
+   "fakegitserver.default/repo/moonraker-update-base-branch": true
 
 # Allowlist of Prow API clients.
 gangway:

--- a/prow/test/integration/test/moonraker_test.go
+++ b/prow/test/integration/test/moonraker_test.go
@@ -133,7 +133,7 @@ git reset --hard ${baseSHA}
 	}
 
 	// Clone the repo out of FGS to our local disk to determine the base SHA of
-	// master branch for repo-moonraker-stres-test, as well as the 100 different
+	// master branch for moonraker-burst, as well as the 100 different
 	// PR head SHAs. We want to figure out the base SHA (master branch HEAD SHA)
 	// and head SHAs (SHAs of each of the 100 changes we created during
 	// repoSetup above) programmatically, so that we don't have to do it

--- a/prow/test/integration/test/moonraker_test.go
+++ b/prow/test/integration/test/moonraker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -27,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
@@ -288,5 +290,312 @@ cat README.txt
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestMoonrakerUpdateBaseBranch checks that the base branch gets updated in the
+// primary clone location. We create a repo on FGS with a regular base branch
+// and PR HEAD that branches off of master. Then we do a ProwYAML lookup of the PR
+// HEAD. After this request, we add a second commit on the master branch in FGS.
+// Then we do a ProwYAML lookup of the same PR HEAD, but with an updated master
+// branch SHA. Finally, we check that Moonraker has advanced the ref to the master
+// branch.
+func TestMoonrakerUpdateBaseBranch(t *testing.T) {
+	const createRepoWithPR = `
+echo hello > README.txt
+git add README.txt
+git commit -m "commit 1"
+git checkout master
+
+mkdir .prow
+cat <<EOF >.prow/presubmits.yaml
+presubmits:
+  - name: my-presubmit
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - image: localhost:5001/alpine
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -eu
+          echo "hello from my-presubmit"
+          cat README.txt
+EOF
+
+git add .prow/presubmits.yaml
+git commit -m "add inrepoconfig for my-presubmit"
+baseSHA=$(git rev-parse HEAD)
+
+# Create another commit which the master branch can advance to. Note that this
+# is a dangling commit because master branch does not point to it (yet). We
+# can't make master branch point to it immediately because then this commit will
+# get fetched alongside "commit 1" in the initial mirror clone in moonraker.
+git checkout -d ${baseSHA}
+echo world >> README.txt
+git add README.txt
+git commit -m "commit-2"
+# Save the SHA to a stable file path so that we can read this out later in the test.
+git rev-parse HEAD > .git/commit-2-SHA
+
+# Create fake PRs. These are "Gerrit" style refs under refs/changes/*.
+num=1
+git checkout -d ${baseSHA}
+# Modify the presubmit name to match the unique num.
+sed -i "s,my-presubmit,my-presubmit (ref refs/changes/00/123/${num})," .prow/presubmits.yaml
+
+git add .prow/presubmits.yaml
+
+git commit -m "PR${num}"
+git update-ref "refs/changes/00/123/${num}" HEAD
+
+git checkout master
+git reset --hard ${baseSHA}
+`
+
+	repoSetup := fakegitserver.RepoSetup{
+		Name:      "moonraker-update-base-branch",
+		Script:    createRepoWithPR,
+		Overwrite: true,
+	}
+
+	// Set up repos on FGS for just this test case.
+	fgsClient := fakegitserver.NewClient("http://localhost/fakegitserver", 5*time.Second)
+	err := fgsClient.SetupRepo(repoSetup)
+	if err != nil {
+		t.Fatalf("FGS repo setup failed: %v", err)
+	}
+
+	// Clone the repo out of FGS to our local disk to determine the base SHA of
+	// master branch for moonraker-update-base-branch, as well as the
+	// PR head SHA. We want to figure out the base SHA (master branch HEAD SHA)
+	// and head SHAs programmatically, so that we don't have to do it
+	// manually as part of writing this test (or making changes to it in the
+	// future).
+	cacheDirBase := "/var/tmp"
+
+	trueVal := true
+	var gitClientFactoryOpt = func(o *git.ClientFactoryOpts) {
+		o.UseInsecureHTTP = &trueVal
+		o.Host = "localhost"
+		o.CacheDirBase = &cacheDirBase
+	}
+
+	gc, err := git.NewClientFactory(gitClientFactoryOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// repoClient points to our local copy of this repo. We will use it to
+	// figure out the base SHA and head SHAs. Because we are not sharing objects
+	// (ShareObjectsWithSourceRepo is false in git.RepoOpts), the repoClient will be
+	// a full mirror clone.
+	repoClient, err := gc.ClientForWithRepoOpts("fakegitserver/repo", repoSetup.Name, git.RepoOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repoClient.Clean()
+
+	baseSHA, err := repoClient.RevParse("HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseSHA = strings.TrimSpace(baseSHA)
+
+	// Determine the SHA for the PR head.
+	// We'll then spawn 100 goroutines and make each one fetch one of these 100
+	// SHAs. We have to fetch the refs from FGS, because the repoClient we are
+	// using is for the secondary clone on disk and does not have a mirror clone
+	// (it only has refs from the primary mirror).
+	remoteResolver := func() (string, error) {
+		return "http://localhost/fakegitserver/repo/moonraker-update-base-branch", nil
+	}
+	repoClient.FetchFromRemote(remoteResolver, "refs/changes/*:refs/changes/*")
+	refs := []string{"refs/changes/00/123/1"}
+	refsToShas, err := repoClient.RevParseN(refs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up client to talk to Moonraker inside the KIND cluster. The moonraker
+	// address here uses localhost, because we're initiating the request from
+	// outside the KIND cluster (this file you are reading is executed outside
+	// the cluster).
+	fca := &fakeConfigAgent{
+		c: &config.Config{
+			ProwConfig: config.ProwConfig{
+				Moonraker: config.Moonraker{
+					ClientTimeout: &metav1.Duration{Duration: 5 * time.Second},
+				},
+			},
+		},
+	}
+	moonrakerClient, err := moonraker.NewClient("http://localhost/moonraker", fca)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := func(ref string) config.Presubmit {
+		return config.Presubmit{
+			JobBase: config.JobBase{
+				Name: fmt.Sprintf("my-presubmit (ref %s)", ref),
+				UtilityConfig: config.UtilityConfig{
+					Decorate: &trueVal,
+				},
+				Spec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image:   "localhost:5001/alpine",
+							Command: []string{"sh"},
+							Args: []string{
+								"-c",
+								fmt.Sprintf(`set -eu
+echo "hello from my-presubmit (ref %s)"
+cat README.txt
+`, ref),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Collect errors from the workers. This is because otherwise we get a
+	// "call to (*T).Fatal from a non-test goroutine" error.
+	errs := make(chan error, 1)
+
+	var sendGetProwYAMLRequest = func(t *testing.T, baseRef, baseSHA, prRef, headSHA string) {
+		refs := &prowjobv1.Refs{
+			// org is the URL of the "org" for the repo, as seen from inside the
+			// KIND cluster (because moonraker is running inside the KIND
+			// cluster). This is why we use the "fakegitserver.default" domain.
+			Org:   "https://fakegitserver.default/repo",
+			Repo:  "moonraker-update-base-branch",
+			Pulls: []prowjobv1.Pull{{SHA: headSHA}},
+		}
+		if baseSHA != "" {
+			refs.BaseSHA = baseSHA
+		}
+		if baseRef != "" {
+			refs.BaseRef = baseRef
+		}
+		got, err := moonrakerClient.GetProwYAML(refs)
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		gotPresubmit := got.Presubmits[0]
+		// Clear out parts of the response that we don't care about.
+		gotPresubmit.Trigger = ""
+		gotPresubmit.RerunCommand = ""
+		gotPresubmit.Reporter = config.Reporter{}
+		gotPresubmit.Brancher = config.Brancher{}
+		gotPresubmit.JobBase.Agent = ""
+		gotPresubmit.JobBase.Cluster = ""
+		gotPresubmit.JobBase.Namespace = nil
+		gotPresubmit.JobBase.ProwJobDefault = nil
+		gotPresubmit.UtilityConfig.DecorationConfig = nil
+
+		// Check that the gotPresubmit is what we expect (what we created in the
+		// createRepoWithPR bit at the beginning of this test function above).
+		if diff := cmp.Diff(gotPresubmit, want(prRef), cmpopts.IgnoreUnexported(
+			config.Presubmit{},
+			config.Brancher{},
+			config.RegexpChangeMatcher{})); diff != "" {
+			errs <- fmt.Errorf("unexpected moonraker response: %s", diff)
+		} else {
+			errs <- nil
+		}
+	}
+
+	// Now make moonraker do lookups of the ProwYAML in the PR we created.
+	// It is at this point that moonraker will learn of the
+	// moonraker-burst repo we've created in FGS.
+	for prRef, headSHA := range refsToShas {
+		go sendGetProwYAMLRequest(t, "", baseSHA, prRef, headSHA)
+	}
+
+	// Check that all requests finished successfully.
+	for range refsToShas {
+		err := <-errs
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Get commit-2-SHA from FGS. Basically runs "kubectl exec" against the FGS
+	// pod, but in Golang.
+	clusterContext := getClusterContext()
+	t.Logf("Creating client for cluster: %s", clusterContext)
+
+	restConfig, err := NewRestConfig("", clusterContext)
+	if err != nil {
+		t.Fatalf("could not create restConfig: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatalf("could not create Clientset: %v", err)
+	}
+
+	fgsPods, err := clientset.CoreV1().Pods("default").List(context.TODO(),
+		metav1.ListOptions{LabelSelector: "app=fakegitserver"})
+	if err != nil {
+		t.Fatalf("could not list FGS pod: %v", err)
+	}
+	fgsPod := fgsPods.Items[0]
+	commit2SHA, _, _ := execRemoteCommand(restConfig, clientset, &fgsPod, []string{"cat", "/git-repo/moonraker-update-base-branch.git/commit-2-SHA"})
+	commit2SHA = strings.TrimSpace(commit2SHA)
+
+	// Confirm that moonraker's primary clone of moonraker-update-base-branch
+	// has a "master" branch that does *NOT* yet point to commit2SHA.
+	moonrakerPods, err := clientset.CoreV1().Pods("default").List(context.TODO(),
+		metav1.ListOptions{LabelSelector: "app=moonraker"})
+	if err != nil {
+		t.Fatalf("could not list Moonraker pod: %v", err)
+	}
+	moonrakerPod := moonrakerPods.Items[0]
+	moonrakerMasterBranchSHA, _, _ := execRemoteCommand(restConfig, clientset, &moonrakerPod,
+		[]string{"git",
+			"-C",
+			"/etc/moonraker-inrepoconfig-pv/https:/fakegitserver.default/repo/moonraker-update-base-branch",
+			"rev-parse",
+			"master",
+		})
+	moonrakerMasterBranchSHA = strings.TrimSpace(moonrakerMasterBranchSHA)
+	if moonrakerMasterBranchSHA == commit2SHA {
+		t.Fatal("programmer error: moonraker master branch is already pointing to commit-2's SHA")
+	}
+
+	// Execute another sendGetProwYAMLRequest(), but this time populate the base
+	// branch name "master" instead of the empty string as before.
+	for prRef, headSHA := range refsToShas {
+		go sendGetProwYAMLRequest(t, "master", commit2SHA, prRef, headSHA)
+	}
+	for range refsToShas {
+		err := <-errs
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Check that moonraker's primary clone's "master" ref is now pointing to
+	// commit2SHA.
+	moonrakerMasterBranchSHA, _, _ = execRemoteCommand(restConfig, clientset, &moonrakerPod,
+		[]string{"git",
+			"-C",
+			"/etc/moonraker-inrepoconfig-pv/https:/fakegitserver.default/repo/moonraker-update-base-branch",
+			"rev-parse",
+			"master",
+		})
+	moonrakerMasterBranchSHA = strings.TrimSpace(moonrakerMasterBranchSHA)
+
+	if diff := cmp.Diff(moonrakerMasterBranchSHA, commit2SHA); diff != "" {
+		t.Fatalf("master branch on moonraker is not pointing to the commit2SHA %s: %s", commit2SHA, diff)
 	}
 }

--- a/prow/tide/codereview.go
+++ b/prow/tide/codereview.go
@@ -244,7 +244,7 @@ type provider interface {
 	// Consumers that pass in a RefGetter implementation that does a call to GitHub and who
 	// also need the result of that GitHub call just keep a pointer to its result, but must
 	// nilcheck that pointer before accessing it.
-	GetPresubmits(identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error)
+	GetPresubmits(identifier, baseBranch string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error)
 	GetChangedFiles(org, repo string, number int) ([]string, error)
 
 	refsForJob(sp subpool, prs []CodeReviewCommon) (prowapi.Refs, error)

--- a/prow/tide/gerrit.go
+++ b/prow/tide/gerrit.go
@@ -391,13 +391,13 @@ func (p *GerritProvider) prMergeMethod(crc *CodeReviewCommon) *types.PullRequest
 //
 // (TODO:chaodaiG): deduplicate this with GitHub, which means inrepoconfig
 // processing all use cache client.
-func (p *GerritProvider) GetPresubmits(identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error) {
+func (p *GerritProvider) GetPresubmits(identifier, baseBranch string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error) {
 	// Get presubmits from Config alone.
 	presubmits := p.cfg().GetPresubmitsStatic(identifier)
 	// If InRepoConfigCache is provided, then it means that we also want to fetch
 	// from an inrepoconfig.
 	if p.inRepoConfigGetter != nil {
-		prowYAML, err := p.inRepoConfigGetter.GetInRepoConfig(identifier, baseSHAGetter, headSHAGetters...)
+		prowYAML, err := p.inRepoConfigGetter.GetInRepoConfig(identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 		if err != nil {
 			return nil, fmt.Errorf("faled to get presubmits from inrepoconfig: %v", err)
 		}

--- a/prow/tide/github.go
+++ b/prow/tide/github.go
@@ -375,8 +375,8 @@ func (gi *GitHubProvider) headContexts(pr *CodeReviewCommon) ([]Context, error) 
 	return contexts, nil
 }
 
-func (gi *GitHubProvider) GetPresubmits(identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error) {
-	return gi.cfg().GetPresubmits(gi.gc, identifier, baseSHAGetter, headSHAGetters...)
+func (gi *GitHubProvider) GetPresubmits(identifier, baseBranch string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error) {
+	return gi.cfg().GetPresubmits(gi.gc, identifier, baseBranch, baseSHAGetter, headSHAGetters...)
 }
 
 func (gi *GitHubProvider) GetChangedFiles(org, repo string, number int) ([]string, error) {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1552,7 +1552,7 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 
 	for _, pr := range sp.prs {
 		log := c.logger.WithField("base-sha", sp.sha).WithFields(pr.logFields())
-		presubmitsForPull, err := c.provider.GetPresubmits(sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(pr.HeadRefOID))
+		presubmitsForPull, err := c.provider.GetPresubmits(sp.org+"/"+sp.repo, pr.BaseRefName, refGetterFactory(sp.sha), refGetterFactory(pr.HeadRefOID))
 		if err != nil {
 			log.WithError(err).Debug("Failed to get presubmits for PR, excluding from subpool")
 			continue
@@ -1605,7 +1605,7 @@ func (c *syncController) presubmitsForBatch(prs []CodeReviewCommon, org, repo, b
 		headRefGetters = append(headRefGetters, refGetterFactory(pr.HeadRefOID))
 	}
 
-	presubmits, err := c.provider.GetPresubmits(org+"/"+repo, refGetterFactory(baseSHA), headRefGetters...)
+	presubmits, err := c.provider.GetPresubmits(org+"/"+repo, baseBranch, refGetterFactory(baseSHA), headRefGetters...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get presubmits for batch: %w", err)
 	}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3168,7 +3168,7 @@ func TestPresubmitsByPull(t *testing.T) {
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "always"},
 			}},
-			prowYAMLGetter: func(_ *config.Config, _ git.ClientFactory, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
+			prowYAMLGetter: func(_ *config.Config, _ git.ClientFactory, _, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
 				if len(headRefs) == 1 && headRefs[0] == "1" {
 					return nil, errors.New("you shall not get jobs")
 				}
@@ -4003,7 +4003,7 @@ func (c *indexingClient) List(ctx context.Context, list ctrlruntimeclient.Object
 }
 
 func prowYAMLGetterForHeadRefs(headRefsToLookFor []string, ps []config.Presubmit) config.ProwYAMLGetter {
-	return func(_ *config.Config, _ git.ClientFactory, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
+	return func(_ *config.Config, _ git.ClientFactory, _, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
 		if len(headRefsToLookFor) != len(headRefs) {
 			return nil, fmt.Errorf("expcted %d headrefs, got %d", len(headRefsToLookFor), len(headRefs))
 		}


### PR DESCRIPTION
Inrepoconfig only deals with SHAs (the base branch's SHA and the PR HEAD SHAs), but this means that over time the base branch tip gets outdated because we only fetch by SHA (and never deal with branch names at all).

Update the base branch to point to the base branch SHA each time we serve an inrepoconfig request. This way, when git-gc happens in Moonraker, those SHAs that are reachable by the base branch won't be garbage-collected. The same holds for other components that fetch inrepoconfigs, not just Moonraker.

Implementation-wise, Moonraker passes in "payload.Refs.BaseRef" as the base branch name so that the base branch gets updated. Other components pass in the base branch name also, if it is readily available. Some things did not have the base branch name available, in which case an empty string is passed in (in which case the setting has no effect), and these are:

- prow/cmd/deck/pr_history.go
- prow/plugins/override/override.go
- prow/plugins/trigger/trigger.go
- prow/tide/gerrit.go
- prow/tide/github.go

Passing in an empty branch name to GetPresubmits or GetPostsubmits or GetInRepoConfig results in a NOP because we only attempt to make the branch retarget (point) to the branch's HEAD SHA if the branch name is not empty (see prowYAMLGetter).

/hold

/cc @cjwagner @airbornepony @timwangmusic 