### PR TITLE
pull-kubernetes-e2e-gce: enable KUBE_WATCHLIST_INCONSISTENCY_DETECTOR

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -216,6 +216,7 @@ presubmits:
             - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
             - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+            - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
             - --extract=local
             - --gcp-master-image=ubuntu
             - --gcp-node-image=ubuntu


### PR DESCRIPTION
When this environmental variable is set then
the reflector performs a data consistency check.

The consistency check is meant to be enforced only in the CI, not in production. The check ensures that data retrieved by the watch-list api call is exactly the same as data received by the standard list api call.

As of today the inconsistency detector [runs with pull-kubernetes-e2e-gce-cos-alpha-features](https://github.com/kubernetes/test-infra/pull/31082) where it is used [only by a single test](https://github.com/kubernetes/kubernetes/blob/f2cfbf44b1fb482671aedbfff820ae2af256a389/test/e2e/apimachinery/watchlist.go#L39).

As we are preparing to promote the WatchList feature to beta and enable it for KCM, this job will be used to check for any inconsistencies.