### PR TITLE
chore: update CAPO maintainers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
@@ -6,12 +6,8 @@ approvers:
   - jichenjc
   - lentzi90
   - mdbooth
-  - seanschneeweiss
-  - tobiasgiese
 
 reviewers:
   - jichenjc
   - lentzi90
   - mdbooth
-  - seanschneeweiss
-  - tobiasgiese


### PR DESCRIPTION
Removing Tobias and Sean.
See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1793

/cc @mdbooth @lentzi90 @jichenjc 