### PR TITLE
Allow `spyglass` to use aliased bucket names

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1151,6 +1151,10 @@ type Spyglass struct {
 	// PRHistLinkTemplate is the template for constructing href of `PR History` button,
 	// by default it's "/pr-history?org={{.Org}}&repo={{.Repo}}&pr={{.Number}}"
 	PRHistLinkTemplate string `json:"pr_history_link_template,omitempty"`
+	// BucketAliases permits a naive URL rewriting functionality.
+	// Keys represent aliases and their values are the authoritative
+	// bucket names they will be substituted with
+	BucketAliases map[string]string `json:"bucket_aliases,omitempty"`
 }
 
 type GCSBrowserPrefixes map[string]string
@@ -1277,7 +1281,9 @@ func (c *Config) ValidateStorageBucket(bucketName string) error {
 	if !c.Deck.shouldValidateStorageBuckets() {
 		return nil
 	}
-
+	if alias, exists := c.Deck.Spyglass.BucketAliases[bucketName]; exists {
+		bucketName = alias
+	}
 	if !c.Deck.AllKnownStorageBuckets.Has(bucketName) {
 		return NotAllowedBucketError(fmt.Errorf("bucket %q not in allowed list (%v)", bucketName, sets.List(c.Deck.AllKnownStorageBuckets)))
 	}
@@ -2607,6 +2613,10 @@ func parseProwConfig(c *Config) error {
 	}
 	if !defaultByBucketExists {
 		c.Deck.Spyglass.GCSBrowserPrefixesByBucket["*"] = c.Deck.Spyglass.GCSBrowserPrefix
+	}
+
+	if c.Deck.Spyglass.BucketAliases == nil {
+		c.Deck.Spyglass.BucketAliases = make(map[string]string)
 	}
 
 	if c.PushGateway.Interval == nil {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -359,6 +359,11 @@ deck:
         # each spyglass page. Using HTML in the template is acceptable.
         # Currently the only variable available is .ArtifactPath, which contains the GCS path for the job artifacts.
         announcement: ' '
+        # BucketAliases permits a naive URL rewriting functionality.
+        # Keys represent aliases and their values are the authoritative
+        # bucket names they will be substituted with
+        bucket_aliases:
+            "": ""
         # GCSBrowserPrefix is used to generate a link to a human-usable GCS browser.
         # If left empty, the link will be not be shown. Otherwise, a GCS path (with no
         # prefix or scheme) will be appended to GCSBrowserPrefix and shown to the user.

--- a/prow/spyglass/storageartifact_fetcher.go
+++ b/prow/spyglass/storageartifact_fetcher.go
@@ -113,6 +113,10 @@ func (af *StorageArtifactFetcher) newStorageJobSource(storagePath string) (*stor
 	}
 	buildID := tokens[len(tokens)-1]
 	name := tokens[len(tokens)-2]
+	potentialAlias := storageURL.Host
+	if bucket, exists := af.cfg().Deck.Spyglass.BucketAliases[potentialAlias]; exists {
+		storageURL.Host = bucket
+	}
 	return &storageJobSource{
 		source:     storageURL.String(),
 		linkPrefix: storageURL.Scheme + "://",


### PR DESCRIPTION
Adds a new configuration option to `Spyglass` to define a mapping of bucket aliases. Each configured alias name will map to one bucket. In the case that the alias is defined, the configured bucket name will be substituted when fetching artifacts from gcs. If no aliases are configured, the functionality will remain unchanged.

This is a follow up to: https://github.com/kubernetes/test-infra/pull/31456. The reasoning for this feature is detailed there.