### PR TITLE
Create kubekins v2 image

### DIFF
--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -1,0 +1,199 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes basic workspace setup, with gcloud and a bootstrap runner
+
+FROM debian:bookworm
+ARG TARGETARCH
+
+WORKDIR /workspace
+RUN mkdir -p /workspace
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+# common util tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    file \
+    git \
+    iproute2 \
+    iputils-ping \
+    jq \
+    kmod \
+    mercurial \
+    openssh-client \
+    pkg-config \
+    procps \
+    python3 \
+    python3-distutils \
+    python3-gflags \
+    python3-pip \
+    python3-venv \
+    python3-yaml \
+    rsync \
+    unzip \
+    wget \
+    xz-utils \
+    zip \
+    zlib1g-dev \
+    graphviz \
+    bc \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip setuptools wheel
+
+# Install gcloud
+
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+ARG GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
+RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz && \
+    /google-cloud-sdk/install.sh \
+    --disable-installation-options \
+    --bash-completion=false \
+    --path-update=false \
+    --usage-reporting=false && \
+    gcloud components install alpha beta kubectl && \
+    gcloud info | tee /workspace/gcloud-info.txt
+
+
+#
+# BEGIN: DOCKER IN DOCKER SETUP
+#
+
+# Install Docker deps, some of these are already installed in the image but
+# that's fine since they won't re-install and we can reuse the code below
+# for another image someday.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add the Docker apt-repository
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker
+# TODO: the `sed` is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+
+
+# Move Docker's storage location
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
+    tee --append /etc/default/docker
+# NOTE this should be mounted and persisted as a volume ideally (!)
+# We will make a fallback one now just in case
+RUN mkdir /docker-graph
+
+#
+# END: DOCKER IN DOCKER SETUP
+#
+
+# install cfssl to prevent https://github.com/kubernetes/kubernetes/issues/55589
+# The invocation at the end is to prevent download failures downloads as in the bug.
+# TODO(porridge): bump CFSSL_VERSION to one where cfssljson supports the -version flag and test it as well.
+ARG CFSSL_VERSION
+RUN wget -q -O cfssl "https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssl_${CFSSL_VERSION}_linux_${TARGETARCH}" && \
+    wget -q -O cfssljson "https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssljson_${CFSSL_VERSION}_linux_${TARGETARCH}" && \
+    chmod +x cfssl cfssljson && \
+    mv cfssl cfssljson /usr/local/bin && \
+    cfssl version
+
+# replace kubectl with one from K8S_RELEASE
+ARG K8S_RELEASE=latest
+RUN rm -f $(which kubectl) && \
+    export KUBECTL_VERSION=$(curl -L https://dl.k8s.io/release/${K8S_RELEASE}.txt) && \
+    wget https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# install go
+ARG GO_VERSION
+ENV GO_TARBALL "go${GO_VERSION}.linux-${TARGETARCH}.tar.gz"
+RUN wget -q "https://go.dev/dl/${GO_TARBALL}" && \
+    tar xzf "${GO_TARBALL}" -C /usr/local && \
+    rm "${GO_TARBALL}"
+
+# install yq
+ARG YQ_VERSION
+RUN wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}" \
+    -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
+# install bazel
+ARG BAZEL_VERSION_ARG
+ENV BAZEL_VERSION=${BAZEL_VERSION_ARG}
+COPY images/kubekins-e2e/install-bazel.sh /
+RUN bash /install-bazel.sh
+
+ARG OLD_BAZEL_VERSION
+COPY --from=old \
+    /usr/local/lib/bazel/bin/bazel-real /usr/local/lib/bazel/bin/bazel-${OLD_BAZEL_VERSION}
+
+# install kind if a version is provided
+ARG KIND_VERSION
+RUN if [ -n "${KIND_VERSION}" ]; then \
+    wget -q -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-${TARGETARCH} && \
+    chmod +x /usr/local/bin/kind; \
+    fi
+
+# install kubetest2 binaries if a version is provided
+# kubetest2 must be installed from git as the makefile embeds the git short hash and the day it was built.
+ARG KUBETEST2_VERSION
+RUN if [ -n "${KUBETEST2_VERSION}" ]; then \
+    git clone https://github.com/kubernetes-sigs/kubetest2.git /tmp/kubetest2 && \
+    cd /tmp/kubetest2 && make install-all && rm -rf /tmp/kubetest2; \
+    fi
+
+# configure dockerd to use mirror.gcr.io
+# per instructions at https://cloud.google.com/container-registry/docs/pulling-cached-images
+ARG DOCKER_REGISTRY_MIRROR_URL=https://mirror.gcr.io
+RUN [ -n "${DOCKER_REGISTRY_MIRROR_URL}" ] && \
+    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --registry-mirror=${DOCKER_REGISTRY_MIRROR_URL}\"" | \
+    tee --append /etc/default/docker
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+
+# note the runner is also responsible for making docker in docker function if
+# env DOCKER_IN_DOCKER_ENABLED is set
+COPY ["runner.sh", \
+    "/usr/local/bin/"]
+
+ENTRYPOINT ["/usr/local/bin/runner.sh"]

