### PR TITLE
CAPI Operator: Setup new jobs for release-0.8 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-8.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-operator-test-release-0-6
+- name: periodic-cluster-api-operator-test-release-0-8
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -8,7 +8,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.6
+    base_ref: release-0.8
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
@@ -27,7 +27,7 @@ periodics:
     testgrid-tab-name: capi-operator-test-release-0-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-operator-e2e-release-0-6
+- name: periodic-cluster-api-operator-e2e-release-0-8
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -39,7 +39,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.6
+    base_ref: release-0.8
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-8.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/cluster-api-operator:
-  - name: pull-cluster-api-operator-build-release-0-5
+  - name: pull-cluster-api-operator-build-release-0-8
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.6$
+    - ^release-0.8$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
@@ -26,7 +26,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.6
       testgrid-tab-name: capi-operator-pr-build-release-0-6
-  - name: pull-cluster-api-operator-make-release-0-6
+  - name: pull-cluster-api-operator-make-release-0-8
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.6$
+    - ^release-0.8$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
@@ -56,7 +56,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.6
       testgrid-tab-name: capi-operator-pr-make-release-0-6
-  - name: pull-cluster-api-operator-apidiff-release-0-6
+  - name: pull-cluster-api-operator-apidiff-release-0-8
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -65,7 +65,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.6$
+    - ^release-0.8$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
@@ -83,7 +83,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.6
       testgrid-tab-name: capi-operator-pr-apidiff-release-0-6
-  - name: pull-cluster-api-operator-verify-release-0-6
+  - name: pull-cluster-api-operator-verify-release-0-8
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -92,7 +92,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.6$
+    - ^release-0.8$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
@@ -109,7 +109,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.6
       testgrid-tab-name: capi-operator-pr-verify-release-0-6
-  - name: pull-cluster-api-operator-test-release-0-6
+  - name: pull-cluster-api-operator-test-release-0-8
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -117,7 +117,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.6$
+    - ^release-0.8$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
@@ -135,7 +135,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.6
       testgrid-tab-name: capi-operator-pr-test-release-0-6
-  - name: pull-cluster-api-operator-e2e-release-0-6
+  - name: pull-cluster-api-operator-e2e-release-0-8
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
     decorate: true
@@ -145,7 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - ^release-0.6$
+    - ^release-0.8$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27


### PR DESCRIPTION
Latest stable release branch of CAPI Operator is [release-0.8](https://github.com/kubernetes-sigs/cluster-api-operator/tree/release-0.8). This PR adds new periodic/presubmit jobs for the new release branch and drop running the CI in the old one (release-0.6).