### PR TITLE
karpenter: use kubekins image w/ go 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.27
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-master
         command:
         - runner.sh
         args:


### PR DESCRIPTION
This PR replaces the 1.27 image with the master image so that we have go 1.21 in the karpenter test runtime environment.