### PR TITLE
pin alpine image to latest (specific) tag

### DIFF
--- a/config/prow/cluster/build/create-loop-devs_daemonset.yaml
+++ b/config/prow/cluster/build/create-loop-devs_daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             done
             sleep 100000000
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:

--- a/config/prow/cluster/build/tune-sysctls_daemonset.yaml
+++ b/config/prow/cluster/build/tune-sysctls_daemonset.yaml
@@ -32,7 +32,7 @@ spec:
             sysctl -w fs.inotify.max_user_watches=524288
             sleep 10
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:


### PR DESCRIPTION
Some nodes are multiple-months old and will use a version of gcr.io/k8s-prow/alpine that is rather old now (although at the time that the image was pulled, it was "new" because `:latest` was pointing to the newest version at that time).

Pin the image to specific version. This is simpler for auditing.

This will also force older nodes to upgrade to the newer version pinned here to pick up vulnerability fixes we've incorporated into the newer alpine versions recently.

/cc @cjwagner @airbornepony @timwangmusic @aojea 

This is a follow-up of the comment from https://github.com/kubernetes/test-infra/pull/29963#discussion_r1336324944