### PR TITLE
Delete kubernetes-scalability-tickets@google.com from ec2 testgrid.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -64,7 +64,7 @@ periodics:
     test.kops.k8s.io/networking: amazonvpc
     testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws
     testgrid-tab-name: ec2-master-scale-performance
-    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, eks-scalability@amazon.com
+    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master


### PR DESCRIPTION
The failures in the testgrid create tickets for us. I believe this test is of no concern to us, scalability oncalls.