### PR TITLE
Remove pjh from sig-windows OWNERS files

### DIFF
--- a/config/jobs/kubernetes/sig-windows/OWNERS
+++ b/config/jobs/kubernetes/sig-windows/OWNERS
@@ -4,14 +4,12 @@ reviewers:
 - jayunit100
 - jsturtevant
 - marosset
-- pjh
 approvers:
 - ddebroy
 - ibabou
 - jayunit100
 - jsturtevant
 - marosset
-- pjh
 emeritus_approvers:
 - chewong
 

--- a/config/testgrids/kubernetes/sig-windows/OWNERS
+++ b/config/testgrids/kubernetes/sig-windows/OWNERS
@@ -3,13 +3,11 @@ reviewers:
 - claudiubelu
 - jsturtevant
 - marosset
-- pjh
 approvers:
 - adelina-t
 - claudiubelu
 - jsturtevant
 - marosset
-- pjh
 
 emeritus_approvers:
 - benmoss


### PR DESCRIPTION
I'm no longer active with the Kubernetes project but I occasionally get added as a reviewer for these files.

Sorry, I should have sent this PR a while ago. Wishing the best for everyone in sig-windows!