### PR TITLE
cluster-api: drop experimental scale job because we run a scale test in e2e-full

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -99,7 +99,7 @@ periodics:
           - "./scripts/ci-e2e.sh"
         env:
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -146,7 +146,7 @@ periodics:
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -190,7 +190,7 @@ periodics:
       - "./scripts/ci-e2e.sh"
       env:
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-5.yaml
@@ -99,7 +99,7 @@ periodics:
           - "./scripts/ci-e2e.sh"
         env:
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -146,7 +146,7 @@ periodics:
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -190,7 +190,7 @@ periodics:
       - "./scripts/ci-e2e.sh"
       env:
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       - name: KUBERNETES_VERSION_MANAGEMENT

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-6.yaml
@@ -99,7 +99,7 @@ periodics:
           - "./scripts/ci-e2e.sh"
         env:
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -146,7 +146,7 @@ periodics:
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+            value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -190,7 +190,7 @@ periodics:
       - "./scripts/ci-e2e.sh"
       env:
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -154,7 +154,7 @@ presubmits:
         - ./scripts/ci-e2e.sh
         env:
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -234,7 +234,7 @@ presubmits:
             # and the upgrade tests are being run as part of the periodic upgrade jobs.
             # This jobs ends up running all the other tests in the E2E suite
             - name: GINKGO_SKIP
-              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -270,7 +270,7 @@ presubmits:
           # and the upgrade tests are being run as part of the periodic upgrade jobs.
           # This jobs ends up running all the other tests in the E2E suite
           - name: GINKGO_SKIP
-            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -332,43 +332,3 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main-1-29-latest
-  # This job is experimental for now. Please do not duplicate it to release branches.
-  - name: pull-cluster-api-e2e-scale-main-experimental
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    decorate: true
-    optional: true
-    always_run: false
-    branches:
-    # The script this job runs is not in all branches.
-    - ^main$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.29
-        args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-        env:
-        - name: BOSKOS_HOST
-          value: "boskos.test-pods.svc.cluster.local"
-        - name: GINKGO_FOCUS
-          value: "\\[Scale\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-scale-main-experimental

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-5.yaml
@@ -154,7 +154,7 @@ presubmits:
         - ./scripts/ci-e2e.sh
         env:
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -266,7 +266,7 @@ presubmits:
             # and the upgrade tests are being run as part of the periodic upgrade jobs.
             # This jobs ends up running all the other tests in the E2E suite
             - name: GINKGO_SKIP
-              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -302,7 +302,7 @@ presubmits:
           # and the upgrade tests are being run as part of the periodic upgrade jobs.
           # This jobs ends up running all the other tests in the E2E suite
           - name: GINKGO_SKIP
-            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -364,43 +364,3 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-release-1-5-1-27-1-28
-  # This job is experimental for now. Please do not duplicate it to release branches.
-  - name: pull-cluster-api-e2e-scale-release-1-5-experimental
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    decorate: true
-    optional: true
-    always_run: false
-    branches:
-    # The script this job runs is not in all branches.
-    - ^release-1.5$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
-        args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-        env:
-        - name: BOSKOS_HOST
-          value: "boskos.test-pods.svc.cluster.local"
-        - name: GINKGO_FOCUS
-          value: "\\[Scale\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
-      testgrid-tab-name: capi-pr-e2e-scale-release-1-5-experimental

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-6.yaml
@@ -154,7 +154,7 @@ presubmits:
         - ./scripts/ci-e2e.sh
         env:
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+          value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -232,7 +232,7 @@ presubmits:
             # and the upgrade tests are being run as part of the periodic upgrade jobs.
             # This jobs ends up running all the other tests in the E2E suite
             - name: GINKGO_SKIP
-              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[Scale\\]"
+              value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ presubmits:
           # and the upgrade tests are being run as part of the periodic upgrade jobs.
           # This jobs ends up running all the other tests in the E2E suite
           - name: GINKGO_SKIP
-            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[Scale\\]"
+            value: "\\[PR-Blocking\\] \\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -330,43 +330,3 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-release-1-6-1-28-1-29
-  # This job is experimental for now. Please do not duplicate it to release branches.
-  - name: pull-cluster-api-e2e-scale-release-1-6-experimental
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    decorate: true
-    optional: true
-    always_run: false
-    branches:
-    # The script this job runs is not in all branches.
-    - ^release-1.6$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
-        args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-        env:
-        - name: BOSKOS_HOST
-          value: "boskos.test-pods.svc.cluster.local"
-        - name: GINKGO_FOCUS
-          value: "\\[Scale\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 7300m
-            memory: 32Gi
-          limits:
-            cpu: 7300m
-            memory: 32Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
-      testgrid-tab-name: capi-pr-e2e-scale-release-1-6-experimental


### PR DESCRIPTION
Drops the experimental scale presubmits because an equivalent test is part of e2e-full.