### PR TITLE
karpenter: make PR test job optional while we debug

### DIFF
--- a/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-karpenter-test
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: false
+    optional: true # TODO set back to false when stabilized
     decorate: true
     path_alias: "sigs.k8s.io/karpenter"
     branches:


### PR DESCRIPTION
This PR sets the `pull-karpenter-test` test job to optional to allow PRs to merge while we debug.

Ref:

- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_karpenter/830/pull-karpenter-test/1729956607976017920