### PR TITLE
Unify Gerrit code URL determination

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1517,7 +1517,7 @@ func HandleGitProviderLink(githubHost string, secure bool) http.HandlerFunc {
 				http.Redirect(w, r, "", http.StatusNotFound)
 				return
 			}
-			orgCodeURL, err := gerritsource.CodeRootURL(org)
+			orgCodeURL, err := gerritsource.CodeURL(org)
 			if err != nil {
 				logrus.WithError(err).WithField("cloneURI", repo).Warn("Failed deriving source code URL from cloneURI.")
 				http.Redirect(w, r, "", http.StatusNotFound)

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -416,12 +416,9 @@ func CreateRefs(instance, project, branch, baseSHA string, changes ...client.Cha
 	var refs prowapi.Refs
 	cloneURI := source.CloneURIFromOrgRepo(instance, project)
 
-	var codeHost string // Something like https://android.googlesource.com
-	parts := strings.SplitN(instance, ".", 2)
-	codeHost = strings.TrimSuffix(parts[0], "-review")
-	if len(parts) > 1 {
-		codeHost += "." + parts[1]
-	}
+	// Something like https://android.googlesource.com
+	codeHost := source.EnsureCodeURL(instance)
+
 	refs = prowapi.Refs{
 		Org:      instance, // Something like android-review.googlesource.com
 		Repo:     project,  // Something like platform/build

--- a/prow/gerrit/source/source_test.go
+++ b/prow/gerrit/source/source_test.go
@@ -194,7 +194,7 @@ func TestOrgRepoFromCloneURI(t *testing.T) {
 	}
 }
 
-func TestCodeRootURL(t *testing.T) {
+func TestCodeURL(t *testing.T) {
 	tests := []struct {
 		name    string
 		in      string
@@ -216,12 +216,17 @@ func TestCodeRootURL(t *testing.T) {
 			in:      "https://foo.googlesource.com",
 			wantErr: true,
 		},
+		{
+			name:    "non-url",
+			in:      "other-review",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotErr := CodeRootURL(tc.in)
+			got, gotErr := CodeURL(tc.in)
 			if tc.wantErr {
 				if gotErr == nil {
 					t.Fatal("Want error, got nil")
@@ -233,6 +238,49 @@ func TestCodeRootURL(t *testing.T) {
 			}
 			if want, got := tc.want, got; want != got {
 				t.Fatalf("Want: %s, got: %s", want, got)
+			}
+		})
+	}
+}
+
+func TestEnsureCodeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "base",
+			in:   "https://foo-review.googlesource.com",
+			want: "https://foo.googlesource.com",
+		},
+		{
+			name: "with-repo",
+			in:   "https://foo-review.googlesource.com/bar",
+			want: "https://foo.googlesource.com/bar",
+		},
+		{
+			name: "other",
+			in:   "https://foo.googlesource.com",
+			want: "https://foo.googlesource.com",
+		},
+		{
+			name: "wrong-place",
+			in:   "https://foo.googlesource-review.com",
+			want: "https://foo.googlesource-review.com",
+		},
+		{
+			name: "non-url",
+			in:   "other-review",
+			want: "other-review",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EnsureCodeURL(tc.in)
+			if want, got := tc.want, got; want != got {
+				t.Errorf("Want: %s, got: %s", want, got)
 			}
 		})
 	}

--- a/prow/resultstore/payload.go
+++ b/prow/resultstore/payload.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	gerrit "k8s.io/test-infra/prow/gerrit/source"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -242,19 +243,10 @@ func startedProperties(started *metadata.Started) []*resultstore.Property {
 	for _, r := range repos {
 		ps = append(ps, &resultstore.Property{
 			Key:   "Repo",
-			Value: fixRepo(r),
+			Value: gerrit.EnsureCodeURL(r),
 		})
 	}
 	return ps
-}
-
-// fixRepo deletes the "-review" segment present in some Gerrit Repos to
-// produce a valid URL. Cf. CreateRefs() in gerrit/adapter/adapter.go.
-func fixRepo(repo string) string {
-	if ps := strings.SplitN(repo, ".", 2); len(ps) > 1 {
-		return strings.TrimSuffix(ps[0], "-review") + "." + ps[1]
-	}
-	return repo
 }
 
 const defaultConfigurationId = "default"


### PR DESCRIPTION
Add EnsureCodeURL(), a permissive version of CodeRootURL() to use in all places where the Gerrit code root is determined from what may be a review URL.

Also renamed CodeRootURL() to CodeURL(), since "Root" didn't seem to add any meaning and could be confusing.

This ensures consistency should these Gerrit mappings ever change.