### PR TITLE
revert to sp based capz cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -176,8 +176,6 @@ presubmits:
               value: "true"
             - name: ENABLE_BLOBFUSE_PROXY
               value: "true"
-            - name: CLUSTER_TEMPLATE # CAPZ config
-              value: https://github.com/kubernetes-sigs/blob-csi-driver/blob/master/test/manifest/capz-template-prow-workload-identity.yaml
     annotations:
       testgrid-dashboards: provider-azure-blobfuse-csi-driver
       testgrid-tab-name: pull-blob-csi-driver-e2e-proxy


### PR DESCRIPTION
revert to sp based capz cluster since current managed identity does not work, this pipeline is broken now