### PR TITLE
Fix gcsweb anonymous auth

### DIFF
--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -738,7 +738,7 @@ func TestParseBucket(t *testing.T) {
 				testCase.wantOptions.bucketAliases = bucketAliases{}
 			}
 			o := &options{bucketAliases: bucketAliases{}}
-			err := o.parseBucket(testCase.bucket)
+			_, err := o.parseBucket(testCase.bucket)
 
 			if err != nil && testCase.wantErr == nil {
 				t.Fatalf("want err nil but got: %v", err)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/31349
by implementing option 1 from https://github.com/kubernetes/test-infra/issues/31349#issuecomment-1837498552.

This PR brings back the legacy GCS client creation that was used before https://github.com/kubernetes/test-infra/pull/31241.
With this, `--use-default-credentials` is effective again: default behavior is using anonymous auth, but users can explicitly opt-in to using application default credentials.
If GCS buckets are served, clients are created exactly like before, so we should be backward-compatible now.
As we can only serve buckets of one provider at the same time with this, gcsweb complains if buckets of different providers are configured.