### PR TITLE
ci-kubernetes-e2e-kind-rootless: add `gcloud auth activate-service-account`

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -619,6 +619,8 @@ periodics:
         # GCE VM is used for setting up cgroup v2 and systemd.
         # (k8s-infra-prow-build lacks cgroup v2, and the kubekins-e2e container lacks systemd)
         (cd ; GO111MODULE=on go install github.com/rootless-containers/kubetest2-kindinv@master)
+        # Initialize the credentials for Google Cloud
+        gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
         mkdir -p -m 0700 ~/.ssh
         cp -f "${GCE_SSH_PRIVATE_KEY_FILE}" ~/.ssh/google_compute_engine
         cp -f "${GCE_SSH_PUBLIC_KEY_FILE}" ~/.ssh/google_compute_engine.pub


### PR DESCRIPTION

Expected to fix:
- #31339