### PR TITLE
Avoid suppressing inrepo config error comments when only processing relevant events.

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -517,7 +517,12 @@ func (c *Controller) handleInRepoConfigError(err error, instance string, change 
 	key := fmt.Sprintf("%s%s%s", instance, change.ID, change.CurrentRevision)
 	if err != nil {
 		// Only report back to Gerrit if we have not reported previously.
-		if _, alreadyReported := c.inRepoConfigFailuresTracker[key]; !alreadyReported {
+		// If any new `/test` commands are given and fail for the same reason we won't post another error message
+		// which can be confusing to users. This behavior is to prevent us from reporting the failure again
+		// on unrelated comments (including the error message itself!), but we don't need this behavior if
+		// we don't process irrelevant comments which is the case if AllowedPresubmitTriggerRe is specified.
+		skipIrrelevantComments := c.config().Gerrit.AllowedPresubmitTriggerReRawString != ""
+		if _, alreadyReported := c.inRepoConfigFailuresTracker[key]; !alreadyReported || skipIrrelevantComments {
 			msg := fmt.Sprintf("%s: %v", inRepoConfigFailed, err)
 			if setReviewWerr := c.gc.SetReview(instance, change.ID, change.CurrentRevision, msg, nil); setReviewWerr != nil {
 				return fmt.Errorf("failed to get inRepoConfig and failed to set Review to notify user: %v and %v", err, setReviewWerr)


### PR DESCRIPTION
/assign @airbornepony @timwangmusic 

Currently, after we've failed to load inrepo config on a triggering event (e.g. a new patchset), if any new `/test` commands are given and also fail to load inrepo config, we won't post another error message. This can be confusing to users since Prow appears to ignore their new `/test` commands. This behavior is intended to prevent us from reporting the failure again in reaction to unrelated comments (including the error message comments themselves), but we don't need this behavior if `AllowedPresubmitTriggerRe` is specified because in that case we don't process irrelevant comments so we can safely assume we are reprocessing the change because of a new triggering event.