### PR TITLE
gerrit: trigger jobs coming out of WIP status

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -46,6 +46,7 @@ import (
 const (
 	inRepoConfigRetries = 2
 	inRepoConfigFailed  = "Unable to get inRepoConfig. This could be due to a merge conflict (please resolve them), an inRepoConfig parsing error (incorrect formatting) in the .prow directory or .prow.yaml file, or a flake. For possible flakes, try again with /test all"
+	noLongerWIP         = "Set Ready For Review"
 )
 
 var gerritMetrics = struct {
@@ -552,6 +553,9 @@ func (c *Controller) shouldSkipProcessingChange(change client.ChangeInfo, lastPr
 
 	for _, message := range currentMessages(change, lastProjectSyncTime) {
 		if c.messageContainsJobTriggeringCommand(message) {
+			return false
+		}
+		if message.Message == noLongerWIP {
 			return false
 		}
 	}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -252,6 +252,28 @@ func TestSkipChangeProcessingChecks(t *testing.T) {
 			latest:   lastUpdateTime,
 			result:   false,
 		},
+		{
+			name:     "trigger jobs for previously-seen change coming out of WIP status",
+			instance: instance,
+			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
+				Revisions: map[string]gerrit.RevisionInfo{
+					"10": {
+						Number: 10,
+						// The associated revision is old (predates
+						// lastUpdateTime)...
+						Created: makeStamp(now.Add(-2 * time.Hour))},
+				}, Messages: []gerrit.ChangeMessageInfo{
+					{
+						Date: makeStamp(now),
+						// ...but we shouldn't skip triggering jobs for it
+						// because the message says this is no longer WIP.
+						Message:        noLongerWIP,
+						RevisionNumber: 10,
+					},
+				}},
+			latest: lastUpdateTime,
+			result: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -165,7 +165,7 @@ func fakeProwYAMLGetter(
 	return &res, nil
 }
 
-func TestSkipChangeProcessingChecks(t *testing.T) {
+func TestShouldTriggerJobs(t *testing.T) {
 	now := time.Now()
 	instance := "gke-host"
 	project := "private-cloud"
@@ -188,17 +188,17 @@ func TestSkipChangeProcessingChecks(t *testing.T) {
 		result   bool
 	}{
 		{
-			name:     "should not skip change processing when revision is new",
+			name:     "trigger jobs when revision is new",
 			instance: instance,
 			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
 				Revisions: map[string]gerrit.RevisionInfo{
 					"10": {Created: makeStamp(now)},
 				}},
 			latest: lastUpdateTime,
-			result: false,
+			result: true,
 		},
 		{
-			name:     "should not skip change processing when comment contains test related commands",
+			name:     "trigger jobs when comment contains test related commands",
 			instance: instance,
 			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
 				Revisions: map[string]gerrit.RevisionInfo{
@@ -211,10 +211,10 @@ func TestSkipChangeProcessingChecks(t *testing.T) {
 					},
 				}},
 			latest: lastUpdateTime,
-			result: false,
+			result: true,
 		},
 		{
-			name:     "should not skip change processing when comment contains custom test name",
+			name:     "trigger jobs when comment contains /test with custom test name",
 			instance: instance,
 			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
 				Revisions: map[string]gerrit.RevisionInfo{
@@ -227,10 +227,10 @@ func TestSkipChangeProcessingChecks(t *testing.T) {
 					},
 				}},
 			latest: lastUpdateTime,
-			result: false,
+			result: true,
 		},
 		{
-			name:     "should skip change processing when command does not conform to requirements",
+			name:     "do not trigger when command does not conform to requirements",
 			instance: instance,
 			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
 				Revisions: map[string]gerrit.RevisionInfo{
@@ -243,14 +243,14 @@ func TestSkipChangeProcessingChecks(t *testing.T) {
 					},
 				}},
 			latest: lastUpdateTime,
-			result: true,
+			result: false,
 		},
 		{
-			name:     "should not skip change processing for postsubmit jobs",
+			name:     "trigger jobs for merge events (in order to trigger postsubmit jobs)",
 			instance: instance,
 			change:   gerrit.ChangeInfo{Status: client.Merged},
 			latest:   lastUpdateTime,
-			result:   false,
+			result:   true,
 		},
 		{
 			name:     "trigger jobs for previously-seen change coming out of WIP status",
@@ -272,14 +272,14 @@ func TestSkipChangeProcessingChecks(t *testing.T) {
 					},
 				}},
 			latest: lastUpdateTime,
-			result: false,
+			result: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := c.shouldSkipProcessingChange(tc.change, tc.latest); got != tc.result {
-				t.Errorf("expected skip change processing checks returns %t, got %t", tc.result, got)
+			if got := c.shouldTriggerJobs(tc.change, tc.latest); got != tc.result {
+				t.Errorf("want %t, got %t", tc.result, got)
 			}
 		})
 	}


### PR DESCRIPTION
In 18997b36a0 (Merge pull request #30269 from
timwangmusic/feat/ignore-irrelavant-change-updates, 2023-08-16), we
started using the `shouldSkipProcessingChange()` function to gate our
previously unconditional call to `triggerJobs()` in
prow/gerrit/adapter/adapter.go. This function by default tries to skip
things aggressively, only letting in a handful of exceptions.

Currently it has exceptions for 3 cases where jobs should be triggered:

1. merge events (a change is merged back to the base branch)

2. new changes (the change's creation time is after the last time we
   synced with Gerrit)

3. "/test ..." events (user explicitly wanted to trigger jobs)

The above cases do not account for the case where we have an old change
whose status changes from being Work-in-Progress to being "Ready For
Review" (which Gerrit denotes with a "Set Ready For Review" message).

Add a new triggering condition for the above case (1st commit).

Also, refactor a bit to increase code readability (2nd commit).

/cc @cjwagner @airbornepony @timwangmusic 
