### PR TITLE
Add `code_freeze_maintainers_team` option to `milestone` prow plugin

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -491,6 +491,8 @@ type Milestone struct {
 	MaintainersID           int    `json:"maintainers_id,omitempty"`
 	MaintainersTeam         string `json:"maintainers_team,omitempty"`
 	MaintainersFriendlyName string `json:"maintainers_friendly_name,omitempty"`
+	// CodeFreezeMaintainersTeam is the GitHub team allowed to set milestones if code freeze is in place.
+	CodeFreezeMaintainersTeam string `json:"code_freeze_maintainers_team,omitempty"`
 }
 
 // BranchToMilestone is a map of the branch name to the configured milestone for that branch.

--- a/prow/plugins/milestone/codefreezechecker/codefreezechecker.go
+++ b/prow/plugins/milestone/codefreezechecker/codefreezechecker.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codefreezechecker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
+)
+
+var defaultBranches = []string{"master", "main"}
+
+// CodeFreezeChecker is the main structure of checking if we're in Code Freeze.
+type CodeFreezeChecker struct{}
+
+// New creates a new CodeFreezeChecker instance.
+func New() *CodeFreezeChecker {
+	return &CodeFreezeChecker{}
+}
+
+// InCodeFreeze returns true if we're in Code Freeze:
+// https://github.com/kubernetes/sig-release/blob/2d8a1cc/releases/release_phases.md#code-freeze
+// This is being checked if the prow tide configuration has milestone restrictions applied like:
+// https://github.com/kubernetes/test-infra/pull/31164/files
+func (c *CodeFreezeChecker) InCodeFreeze(prowConfig *config.Config, milestone, org, repo string) bool {
+	orgRepo := config.OrgRepo{Org: org, Repo: repo}
+	queries := prowConfig.Tide.Queries.QueryMap().ForRepo(orgRepo)
+
+	for _, query := range queries {
+		if query.Milestone != milestone {
+			continue
+		}
+
+		includedBranches := sets.New(query.IncludedBranches...)
+		releaseBranchFromMilestone := fmt.Sprintf("release-%s", strings.TrimPrefix(query.Milestone, "v"))
+
+		if includedBranches.Has(releaseBranchFromMilestone) && includedBranches.HasAny(defaultBranches...) {
+			logrus.Infof("Found code freeze for milestone %s", query.Milestone)
+			return true
+		}
+	}
+
+	return false
+}

--- a/prow/plugins/milestone/codefreezechecker/codefreezechecker_test.go
+++ b/prow/plugins/milestone/codefreezechecker/codefreezechecker_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codefreezechecker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestInCodeFreeze(t *testing.T) {
+	const (
+		testOrg           = "org"
+		testRepo          = "repo"
+		testMilestone     = "v1.29"
+		testReleaseBranch = "release-1.29"
+	)
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		config          *config.Config
+		isInCodeFreezte bool
+	}{
+		{
+			name: "in code freeze",
+			config: &config.Config{
+				ProwConfig: config.ProwConfig{
+					Tide: config.Tide{
+						TideGitHubConfig: config.TideGitHubConfig{
+							Queries: config.TideQueries{
+								{
+									Milestone:        testMilestone,
+									Repos:            []string{fmt.Sprintf("%s/%s", testOrg, testRepo)},
+									IncludedBranches: []string{testReleaseBranch, defaultBranches[0]},
+								},
+							},
+						},
+					},
+				},
+			},
+			isInCodeFreezte: true,
+		},
+		{
+			name: "different milestone",
+			config: &config.Config{
+				ProwConfig: config.ProwConfig{
+					Tide: config.Tide{
+						TideGitHubConfig: config.TideGitHubConfig{
+							Queries: config.TideQueries{
+								{
+									Milestone:        "different",
+									Repos:            []string{fmt.Sprintf("%s/%s", testOrg, testRepo)},
+									IncludedBranches: []string{testReleaseBranch, defaultBranches[0]},
+								},
+							},
+						},
+					},
+				},
+			},
+			isInCodeFreezte: false,
+		},
+		{
+			name: "different repo",
+			config: &config.Config{
+				ProwConfig: config.ProwConfig{
+					Tide: config.Tide{
+						TideGitHubConfig: config.TideGitHubConfig{
+							Queries: config.TideQueries{
+								{
+									Milestone:        testMilestone,
+									Repos:            []string{"bar"},
+									IncludedBranches: []string{testReleaseBranch, defaultBranches[0]},
+								},
+							},
+						},
+					},
+				},
+			},
+			isInCodeFreezte: false,
+		},
+		{
+			name: "different included branches",
+			config: &config.Config{
+				ProwConfig: config.ProwConfig{
+					Tide: config.Tide{
+						TideGitHubConfig: config.TideGitHubConfig{
+							Queries: config.TideQueries{
+								{
+									Milestone:        testMilestone,
+									Repos:            []string{fmt.Sprintf("%s/%s", testOrg, testRepo)},
+									IncludedBranches: []string{"some", "other", "branches"},
+								},
+							},
+						},
+					},
+				},
+			},
+			isInCodeFreezte: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := New().InCodeFreeze(tc.config, testMilestone, testOrg, testRepo)
+			assert.Equal(t, tc.isInCodeFreezte, res)
+		})
+	}
+}

--- a/prow/plugins/milestone/milestone_test.go
+++ b/prow/plugins/milestone/milestone_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/plugins"
@@ -124,7 +125,7 @@ func TestMilestoneStatus(t *testing.T) {
 			repoMilestone["org/repo"] = plugins.Milestone{MaintainersTeam: maintainersTeamName}
 		}
 
-		if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {
+		if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone, &config.Config{}); err != nil {
 			t.Errorf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			continue
 		}


### PR DESCRIPTION
The new option allows to set a specific team (like the release-team-leads) to  be milestone maintainer when code freeze is in place. For that we extend the milestone plugin to be able to validate codefreeze based on the tide configuration of the repository.

Ref:

- https://github.com/kubernetes/sig-release/issues/2386

PRs for code freeze updates:
- https://github.com/kubernetes/test-infra/pull/31164
- https://github.com/kubernetes/test-infra/pull/29259

cc @kubernetes/release-managers 

Still in WIP, I'm not sure about 1-2 approaches here (see comments below).