### PR TITLE
cloud-provider-azure v1.25 use capz v1.11

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -47,7 +47,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.12
+          base_ref: release-1.11
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -100,7 +100,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.12
+          base_ref: release-1.11
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
         - org: kubernetes
@@ -161,7 +161,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.12
+          base_ref: release-1.11
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -239,7 +239,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.12
+          base_ref: release-1.11
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:


### PR DESCRIPTION
capz 1.12 has changes for OOT credential provider but support of k8s starts from 1.26

You need a Kubernetes cluster with nodes that support kubelet credential provider plugins. This support is available in Kubernetes 1.28; Kubernetes v1.24 and v1.25 included this as a beta feature, enabled by default. A working implementation of a credential provider exec plugin. You can build your own plugin or use one provided by cloud providers.