### PR TITLE
peribolos: increase peribolos timeout by 30 mins

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -4,7 +4,7 @@ postsubmits:
     cluster: test-infra-trusted
     decorate: true
     decoration_config:
-      timeout: 150m
+      timeout: 180m
     branches:
     - ^main$
     max_concurrency: 1
@@ -551,7 +551,7 @@ periodics:
   cluster: test-infra-trusted
   decorate: true
   decoration_config:
-    timeout: 150m
+    timeout: 180m
   max_concurrency: 1
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
Peribolos has been failing for the past few days due to timeouts: https://testgrid.k8s.io/sig-contribex-org#post-peribolos

Error message:
```
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:169","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h30m0s timeout","severity":"error","time":"2023-12-26T16:40:00Z"}
```

This is a second bump in timeout (first at https://github.com/kubernetes/test-infra/pull/30925)

I don't think it should be taking this long.

We need to figure out why this is happening, and this bump in timeout should be considered a temporary fix.

/assign @Priyankasaggu11929 @cblecker 