### PR TITLE
Add a couple of more al2023 based periodic jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -624,17 +624,29 @@ presubmits:
             - -c
             - |
               set -x
+              build_eks_arch=""
+              target_build_arch="linux/amd64"
+              if [[ ${BUILD_EKS_AMI_ARCH:-""} == "arm64" ]]; then
+                build_eks_arch="arm64-"
+                target_build_arch="linux/arm64"
+              fi
               pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
                 KUBE_MINOR_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}' | sed -E 's/v([0-9]+)\.([0-9]+).*/v\1.\2/')
               popd
               TODAYS_DATE=$(date -u +'%Y%m%d')
-              AMI_NAME="amazon-eks-al2023-node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+              AMI_VERSION="v$TODAYS_DATE"
+              AMI_NAME="amazon-eks-al2023-${build_eks_arch}node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
               AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
 
               if [ -z "$AMI_ID" ] ; then
                 export AMI_NAME
+                export AMI_VERSION
                 $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
                 AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+                if [ -z "$AMI_ID" ] ; then
+                  echo "ami build failed, exiting..."
+                  exit 1
+                fi
               else
                 echo "found existing ami : $AMI_ID skipping building a new AMI..."
               fi
@@ -825,17 +837,29 @@ periodics:
           - -c
           - |
             set -x
+            build_eks_arch=""
+            target_build_arch="linux/amd64"
+            if [[ ${BUILD_EKS_AMI_ARCH:-""} == "arm64" ]]; then
+              build_eks_arch="arm64-"
+              target_build_arch="linux/arm64"
+            fi
             pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
               KUBE_MINOR_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}' | sed -E 's/v([0-9]+)\.([0-9]+).*/v\1.\2/')
             popd
             TODAYS_DATE=$(date -u +'%Y%m%d')
-            AMI_NAME="amazon-eks-al2023-node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+            AMI_VERSION="v$TODAYS_DATE"
+            AMI_NAME="amazon-eks-al2023-${build_eks_arch}node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
             AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
 
             if [ -z "$AMI_ID" ] ; then
               export AMI_NAME
+              export AMI_VERSION
               $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
               AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+              if [ -z "$AMI_ID" ] ; then
+                echo "ami build failed, exiting..."
+                exit 1
+              fi
             else
               echo "found existing ami : $AMI_ID skipping building a new AMI..."
             fi
@@ -923,6 +947,10 @@ periodics:
               export AMI_VERSION
               $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
               AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+              if [ -z "$AMI_ID" ] ; then
+                echo "ami build failed, exiting..."
+                exit 1
+              fi
             else
               echo "found existing ami : $AMI_ID skipping building a new AMI..."
             fi
@@ -940,6 +968,190 @@ periodics:
              -- \
              --use-built-binaries true \
              --focus-regex='\[Conformance\]'
+        env:
+          - name: BUILD_EKS_AMI_OS
+            value: "al2023"
+          - name: BUILD_EKS_AMI_ARCH
+            value: "arm64"
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 6h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-e2e-ec2-eks-al2023
+  annotations:
+    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-tab-name: ci-kubernetes-e2e-ec2-eks-al2023
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster (al2023 EKS image) created with kubetest2-ec2
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -x
+            build_eks_arch=""
+            target_build_arch="linux/amd64"
+            if [[ ${BUILD_EKS_AMI_ARCH:-""} == "arm64" ]]; then
+              build_eks_arch="arm64-"
+              target_build_arch="linux/arm64"
+            fi
+            pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
+              KUBE_MINOR_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}' | sed -E 's/v([0-9]+)\.([0-9]+).*/v\1.\2/')
+            popd
+            TODAYS_DATE=$(date -u +'%Y%m%d')
+            AMI_VERSION="v$TODAYS_DATE"
+            AMI_NAME="amazon-eks-al2023-${build_eks_arch}node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+            AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+
+            if [ -z "$AMI_ID" ] ; then
+              export AMI_NAME
+              export AMI_VERSION
+              $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
+              AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+              if [ -z "$AMI_ID" ] ; then
+                echo "ami build failed, exiting..."
+                exit 1
+              fi
+            else
+              echo "found existing ami : $AMI_ID skipping building a new AMI..."
+            fi
+
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch linux/amd64 \
+             --worker-image "$AMI_ID" \
+             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --parallel=30 \
+             --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+        env:
+          - name: BUILD_EKS_AMI_OS
+            value: "al2023"
+          - name: BUILD_EKS_AMI_ARCH
+            value: "x86_64"
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 8
+            memory: 10Gi
+          requests:
+            cpu: 8
+            memory: 10Gi
+- interval: 6h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-e2e-ec2-eks-al2023-arm64
+  annotations:
+    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-tab-name: ci-kubernetes-e2e-ec2-eks-al2023-arm64
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) cluster (al2023 EKS image) created with kubetest2-ec2 on arm64
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -x
+            build_eks_arch=""
+            target_build_arch="linux/amd64"
+            if [[ ${BUILD_EKS_AMI_ARCH:-""} == "arm64" ]]; then
+              build_eks_arch="arm64-"
+              target_build_arch="linux/arm64"
+            fi
+            pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
+              KUBE_MINOR_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}' | sed -E 's/v([0-9]+)\.([0-9]+).*/v\1.\2/')
+            popd
+            TODAYS_DATE=$(date -u +'%Y%m%d')
+            AMI_VERSION="v$TODAYS_DATE"
+            AMI_NAME="amazon-eks-al2023-${build_eks_arch}node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+            AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+
+            if [ -z "$AMI_ID" ] ; then
+              export AMI_NAME
+              export AMI_VERSION
+              $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/hack/build-ami.sh
+              AMI_ID=$(aws ec2 describe-images --region=us-east-1 --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1)
+              if [ -z "$AMI_ID" ] ; then
+                echo "ami build failed, exiting..."
+                exit 1
+              fi
+            else
+              echo "found existing ami : $AMI_ID skipping building a new AMI..."
+            fi
+
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            kubetest2 ec2 \
+             --build \
+             --target-build-arch $target_build_arch \
+             --worker-image "$AMI_ID" \
+             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
+             --stage provider-aws-test-infra \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --use-built-binaries true \
+             --test-args='--node-os-arch=arm64' \
+             --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
         env:
           - name: BUILD_EKS_AMI_OS
             value: "al2023"


### PR DESCRIPTION
Runs the same set of test cases as covered by `pull-kubernetes-e2e-gce`, Also very similar to `ci-kubernetes-e2e-ubuntu-ec2-containerd` and `ci-kubernetes-e2e-ubuntu-ec2-arm64-containerd` which use ubuntu based images for worker nodes, however these 2 jobs use al2023 images.

Note: also standardized the snippet that ensures an image is available before the tests are run (and fail fast as well if the image was not built properly)