### PR TITLE
clean only us-east-1 as we do not use other regions

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -1237,6 +1237,7 @@ periodics:
         args:
         - --ttl=6h
         - --path=s3://provider-aws-test-infra/objs.json
+        - --region=us-east-1
         image: gcr.io/k8s-staging-boskos/aws-janitor:v20230908-da54d76
         resources:
           requests:


### PR DESCRIPTION
Don't want to expand the radius of the role. 

Snippet from: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-aws-ec2-janitor/1730911283240243200/build-log.txt
```
{"component":"aws-janitor","file":"/go/src/app/cmd/aws-janitor/main.go:198","func":"main.markAndSweep","level":"info","msg":"Regions: [ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-south-1 ap-southeast-1 ap-southeast-2 ca-central-1 eu-central-1 eu-north-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1 us-east-1 us-east-2 us-west-1 us-west-2]","severity":"info","time":"2023-12-02T11:26:27Z"}
{"component":"aws-janitor","file":"/go/src/app/cmd/aws-janitor/main.go:171","func":"main.main","level":"error","msg":"Error marking and sweeping resources: Error sweeping resources.CloudFormationStacks: AccessDenied: User: arn:aws:sts::855606814420:assumed-role/node-e2e-tests/78763061-48ca-4f02-bedd-e1169634fe50 is not authorized to perform: cloudformation:ListStacks on resource: arn:aws:cloudformation:ap-northeast-1:855606814420:stack/*/* because no identity-based policy allows the cloudformation:ListStacks action\n\tstatus code: 403, request id: b4cd46bf-f38d-4a18-9e34-b2448414658b","severity":"error","time":"2023-12-02T11:26:27Z"}
```