### PR TITLE
secrets-store: remove unused windows preset label

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -557,7 +557,6 @@ presubmits:
     - ^release-*
     labels:
       preset-azure-cred: "true"
-      preset-azure-windows: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
       preset-azure-secrets-store-creds: "true"


### PR DESCRIPTION
/kind cleanup

The env vars set by `preset-azure-windows: "true"` are not used. 