### PR TITLE
Set CAPV e2e-full test timeout to 3h

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics-main.yaml
@@ -85,6 +85,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 180m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits-main.yaml
@@ -174,6 +174,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 180m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:


### PR DESCRIPTION
We recently set the ginkgo timeout in CAPV to 3h. We also have to increase the job timeout accordingly (default is 2h)

xref: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2567

Signed-off-by: Stefan Büringer buringerst@vmware.com