### PR TITLE
Set .conntrack.tcpBeLiberal for nftables proxy

### DIFF
--- a/experiment/kind-nftables-e2e.sh
+++ b/experiment/kind-nftables-e2e.sh
@@ -151,6 +151,8 @@ ${kubelet_extra_args}
   ---
   kind: KubeProxyConfiguration
   mode: "nftables"
+  conntrack:
+    tcpBeLiberal: true
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2


### PR DESCRIPTION
We want to remove the invalid-conntrack-state hack from nftables kube-proxy (https://github.com/kubernetes/kubernetes/pull/122663), but e2e has a test about it, so we should use the _other_ (better) workaround for the bug instead.

/assign @aojea @aroradaman 
