### PR TITLE
fix: Update ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures config to work with external cloud provider flag

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -25,7 +25,10 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+      # TODO: Fix generate_tests.py to set DisableCloudProviders,DisableKubeletCloudCredentialProviders to true when --cloud-proider=external
+      # And also add --env=ENABLE_AUTH_PROVIDER_GCP=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true
+      - --env=ENABLE_AUTH_PROVIDER_GCP=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/122012

This fix is just to get the job back to green. The actual generator script needs to be updated to fix the root cause.