### PR TITLE
Use n2 machine types for scalability master instances

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -6,6 +6,8 @@ presets:
     value: type=nvidia-tesla-k80,count=2
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
+  - name: NODE_SIZE
+    value: n1-standard-2
 
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -2,8 +2,11 @@ presets:
 - labels:
     preset-ci-gce-device-plugin-gpu: "true"
   env:
+  # K80s will be uncreatable after 1st of May 2024
   - name: NODE_ACCELERATORS
     value: type=nvidia-tesla-k80,count=2
+  - name: NODE_SIZE
+    value: n1-standard-2
 
 periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -148,7 +148,9 @@ presets:
     value: "true"
   # Ensure good enough architecture for master machines.
   - name: MASTER_MIN_CPU_ARCHITECTURE
-    value: "Intel Skylake"
+    value: "Intel Ice Lake"
+  - name: MASTER_SIZE
+    value: "n2-standard-32"
   # Turn on profiling for various components and
   # increase throughput in master components.
   - name: ETCD_EXTRA_ARGS


### PR DESCRIPTION
/cc @pacoxu @dims 

This should fix the scalability/GPU failures on the release informing/blocking boards.

https://cloud.google.com/compute/docs/general-purpose-machines#n2_series
https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#availablezones

Caused by https://github.com/kubernetes/kubernetes/pull/118626