### PR TITLE
CAPI: bump jobs for v1.29

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -1,60 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-main
-  cluster: eks-prow-build-cluster
-  interval: 24h
-  decorate: true
-  rerun_auth_config:
-    github_team_slugs:
-    - org: kubernetes-sigs
-      slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.29
-      args:
-      - runner.sh
-      - "./scripts/ci-e2e.sh"
-      env:
-      - name: ALWAYS_BUILD_KIND_IMAGES
-        value: "true"
-      - name: KUBERNETES_VERSION_UPGRADE_FROM
-        value: "stable-1.23"
-      - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "stable-1.24"
-      - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.3-0"
-      - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.8.6"
-      - name: GINKGO_FOCUS
-        value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7300m
-          memory: 32Gi
-        limits:
-          cpu: 7300m
-          memory: 32Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-23-1-24
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-
 - name: periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-main
   cluster: eks-prow-build-cluster
   interval: 24h
@@ -275,7 +220,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-28-latest-main
+- name: periodic-cluster-api-e2e-workload-upgrade-1-28-1-29-main
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -307,11 +252,11 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.28"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "ci/latest-1.29"
+        value: "stable-1.29"
       - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.9-0"
+        value: "3.5.10-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.10.1"
+        value: "v1.11.1"
       - name: GINKGO_FOCUS
         value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -326,6 +271,61 @@ periodics:
           memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-28-latest
+    testgrid-tab-name: capi-e2e-main-1-28-1-29
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-29-latest-main
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.29
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: ALWAYS_BUILD_KIND_IMAGES
+        value: "true"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.29"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.30"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.10-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.11.1"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+          memory: 32Gi
+        limits:
+          cpu: 7300m
+          memory: 32Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-29-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -58,7 +58,7 @@ periodics:
       # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
       # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
       - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-        value: "1.25.0"
+        value: "1.26.1"
       resources:
         requests:
           cpu: 7300m
@@ -196,9 +196,9 @@ periodics:
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
       # docs (look for minimum supported k8s version for management cluster, i.e N-3).
       # Please also make sure to refer a version where a kindest/node image exists
-      # for (see https://github.com/kubernetes-sigs/kind/releases/tag)
+      # for (see https://github.com/kubernetes-sigs/kind/releases/)
       - name: KUBERNETES_VERSION_MANAGEMENT
-        value: "v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8"
+        value: "v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6-upgrades.yaml
@@ -275,7 +275,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-28-latest-release-1-6
+- name: periodic-cluster-api-e2e-workload-upgrade-1-28-1-29-release-1-6
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -307,11 +307,11 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.28"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "ci/latest-1.29"
+        value: "stable-1.29"
       - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.9-0"
+        value: "3.5.10-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.10.1"
+        value: "v1.11.1"
       - name: GINKGO_FOCUS
         value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -326,6 +326,6 @@ periodics:
           memory: 32Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
-    testgrid-tab-name: capi-e2e-release-1-6-1-28-latest
+    testgrid-tab-name: capi-e2e-release-1-6-1-28-1-29
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -124,7 +124,7 @@ presubmits:
         # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
         # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
         - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-          value: "1.25.0"
+          value: "1.26.1"
         resources:
           requests:
             cpu: 7300m
@@ -159,8 +159,10 @@ presubmits:
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
         # docs (look for minimum supported k8s version for management cluster, i.e N-3).
+        # Please also make sure to refer a version where a kindest/node image exists
+        # for (see https://github.com/kubernetes-sigs/kind/releases/)
         - name: KUBERNETES_VERSION_MANAGEMENT
-          value: "v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8"
+          value: "v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -282,7 +284,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
-  - name: pull-cluster-api-e2e-workload-upgrade-1-28-latest-main
+  - name: pull-cluster-api-e2e-workload-upgrade-1-29-latest-main
     cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
@@ -308,13 +310,13 @@ presubmits:
           - name: ALWAYS_BUILD_KIND_IMAGES
             value: "true"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.28"
+            value: "stable-1.29"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.29"
+            value: "ci/latest-1.30"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.9-0"
+            value: "3.5.10-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.10.1"
+            value: "v1.11.1"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
@@ -329,7 +331,7 @@ presubmits:
             memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-main-1-28-latest
+      testgrid-tab-name: capi-pr-e2e-main-1-29-latest
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-main-experimental
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-6.yaml
@@ -282,7 +282,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-full-release-1-6
-  - name: pull-cluster-api-e2e-workload-upgrade-1-28-latest-release-1-6
+  - name: pull-cluster-api-e2e-workload-upgrade-1-28-1-29-release-1-6
     cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
@@ -310,11 +310,11 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "stable-1.28"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.29"
+            value: "stable-1.29"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.9-0"
+            value: "3.5.10-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.10.1"
+            value: "v1.11.1"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
@@ -329,7 +329,7 @@ presubmits:
             memory: 32Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
-      testgrid-tab-name: capi-pr-e2e-release-1-6-1-28-latest
+      testgrid-tab-name: capi-pr-e2e-release-1-6-1-28-1-29
   # This job is experimental for now. Please do not duplicate it to release branches.
   - name: pull-cluster-api-e2e-scale-release-1-6-experimental
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api/issues/9578

Prerequirements before merging:
- [x] wait for kubernetest v1.29 release
- [x] wait for merge:
  - https://github.com/kubernetes-sigs/cluster-api/pull/9872