### PR TITLE
Increase CPU allocated to simulator's linter job

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -24,10 +24,10 @@ presubmits:
           make lint
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 6Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 6Gi
   - name: pull-kube-scheduler-simulator-frontend-lint
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Increase CPU allocated to simulator's linter job, which takes a lot of time after upgrading golang.
