### PR TITLE
bump conformance image e2e timeout to 3h

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decorate: true
     decoration_config:
-      timeout: 60m
+      timeout: 3h
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
@@ -109,7 +109,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 3h
   extra_refs:
   - org: kubernetes
     repo: test-infra


### PR DESCRIPTION
serial conformance takes more than 2h these days:
https://testgrid.k8s.io/sig-testing-kind#conformance-ga-only&graph-metrics=test-duration-minutes

xref: https://github.com/kubernetes/kubernetes/issues/121985#issuecomment-1834391041

cc @liggitt 