### PR TITLE
secrets-store: add windows experimental job to test with aks

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -603,6 +603,42 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-akeyless
       description: "Run e2e test with akeyless provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-windows-experimental
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    always_run: false
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    optional: true
+    branches:
+    - ^main$
+    labels:
+      preset-azure-cred: "true"
+      preset-azure-windows: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+      preset-azure-secrets-store-creds: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            ./test/scripts/run-e2e-windows.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows-experimental
+      description: "Run E2E tests on a Windows cluster for Secrets Store CSI driver (Experimental)."
+      testgrid-num-columns-recent: '30'
 
   # release jobs
   - name: release-secrets-store-csi-driver-e2e-aws


### PR DESCRIPTION
- Add experimental job for windows. The script will be hosted in https://github.com/kubernetes-sigs/secrets-store-csi-driver and run tests in AKS cluster with windows nodes.

part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/860

/assign @nilekhc 