### PR TITLE
[sig-windows] Use ws2022 for containerd nightly job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -260,6 +260,7 @@ presubmits:
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-azure-capz-sa-cred: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -286,8 +287,6 @@ presubmits:
               cpu: 2
               memory: "9Gi"
           env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time
     annotations:
@@ -311,6 +310,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -337,8 +337,6 @@ presubmits:
               cpu: 2
               memory: "9Gi"
           env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
           - name: HYPERV
             value: "true"
           - name: GINKGO_FOCUS
@@ -366,6 +364,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -392,8 +391,6 @@ presubmits:
               cpu: 2
               memory: "9Gi"
           env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
           - name: GINKGO_NODES
             value: "1"
           - name: GMSA

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -240,6 +240,7 @@ periodics:
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-windows-private-registry-cred: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -269,9 +270,6 @@ periodics:
           requests:
             cpu: 2
             memory: "9Gi"
-        env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
@@ -291,6 +289,7 @@ periodics:
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
     preset-windows-private-registry-cred: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -321,8 +320,6 @@ periodics:
             cpu: 2
             memory: "9Gi"
         env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP
@@ -345,6 +342,7 @@ periodics:
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -375,8 +373,6 @@ periodics:
             cpu: 2
             memory: "9Gi"
         env:
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
           - name: GINKGO_SKIP
@@ -398,6 +394,7 @@ periodics:
     preset-windows-private-registry-cred: "true"
     preset-capz-windows-common: "true"
     preset-azure-capz-sa-cred: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
As a follow up to https://github.com/containerd/containerd/pull/9601#issuecomment-1877679153 this sets WS2022 on the containerd nightly job.  It also cleans up the usage of ENVs to be consistent with the usage of the WS2022 preset.

/sig windows 
/assign @marosset 

/hold
waiting for a clean signal on nightly job after https://github.com/containerd/containerd/pull/9601 merged.

