### PR TITLE
[kops] Migrate jobs to use kubetest2's --test-package-url

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -121,7 +121,7 @@ def build_test(cloud='aws',
             extra_flags = []
         extra_flags.append("--discovery-store=s3://k8s-kops-prow/discovery")
 
-    marker, k8s_deploy_url, test_package_bucket, test_package_dir = k8s_version_info(k8s_version)
+    marker, k8s_deploy_url, test_package_url, test_package_dir = k8s_version_info(k8s_version)
     args = create_args(kops_channel, networking, extra_flags, kops_image)
 
     node_ig_overrides = ""
@@ -173,7 +173,7 @@ def build_test(cloud='aws',
         skip_regex=skip_regex,
         kops_feature_flags=','.join(feature_flags),
         terraform_version=terraform_version,
-        test_package_bucket=test_package_bucket,
+        test_package_url=test_package_url,
         test_package_dir=test_package_dir,
         focus_regex=focus_regex,
         publish_version_marker=publish_version_marker,
@@ -294,7 +294,7 @@ def presubmit_test(branch='master',
     if irsa and cloud == "aws" and scenario is None:
         extra_flags.append("--discovery-store=s3://k8s-kops-prow/discovery")
 
-    marker, k8s_deploy_url, test_package_bucket, test_package_dir = k8s_version_info(k8s_version)
+    marker, k8s_deploy_url, test_package_url, test_package_dir = k8s_version_info(k8s_version)
     args = create_args(kops_channel, networking, extra_flags, kops_image)
 
     # Scenario-specific parameters
@@ -331,7 +331,7 @@ def presubmit_test(branch='master',
         skip_regex=skip_regex,
         kops_feature_flags=','.join(feature_flags),
         terraform_version=terraform_version,
-        test_package_bucket=test_package_bucket,
+        test_package_url=test_package_url,
         test_package_dir=test_package_dir,
         focus_regex=focus_regex,
         run_if_changed=run_if_changed,

--- a/config/jobs/kubernetes/kops/helpers.py
+++ b/config/jobs/kubernetes/kops/helpers.py
@@ -76,7 +76,7 @@ def should_skip_newer_k8s(k8s_version, kops_version):
     return float(k8s_version) > float(kops_version)
 
 def k8s_version_info(k8s_version):
-    test_package_bucket = ''
+    test_package_url = ''
     test_package_dir = ''
     if k8s_version == 'latest':
         marker = 'latest.txt'
@@ -84,7 +84,7 @@ def k8s_version_info(k8s_version):
     elif k8s_version == 'ci':
         marker = 'latest.txt'
         k8s_deploy_url = "https://storage.googleapis.com/k8s-release-dev/ci/latest.txt"
-        test_package_bucket = 'k8s-release-dev'
+        test_package_url = 'https://storage.googleapis.com/k8s-release-dev'
         test_package_dir = 'ci'
     elif k8s_version == 'stable':
         marker = 'stable.txt'
@@ -94,7 +94,7 @@ def k8s_version_info(k8s_version):
         k8s_deploy_url = f"https://dl.k8s.io/release/stable-{k8s_version}.txt" # pylint: disable=line-too-long
     else:
         raise Exception('missing required k8s_version')
-    return marker, k8s_deploy_url, test_package_bucket, test_package_dir
+    return marker, k8s_deploy_url, test_package_url, test_package_dir
 
 def create_args(kops_channel, networking, extra_flags, kops_image):
     args = f"--channel={kops_channel} --networking=" + networking

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -544,7 +544,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -170,7 +170,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25
@@ -236,7 +236,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25
@@ -1139,7 +1139,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25
@@ -1205,7 +1205,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Conformance\]|\[NodeConformance\]" \
@@ -1273,7 +1273,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Conformance\]|\[NodeConformance\]" \
@@ -2028,7 +2028,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=120m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Feature:SELinux\]" \
@@ -2097,7 +2097,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
@@ -2164,7 +2164,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
@@ -2231,7 +2231,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m --master-os-distro=ubuntu --node-os-distro=ubuntu" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
@@ -2298,7 +2298,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=150m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Slow\]" \
@@ -2366,7 +2366,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=150m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Slow\]" \
@@ -2434,7 +2434,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=200m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Conformance\]|\[NodeConformance\]" \
@@ -2502,7 +2502,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=200m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Conformance\]" \
@@ -2571,7 +2571,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=200m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Conformance\]" \
@@ -2640,7 +2640,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=200m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Conformance\]" \
@@ -2708,7 +2708,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=600m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Disruptive\]" \
@@ -2776,7 +2776,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=300m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Feature:Reboot\]" \
@@ -2844,7 +2844,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=500m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Disruptive\]" \
@@ -2913,7 +2913,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=600m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Serial\]" \
@@ -2981,7 +2981,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=600m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Serial\]" \
@@ -3050,7 +3050,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=240m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \
@@ -3119,7 +3119,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=240m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2158,7 +2158,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2360,7 +2360,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2496,7 +2496,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2564,7 +2564,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --cluster-name="kubernetes-e2e-al2023-aws-conformance-aws-cni.k8s.local" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
@@ -2633,7 +2633,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeProxy.enabled=false --set=spec.networking.cilium.enableNodePort=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeProxy.enabled=false --set=spec.networking.cilium.enableNodePort=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
           --cluster-name="kubernetes-e2e-al2023-aws-conformance-cilium.k8s.local" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
