### PR TITLE
Added simple run test to hydrophone

### DIFF
--- a/config/jobs/kubernetes-sigs/hydrophone/hydrophone-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/hydrophone/hydrophone-presubmit.yaml
@@ -68,9 +68,6 @@ presubmits:
         testgrid-tab-name: hydrophone-verify
     - name: pull-hydrophone-dry-run
       cluster: eks-prow-build-cluster
-      annotations:
-        testgrid-dashboards: sig-testing-misc
-        testgrid-tab-name: hydrophone-dry-run
       always_run: true
       decorate: true
       path_alias: "sigs.k8s.io/hydrophone"
@@ -87,12 +84,18 @@ presubmits:
                 value: "v1.29.0"
               - name: KIND_VERSION
                 value: "v0.20.0"
+              - name: FOCUS
+                value: "Simple pod should contain last line of the log"
+              - name: DRYRUN
+                value: "true"
+              - name: CHECK_DURATION
+                value: "true"
             args:
               - bash
               - -c
               - |
                 make build
-                hack/dryrun-e2e.sh
+                hack/run-e2e.sh
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -103,3 +106,47 @@ presubmits:
               limits:
                 cpu: 2
                 memory: 4Gi
+      annotations:
+        testgrid-dashboards: sig-testing-misc
+        testgrid-tab-name: hydrophone-dry-run
+    - name: pull-hydrophone-simple-run
+      cluster: eks-prow-build-cluster
+      always_run: true
+      decorate: true
+      path_alias: "sigs.k8s.io/hydrophone"
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+              - runner.sh
+            env:
+              - name: K8S_VERSION
+                value: "v1.29.0"
+              - name: KIND_VERSION
+                value: "v0.20.0"
+              - name: FOCUS
+                value: "Simple pod should contain last line of the log"
+              - name: CHECK_DURATION
+                value: "true"
+            args:
+              - bash
+              - -c
+              - |
+                make build
+                hack/run-e2e.sh
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+              limits:
+                cpu: 2
+                memory: 4Gi
+      annotations:
+        testgrid-dashboards: sig-testing-misc
+        testgrid-tab-name: hydrophone-simple-run


### PR DESCRIPTION
This PR uses the new run-e2e script and separates out the dry-run and simple test into two different tests. 

/cc @dims 