### PR TITLE
Fix kubemark release jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -193,7 +193,7 @@ periodics:
     repo: perf-tests
   labels:
     preset-dind-enabled: "true"
-    preset-e2e-kubemark-common: "true"
+    preset-e2e-kubemark-common-legacy: "true"
     preset-e2e-scalability-periodics: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1205,7 +1205,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1284,7 +1284,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-kubemark-gce-scale: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
@@ -1827,7 +1827,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -198,7 +198,7 @@ periodics:
     repo: perf-tests
   labels:
     preset-dind-enabled: "true"
-    preset-e2e-kubemark-common: "true"
+    preset-e2e-kubemark-common-legacy: "true"
     preset-e2e-scalability-periodics: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1160,7 +1160,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1239,7 +1239,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-kubemark-gce-scale: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
@@ -1788,7 +1788,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -198,7 +198,7 @@ periodics:
     repo: perf-tests
   labels:
     preset-dind-enabled: "true"
-    preset-e2e-kubemark-common: "true"
+    preset-e2e-kubemark-common-legacy: "true"
     preset-e2e-scalability-periodics: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1387,7 +1387,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1466,7 +1466,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-kubemark-gce-scale: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
@@ -2015,7 +2015,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -198,7 +198,7 @@ periodics:
     repo: perf-tests
   labels:
     preset-dind-enabled: "true"
-    preset-e2e-kubemark-common: "true"
+    preset-e2e-kubemark-common-legacy: "true"
     preset-e2e-scalability-periodics: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1572,7 +1572,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1651,7 +1651,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-kubemark-gce-scale: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
@@ -2250,7 +2250,7 @@ presubmits:
       repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-common-legacy: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -110,6 +110,116 @@ presets:
   - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
     value: pd.csi.storage.gke.io
 
