### PR TITLE
[kubetest2-ec2] Add external load balancer for the slow/loadbalancer related CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
@@ -43,6 +43,7 @@ periodics:
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
              --stage provider-aws-test-infra \
              --external-cloud-provider true \
+             --external-load-balancer true \
              --up \
              --down \
              --test=ginkgo \
@@ -113,6 +114,7 @@ periodics:
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
              --stage provider-aws-test-infra \
              --external-cloud-provider true \
+             --external-load-balancer true \
              --up \
              --down \
              --test=ginkgo \


### PR DESCRIPTION
looks like external-cloud-provider is not enough, let's add the external load balancer as well

- https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-eks-al2023-slow&width=20
- https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-eks-al2023-arm64-slow&width=20