### PR TITLE
integration test: mount git-gc configuration example

### DIFF
--- a/prow/test/integration/config/prow/cluster/git-config-system.yaml
+++ b/prow/test/integration/config/prow/cluster/git-config-system.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-config-system
+data:
+  config: |
+    [gc]
+        pruneexpire = 1.day.ago

--- a/prow/test/integration/config/prow/cluster/moonraker_deployment.yaml
+++ b/prow/test/integration/config/prow/cluster/moonraker_deployment.yaml
@@ -54,6 +54,9 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: git-config-system
+          mountPath: /etc/git-config-system
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -72,6 +75,8 @@ spec:
         # This allows us to use "https://..." addresses to fakegitserver.
         - name: GIT_SSL_NO_VERIFY
           value: "1"
+        - name: GIT_CONFIG_SYSTEM
+          value: /etc/git-config-system/config
       volumes:
       - name: cookies
         secret:
@@ -83,3 +88,6 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: git-config-system
+        configMap:
+          name: git-config-system

--- a/prow/test/integration/lib.sh
+++ b/prow/test/integration/lib.sh
@@ -116,6 +116,9 @@ declare -ra PROW_DEPLOYMENT_ORDER=(
   50_crd.yaml
   WAIT_FOR_CRD_prowjobs.prow.k8s.io,default
 
+  git-config-system.yaml
+  WAIT_FOR_RESOURCE_configmaps,git-config-system,default
+
   100_starter.yaml
   WAIT_FOR_RESOURCE_namespaces,test-pods,default
   WAIT_FOR_RESOURCE_secrets,oauth-token,default


### PR DESCRIPTION
Git runs `git-gc` automatically (see the manpage for it). By default only unreachable objects older than 2 weeks are pruned. Use a default of 1 day.

This was tested by exec-ing into the moonraker integration test container and running

    git config --get gc.pruneexpire

which gave a result of

    1.day.ago

Now that https://github.com/kubernetes/test-infra/pull/31301 is merged, I think we can get this merged. Technically this has no effect, but it serves as a good demonstration/example of how to tweak Git settings for Moonraker. Production Prow installations can now use this example to get Moonraker to do garbage collection without worrying about deleting the latest objects for the base branch.

/cc @cjwagner @airbornepony @timwangmusic 