### PR TITLE
drop 1.24 from jobset as its out of support

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit.yaml
@@ -55,39 +55,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-main-1-24
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-jobset-test-e2e-main-1-24
-      description: "Run jobset end to end tests for Kubernetes 1.24"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.24.7
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
   - name: pull-jobset-test-e2e-main-1-25
     cluster: eks-prow-build-cluster
     always_run: true


### PR DESCRIPTION
1.24 is no longer in support for upstream so we shouldn't be running tests against it.

We have 1.25-1.28 (and soon will add 1.29 once that is released).

/cc @ahg-g @danielvegamyhre 