### PR TITLE
add 1.29 to kueue presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -58,44 +58,6 @@ presubmits:
           limits:
             cpu: "4"
             memory: "6Gi"
-  - name: pull-kueue-test-e2e-main-1-25
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-25
-      description: "Run kueue end to end tests for Kubernetes 1.25"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.25.11
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.21
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "10"
-            memory: "10Gi"
-          limits:
-            cpu: "10"
-            memory: "10Gi"
   - name: pull-kueue-test-e2e-main-1-26
     cluster: eks-prow-build-cluster
     branches:
@@ -191,6 +153,44 @@ presubmits:
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.28.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.21
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
+  - name: pull-kueue-test-e2e-main-1-29
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^main
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-main-1-29
+      description: "Run kueue end to end tests for Kubernetes 1.29"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.29.0
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.21
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-5.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-5.yaml
@@ -210,6 +210,44 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
+  - name: pull-kueue-test-e2e-release-0-5-1-29
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^release-0.5
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-5-1-29
+      description: "Run kueue end to end tests for Kubernetes 1.29"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.29.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.21
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
   - name: pull-kueue-verify-release-0-5
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -261,3 +261,49 @@ periodics:
             limits:
               cpu: "10"
               memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-main-1-29
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-main-1-29
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue end to end tests for Kubernetes 1.29"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.29.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.21
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"


### PR DESCRIPTION
Add 1.29 to Kueue e2e tests.

Question to reviewer:

Should I include these for all releases of Kueue and the release-blocking tests?

