### PR TITLE
Draft: kops: add --service-proxy-type override to test suite

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1294,6 +1294,9 @@ def generate_network_plugins():
         focus_regex = None
         if plugin == 'cilium-eni':
             focus_regex = r'\[Conformance\]|\[NodeConformance\]'
+        test_args = None
+        if plugin == 'kuberouter':
+            test_args = '--service-proxy-type=ipvs'
         results.append(
             build_test(
                 distro=distro,
@@ -1304,7 +1307,8 @@ def generate_network_plugins():
                 extra_flags=['--node-size=t3.large'],
                 extra_dashboards=['kops-network-plugins'],
                 runs_per_day=3,
-                focus_regex=focus_regex
+                focus_regex=focus_regex,
+                test_args=test_args
             )
         )
     return results
@@ -1651,6 +1655,7 @@ def generate_presubmits_network_plugins():
         optional = False
         distro = 'u2204arm64'
         focus_regex = None
+        test_args = None
         if plugin == 'cilium-eni':
             focus_regex = r'\[Conformance\]|\[NodeConformance\]'
             optional = True
@@ -1663,6 +1668,7 @@ def generate_presubmits_network_plugins():
         if plugin == 'kuberouter':
             networking_arg = 'kube-router'
             optional = True
+            test_args = '--service-proxy-type=ipvs'
         extra_flags = ['--node-size=t3.large']
         if 'arm64' in distro:
             extra_flags = ["--node-size=t4g.large"]
@@ -1678,6 +1684,7 @@ def generate_presubmits_network_plugins():
                 focus_regex=focus_regex,
                 run_if_changed=run_if_changed,
                 optional=optional,
+                test_args=test_args,
             )
         )
         if plugin in supports_ipv6:

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -550,7 +550,7 @@ periodics:
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
           -- \
-          --test-args="-test.timeout=60m" \
+          --test-args="-test.timeout=60m --service-proxy-type=ipvs" \
           --test-package-marker=stable.txt \
           --parallel=25
       env:

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -721,7 +721,7 @@ presubmits:
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
             -- \
-            --test-args="-test.timeout=60m" \
+            --test-args="-test.timeout=60m --service-proxy-type=ipvs" \
             --test-package-marker=stable.txt \
             --parallel=25
         securityContext:


### PR DESCRIPTION
@hakman 

Utilizes the change introduce here: https://github.com/kubernetes/kubernetes/pull/122440 to override the proxy type for kube-router tests so that we can accurately test service affinity settings for ClusterIP and NodePort.

https://github.com/kubernetes/kubernetes/pull/122440 has to be merged and released before this is a viable change.