### PR TITLE
Prevent clients created with `GitHubOptions.GitClientFactory` from leaking secrets

### DIFF
--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -337,6 +337,7 @@ func (o *GitHubOptions) GitHubClientWithAccessToken(token string) (github.Client
 // github.go.
 func (o *GitHubOptions) GitClientFactory(cookieFilePath string, cacheDir *string, dryRun, persistCache bool) (gitv2.ClientFactory, error) {
 	opts := gitv2.ClientFactoryOpts{
+		Censor:         secret.Censor,
 		CookieFilePath: cookieFilePath,
 		Host:           o.Host,
 		Persist:        &persistCache,


### PR DESCRIPTION
/sig testing
/area prow
/kind bug

Git clients created with [GitHubOptions.GitClientFactory](https://github.com/kubernetes/test-infra/blob/b727a6f4e55785caef7ab8d12681058504f22aa9/prow/flagutil/github.go#L338) can leak secrets when they use [Github Authentication](https://github.com/kubernetes/test-infra/blob/b727a6f4e55785caef7ab8d12681058504f22aa9/prow/flagutil/github.go#L350).
This happens because the token is [added to the secrets manager](https://github.com/kubernetes/test-infra/blob/b727a6f4e55785caef7ab8d12681058504f22aa9/prow/flagutil/github.go#L269), but `GitClientFactory` does not add a `Censor` to its options.
The [base options of githubClient](https://github.com/kubernetes/test-infra/blob/b727a6f4e55785caef7ab8d12681058504f22aa9/prow/flagutil/github.go#L308) adds `secret.Censor`, so this PR does the same for `GitClientFactory`.
In the current implementation when no `Censor` is specified, the default options create a [noop Censor](https://github.com/kubernetes/test-infra/blob/b727a6f4e55785caef7ab8d12681058504f22aa9/prow/git/v2/client_factory.go#L207-L209).

When you check logs of [cherrypicker](https://github.com/kubernetes/test-infra/tree/master/prow/external-plugins/cherrypicker), you might find some github tokens.