### PR TITLE
Use capz 1.12 for vmss 1.25 jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml
@@ -47,7 +47,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
@@ -243,7 +243,7 @@ presubmits:
       extra_refs:
         - org: kubernetes-sigs
           repo: cluster-api-provider-azure
-          base_ref: release-1.11
+          base_ref: release-1.12
           path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:


### PR DESCRIPTION
vmss 1.25 job templates have CAAPH, which is a capz 1.12 feature. non-vmss 1.25 job templates don't CAAPH and to avoid credential provider support compatibility issue, they should use old capz 1.11.