--- a/images/kubekins-e2e-v2/Makefile
+++ b/images/kubekins-e2e-v2/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+push-prod:
+	../../hack/make-rules/go-run/arbitrary.sh run ./images/builder --project=k8s-staging-test-infra --scratch-bucket=gs://k8s-staging-test-infra-gcb images/kubekins-v2
+
+push:
+	../../hack/make-rules/go-run/arbitrary.sh run ./images/builder --allow-dirty images/kubekins-v2
+
+.PHONY: push push-prod

--- a/images/kubekins-e2e-v2/OWNERS
+++ b/images/kubekins-e2e-v2/OWNERS
@@ -17,7 +17,6 @@ approvers:
 emeritus_approvers:
 - amwat
 - spiffxp
-- MushuEE
 
 labels:
 - sig/release

--- a/images/kubekins-e2e-v2/README.md
+++ b/images/kubekins-e2e-v2/README.md
@@ -1,0 +1,12 @@
+# kubekins-e2e-v2
+
+This is a modernised and lean image of the kubekins-e2e image optimised for the core tools required in an e2e image.
+
+Features:
+- multi-arch, supports both amd64 and arm64
+- kubetest2
+- kind
+- aws-cli v1
+- gcloud
+- DinD
+- runner.sh wrapper

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -1,0 +1,39 @@
+steps:
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
+    entrypoint: /buildx-entrypoint
+    args:
+    - build
+    - --tag=us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - --build-arg=IMAGE_ARG=us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - --platform=linux/amd64,linux/arm64
+    - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
+    - --build-arg=GO_VERSION=$_GO_VERSION
+    - --build-arg=K8S_RELEASE=$_K8S_RELEASE
+    - --build-arg=KIND_VERSION=$_KIND_VERSION
+    - --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION
+    - --build-arg=YQ_VERSION=$_YQ_VERSION
+    - .
+    dir: images/kubekins-e2e-v2
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
+    entrypoint: gcloud
+    args:
+    - tag
+    - container
+    - images
+    - add-tag
+    - us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:latest-$_CONFIG
+substitutions:
+  _CFSSL_VERSION: 1.6.4
+  _CONFIG: master
+  _GIT_TAG: '12345'
+  _GO_VERSION: 1.13.5
+  _K8S_RELEASE: stable
+  _KIND_VERSION: ''
+  _KUBETEST2_VERSION: 'master'
+  _YQ_VERSION: v4.40.4
+timeout: 1800s  
+options:
+  substitution_option: ALLOW_LOOSE
+  # this is a large and critical CI image, builds are slow on the default 1 core
+  machineType: E2_HIGHCPU_32

