### PR TITLE
karpenter: run per-version PR presubmit tests

### DIFF
--- a/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/karpenter/karpenter-presubmit-main.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/karpenter:
-  - name: pull-karpenter-test
+  - name: pull-karpenter-test-1-26
     cluster: eks-prow-build-cluster
     always_run: true
     optional: true # TODO set back to false when stabilized
@@ -10,13 +10,12 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.26
         command:
         - runner.sh
         args:
         - make
-        - toolchain
-        - test
+        - presubmit
         securityContext:
           privileged: true
         resources:
@@ -28,4 +27,88 @@ presubmits:
             memory: 16Gi
     annotations:
       testgrid-dashboards: sig-autoscaling-karpenter
-      testgrid-tab-name: karpenter-pr-test-main
+      testgrid-tab-name: karpenter-pr-test-1-26-main
+  - name: pull-karpenter-test-1-27
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true # TODO set back to false when stabilized
+    decorate: true
+    path_alias: "sigs.k8s.io/karpenter"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.27
+        command:
+        - runner.sh
+        args:
+        - make
+        - presubmit
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: 16Gi
+          requests:
+            cpu: 6
+            memory: 16Gi
+    annotations:
+      testgrid-dashboards: sig-autoscaling-karpenter
+      testgrid-tab-name: karpenter-pr-test-1-27-main
+  - name: pull-karpenter-test-1-28
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true # TODO set back to false when stabilized
+    decorate: true
+    path_alias: "sigs.k8s.io/karpenter"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
+        command:
+        - runner.sh
+        args:
+        - make
+        - presubmit
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: 16Gi
+          requests:
+            cpu: 6
+            memory: 16Gi
+    annotations:
+      testgrid-dashboards: sig-autoscaling-karpenter
+      testgrid-tab-name: karpenter-pr-test-1-28-main
+  - name: pull-karpenter-test-1-29
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true # TODO set back to false when stabilized
+    decorate: true
+    path_alias: "sigs.k8s.io/karpenter"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.29
+        command:
+        - runner.sh
+        args:
+        - make
+        - presubmit
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: 16Gi
+          requests:
+            cpu: 6
+            memory: 16Gi
+    annotations:
+      testgrid-dashboards: sig-autoscaling-karpenter
+      testgrid-tab-name: karpenter-pr-test-1-29-main


### PR DESCRIPTION
This PR adds a karpenter presubmit test for each current version of Kubernetes