### PR TITLE
Update milestone applier for k/website dev-1.30 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -541,7 +541,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.29: 1.29
+    dev-1.30: 1.30
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Update the k/website milestone applier for the dev-1.30 branch to automatically apply the 1.30 milestone for PRs created against the dev-1.30 branch.

/hold for review from @kubernetes/sig-docs-leads