### PR TITLE
enable external cloud provider for the al2023 slow ci jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
@@ -42,6 +42,7 @@ periodics:
              --worker-image "$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
              --stage provider-aws-test-infra \
+             --external-cloud-provider true \
              --up \
              --down \
              --test=ginkgo \
@@ -111,6 +112,7 @@ periodics:
              --worker-image "$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
              --stage provider-aws-test-infra \
+             --external-cloud-provider true \
              --up \
              --down \
              --test=ginkgo \


### PR DESCRIPTION
trying to fix both jobs that are failing now.
- https://testgrid.k8s.io/amazon-ec2-al2023#ci-kubernetes-e2e-ec2-eks-al2023-arm64-slow&width=20
- https://testgrid.k8s.io/amazon-ec2-al2023#ci-kubernetes-e2e-ec2-eks-al2023-slow&width=20