### PR TITLE
Teach config bootstrapper to delete stale keys

### DIFF
--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -109,6 +109,10 @@ func run(sourcePaths []string, defaultNamespace string, configUpdater plugins.Co
 	var changes []github.PullRequestChange
 	var version string
 
+	// Pretend that all files found in the sourcePaths are newly added
+	// (github.PullRequestFileAdded). This is because we are running against a
+	// static set of files and are not sure how these files came to be. So we
+	// pretend that these files are newly added.
 	for _, sourcePath := range sourcePaths {
 
 		versionFilePath := filepath.Join(sourcePath, config.ConfigVersionFileName)

--- a/prow/cmd/config-bootstrapper/main_test.go
+++ b/prow/cmd/config-bootstrapper/main_test.go
@@ -450,6 +450,60 @@ func testRun(clients localgit.Clients, t *testing.T) {
 				},
 			},
 		},
+		{
+			// The keys for files a, b, and c are unaccounted for (they don't
+			// exist in the repo), so they should be deleted.
+			name:             "untouched keys are deleted",
+			sourcePaths:      []string{filepath.Join(lg.Dir, "openshift/other")},
+			defaultNamespace: defaultNamespace,
+			configUpdater: plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"config/other-foo.yaml": {
+						Name: "job-config",
+					},
+					"config/other-bar.yaml": {
+						Name: "job-config",
+					},
+				},
+			},
+			existConfigMaps: []runtime.Object{
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job-config",
+						Namespace: defaultNamespace,
+						Labels: map[string]string{
+							"app.kubernetes.io/name":      "prow",
+							"app.kubernetes.io/component": "updateconfig-plugin",
+						},
+					},
+					Data: map[string]string{
+						"other-foo.yaml": "#other-foo.yaml",
+						"other-bar.yaml": "#other-bar.yaml",
+
+						// The ones below should be deleted.
+						"a": "xxx",
+						"b": "xxx",
+						"c": "xxx",
+					},
+				},
+			},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job-config",
+						Namespace: defaultNamespace,
+						Labels: map[string]string{
+							"app.kubernetes.io/name":      "prow",
+							"app.kubernetes.io/component": "updateconfig-plugin",
+						},
+					},
+					Data: map[string]string{
+						"other-foo.yaml": "#other-foo.yaml",
+						"other-bar.yaml": "#other-bar.yaml",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
The config-bootstrapper works by looking at local files, and treating
all files it finds as a file addition. Then these files are converted
into "ConfigMapUpdate" entries, and sent to updateconfig.Update() to
update the corresponding ConfigMap key.

The problem is that the above mechanism doesn't work for deleting keys.
For example, deleting a file and then running config-bootstrapper again
will simply "update" all other files except the deleted one (because it
doesn't see it in the local filesystem).

Teach updateconfig.Update() how to delete ConfigMap keys that are not
updated. Do this by calling updateconfig.MarkStaleKeysForDeletion()
which checks for those ConfigMap keys that were left untouched and
creates corresponding ConfigMapUpdate entries signaling their deletion.

An alternative way would be to call the "patch" verb to delete those
keys individually. However, this would incur additional API overhead of
needing to call both "update" (to send the locally modified ConfigMap
object) and the "patch" verb (to delete untouched keys), not to mention
that we would be bypassing the existing mechanism we already have in
updateconfig.Update(), which already knows how to delete keys inside the
locally modified ConfigMap object [1]).

For these reasons, continue to use the "Update" verb without "Patch". We
have to send the entire object over (instead of only sending a diff),
but we've already been doing this and we don't want to make large
changes in this sensitive area. The previous commit records for the
record why using "Update" isn't very accurate in terms of unit tests,
but this is a minor cost to pay in exchange for making this commit much
simpler (no need to modify how deletions are done at [1]).

[1] https://github.com/kubernetes/test-infra/blob/d3ef1505f12cd2dd9f2bfc898bb987dc22c48066/prow/plugins/updateconfig/updateconfig.go#L140-L144