+# Delete this preset once 1.29 is EoL
+- labels:
+    preset-e2e-kubemark-common-legacy: "true"
+  env:
+  - name: KUBE_GCS_UPDATE_LATEST
+    value: "n"
+  - name: KUBE_FASTBUILD
+    value: "true"
+  - name: KUBE_GCE_ENABLE_IP_ALIASES
+    value: "true"
+  - name: CREATE_CUSTOM_NETWORK
+    value: "true"
+  - name: ENABLE_HOLLOW_NODE_LOGS
+    value: "true"
+  # Turn on profiling for various components.
+  - name: ETCD_TEST_ARGS
+    value: "--enable-pprof"
+  - name: APISERVER_TEST_ARGS
+    value: "--profiling --contention-profiling"
+  # Number of bytes of an additional nodes objects annotation in a kubemark
+  # cluster. The annotation label is added to make nodes objects sizes similar
+  # to regular cluster nodes.
+  - name: KUBEMARK_NODE_OBJECT_SIZE_BYTES
+    value: 15000
+  # Increase throughput in Kubemark master components and turn on profiling.
+  - name: KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
+  - name: KUBEMARK_SCHEDULER_TEST_ARGS
+    value: "--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100"
+  # Reduce logs verbosity
+  - name: TEST_CLUSTER_LOG_LEVEL
+    value: "--v=2"
+  - name: API_SERVER_TEST_LOG_LEVEL
+    value: "--v=3"
+  # Increase controller-manager's resync period to simulate production.
+  - name: TEST_CLUSTER_RESYNC_PERIOD
+    value: "--min-resync-period=12h"
+  # Reduce etcd compaction frequency to match production.
+  - name: KUBEMARK_ETCD_COMPACTION_INTERVAL_SEC
+    value: "150"
+  # Allow one node to not be ready after cluster creation.
+  - name: ALLOWED_NOTREADY_NODES
+    value: 1
+  - name: ENABLE_PROMETHEUS_SERVER
+    value: "true"
+  - name: KUBE_MASTER_NODE_LABELS
+    value: "node.kubernetes.io/node-exporter-ready=true"
+  # Keep all logrotated files (not just 5 latest which is a default)
+  - name: LOGROTATE_FILES_MAX_COUNT
+    value: 1000
+  - name: LOGROTATE_MAX_SIZE
+    value: "5G"
+  # Ensure good enough architecture for master machines.
+  - name: MASTER_MIN_CPU_ARCHITECTURE
+    value: "Intel Skylake"
+  # Increase delete collection parallelism.
+  - name: TEST_CLUSTER_DELETE_COLLECTION_WORKERS
+    value: --delete-collection-workers=16
+  # Dump full systemd journal on master and nodes.
+  - name: LOG_DUMP_SYSTEMD_JOURNAL
+    value: "true"
+  # Timeout for the log dumping over SSH. Relevant only if fallback to SSH log dumping takes place
+  # e.g. when logexporter daemonset fails for some reason.
+  # We deliberately cap it at 1h to avoid spending too much time (e.g. over 5h for 5k node cluster)
+  # on dumping logs that in most cases we won't need anyway.
+  - name: LOG_DUMP_SSH_TIMEOUT_SECONDS
+    value: 3600
+  # Use private clusters for scalability tests - https://github.com/kubernetes/kubernetes/issues/76374
+  - name: KUBE_GCE_PRIVATE_CLUSTER
+    value: "true"
+  # We create approx. 70 hollow nodes per VM. Allow ~4 connections from each of them.
+  - name: KUBE_GCE_PRIVATE_CLUSTER_PORTS_PER_VM
+    value: 300
+  - name: PROMETHEUS_SCRAPE_ETCD
+    value: "true"
+  # Disable kubernetes-dashboard
+  - name: KUBE_ENABLE_CLUSTER_UI
+    value: "false"
+  # Enable assertions on scheduler throughput in density test.
+  # Setting the threshold to 90 should allow us to catch regressions like
+  # https://github.com/kubernetes/kubernetes/pull/85030 while not making the tests flaky.
+  - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
+    value: 90
+  - name: CL2_ALLOWED_SLOW_API_CALLS
+    value: 1
+  # Disable PVs until these are fixed in Kubemark:
+  # https://github.com/kubernetes/perf-tests/issues/803
+  - name: CL2_ENABLE_PVS
+    value: "false"
+  # Switch to using log-dump.sh script included in the kubekins-e2e image
+  # instead of relying on the deprecated one from k/k repository.
+  - name: USE_TEST_INFRA_LOG_DUMPING
+    value: "true"
+  # If log dumping of nodes is enabled and logexporter creation fails or less than 50 %
+  # of the nodes got logexported successfully, then report a failure.
+  - name: LOG_DUMP_EXPECTED_SUCCESS_PERCENTAGE
+    value: 50
+  - name: PERF_TESTS_PRINT_COMMIT_HISTORY
+    value: true
+  - name: DUMP_TO_GCS_ONLY
+    value: true
+  # Disable konnectivity in kubemark as it doesn't work (see https://github.com/kubernetes/perf-tests/issues/1828)
+  # TODO(https://github.com/kubernetes/perf-tests/issues/1828): Use konnectivity in kubemark.
+  - name: KUBE_ENABLE_KONNECTIVITY_SERVICE
+    value: false
+  - name: DEPLOY_GCI_DRIVER
+    value: true
+  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
+    value: pd.csi.storage.gke.io
+
 ### kubemark-gce-scale
 - labels:
     preset-e2e-kubemark-gce-scale: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -360,7 +360,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
-        - --gcp-master-size=n1-standard-4
+        - --gcp-master-size=n2-standard-4
         - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
@@ -640,7 +640,7 @@ presubmits:
         args:
         - --cluster=
         - --extract=ci/latest
-        - --gcp-master-size=n1-standard-2
+        - --gcp-master-size=n2-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
         - --gcp-project-type=scalability-presubmit-project


### PR DESCRIPTION
The patch in #31609 broke release branches because https://github.com/kubernetes/kubernetes/pull/118626 isn't backported to release branches