### PR TITLE
Bump checkconfig image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20231128-bb6aa76183
+      - image: gcr.io/k8s-prow/checkconfig:v20231130-2f95ffc454
         command:
         - checkconfig
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -850,7 +850,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20231128-bb6aa76183
+    - image: gcr.io/k8s-prow/checkconfig:v20231130-2f95ffc454
       command:
       - checkconfig
       args:


### PR DESCRIPTION
Update the checkconfig image to the latest version. Required for https://github.com/kubernetes/test-infra/pull/31336.