### PR TITLE
drop 1.25 from kueue periodics

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -78,52 +78,6 @@ periodics:
               cpu: "4"
               memory: "6Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-25
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-25
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.25"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.25.11
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.21
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-main-1-26
     cluster: eks-prow-build-cluster
     annotations:


### PR DESCRIPTION
We dropped support for 1.25 from the presubmits but we forgot to drop the periodic job: https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-25.

This PR removes the test.