### PR TITLE
Increase interval for 5k nodes test on AWS

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -33,7 +33,7 @@ periodics:
   - "perfDashBuildsCount: 270"
   - "perfDashJobType: performance"
   cluster: eks-prow-build-cluster
-  interval: 12h
+  interval: 24h
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"


### PR DESCRIPTION
Ensure ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2 run every 24h to reduce costs.