### PR TITLE
Fix: increase gcsK8sReporter report timeout to 20 seconds

### DIFF
--- a/prow/crier/reporters/gcs/kubernetes/reporter.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter.go
@@ -106,7 +106,7 @@ func (gr *gcsK8sReporter) Report(ctx context.Context, log *logrus.Entry, pj *pro
 }
 
 func (gr *gcsK8sReporter) report(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) (*reconcile.Result, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
 	// Check if we have a destination before adding a finalizer so we don't add


### PR DESCRIPTION
We observe that the reporter fails to upload `podinfo.json` intermittently due to IO timeout with context canceled. This change doubles the timeout from 10 seconds to 20 seconds.

/assign: @cjwagner @airbornepony @listx 