### PR TITLE
Fix prow-controller-manager starter manifests RBAC

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -1075,6 +1075,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - delete
       - list
       - watch

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -1077,6 +1077,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - delete
       - list
       - watch

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -1117,6 +1117,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - delete
       - list
       - watch

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -1075,6 +1075,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - delete
       - list
       - watch


### PR DESCRIPTION
Add the missing pods `get` verb to the `prow-controller-manager` role.

Fixes https://github.com/kubernetes/test-infra/issues/29286.

/area prow