### PR TITLE
Revert "Merge pull request #31220 from rjsadow/lru-cache"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.2
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/klauspost/pgzip v1.2.1
 	github.com/mattn/go-zglob v0.0.2
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1

--- a/prow/cache/cache.go
+++ b/prow/cache/cache.go
@@ -17,12 +17,11 @@ limitations under the License.
 package cache
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
+	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/sirupsen/logrus"
-	"k8s.io/utils/lru"
 )
 
 // Overview
@@ -46,7 +45,7 @@ import (
 // LRUCache is the actual concurrent non-blocking cache.
 type LRUCache struct {
 	*sync.Mutex
-	*lru.Cache
+	*simplelru.LRU
 	callbacks Callbacks
 }
 
@@ -65,7 +64,7 @@ type Callbacks struct {
 	LookupsCallback         EventCallback
 	HitsCallback            EventCallback
 	MissesCallback          EventCallback
-	ForcedEvictionsCallback lru.EvictionFunc
+	ForcedEvictionsCallback simplelru.EvictCallback
 	ManualEvictionsCallback EventCallback
 }
 
@@ -121,10 +120,10 @@ func (p *Promise) resolve() {
 // underlying cache.
 func NewLRUCache(size int,
 	callbacks Callbacks) (*LRUCache, error) {
-	if size <= 0 {
-		return nil, errors.New("Must provide a positive size")
+	cache, err := simplelru.NewLRU(size, callbacks.ForcedEvictionsCallback)
+	if err != nil {
+		return nil, err
 	}
-	cache := lru.NewWithEvictionFunc(size, callbacks.ForcedEvictionsCallback)
 
 	return &LRUCache{
 		&sync.Mutex{},
@@ -216,7 +215,7 @@ func (lruCache *LRUCache) GetOrAdd(
 		// don't care if the underlying LRU cache had to evict an existing
 		// entry.
 		promise = newPromise(valConstructor)
-		lruCache.Add(key, promise)
+		_ = lruCache.Add(key, promise)
 		// We must unlock here so that the cache does not block other GetOrAdd()
 		// calls to it for different (or same) key/value pairs.
 		lruCache.Unlock()
@@ -260,8 +259,17 @@ func (lruCache *LRUCache) GetOrAdd(
 			logrus.WithField("key", key).Infof("promise was successfully resolved, but the call to resolve() returned an error; deleting key from cache...")
 
 			lruCache.Lock()
-			lruCache.Remove(key)
+			weDeletedThisKey := lruCache.Remove(key)
 			lruCache.Unlock()
+			if weDeletedThisKey {
+				if lruCache.callbacks.ManualEvictionsCallback != nil {
+					lruCache.callbacks.ManualEvictionsCallback(key)
+				}
+				logrus.WithField("key", key).Infof("successfully deleted")
+			} else {
+				err := fmt.Errorf("unexpected (non-problematic) race: key deleted by the cache without our knowledge; our own deletion of this key was a NOP but this does not constitute a problem")
+				logrus.WithField("key", key).Info(err)
+			}
 		}
 	}
 

--- a/prow/cache/cache_test.go
+++ b/prow/cache/cache_test.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-
-	"k8s.io/utils/lru"
 )
 
 // TestGetOrAddSimple is a basic check that the underlying LRU cache
@@ -152,7 +150,7 @@ func TestGetOrAddSimple(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset test state.
 			valConstructorCalls = 0
-			simpleCache.Clear()
+			simpleCache.Purge()
 
 			for k, v := range tc.cacheInitialState {
 				if tc.cache != nil {
@@ -284,7 +282,7 @@ func TestGetOrAddBurst(t *testing.T) {
 	}
 
 	valConstructorCalls = 0
-	lruCache.Clear()
+	lruCache.Purge()
 
 	// Consider the case where all threads perform one of 5 different cache lookups.
 	wg.Add(maxConcurrentRequests)
@@ -356,7 +354,7 @@ func TestCallbacks(t *testing.T) {
 	lookupsCallback := mkCallback(&lookupsCounter)
 	hitsCallback := mkCallback(&hitsCounter)
 	missesCallback := mkCallback(&missesCounter)
-	forcedEvictionsCallback := func(key lru.Key, _ interface{}) {
+	forcedEvictionsCallback := func(key interface{}, _ interface{}) {
 		forcedEvictionsCounter++
 	}
 	manualEvictionsCallback := mkCallback(&manualEvictionsCounter)

--- a/prow/config/cache.go
+++ b/prow/config/cache.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/test-infra/prow/cache"
 	"k8s.io/test-infra/prow/git/v2"
-	"k8s.io/utils/lru"
 )
 
 // Overview
@@ -165,7 +164,7 @@ func NewInRepoConfigCache(
 	lookupsCallback := mkCacheEventCallback(inRepoConfigCacheMetrics.lookups)
 	hitsCallback := mkCacheEventCallback(inRepoConfigCacheMetrics.hits)
 	missesCallback := mkCacheEventCallback(inRepoConfigCacheMetrics.misses)
-	forcedEvictionsCallback := func(key lru.Key, _ interface{}) {
+	forcedEvictionsCallback := func(key interface{}, _ interface{}) {
 		org, repo, err := keyToOrgRepo(key)
 		if err != nil {
 			return
@@ -196,8 +195,7 @@ func NewInRepoConfigCache(
 		lruCache.Mutex.Lock()         // Lock the mutex
 		defer lruCache.Mutex.Unlock() // Unlock the mutex when done
 		// Record all unique orgRepo combinations we've seen so far.
-		for i := lruCache.Len(); i > 0; i-- {
-			key, _ := lruCache.Get(i)
+		for _, key := range lruCache.Keys() {
 			org, repo, err := keyToOrgRepo(key)
 			if err != nil {
 				// This should only happen if we are deliberately using things

--- a/prow/config/cache_test.go
+++ b/prow/config/cache_test.go
@@ -398,7 +398,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 			// Simulate storing a value of the wrong type in the cache (a string
 			// instead of a *ProwYAML).
 			if tc.cacheCorrupted {
-				cache.Clear()
+				cache.Purge()
 
 				for _, kp := range tc.cacheInitialState {
 					k, err := kp.CacheKey()


### PR DESCRIPTION
This reverts commit 3897be59f6 (Merge pull request #31220 from rjsadow/lru-cache, 2023-11-14)).
5a589886b161f561b69449e3e8635de496d2c86f.

The implementation was faulty and resulted in broken metrics for reporting cache sizes grouped by org and repo. If k8s.io/utils/lru can support iterating over keys/values like in simplelru, we can revisit the idea in the reverted PR again.

/cc @rjsadow @cjwagner @airbornepony @timwangmusic 