### PR TITLE
Bump golang from 1.19 to 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - /bin/bash
         - -c

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.19
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Bump golang from 1.19 to 1.21 in the simulator's jobs, which is required in https://github.com/kubernetes-sigs/kube-scheduler-simulator/pull/329.

/cc @196Ikuchil @utam0k 