@@ -2838,7 +2838,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2975,7 +2975,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -3043,7 +3043,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --discovery-store=s3://k8s-kops-prow/discovery" \
           --kubernetes-feature-gates=AllAlpha,-InTreePluginGCEUnregister,DisableCloudProviders,DisableKubeletCloudCredentialProviders \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -551,7 +551,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -39,7 +39,7 @@ periodics:
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -571,7 +571,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.3.20231218.0-kernel-6.1-x86_64' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='137112412989/al2023-ami-2023.3.20240108.0-kernel-6.1-x86_64' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -41,7 +41,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=60m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --focus-regex="\[Conformance\]|\[NodeConformance\]" \
@@ -111,7 +111,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=60m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --focus-regex="\[Conformance\]|\[NodeConformance\]" \
@@ -511,7 +511,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=60m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --parallel=25
@@ -648,7 +648,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=60m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --parallel=25
@@ -2362,7 +2362,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=500m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --focus-regex="\[Serial\]" \
@@ -2432,7 +2432,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=40m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
@@ -2501,7 +2501,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=70m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --focus-regex="\[Slow\]" \

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -722,7 +722,7 @@ presubmits:
             --test=kops \
             -- \
             --test-args="-test.timeout=60m" \
-            --test-package-bucket=k8s-release-dev \
+            --test-package-url=https://storage.googleapis.com/k8s-release-dev \
             --test-package-dir=ci \
             --test-package-marker=latest.txt \
             --parallel=25

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -80,8 +80,8 @@
           {%- else %}
           --test-args="-test.timeout={{test_timeout}}" \
           {%- endif %}
-          {%- if test_package_bucket %}
-          --test-package-bucket={{test_package_bucket}} \
+          {%- if test_package_url %}
+          --test-package-url={{test_package_url}} \
           {%- endif %}
           {%- if test_package_dir %}
           --test-package-dir={{test_package_dir}} \

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -16,10 +16,6 @@
       {%- if not boskos_resource_type %}
       preset-aws-credential: "true"
       {%- endif %}
-      {%- if branch in ["release-1.22", "release-1.23"] %}
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      {%- endif %}
       preset-dind-enabled: "true"
       {%- else %}
       preset-k8s-ssh: "true"
@@ -63,11 +59,7 @@
             --boskos-resource-type={{boskos_resource_type}} \
             {%- endif %}
             --kubernetes-version={{k8s_deploy_url}} \
-            {%- if branch in ["release-1.22", "release-1.23"] %}
-            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
-            {%- else %}
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
-            {%- endif %}
             {%- if terraform_version %}
             --terraform-version={{terraform_version}} \
             {%- endif %}

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -73,8 +73,8 @@
             {%- else %}
             --test-args="-test.timeout={{test_timeout}}" \
             {%- endif %}
-            {%- if test_package_bucket %}
-            --test-package-bucket={{test_package_bucket}} \
+            {%- if test_package_url %}
+            --test-package-url={{test_package_url}} \
             {%- endif %}
             {%- if test_package_dir %}
             --test-package-dir={{test_package_dir}} \


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/kubetest2/pull/251 and https://github.com/kubernetes/kops/pull/16234

Note, we dont need to worry about https://github.com/kubernetes/kops/pull/16234 not being cherrypicked to kops' release branches because the e2e presubmit jobs on release branches dont set --test-package-bucket (and therefore dont need --test-package-url) because they use the default value and download the stable release binaries from the default location.