### PR TITLE
Use latest instead of latest-fast for gce conformance

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -4,7 +4,7 @@ periodics:
   name: ci-kubernetes-gce-conformance-latest-kubetest2
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "MARKER_VERSION=latest-fast.txt -> MARKER_VERSION=latest-{{.Version}}.txt"
+    fork-per-release-replacements: "MARKER_VERSION=latest.txt -> MARKER_VERSION=latest-{{.Version}}.txt"
     testgrid-dashboards: sig-release-master-blocking, conformance-all, conformance-gce
     testgrid-tab-name: Conformance - GCE - master - kubetest2
     description: Runs conformance tests using kubetest2 against kubernetes master on GCE
@@ -49,16 +49,16 @@ periodics:
         go install sigs.k8s.io/kubetest2@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-        MARKER_VERSION=latest-fast.txt;
+        MARKER_VERSION=latest.txt;
         kubetest2 gce \;
           --v=9 \;
           --legacy-mode \;
           --up \;
           --down \;
-          --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/$MARKER_VERSION \;
+          --kubernetes-version=https://dl.k8s.io/ci/$MARKER_VERSION \;
           --test=ginkgo \;
           -- \;
-          --test-package-url=https://storage.googleapis.com/k8s-release-dev \;
+          --test-package-url=https://dl.k8s.io \;
           --test-package-dir=ci \;
           --test-package-marker=$MARKER_VERSION \;
           --focus-regex='\[Conformance\]'


### PR DESCRIPTION
When krel builds latest-fast.txt, it puts the marker in the wrong place. https://github.com/kubernetes/release/issues/3403

For now, i'm using latest.txt to mitigate this.

kubetest2 assumes the following:
```
 mahamed  MAHAALI-M-2PY9  ~  Desktop  Git  $  curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt && echo
v1.30.0-alpha.0.341+d647d19f6aef81
 mahamed  MAHAALI-M-2PY9  ~  Desktop  Git  $  curl https://storage.googleapis.com/k8s-release-dev/ci/v1.30.0-alpha.0.341+d647d19f6aef81/kubernetes.tar.gz -I
HTTP/2 200
x-guploader-uploadid: ABPtcPoVoPSTrHrPjRjoemgJc8HLW6F8kRZl6q_Qq-Ch937Ipzl3ySzt2O-itW-Hq0Bb0iZ3JSi9uNS9lw
expires: Tue, 19 Dec 2023 18:29:20 GMT
date: Tue, 19 Dec 2023 17:29:20 GMT
cache-control: public, max-age=3600
last-modified: Tue, 19 Dec 2023 17:15:35 GMT
etag: "f88cb622056e230835757a3d1cdaba86"
x-goog-generation: 1703006135769937
x-goog-metageneration: 1
x-goog-stored-content-encoding: identity
x-goog-stored-content-length: 518382
x-goog-meta-goog-reserved-file-mtime: 1703005200
content-type: application/x-tar
x-goog-hash: crc32c=7Agftg==
x-goog-hash: md5=+Iy2IgVuIwg1dXo9HNq6hg==
x-goog-expiration: Mon, 18 Mar 2024 17:15:35 GMT
x-goog-storage-class: STANDARD
accept-ranges: bytes
content-length: 518382
server: UploadServer
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

which breaks because when krel does a fast build, it stores it at https://storage.googleapis.com/k8s-release-dev/ci/fast/v1.30.0-alpha.0.341+d647d19f6aef81/kubernetes.tar.gz