### PR TITLE
Build k/k on post-submits only

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -31,91 +31,88 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
 
-periodics:
-- name: ci-kubernetes-build
-  interval: 1h
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
-      imagePullPolicy: Always
-      command:
-      - wrapper.sh
-      - /krel
-      - ci-build
-      - --configure-docker
-      - --allow-dup
-      - --bucket=k8s-release-dev
-      - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-master
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: "7"
-          memory: "34Gi"
-        requests:
-          cpu: "7"
-          memory: "34Gi"
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes
-        slug: release-managers
-  annotations:
-    fork-per-release: "true"
-    fork-per-release-replacements: "k8s-master -> k8s-beta, latest-default -> latest-{{.Version}}"
-    testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
-    testgrid-tab-name: build-master
-    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+postsubmits:
+  kubernetes/kubernetes:
+  - name: post-kubernetes-build
+    cluster: k8s-infra-prow-build
+    decorate: true
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    max_concurrency: 1
+    job_queue_name: build-master-fast
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+        imagePullPolicy: Always
+        command:
+        - wrapper.sh
+        - /krel
+        - ci-build
+        - --configure-docker
+        - --bucket=k8s-release-dev
+        - --registry=gcr.io/k8s-staging-ci-images
+        - --extra-version-markers=k8s-master
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "7"
+            memory: "34Gi"
+          requests:
+            cpu: "7"
+            memory: "34Gi"
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes
+          slug: release-managers
+    annotations:
+      fork-per-release: "true"
+      fork-per-release-replacements: "k8s-master -> k8s-beta, latest-default -> latest-{{.Version}}"
+      testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
+      testgrid-tab-name: build-master
+      testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
 
-- interval: 5m
-  name: ci-kubernetes-build-fast
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
-      imagePullPolicy: Always
-      command:
-      - wrapper.sh
-      - /krel
-      - ci-build
-      - --configure-docker
-      - --allow-dup
-      - --fast
-      - --bucket=k8s-release-dev
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 6
-          memory: "12Gi"
-        requests:
-          cpu: 6
-          memory: "12Gi"
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes
-        slug: release-managers
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
-    testgrid-tab-name: build-master-fast
-    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    description: 'Ends up running: make quick-release'
+  - name: post-kubernetes-build-fast
+    cluster: k8s-infra-prow-build
+    branches:
+    - master
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    max_concurrency: 1
+    job_queue_name: build-master-fast
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+        imagePullPolicy: Always
+        command:
+        - wrapper.sh
+        - /krel
+        - ci-build
+        - --configure-docker
+        - --fast
+        - --bucket=k8s-release-dev
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: "12Gi"
+          requests:
+            cpu: 6
+            memory: "12Gi"
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes
+          slug: release-managers
+    annotations:
+      testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
+      testgrid-tab-name: build-master-fast
+      testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+      description: 'runs: make quick-release which creates amd64 release assets only'

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -8,6 +8,8 @@ plank:
   pod_unscheduled_timeout: 5m
   job_queue_capacities:
     'k8sio-image-promo': 1
+    'build-master': 1
+    'build-master-fast': 1
   default_decoration_config_entries:
   - config:
       timeout: 2h

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -15,7 +15,6 @@ external_services:
     prow_url: prow.istio.io
 jobs:
   kubernetes-jenkins/logs/:
-  - ci-kubernetes-build
   - ci-kubernetes-e2e-gce-scale-correctness
   - ci-kubernetes-e2e-gce-scale-performance
   - ci-kubernetes-e2e-gci-gce


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/3403
Slack thread: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1702989172852119

Right now, we run a fast build of k/k every 5 minutes and a full build every 2 hours. This is problematic for a few reasons:
- Waste of compute resources
- kops verifies binary checksums in the CI bucket and there are a number of jobs that fail because a published release has been rebuilt and has a new checksum
```
W1218 16:42:33.722140     781 main.go:133] got error running nodeup (will retry in 30s): error adding asset "f0629ade02c3f8061d2956e82604f3355885fecfc569a8c54a36881331d755c0@https://storage.googleapis.com/k8s-release-dev/ci/v1.30.0-alpha.0.322+368dfe3a88d222/bin/linux/amd64/kubelet": downloaded from "https://storage.googleapis.com/k8s-release-dev/ci/v1.30.0-alpha.0.322+368dfe3a88d222/bin/linux/amd64/kubelet" but hash did not match expected "sha256:f0629ade02c3f8061d2956e82604f3355885fecfc569a8c54a36881331d755c0"
I1218 16:43:03.917136     781 resolver.go:201] Found cluster-name="e2e-e2e-ci-kubernetes-e2e-cos-gce-can 
```

I have configured the build jobs to run with the following changes:
- when a PR is merged, a postsubmit is triggered that creates both a fast and a full build. (The bucket has a 90 day retention policy and we merge PRs every week)
- `max_concurrency` is set to avoid markers being mutated by concurrent builds. each commit will be built once and sequentially to avoid a previous build being mutated
- fast builds are stored inside `gs://k8s-release-dev/ci/fast` and full builds are stored inside `gs://k8s-release-dev/ci` ensuring the 2 jobs don't mutate each others files
- `--allow-dup` flag is no longer needed as each build will be a unique commit

@kubernetes/release-managers @kubernetes/release-engineering 