### PR TITLE
Separate dashboard for al2023 related CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -163,7 +163,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node,amazon-ec2-al2023
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -212,7 +212,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node,amazon-ec2-al2023
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks
       testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     labels:
@@ -525,7 +525,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node,amazon-ec2-al2023
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m
@@ -575,7 +575,7 @@ periodics:
   - name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
     interval: 6h
     annotations:
-      testgrid-dashboards: sig-node-containerd,amazon-ec2-node
+      testgrid-dashboards: sig-node-containerd,amazon-ec2-node,amazon-ec2-al2023
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
     decoration_config:
       timeout: 240m

--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -807,7 +807,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-ec2-eks-al2023-conformance-latest
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-dashboards: amazon-ec2, conformance-ec2, amazon-ec2-al2023
     testgrid-tab-name: Conformance - EC2/EKS/AL2023 - master
     description: Runs conformance tests using kubetest against kubernetes master on EC2 using EKS worker nodes
   labels:
@@ -898,7 +898,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-ec2-eks-al2023-arm64-conformance-latest
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-dashboards: amazon-ec2, conformance-ec2, amazon-ec2-al2023
     testgrid-tab-name: Conformance - EC2/EKS/AL2023 - master on arm64
     description: Runs conformance tests using kubetest against kubernetes master on EC2 using EKS arm64 worker nodes
   labels:
@@ -989,7 +989,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-e2e-ec2-eks-al2023
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-dashboards: amazon-ec2, conformance-ec2, amazon-ec2-al2023
     testgrid-tab-name: ci-kubernetes-e2e-ec2-eks-al2023
     description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster (al2023 EKS image) created with kubetest2-ec2
   labels:
@@ -1081,7 +1081,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-e2e-ec2-eks-al2023-arm64
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-ec2
+    testgrid-dashboards: amazon-ec2, conformance-ec2, amazon-ec2-al2023
     testgrid-tab-name: ci-kubernetes-e2e-ec2-eks-al2023-arm64
     description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) cluster (al2023 EKS image) created with kubetest2-ec2 on arm64
   labels:

--- a/config/testgrids/amazon/amazon.yaml
+++ b/config/testgrids/amazon/amazon.yaml
@@ -4,6 +4,7 @@
 dashboards:
 - name: amazon-ec2
 - name: amazon-ec2-node
+- name: amazon-ec2-al2023
 - name: amazon-ec2-provider
 
 #
@@ -14,4 +15,5 @@ dashboard_groups:
   dashboard_names:
   - amazon-ec2
   - amazon-ec2-node
+  - amazon-ec2-al2023
   - amazon-ec2-provider


### PR DESCRIPTION
Since al2023 is new to our CI, i'd like a better view of how things are on this OS. Will update `kops` jobs in a subsequent PR.