### PR TITLE
add image build job for k-sigs/cluster-api-ipam-provider-in-cluster

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -374,6 +374,31 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - --build-dir=.
               - hack/ccm
+  kubernetes-sigs/cluster-api-ipam-provider-in-cluster:
+    - name: post-cluster-api-ipam-provider-in-cluster
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^main$
+        - ^release-.*
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20230711-e33377c2b4
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-capi-ipam-ic
+              - --scratch-bucket=gs://k8s-staging-capi-ipam-ic-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
+              - .
 
 periodics:
   - name: cluster-api-push-images-nightly


### PR DESCRIPTION
Adds a postsubmit job for kubernetes-sigs/cluster-api-ipam-provider-in-cluster that builds staging images. It's identical to the cluster-api job in the same file.

This is my first time setting up a prow job, so a thorough review would be appreciated!

The cloudbuild.yaml is still work in progress, any feedback is appreciated as well: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/pull/208/files