### PR TITLE
Fix containerd jobs failure: version `GLIBC_2.34' not found

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -979,7 +979,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-stable
+      - --image-family=cos-beta
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1027,7 +1027,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-stable
+      - --image-family=cos-beta
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1463,7 +1463,7 @@ periodics:
       - --gcp-nodes=1
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
-      - --image-family=cos-stable
+      - --image-family=cos-beta
       - --image-project=cos-cloud
       - --provider=gce
       # Currently, in-place pod resize tests have two SIGDescribe jobs:
@@ -1518,7 +1518,7 @@ periodics:
       - --gcp-nodes=1
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
-      - --image-family=cos-stable
+      - --image-family=cos-beta
       - --image-project=cos-cloud
       - --provider=gce
       # Currently, in-place pod resize tests have two SIGDescribe jobs:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -470,7 +470,7 @@ periodics:
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
       - --env=KUBE_NODE_OS_DISTRIBUTION=gci
-      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
+      - --env=KUBE_GCE_NODE_IMAGE=cos-beta-109-17800-66-33
       - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2432,6 +2432,8 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --gcp-nodes=1
+        - --image-project=cos-cloud
+        - --image-family=cos-beta
         - --runtime-config=api/all=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-inplace-pod-resize-containerd-main-v2
         - --test_args=--ginkgo.focus=\[Feature:InPlacePodVerticalScaling\]


### PR DESCRIPTION
This is a naive attempt to fix https://github.com/kubernetes/kubernetes/issues/121309

The problem seems to be that containerd binaries are built on a system with higher version GLiBC than exists in any of cos-stable images. This can be solved in a bunch of different ways. The best way in my opinion would be using statically built containerd, which would guarantee that this error will not bite us in future. However, this may take some time to implement.

I'm proposing this quick solution as it's better to fix 5 test failures now than wait until a better solution for a long time.