### PR TITLE
sig-scalability/watch-list: use n2 machine types for master instances

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -165,7 +165,7 @@ periodics:
           - --env=KUBE_GCE_PRIVATE_CLUSTER=false #TODO(#29500): revert when private cluster setup is fixed
           - --extract=ci/latest
           - --gcp-node-image=gci
-          - --gcp-master-size=n1-standard-32
+          - --gcp-master-size=n2-standard-32
           - --gcp-node-size=e2-standard-16
           - --gcp-nodes=1
           - --gcp-project-type=scalability-project
@@ -231,7 +231,7 @@ periodics:
           - --env=KUBE_FEATURE_GATES=WatchList=true
           - --extract=ci/latest
           - --gcp-node-image=gci
-          - --gcp-master-size=n1-standard-32
+          - --gcp-master-size=n2-standard-32
           - --gcp-node-size=e2-standard-16
           - --gcp-nodes=1
           - --gcp-project-type=scalability-project


### PR DESCRIPTION
At the moment the tests fail with (https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-watch-list-on):

```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The selected machine type (n1-standard-32) is not compatible with CPU platform icelake Failed to create master instance due to non-retryable error
```

Possibly caused by kubernetes/kubernetes#118626

https://cloud.google.com/compute/docs/general-purpose-machines#n2_series