### PR TITLE
[aws][janitor] exclude resources tagged with "Shared=True"

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -14,6 +14,7 @@ periodics:
       args:
       - --ttl=6h
       - --path=s3://cloud-provider-aws-shared-e2e/objs.json
+      - --exclude-tags=Shared=Ignore
       image: gcr.io/k8s-staging-boskos/aws-janitor:v20230908-da54d76
       resources:
         requests:
@@ -41,6 +42,7 @@ periodics:
       args:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json
+      - --exclude-tags=Shared=Ignore
       image: gcr.io/k8s-staging-boskos/aws-janitor:v20230908-da54d76
   annotations:
     testgrid-dashboards: sig-testing-maintenance


### PR DESCRIPTION
roles for example `aws-shared-testing-role` are getting cleaned up! so let's add a tag that the janitor can ignore