### PR TITLE
Enable gofailpoint for e2e test

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -95,6 +95,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
+          make gofail-enable
           VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:


### PR DESCRIPTION
In etcd's workflow, some e2e test cases require the gofailpoint to be enabled.

FYI. https://github.com/etcd-io/etcd/blob/9d18fb0c6c297deae28b8055bb041092933d4632/.github/workflows/e2e.yaml#L30-L31