### PR TITLE
Update minikube prow job to point to v0.0.6 image

### DIFF
--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-minikube/prow-test:v0.0.5
+      - image: gcr.io/k8s-minikube/prow-test:v0.0.6
         # we add --force since minikube is running as root
         command:
         - wrapper.sh


### PR DESCRIPTION
Pointing the minikube prow image to v0.0.6 to update the Go version to 1.21

Will fix the prow build on https://github.com/kubernetes/minikube/pull/17909