### PR TITLE
`deck`: add bucket aliases in `/job-history`

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -438,6 +438,11 @@ func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener 
 	if err != nil {
 		return tmpl, fmt.Errorf("invalid url %s: %w", url.String(), err)
 	}
+
+	if bucketAlias, exists := cfg().Deck.Spyglass.BucketAliases[bucketName]; exists {
+		bucketName = bucketAlias
+	}
+
 	bucket, err := newBlobStorageBucket(bucketName, storageProvider, cfg(), opener)
 	if err != nil {
 		return tmpl, err

--- a/prow/cmd/deck/job_history_test.go
+++ b/prow/cmd/deck/job_history_test.go
@@ -351,6 +351,9 @@ func Test_getJobHistory(t *testing.T) {
 		ProwConfig: config.ProwConfig{
 			Deck: config.Deck{
 				SkipStoragePathValidation: &boolTrue,
+				Spyglass: config.Spyglass{
+					BucketAliases: map[string]string{"kubernetes-jenkins-old": "kubernetes-jenkins"},
+				},
 			},
 		},
 	})
@@ -379,6 +382,11 @@ func Test_getJobHistory(t *testing.T) {
 		{
 			name: "get job history logs (new format)",
 			url:  "https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/post-cluster-api-provider-openstack-push-images",
+			want: wantedLogsJobHistoryTemplate,
+		},
+		{
+			name: "get job history logs through a bucket alias (new format)",
+			url:  "https://prow.k8s.io/job-history/gs/kubernetes-jenkins-old/logs/post-cluster-api-provider-openstack-push-images",
 			want: wantedLogsJobHistoryTemplate,
 		},
 	}


### PR DESCRIPTION
This is a follow up of https://github.com/kubernetes/test-infra/pull/31543 and https://github.com/kubernetes/test-infra/pull/31456 that extends the aliasing feature to the `/job-history` path.