### PR TITLE
Fix spelling in CRI-O config README

### DIFF
--- a/jobs/e2e_node/crio/README.md
+++ b/jobs/e2e_node/crio/README.md
@@ -4,7 +4,7 @@
 [@kubernetes/sig-node-cri-o-test-maintainers](https://github.com/orgs/kubernetes/teams/sig-node-cri-o-test-maintainers)
 on the related issue or pull request.**
 
-All jobs maintained within this directoy are part of the `sig-node-cri-o`
+All jobs maintained within this directory are part of the `sig-node-cri-o`
 testgrid dashboard: https://testgrid.k8s.io/sig-node-cri-o
 
 ---


### PR DESCRIPTION
CI complains about this all over the place, so we now fix that.

cc @kubernetes/sig-node-cri-o-test-maintainers 