### PR TITLE
Disable duplicate ci-builds for k/k

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -52,7 +52,7 @@ periodics:
       - /krel
       - ci-build
       - --configure-docker
-      - --allow-dup
+      - --allow-dup=false
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
       - --extra-version-markers=k8s-master
@@ -97,7 +97,7 @@ periodics:
       - /krel
       - ci-build
       - --configure-docker
-      - --allow-dup
+      - --allow-dup=false
       - --fast
       - --bucket=k8s-release-dev
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
Alternate approach to #31487 

/cc @BenTheElder @kubernetes/release-engineering 

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-build-fast/1742958855677022208 most recent run has passed with the changes merged in https://github.com/kubernetes/release/pull/3405

WE NEED TO UPDATE THE KUBETEST1 JOB MARKER LOCATIONS AS WELL. Done in https://github.com/kubernetes/test-infra/pull/31527