### PR TITLE
Add notifications to alert AWS Team on failures and Release blocking Sig

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -64,6 +64,7 @@ periodics:
     test.kops.k8s.io/networking: amazonvpc
     testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws
     testgrid-tab-name: ec2-master-scale-performance
+    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, eks-scalability@amazon.com
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master


### PR DESCRIPTION
- Add notifications to alert AWS Scalability Team on failures and Release blocking Sig
- Also add them onto release blocking testgrid dashboards


- Discussed in Sig-scalability meeting today and AWS team and Google team will collaborate on overlapping failures