### PR TITLE
Store tree hash for CR & CT PRs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -263,6 +263,8 @@ lgtm:
   - kubernetes-sigs/cluster-api-operator
   - kubernetes-sigs/cluster-api-provider-azure
   - kubernetes-sigs/cluster-api-provider-vsphere
+  - kubernetes-sigs/controller-runtime
+  - kubernetes-sigs/controller-tools
   - kubernetes-sigs/kueue
   store_tree_hash: true
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

This change stores the git directory tree hash when lgtm is added on PRs. This allows us to squash / force push the same commits without losing the lgtm.

I think this is a nice small optimization, as we're then able to re-trigger CI with a force push without having to ask for an lgtm afterwards again.