### PR TITLE
configure PR behaviour for kubernetes-sigs/cluster-api-ipam-provider-in-cluster

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -84,6 +84,7 @@ approve:
   - kubernetes/cloud-provider-openstack
   - kubernetes-sigs/cluster-api
   - kubernetes-sigs/cluster-api-operator
+  - kubernetes-sigs/cluster-api-ipam-provider-in-cluster
   - kubernetes-sigs/cluster-api-provider-aws
   - kubernetes-sigs/cluster-api-provider-azure
   - kubernetes-sigs/cluster-api-provider-vsphere
@@ -223,6 +224,7 @@ lgtm:
   - kubernetes-sigs/aws-ebs-csi-driver
   - kubernetes-sigs/bom
   - kubernetes-sigs/boskos
+  - kubernetes-sigs/cluster-api-ipam-provider-in-cluster
   - kubernetes-sigs/cluster-api-provider-digitalocean
   - kubernetes-sigs/cluster-api-provider-gcp
   - kubernetes-sigs/cri-tools


### PR DESCRIPTION
Changes GH approve to act as lgtm instead of approval. Require explicit self approval.

(I'm a [maintainer](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/blob/main/OWNERS_ALIASES) of kubernetes-sigs/cluster-api-ipam-provider-in-cluster repository)