### PR TITLE
ResultStore: determine content type from filenames

### DIFF
--- a/prow/crier/reporters/resultstore/reporter.go
+++ b/prow/crier/reporters/resultstore/reporter.go
@@ -162,9 +162,8 @@ func defaultFiles(pj *v1.ProwJob) []resultstore.DefaultFile {
 	// case of error, skip it since the GCS reporter won't write it.
 	if bs, err := util.MarshalProwJob(pj); err == nil {
 		fs = append(fs, resultstore.DefaultFile{
-			Name:        "prowjob.json",
-			Size:        int64(len(bs)),
-			ContentType: "application/json",
+			Name: "prowjob.json",
+			Size: int64(len(bs)),
 		})
 	}
 	return fs


### PR DESCRIPTION
Retreiving content type from GCS requires per-file GCS access via the opener.Attributes function which is expensive, and untenable when many files are involved.

While we believe ResultStore and/or its UI should take care of fetching file attributes, that is not the case today. So to resolve this TODO, we will take the length from the io.Iterator and determine the type using the mime package.

An override is present for *.log files, to use text/plain instead of text/x-log.