### PR TITLE
pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2: fix 'GLIBC_2.34 not found' failure

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2425,6 +2425,7 @@ presubmits:
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation
         - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
         - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
+        - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-66-33
         - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
         - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
         - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd


### PR DESCRIPTION
This is a follow-up PR for the https://github.com/kubernetes/test-infra/pull/31463
It sets node image to the latest cos-stable. Currently this job uses cos-97, which has older glibc version.
Here is a quote from the latest [build log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/120459/pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2/1736289895694995456/build-log.txt):
```
Using image: cos-97-16919-404-21 from project: cos-cloud as node image
```