### PR TITLE
Update etcd verify job to run full verification suite

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
             cpu: "4"
             memory: "4Gi"
 
-  - name: pull-etcd-verify-lint
+  - name: pull-etcd-verify
     cluster: eks-prow-build-cluster
     always_run: true
     branches:
@@ -58,7 +58,7 @@ presubmits:
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
-      testgrid-tab-name: pull-etcd-verify-lint
+      testgrid-tab-name: pull-etcd-verify
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
@@ -66,7 +66,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - verify-lint
+        - verify
         resources:
           requests:
             cpu: "4"

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -63,10 +63,20 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
         command:
-        - runner.sh
+        - /bin/bash
         args:
-        - make
-        - verify
+        - -c
+        - |
+          make verify
+          make fix
+          DIFF=$(git status --porcelain)
+          if [ -n "$DIFF" ]; then
+            echo "These files were modified:"
+            echo
+            echo "$DIFF"
+            echo
+            exit 1
+          fi
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Over time the etcd project aims to make better use of the Kubernetes community test infrastructure and gradually migrate away from GitHub actions.

This PR improves parity between the prow etcd verify pre-submit job and the historic GitHub actions job: https://github.com/etcd-io/etcd/blob/main/.github/workflows/static-analysis.yaml 