### PR TITLE
Use default cos image

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -149,7 +149,6 @@ periodics:
         ./test/build.sh get-ci-env &&
         source ci.env &&
         /workspace/scenarios/kubernetes_e2e.py
-        --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
         --cluster=
         --extract=ci/latest
         --provider=gce
@@ -195,7 +194,6 @@ periodics:
         ./test/build.sh -f get-ci-env &&
         source ci-custom-flags.env &&
         /workspace/scenarios/kubernetes_e2e.py
-        --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
         --cluster=
         --extract=ci/latest
         --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -45,9 +45,7 @@ presubmits:
         - --extract=local
         # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
         # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-        - --env=KUBE_NODE_OS_DISTRIBUTION=gci
         - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
-        - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
         - --gcp-node-image=gci
         - --gcp-nodes=4
         - --gcp-project-type=gpu-project

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -37,9 +37,7 @@ periodics:
       - --extract-ci-bucket=k8s-release-dev
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
-      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b
@@ -80,9 +78,7 @@ periodics:
       - --extract-ci-bucket=k8s-release-dev
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
-      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project=k8s-infra-e2e-gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -67,7 +67,6 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-0-47
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
@@ -469,10 +468,7 @@ periodics:
       - --extract=ci/latest
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-      - --env=KUBE_NODE_OS_DISTRIBUTION=gci
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
-      - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b
@@ -972,7 +968,6 @@ periodics:
       args:
       - --check-leaked-resources
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
@@ -1021,7 +1016,6 @@ periodics:
       args:
       - --check-leaked-resources
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
@@ -1458,7 +1452,6 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd
@@ -1514,7 +1507,6 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1
       - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2424,8 +2424,6 @@ presubmits:
         - --cluster=
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation
         - --env=KUBE_FEATURE_GATES=InPlacePodVerticalScaling=true
-        - --env=KUBE_GCE_MASTER_IMAGE=cos-109-17800-66-33
-        - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-66-33
         - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
         - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
         - --env=KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service --cgroup-driver=systemd


### PR DESCRIPTION
This is a follow up PR for https://github.com/kubernetes/kubernetes/pull/122359

Dropped explicit specification of the master and node cos images in the job configurations due to the changed default images with the following exceptions:
- nvidia-gpu jobs as nvidia installer images should also be changed (this can be addressed in a separate PR)
- release branch jobs

Here is a list of kept settings:
```
config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml:        - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
config/jobs/kubernetes/sig-node/containerd.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml:        - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml:        - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml:      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml:        - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47

```