### PR TITLE
set default merge method to squash for ingress2gateway

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -790,6 +790,7 @@ tide:
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash
     kubernetes/ingress-nginx: squash
+    kubernetes-sigs/ingress2gateway: squash
   pr_status_base_urls:
     '*': https://prow.k8s.io/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
set default merge method to squash for ingress2gateway so we do not need to add the label manually every time
