### PR TITLE
descheduler: update presubmits for 1.29 release

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -10,6 +10,8 @@ postsubmits:
         - damemi
         - ingvagabund
         - seanmalloy
+        - a7i
+        - knelasevero
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -14,7 +14,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20.7
+      - image: public.ecr.aws/docker/library/golang:1.21.5
         command:
         - make
         args:
@@ -39,7 +39,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20.7
+      - image: public.ecr.aws/docker/library/golang:1.21.5
         command:
         - make
         args:
@@ -65,7 +65,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20.7
+      - image: public.ecr.aws/docker/library/golang:1.21.5
         command:
         - make
         args:
@@ -76,6 +76,44 @@ presubmits:
             memory: 4Gi
           requests:
             cpu: 6
+            memory: 4Gi
+  - name: pull-descheduler-test-e2e-k8s-master-1-29
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.29
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.29.0"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-28
     cluster: eks-prow-build-cluster
@@ -138,44 +176,6 @@ presubmits:
         env:
         - name: KUBERNETES_VERSION
           value: "v1.27.3"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 4
-            memory: 4Gi
-          requests:
-            cpu: 4
-            memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-master-1-26
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.26
-    decorate: true
-    decoration_config:
-      timeout: 20m
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.26.6"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
@@ -1,20 +1,20 @@
 # sigs.k8s.io/descheduler presubmits
 presubmits:
   kubernetes-sigs/descheduler:
-  - name: pull-descheduler-verify-release-1-25
+  - name: pull-descheduler-verify-release-1-29
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-release-1.25
+      testgrid-tab-name: pull-descheduler-verify-release-1.29
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.25$
+    - ^release-1.29$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.0
+      - image: public.ecr.aws/docker/library/golang:1.21.5
         command:
         - make
         args:
@@ -26,20 +26,20 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-verify-build-release-1-25
+  - name: pull-descheduler-verify-build-release-1-29
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-build-release-1.25
+      testgrid-tab-name: pull-descheduler-verify-build-release-1.29
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.25$
+    - ^release-1.29$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.0
+      - image: public.ecr.aws/docker/library/golang:1.21.5
         command:
         - make
         args:
@@ -51,21 +51,21 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-unit-test-release-1-25
+  - name: pull-descheduler-unit-test-release-1-29
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-unit-test-release-1.25
+      testgrid-tab-name: pull-descheduler-unit-test-release-1.29
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.25$
+    - ^release-1.29$
     always_run: false
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19.0
+      - image: public.ecr.aws/docker/library/golang:1.21.5
         command:
         - make
         args:
@@ -77,11 +77,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-25-1-25
+  - name: pull-descheduler-test-e2e-k8s-release-1-29-1-29
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-25-1.25
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-29-1.29
     decorate: true
     decoration_config:
       timeout: 20m
@@ -90,7 +90,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.25
+    - release-1.29
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
@@ -99,7 +99,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.25.11"
+          value: "v1.29.0"
         - name: KIND_E2E
           value: "true"
         args:
@@ -115,11 +115,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-25-1-24
+  - name: pull-descheduler-test-e2e-k8s-release-1-29-1-28
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-25-1.24
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-29-1.28
     decorate: true
     decoration_config:
       timeout: 20m
@@ -128,7 +128,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.25
+    - release-1.29
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
@@ -137,7 +137,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.24.15"
+          value: "v1.28.0"
         - name: KIND_E2E
           value: "true"
         args:
@@ -153,11 +153,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-25-1-23
+  - name: pull-descheduler-test-e2e-k8s-release-1-29-1-27
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-25-1.23
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-29-1.27
     decorate: true
     decoration_config:
       timeout: 20m
@@ -166,7 +166,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.25
+    - release-1.29
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.23.17"
+          value: "v1.27.3"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
/cc @seanmalloy @damemi @ingvagabund @knelasevero @jklaw90 

update descheduler repo for 1.29 presubmits testing. Previous update: https://github.com/kubernetes/test-infra/pull/29285

related issue: https://github.com/kubernetes-sigs/descheduler/issues/1323