### PR TITLE
Add 30 seconds timeout for `docker stop`

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -29,7 +29,8 @@ cleanup_dind() {
     if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
         echo "Cleaning up after docker"
         docker ps -aq | xargs -r docker rm -f || true
-        service docker stop || true
+        echo "Waiting for docker to stop for 30 seconds"
+        timeout 30 service docker stop || true
     fi
 }
 

--- a/images/krte/wrapper.sh
+++ b/images/krte/wrapper.sh
@@ -40,7 +40,8 @@ cleanup(){
   if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
     >&2 echo "wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ..."
     docker ps -aq | xargs -r docker rm -f || true
-    service docker stop || true
+    >&2 echo "wrapper.sh] [CLEANUP] Waiting for docker to stop for 30 seconds"
+    timeout 30 service docker stop || true
     >&2 echo "wrapper.sh] [CLEANUP] Done cleaning up after Docker in Docker."
   fi
 }


### PR DESCRIPTION
Seeing some odd behavior where docker is refusing to come down and the prow job just sits there (waiting for it to die) even after the script has finished running. Hoping if we can do a timeout, that will do the trick?

Log snippet from [here](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-local-e2e/1741211742429515776/build-log.txt)
```
2023/12/30 23:39:38 process.go:155: Step 'bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"' finished in 6.087183ms
+ EXIT_VALUE=0
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Cleaning up after docker
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:169","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 4h0m0s timeout","severity":"error","time":"2023-12-31T01:36:48Z"}
{"component":"entrypoint","error":"os: process already finished","file":"k8s.io/test-infra/prow/entrypoint/run.go:255","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Could not interrupt process after timeout","severity":"error","time":"2023-12-31T01:36:48Z"}
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:267","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15m0s grace period","severity":"error","time":"2023-12-31T01:51:48Z"}
{"component":"entrypoint","error":"os: process already finished","file":"k8s.io/test-infra/prow/entrypoint/run.go:269","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Could not kill process after grace period","severity":"error","time":"2023-12-31T01:51:48Z"}
```