### PR TITLE
Fix kubemark-100

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -161,7 +161,7 @@ periodics:
       args:
       - --cluster=kubemark-100
       - --extract=ci/latest
-      - --gcp-master-size=n1-standard-2
+      - --gcp-master-size=n2-standard-2
       - --gcp-node-image=gci
       - --gcp-node-size=e2-standard-4
       - --gcp-nodes=4


### PR DESCRIPTION
Kubemarks [haven't been](https://testgrid.k8s.io/sig-scalability-kubemark#kubemark-100) working ever since the min supported cpu platform got changed to `Intel Ice Lake` from `Intel Skylake` in this [PR 31609](https://github.com/kubernetes/test-infra/pull/31609) resulting in conflicts between n1 and min supported architecture. Then most of kubemarks got fixed in [PR 31622](https://github.com/kubernetes/test-infra/pull/31622). 

However `kubemark-100` hasn't been fixed. From it's [prow](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-kubemark-100-gce/1747264828063354880):
```
- The selected machine type (n1-standard-2) is not compatible with CPU platform icelake
Failed to create master instance due to non-retryable error
```
This PR attempts to fix the issue.

/cc upodroid