### PR TITLE
gerrit adapter: recognize "no longer WIP" status more broadly

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -46,7 +46,6 @@ import (
 const (
 	inRepoConfigRetries = 2
 	inRepoConfigFailed  = "Unable to get inRepoConfig. This could be due to a merge conflict (please resolve them), an inRepoConfig parsing error (incorrect formatting) in the .prow directory or .prow.yaml file, or a flake. For possible flakes, try again with /test all"
-	noLongerWIP         = "Set Ready For Review"
 )
 
 var gerritMetrics = struct {
@@ -558,7 +557,7 @@ func (c *Controller) shouldTriggerJobs(change client.ChangeInfo, lastProjectSync
 		if c.messageContainsJobTriggeringCommand(message) {
 			return true
 		}
-		if message.Message == noLongerWIP {
+		if indicatesChangeFromDraftToActiveState(message.Message) {
 			return true
 		}
 	}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -253,7 +253,7 @@ func TestShouldTriggerJobs(t *testing.T) {
 			result:   true,
 		},
 		{
-			name:     "trigger jobs for previously-seen change coming out of WIP status",
+			name:     "trigger jobs for previously-seen change coming out of WIP status (via ReadyForReviewMessageFixed)",
 			instance: instance,
 			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
 				Revisions: map[string]gerrit.RevisionInfo{
@@ -267,7 +267,29 @@ func TestShouldTriggerJobs(t *testing.T) {
 						Date: makeStamp(now),
 						// ...but we shouldn't skip triggering jobs for it
 						// because the message says this is no longer WIP.
-						Message:        noLongerWIP,
+						Message:        client.ReadyForReviewMessageFixed,
+						RevisionNumber: 10,
+					},
+				}},
+			latest: lastUpdateTime,
+			result: true,
+		},
+		{
+			name:     "trigger jobs for previously-seen change coming out of WIP status (via ReadyForReviewMessageCustomizable)",
+			instance: instance,
+			change: gerrit.ChangeInfo{ID: "1", CurrentRevision: "10", Project: project,
+				Revisions: map[string]gerrit.RevisionInfo{
+					"10": {
+						Number: 10,
+						// The associated revision is old (predates
+						// lastUpdateTime)...
+						Created: makeStamp(now.Add(-2 * time.Hour))},
+				}, Messages: []gerrit.ChangeMessageInfo{
+					{
+						Date: makeStamp(now),
+						// ...but we shouldn't skip triggering jobs for it
+						// because the message says this is no longer WIP.
+						Message:        client.ReadyForReviewMessageCustomizable,
 						RevisionNumber: 10,
 					},
 				}},

--- a/prow/gerrit/adapter/trigger.go
+++ b/prow/gerrit/adapter/trigger.go
@@ -55,6 +55,11 @@ func currentMessages(change gerrit.ChangeInfo, since time.Time) []gerrit.ChangeM
 	return messages
 }
 
+func indicatesChangeFromDraftToActiveState(s string) bool {
+	return strings.HasSuffix(s, client.ReadyForReviewMessageFixed) ||
+		strings.HasSuffix(s, client.ReadyForReviewMessageCustomizable)
+}
+
 // messageFilter returns filter that matches all /test all, /test foo, /retest comments since lastUpdate.
 //
 // The behavior of each message matches the behavior of pjutil.PresubmitFilter.
@@ -77,7 +82,7 @@ func messageFilter(messages []gerrit.ChangeMessageInfo, failingContexts, allCont
 		})
 		// If the Gerrit Change changed from draft to active state, trigger all
 		// presubmit Prow jobs.
-		if strings.HasSuffix(message.Message, client.ReadyForReviewMessageFixed) || strings.HasSuffix(message.Message, client.ReadyForReviewMessageCustomizable) {
+		if indicatesChangeFromDraftToActiveState(message.Message) {
 			filters = append(filters, &timeAnnotationFilter{
 				Filter:       pjutil.NewTestAllFilter(),
 				eventTime:    message.Date.Time,


### PR DESCRIPTION
It turns out that we already had constants defined in our client describing the messages we would get from Gerrit

    // This message will be sent if users press the `MARK AS ACTIVE` button.
    ReadyForReviewMessageFixed = "Set Ready For Review"
    // This message will be sent if users press the `SEND AND START REVIEW` button.
    ReadyForReviewMessageCustomizable = "This change is ready for review."

which come from fe351fac05 (Merge pull request #22912 from chizhg/fix-draft-to-active, 2021-07-15). Reuse these constants so that we recognize the additional "This change is ready for review." string, instead of just "Set Ready For Review", which was added in ae771873b4 (Merge pull request #31448 from
listx/gerrit-trigger-jobs-coming-out-of-WIP-status, 2023-12-21).

Intuitively, it's strange that we even had to have #31448 in the first place, because we already "fixed" this bug in #22912. The reason is because in 18997b3 (Merge pull request #30269 from timwangmusic/feat/ignore-irrelavant-change-updates, 2023-08-16) we started making the Gerrit adapter preemptively start filtering out messages if they did not meet certain conditions. This filtering process happens _before_ the message is sent to the "triggerJobs()" function, which is what #22912 modified.

Add an additional test case to guard against future regressions.

Lastly, the inclusion of the word "Customizable" in the constant "ReadyForReviewMessageCustomizable" suggests that this field could potentially be customized by users. However, this string is already a default used by Gerrit itself [1], so this is an important case we should still check for.

[1] https://gerrit.googlesource.com/gerrit/+/7af3e67705aab20e144fd526cf51f6e98ed6f63a/java/com/google/gerrit/server/restapi/change/PostReviewOp.java#181

/cc @cjwagner @airbornepony @timwangmusic 