### PR TITLE
change default merge method for Karpenter to squash

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -801,6 +801,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/ibm-vpc-block-csi-driver: squash
+    kubernetes-sigs/karpenter: squash
     kubernetes-sigs/kernel-module-management: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash


### PR DESCRIPTION
We've been using squash and merge as the default prior to the migration to kubernetes-sigs. I believe the default is just to merge, where we only want to see the PR description as the commit when looking at the commit history.