### PR TITLE
`Spyglass`: check for bucket alias when resolving symlink

### DIFF
--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -187,6 +187,10 @@ func (sg *Spyglass) ResolveSymlink(src string) (string, error) {
 		if keyType == api.GCSKeyType {
 			keyType = providers.GS
 		}
+		potentialAlias := strings.Split(key, "/")[0]
+		if bucket, exists := sg.cfg().Deck.Spyglass.BucketAliases[potentialAlias]; exists {
+			key = strings.Replace(key, potentialAlias, bucket, 1)
+		}
 		reader, err := sg.opener.Reader(context.TODO(), fmt.Sprintf("%s://%s.txt", keyType, key))
 		if err != nil {
 			if pkgio.IsNotExist(err) {

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -1474,6 +1474,11 @@ func TestResolveSymlink(t *testing.T) {
 			result: "gs/test-bucket/better-logs/42",
 		},
 		{
+			name:   "non-symlink with aliased bucket is replaced",
+			path:   "gcs/alias/better-logs/42",
+			result: "gs/test-bucket/better-logs/42",
+		},
+		{
 			name:   "prowjob without trailing slash is unchanged",
 			path:   "prowjob/better-logs/42",
 			result: "prowjob/better-logs/42",
@@ -1496,7 +1501,17 @@ func TestResolveSymlink(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		fakeConfigAgent := fca{}
+		fakeConfigAgent := fca{
+			c: config.Config{
+				ProwConfig: config.ProwConfig{
+					Deck: config.Deck{
+						Spyglass: config.Spyglass{
+							BucketAliases: map[string]string{"alias": "test-bucket"}},
+					},
+				},
+			},
+		}
+		//fakeConfigAgent.Config().Deck.Spyglass.BucketAliases = map[string]string{"alias": "test-bucket"}
 		fakeJa = jobs.NewJobAgent(context.Background(), fkc{}, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 		fakeJa.Start()
 


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/31543, where it was missed that the alias would also need to be checked when attempting to resolve a symlink.