### PR TITLE
Add post-k8sio-deploy-app-k8s-io-packages job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.yaml
@@ -207,6 +207,50 @@ postsubmits:
         - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
           command:
           - ./apps/k8s-io/deploy.sh
+    - name: post-k8sio-deploy-app-k8s-io-packages
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      max_concurrency: 1
+      # intended for ignoring changes to README.md or OWNERS
+      run_if_changed: '^apps\/k8s-io-packages\/(.*.yaml|deploy.sh|test.py)$'
+      branches:
+      - ^main$
+      reporter_config:
+        slack:
+          channel: "k8s-infra-alerts"
+          job_states_to_report:
+          - success
+          - failure
+          - aborted
+          - error
+          report_template: 'Deploying k8s-io-packages: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-k8s-infra-apps#deploy-k8s-io|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
+      annotations:
+        testgrid-create-test-group: 'true'
+        testgrid-dashboards: sig-k8s-infra-apps
+        testgrid-tab-name: deploy-k8s-io-packages
+        testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/k8s-io-packages/deploy.sh if files change in kubernetes/k8s.io/apps/k8s-io-packages'
+        testgrid-alert-email: k8s-infra-rbac-k8s-io@kubernetes.io, k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+      rerun_auth_config:
+        github_team_slugs:
+        # proxy for sig-k8s-infra-oncall
+        - org: kubernetes
+          slug: sig-k8s-infra-leads
+        # proxy for test-infra-oncall
+        - org: kubernetes
+          slug: test-infra-admins
+        # proxy for release-managers
+        - org: kubernetes
+          slug: release-managers
+        # TODO: sig-specific team in charge of this app
+        # - org: kubernetes
+        #   slug: sig-foo-bar
+      spec:
+        serviceAccountName: prow-deployer
+        containers:
+        - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+          command:
+          - ./apps/k8s-io-packages/deploy.sh
     - name: post-k8sio-deploy-app-kubernetes-external-secrets
       cluster: k8s-infra-prow-build-trusted
       decorate: true


### PR DESCRIPTION
This PR adds `post-k8sio-deploy-app-k8s-io-packages` job that's going to deploy a newly-added `k8s-io-packages` app (https://github.com/kubernetes/k8s.io/pull/6159). The job has been created as a copy of `post-k8sio-deploy-app-k8s-io` with the following changes:

- `k8s-io` is replaced with `k8s-io-packages` (e.g. script name, testgrid dashboard tab, `run_if_changed`)
- @kubernetes/release-managers are allowed to restart the job

xref https://github.com/kubernetes/k8s.io/pull/6156 

/assign @upodroid @ameukam 