### PR TITLE
migrate cluster-api 1.6 jobs to community clusters

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6-upgrades.yaml
@@ -1,10 +1,9 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -22,7 +21,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       args:
@@ -47,6 +45,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-23-1-24
@@ -54,10 +56,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -75,7 +76,6 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -100,6 +100,10 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-24-1-25
@@ -107,10 +111,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -128,7 +131,6 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -153,6 +155,10 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-25-1-26
@@ -160,10 +166,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -181,7 +186,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       args:
@@ -206,6 +210,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-26-1-27
@@ -213,10 +221,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -234,7 +241,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       args:
@@ -259,6 +265,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-27-1-28
@@ -266,10 +276,9 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-28-latest-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -287,7 +296,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       args:
@@ -312,6 +320,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-28-latest

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6.yaml
@@ -1,9 +1,8 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -14,7 +13,6 @@ periodics:
     base_ref: release-1.6
     path_alias: sigs.k8s.io/cluster-api
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       command:
@@ -23,16 +21,19 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-test-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-test-mink8s-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -43,7 +44,6 @@ periodics:
     base_ref: release-1.6
     path_alias: sigs.k8s.io/cluster-api
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       command:
@@ -62,16 +62,19 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 9Gi
+        limits:
+          cpu: 7300m
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-test-mink8s-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -89,7 +92,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -104,16 +106,19 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-dualstack-and-ipv6-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes-sigs
@@ -131,7 +136,6 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -149,16 +153,19 @@ periodics:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-6
+  cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
-  decoration_config:
-    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -176,7 +183,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
       args:
@@ -199,6 +205,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-mink8s-release-1-6

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-6.yaml
@@ -1,28 +1,32 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build-release-1-6
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+        resources:
+          requests:
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-build-release-1-6
   - name: pull-cluster-api-apidiff-release-1-6
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -30,19 +34,24 @@ presubmits:
     - ^release-1.6$
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
+        resources:
+          requests:
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-apidiff-release-1-6
   - name: pull-cluster-api-verify-release-1-6
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -51,7 +60,6 @@ presubmits:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         command:
@@ -60,22 +68,24 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-verify-release-1-6
   - name: pull-cluster-api-test-release-1-6
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -84,20 +94,22 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-test-release-1-6
   - name: pull-cluster-api-test-mink8s-release-1-6
+    cluster: eks-prow-build-cluster
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -116,23 +128,25 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-test-mink8s-release-1-6
   - name: pull-cluster-api-e2e-mink8s-release-1-6
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -153,23 +167,25 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-6
   - name: pull-cluster-api-e2e-release-1-6
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     path_alias: sigs.k8s.io/cluster-api
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -184,23 +200,25 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-release-1-6
   - name: pull-cluster-api-e2e-full-dualstack-and-ipv6-release-1-6
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     always_run: false
     branches:
       # The script this job runs is not in all branches.
       - ^release-1.6$
     path_alias: sigs.k8s.io/cluster-api
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
           args:
@@ -221,23 +239,25 @@ presubmits:
           resources:
             requests:
               cpu: 7300m
+              memory: 32Gi
+            limits:
+              cpu: 7300m
+              memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-full-dualstack-and-ipv6-release-1-6
   - name: pull-cluster-api-e2e-full-release-1-6
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     always_run: false
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
     path_alias: sigs.k8s.io/cluster-api
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -255,16 +275,19 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-full-release-1-6
   - name: pull-cluster-api-e2e-workload-upgrade-1-28-latest-release-1-6
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -276,7 +299,6 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -301,11 +323,16 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-release-1-6-1-28-latest
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-release-1-6-experimental
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -320,7 +347,6 @@ presubmits:
     - ^release-1.6$
     path_alias: sigs.k8s.io/cluster-api
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-1.28
         args:
@@ -337,6 +363,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-scale-release-1-6-experimental


### PR DESCRIPTION
this commit updates capi 1.6 jobs to run on eks-prow-build-cluster.

Signed-off-by: Anurag <81210977+kranurag7@users.noreply.github.com>
