### PR TITLE
kubernetes-sigs/nfd: remove cluster field from presubmit config

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -1,7 +1,6 @@
 presubmits:
   kubernetes-sigs/node-feature-discovery:
   - name: pull-node-feature-discovery-verify-master
-    cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     branches:
     - ^master


### PR DESCRIPTION
Community cluster is missing the required secret so job was pending indefinitely.

This reverts commit c10e601fb9ceab532295def20ae5f93115d63ca7.