### PR TITLE
external-dns: Drop linting job for PR

### DIFF
--- a/config/jobs/kubernetes-sigs/external-dns/external-dns-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/external-dns/external-dns-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/external-dns:
-  - name: pull-external-dns-lint
+  - name: pull-external-dns-licensecheck
     cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - lint
+        - licensecheck
         resources:
           limits:
             cpu: 1
@@ -23,8 +23,8 @@ presubmits:
             memory: 4Gi
     annotations:
       testgrid-dashboards: sig-network-external-dns
-      testgrid-tab-name: lint
-      description: external-dns code lint
+      testgrid-tab-name: licensecheck
+      description: external-dns code license check
       testgrid-num-columns-recent: '30'
   - name: pull-external-dns-unit-test
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Github actions already [lints](https://github.com/kubernetes-sigs/external-dns/blob/a9199c10816ccea9365b6ebfa13fb429225fb3be/.github/workflows/lint.yaml) so we can skip this here and safe some compute on prow.
If the licensecheck is something you'd want to preserve, we should add this to github actions as well.

Context: https://github.com/kubernetes-sigs/external-dns/pull/4078#issuecomment-1848355789

 @johngmyers @raffo @njuettner @szuecs @mloiseleur 
