### PR TITLE
ResultStore: Add .txt mime content type

### DIFF
--- a/prow/resultstore/files.go
+++ b/prow/resultstore/files.go
@@ -239,6 +239,8 @@ func (b *filesBuilder) AddDir(name string) {
 func init() {
 	// Avoid the default of "text/x-log" for log files.
 	mime.AddExtensionType(".log", "text/plain")
+	// May not exist in the container.
+	mime.AddExtensionType(".txt", "text/plain")
 }
 
 func contentType(name string) string {


### PR DESCRIPTION
This common type is not supported by Crier's container, so add it.