### PR TITLE
secrets-store: replace aks-engine windows job with aks

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -242,64 +242,6 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-deploy-manifest-azure
       description: "Run e2e test using deploy manifest with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-windows
-    decorate: true
-    decoration_config:
-      timeout: 90m
-    always_run: true
-    path_alias: sigs.k8s.io/secrets-store-csi-driver
-    optional: false
-    branches:
-    - ^main$
-    - ^release-*
-    labels:
-      preset-azure-cred: "true"
-      preset-azure-windows: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-azure-secrets-store-creds: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-master
-        command:
-          - runner.sh
-          - kubetest
-        args:
-          - --test
-          - --up
-          - --down
-          - --build=quick
-          - --dump=$(ARTIFACTS)
-          - --provider=skeleton
-          - --deployment=aksengine
-          - --aksengine-admin-username=azureuser
-          - --aksengine-creds=$(AZURE_CREDENTIALS)
-          - --aksengine-orchestratorRelease=1.23
-          - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
-          - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-          - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/test/bats/tests/azure/job_templates/kubernetes_windows.json
-          - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-          - --test-secrets-store-csi-driver
-        securityContext:
-          privileged: true
-        env:
-          - name: TEST_WINDOWS
-            value: "true"
-        resources:
-          requests:
-            cpu: "4"
-            memory: "6Gi"
-    annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows
-      description: "Run E2E tests on a Windows cluster for Secrets Store CSI driver."
-      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-gcp
     decorate: true
     decoration_config:
@@ -603,15 +545,16 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-akeyless
       description: "Run e2e test with akeyless provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-windows-experimental
+  - name: pull-secrets-store-csi-driver-e2e-windows
     decorate: true
     decoration_config:
       timeout: 90m
-    always_run: false
+    always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
-    optional: true
+    optional: false
     branches:
     - ^main$
+    - ^release-*
     labels:
       preset-azure-cred: "true"
       preset-azure-windows: "true"
@@ -634,10 +577,13 @@ presubmits:
           requests:
             cpu: "4"
             memory: "4Gi"
+        env:
+          - name: TEST_WINDOWS
+            value: "true"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows-experimental
-      description: "Run E2E tests on a Windows cluster for Secrets Store CSI driver (Experimental)."
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows
+      description: "Run E2E tests on a AKS Windows cluster for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
 
   # release jobs


### PR DESCRIPTION
- Replace aks-engine windows job with aks.

PR to add script: https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/1405. The script has been tested using `pr-secrets-store-csi-driver-e2e-windows-experimental` job: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_secrets-store-csi-driver/1405/pull-secrets-store-csi-driver-e2e-windows-experimental/1744419379304468480

part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/860

/assign @nilekhc 