### PR TITLE
[kops] Pin cilium-eni jobs to Ubuntu 20.04

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1297,7 +1297,8 @@ def generate_network_plugins():
         networking_arg = plugin.replace('amazon-vpc', 'amazonvpc').replace('kuberouter', 'kube-router') # pylint: disable=line-too-long
         k8s_version = 'stable'
         distro = 'u2204'
-        if plugin == 'amazon-vpc':
+        # https://github.com/kubernetes/kops/issues/15720
+        if plugin in ('amazon-vpc', 'cilium-eni'):
             distro = 'u2004'
         if plugin in ['canal', 'flannel']:
             k8s_version = '1.27'
@@ -1591,7 +1592,8 @@ def generate_presubmits_network_plugins():
         if plugin == 'cilium-eni':
             focus_regex = r'\[Conformance\]|\[NodeConformance\]'
             optional = True
-        if plugin == 'amazonvpc':
+        # https://github.com/kubernetes/kops/issues/15720
+        if plugin in ('amazonvpc', 'cilium-eni'):
             distro = 'u2004'
             optional = True
         if plugin in ['canal', 'flannel']:

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -322,7 +322,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-etcd
 
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-aws-cni-cilium-eni
   cron: '13 5-23/8 * * *'
   labels:
@@ -352,7 +352,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231128' --channel=alpha --networking=cilium-eni --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20231127' --channel=alpha --networking=cilium-eni --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -377,13 +377,13 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-eni
 

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -546,7 +546,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-cilium-etcd
 
-# {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
+# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
   - name: pull-kops-e2e-cni-cilium-eni
     cluster: default
     branches:
@@ -579,7 +579,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20231128' --channel=alpha --networking=cilium-eni --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20231127' --channel=alpha --networking=cilium-eni --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -606,8 +606,8 @@ presubmits:
             memory: 6Gi
     annotations:
       test.kops.k8s.io/cloud: aws
-      test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/distro: u2004
+      test.kops.k8s.io/extra_flags: --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium-eni


### PR DESCRIPTION
My theory is that these Cilium 1.14 jobs are failing for the same reason as https://github.com/kubernetes/kops/issues/15720. I'm using this change to test https://github.com/kubernetes/kops/pull/16132