### PR TITLE
Specify the aws provider for slow jobs (to prevent some tests from running)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
@@ -49,7 +49,7 @@ periodics:
              --test=ginkgo \
              -- \
              --use-built-binaries true \
-             --test-args="--node-os-arch=$NODE_OS_ARCH" \
+             --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws" \
              --focus-regex="\[Slow\]" \
              --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
              --parallel=25
@@ -120,7 +120,7 @@ periodics:
              --test=ginkgo \
              -- \
              --use-built-binaries true \
-             --test-args="--node-os-arch=$NODE_OS_ARCH" \
+             --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws" \
              --focus-regex="\[Slow\]" \
              --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
              --parallel=25


### PR DESCRIPTION
Some of the CI tests we see in the following for example have a `skip` for `aws` as they are known to fail (unsupported):
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-ec2-eks-al2023-slow/1733769918962208768
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-ec2-eks-al2023-arm64-slow/1733769919008346112

https://cs.k8s.io/?q=SkipIfProviderIs.*aws&i=nope&files=loadbalancer%5C.go&excludeFiles=&repos=

So let's make sure we set it to prevent 🟥 in test-grid.