### PR TITLE
yet another fix to the nftables script

### DIFF
--- a/experiment/kind-nftables-e2e.sh
+++ b/experiment/kind-nftables-e2e.sh
@@ -107,7 +107,7 @@ create_cluster() {
   fi
 
   # JSON map injected into featureGates config
-  feature_gates="{"NFTablesProxyMode":true}"
+  feature_gates='{"NFTablesProxyMode":"true"}'
   # --runtime-config argument value passed to the API server
   runtime_config="{}"
 

--- a/experiment/kind-nftables-e2e.sh
+++ b/experiment/kind-nftables-e2e.sh
@@ -107,7 +107,7 @@ create_cluster() {
   fi
 
   # JSON map injected into featureGates config
-  feature_gates='{"NFTablesProxyMode":"true"}'
+  feature_gates='{"NFTablesProxyMode": true}'
   # --runtime-config argument value passed to the API server
   runtime_config="{}"
 


### PR DESCRIPTION
bash and quotes things

```
apiVersion: kubeproxy.config.k8s.io/v1alpha1
conntrack:
  maxPerCore: 0
featureGates:
  NFTablesProxyMode:true: false
iptables:
  minSyncPeriod: 1s
```

Change-Id: I1c1c2911514bb87c5a0f57295b4e480e06472cfa