### PR TITLE
azure: update CAPZ custom template jobs to use new templates for CAPZ v1.12

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -926,7 +926,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -968,7 +968,8 @@ presubmits:
             - name: CLUSTER_PROVISIONING_TOOL # azuredisk-csi-driver config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+              # TODO revert when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
             - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
               value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
             - name: ENABLE_VMSS_FLEX # azuredisk-csi-driver config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -99,7 +99,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -128,7 +128,8 @@ presubmits:
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz
@@ -151,7 +152,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -180,7 +181,8 @@ presubmits:
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz
@@ -204,7 +206,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -233,7 +235,8 @@ presubmits:
             - name: ORCHESTRATION_MODE # CAPZ config
               value: "Flexible"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -383,7 +386,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -413,7 +416,8 @@ presubmits:
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz
@@ -436,7 +440,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -466,7 +470,8 @@ presubmits:
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz
@@ -490,7 +495,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -515,7 +520,8 @@ presubmits:
             - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: ENABLE_MULTI_SLB # cloud-provider-azure config
@@ -556,7 +562,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.11
+        base_ref: release-1.12
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:
@@ -581,7 +587,8 @@ presubmits:
             - name: KUBERNETES_VERSION # CAPZ config
               value: "latest"
             - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+              # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+              value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
@@ -648,7 +655,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.11
+      base_ref: release-1.12
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -682,7 +689,8 @@ periodics:
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+          # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+          value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz
@@ -703,7 +711,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.11
+      base_ref: release-1.12
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -737,7 +745,8 @@ periodics:
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+          # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+          value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz
@@ -758,7 +767,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.11
+      base_ref: release-1.12
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -792,7 +801,8 @@ periodics:
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+          # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+          value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-dualstack-capz
@@ -813,7 +823,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.11
+      base_ref: release-1.12
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -847,7 +857,8 @@ periodics:
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+          # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+          value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -47,7 +47,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -72,7 +72,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -239,7 +240,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.10
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -264,7 +265,8 @@ presubmits:
               - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.25"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: ENABLE_MULTI_SLB # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -47,7 +47,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -72,7 +72,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -239,7 +240,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.10
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -264,7 +265,8 @@ presubmits:
               - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.26"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: ENABLE_MULTI_SLB # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -47,7 +47,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -72,7 +72,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -237,7 +238,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -266,7 +267,8 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27-presubmit
@@ -288,7 +290,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -317,7 +319,8 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27-presubmit
@@ -339,7 +342,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -369,7 +372,8 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27-presubmit
@@ -391,7 +395,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -421,7 +425,8 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27-presubmit
@@ -445,7 +450,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.10
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -470,7 +475,8 @@ presubmits:
               - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.27"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: ENABLE_MULTI_SLB # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -47,7 +47,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -72,7 +72,8 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -210,7 +211,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.10
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -235,7 +236,8 @@ presubmits:
               - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.28"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: ENABLE_MULTI_SLB # cloud-provider-azure config
@@ -277,7 +279,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.10
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -302,7 +304,8 @@ presubmits:
               - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.28"
               - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
+                # TODO change back to kubernetes-sigs/cloud-provider-azure/master when https://github.com/kubernetes-sigs/cloud-provider-azure/pull/5078 merges
+                value: https://raw.githubusercontent.com/jackfrancis/cloud-provider-azure/capz-templates-caaph-calico/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config


### PR DESCRIPTION
This PR updates Azure test jobs that use custom CAPZ templates to use the latest release, and to use a custom template reference that includes the required `HelmChartProxy` spec for calico.