--- a/images/kubekins-e2e-v2/runner.sh
+++ b/images/kubekins-e2e-v2/runner.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generic runner script, handles DIND, etc.
+
+# runs custom docker data root cleanup binary and debugs remaining resources
+cleanup_dind() {
+    if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+        echo "Cleaning up after docker"
+        docker ps -aq | xargs -r docker rm -f || true
+        service docker stop || true
+    fi
+}
+
+early_exit_handler() {
+    if [ -n "${WRAPPED_COMMAND_PID:-}" ]; then
+        kill -TERM "$WRAPPED_COMMAND_PID" || true
+    fi
+    cleanup_dind
+}
+
+# optionally enable ipv6 docker
+export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
+    echo "Enabling IPV6 for Docker."
+    # configure the daemon with ipv6
+    mkdir -p /etc/docker/
+    cat <<EOF >/etc/docker/daemon.json
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "fc00:db8:1::/64"
+}
+EOF
+    # enable ipv6
+    sysctl net.ipv6.conf.all.disable_ipv6=0
+    sysctl net.ipv6.conf.all.forwarding=1
+    # enable ipv6 iptables
+    modprobe -v ip6table_nat
+fi
+
+# Check if the job has opted-in to docker-in-docker availability.
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Docker in Docker enabled, initializing..."
+    printf '=%.0s' {1..80}; echo
+    # If we have opted in to docker in docker, start the docker daemon,
+    service docker start
+    # the service can be started but the docker socket not ready, wait for ready
+    WAIT_N=0
+    MAX_WAIT=5
+    while true; do
+        # docker ps -q should only work if the daemon is ready
+        docker ps -q > /dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N+1))
+            echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo "Reached maximum attempts, not waiting any longer..."
+            break
+        fi
+    done
+    printf '=%.0s' {1..80}; echo
+    echo "Done setting up docker in docker."
+
+    # Workaround for https://github.com/kubernetes/test-infra/issues/23741
+    # Instead of removing, disabled by default in case we need to address again
+    if [[ "${BOOTSTRAP_MTU_WORKAROUND:-"false"}" == "true" ]]; then
+        echo "configure iptables to set MTU"
+        iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    fi
+fi
+
+trap early_exit_handler INT TERM
+
+# disable error exit so we can run post-command cleanup
+set +o errexit
+
+# add $GOPATH/bin to $PATH
+export PATH="${GOPATH}/bin:${PATH}"
+mkdir -p "${GOPATH}/bin"
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+# Use a reproducible build date based on the most recent git commit timestamp.
+SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+export SOURCE_DATE_EPOCH
+
+# actually start bootstrap and the job
+set -o xtrace
+"$@" &
+WRAPPED_COMMAND_PID=$!
+wait $WRAPPED_COMMAND_PID
+EXIT_VALUE=$?
+set +o xtrace
+
+# cleanup after job
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Cleaning up after docker in docker."
+    printf '=%.0s' {1..80}; echo
+    cleanup_dind
+    printf '=%.0s' {1..80}; echo
+    echo "Done cleaning up after docker in docker."
+fi
+
+# preserve exit value from job / bootstrap
+exit ${EXIT_VALUE}

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,0 +1,38 @@
+variants:
+  experimental:
+    CONFIG: experimental
+    GO_VERSION: 1.21.6
+    K8S_RELEASE: stable
+  go-canary:
+    CONFIG: go-canary
+    GO_VERSION: 1.21.6
+    K8S_RELEASE: stable
+  test-infra:
+    CONFIG: test-infra
+    GO_VERSION: 1.21.6
+    K8S_RELEASE: stable
+    KIND_VERSION: 0.17.0
+  master:
+    CONFIG: master
+    GO_VERSION: 1.21.6
+    K8S_RELEASE: stable
+  main:
+    CONFIG: main
+    GO_VERSION: 1.21.5
+    K8S_RELEASE: stable
+  '1.29':
+    CONFIG: '1.29'
+    GO_VERSION: 1.21.6
+    K8S_RELEASE: latest-1.29
+  '1.28':
+    CONFIG: '1.28'
+    GO_VERSION: 1.20.13
+    K8S_RELEASE: latest-1.28
+  '1.27':
+    CONFIG: '1.27'
+    GO_VERSION: 1.20.13
+    K8S_RELEASE: stable-1.27
+  '1.26':
+    CONFIG: '1.26'
+    GO_VERSION: 1.20.13
+    K8S_RELEASE: stable-1.26

--- a/images/kubekins-e2e/README.md
+++ b/images/kubekins-e2e/README.md
@@ -1,0 +1,7 @@
+# Deprecated
+
+This image is deprecated in favour of kubekins-e2e-v2 image. Please use that image if you don't need the legacy CI kruft such as:
+- bootstrap
+- kubetest1
+- scenarios/*
+- various unmaintained tools such as logexporter, etc


### PR DESCRIPTION
I'm creating a new version of the kubekins-e2e image that can immediately replace the kubekins image usage everywhere except k/k e2e jobs and few jobs that rely on legacy tooling.

New features:

1. lean image
2. multi-arch (etcd e2e requires an arm64 image)
3. all the legacy CI cruft is gone

Fixes: https://github.com/kubernetes/test-infra/issues/31273