### PR TITLE
Increase pod limits as pods are getting deleted intermittently

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -166,11 +166,11 @@ presubmits:
           value: "true"
         resources:
           requests:
-            cpu: "6"
-            memory: "16Gi"
+            cpu: "10"
+            memory: "48Gi"
           limits:
-            cpu: "6"
-            memory: "16Gi"
+            cpu: "10"
+            memory: "48Gi"
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2204

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -124,8 +124,8 @@ periodics:
         value: "true"
       resources:
         requests:
-          cpu: "6"
-          memory: "16Gi"
+          cpu: "10"
+          memory: "48Gi"
         limits:
-          cpu: "6"
-          memory: "16Gi"
+          cpu: "10"
+          memory: "48Gi"


### PR DESCRIPTION
Example test run:
- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/16172/presubmit-kops-aws-scale-amazonvpc-using-cl2/1734768234244083712
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2/1734454386119151616 
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2/1733367010277986304 


Given there is no way to know exactly why these test pods are getting deleted due to  no access to Host cluster where these pods are running, my guess is resource contention, so raising the limits to see if it helps.
