### PR TITLE
Update Kubespray CI image and owner file

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -9,6 +9,7 @@ reviewers:
 - riverzhang
 - woopstar
 - miouge1
+- yankay
 approvers:
 - ant31
 - mattymo
@@ -18,3 +19,4 @@ approvers:
 - riverzhang
 - woopstar
 - miouge1
+- yankay

--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: quay.io/kubespray/kubespray:v2.13.0
+      - image: quay.io/kubespray/kubespray:v2.23.1
         args:
         - yamllint
         - "--strict"


### PR DESCRIPTION
Kubespray [v2.23.1](https://github.com/kubernetes-sigs/kubespray/releases/tag/v2.23.1) was released , so let's switch to that image for CI.

Also adding myself as approver since now I'm member of the kubernetes org (https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml#L423)