### PR TITLE
karpenter: add presubmit job for main UT

### DIFF
--- a/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
@@ -1,0 +1,31 @@
+presubmits:
+  kubernetes-sigs/karpenter:
+  - name: pull-karpenter-test
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/karpenter"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.27
+        command:
+        - runner.sh
+        args:
+        - make
+        - toolchain
+        - test
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: 16Gi
+          requests:
+            cpu: 6
+            memory: 16Gi
+    annotations:
+      testgrid-dashboards: sig-autoscaling-karpenter
+      testgrid-tab-name: karpenter-pr-test-main

--- a/config/testgrids/kubernetes/sig-autoscaling/config.yaml
+++ b/config/testgrids/kubernetes/sig-autoscaling/config.yaml
@@ -4,8 +4,10 @@ dashboard_groups:
     - sig-autoscaling-cluster-autoscaler
     - sig-autoscaling-hpa
     - sig-autoscaling-vpa
+    - sig-autoscaling-karpenter
 
 dashboards:
 - name: sig-autoscaling-cluster-autoscaler
 - name: sig-autoscaling-hpa
 - name: sig-autoscaling-vpa
+- name: sig-autoscaling-karpenter


### PR DESCRIPTION
This PR adds a new presubmit job (a job that runs against a PR) for `sigs.k8s.io/karpenter` to get UT signal.