### PR TITLE
Dang! bump parallel tests - no wonder arm64 job took longer

### DIFF
--- a/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml
@@ -1029,6 +1029,7 @@ periodics:
              -- \
              --use-built-binaries true \
              --test-args="--node-os-arch=$NODE_OS_ARCH" \
+             --parallel=30 \
              --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
         env:
           - name: BUILD_EKS_AMI_OS


### PR DESCRIPTION
Compare with the non-arm64 ci job:
https://github.com/kubernetes/test-infra/blob/1b194da2d156ea01716aa677dd2694cb7a9462ef/config/jobs/kubernetes/sig-testing/ec2-e2e.yaml#L964