### PR TITLE
Add 1.28&1.29 to kind e2e presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -235,6 +235,98 @@ presubmits:
             cpu: "4"
             memory: 9000Mi
   # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
+  - name: pull-kind-e2e-kubernetes-1-29
+    cluster: k8s-infra-prow-build
+    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
+    optional: false
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.29
+      path_alias: k8s.io/kubernetes
+    path_alias: sigs.k8s.io/kind
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20231206-f7b83ffbe6-1.29
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: FOCUS
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
+        # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
+        # and then pull-kubernetes-e2e-kind
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
+  - name: pull-kind-e2e-kubernetes-1-28
+    cluster: k8s-infra-prow-build
+    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
+    optional: false
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.28
+      path_alias: k8s.io/kubernetes
+    path_alias: sigs.k8s.io/kind
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20231206-f7b83ffbe6-1.28
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: FOCUS
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
+        # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
+        # and then pull-kubernetes-e2e-kind
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
   - name: pull-kind-e2e-kubernetes-1-27
     cluster: k8s-infra-prow-build
     skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
@@ -313,92 +405,6 @@ presubmits:
         - name: PARALLEL
           value: "true"
         image: gcr.io/k8s-staging-test-infra/krte:v20231206-f7b83ffbe6-1.26
-        name: ""
-        resources:
-          limits:
-            cpu: "4"
-            memory: 9000Mi
-          requests:
-            cpu: "4"
-            memory: 9000Mi
-        securityContext:
-          privileged: true
-  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
-  - skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
-    optional: false
-    decorate: true
-    decoration_config:
-      grace_period: 15m0s
-      timeout: 1h0m0s
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.25
-      path_alias: k8s.io/kubernetes
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    name: pull-kind-e2e-kubernetes-1-25
-    cluster: k8s-infra-prow-build
-    path_alias: sigs.k8s.io/kind
-    spec:
-      containers:
-      - command:
-        - wrapper.sh
-        - bash
-        - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
-        env:
-        - name: FOCUS
-          value: .
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
-        - name: PARALLEL
-          value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20231012-0288f8bc6c-1.25
-        name: ""
-        resources:
-          limits:
-            cpu: "4"
-            memory: 9000Mi
-          requests:
-            cpu: "4"
-            memory: 9000Mi
-        securityContext:
-          privileged: true
-  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
-  - skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
-    optional: false
-    decorate: true
-    decoration_config:
-      grace_period: 15m0s
-      timeout: 1h0m0s
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.24
-      path_alias: k8s.io/kubernetes
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    name: pull-kind-e2e-kubernetes-1-24
-    cluster: k8s-infra-prow-build
-    path_alias: sigs.k8s.io/kind
-    spec:
-      containers:
-      - command:
-        - wrapper.sh
-        - bash
-        - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
-        env:
-        - name: FOCUS
-          value: .
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
-        - name: PARALLEL
-          value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230904-8a576657a3-1.24
         name: ""
         resources:
           limits:


### PR DESCRIPTION
Add 1.28&1.29 to kind e2e test.

I just copy write from `pull-kind-e2e-kubernetes-1-27`, so I hope this PR didn't miss anything, please help me review it in detail,Thanks.