### PR TITLE
Use `review_acts_as_lgtm` for `release-actions` repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -239,6 +239,7 @@ lgtm:
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
   - kubernetes-sigs/prow
+  - kubernetes-sigs/release-actions
   - kubernetes-sigs/release-notes
   - kubernetes-sigs/release-sdk
   - kubernetes-sigs/release-utils


### PR DESCRIPTION
Another one we forgot on the list.

cc @kubernetes/release-managers 