### PR TITLE
Remove ClusterStatusUnreachable following FIXME comment

### DIFF
--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1854,7 +1854,7 @@ func TestValidateClusterField(t *testing.T) {
 									Cluster: "build1",
 								},
 							}}}}},
-			clusterStatusFile: fmt.Sprintf(`{"default": %q, "build1": %q, "build2": %q}`, plank.ClusterStatusReachable, plank.ClusterStatusReachable, plank.ClusterStatusUnreachable),
+			clusterStatusFile: fmt.Sprintf(`{"default": %q, "build1": %q, "build2": %q}`, plank.ClusterStatusReachable, plank.ClusterStatusReachable, plank.ClusterStatusError),
 		},
 		{
 			name: "cluster validates with multiple clusters, specified is unreachable (just warn)",
@@ -1871,7 +1871,7 @@ func TestValidateClusterField(t *testing.T) {
 									Cluster: "build2",
 								},
 							}}}}},
-			clusterStatusFile: fmt.Sprintf(`{"default": %q, "build1": %q, "build2": %q}`, plank.ClusterStatusReachable, plank.ClusterStatusReachable, plank.ClusterStatusUnreachable),
+			clusterStatusFile: fmt.Sprintf(`{"default": %q, "build1": %q, "build2": %q}`, plank.ClusterStatusReachable, plank.ClusterStatusReachable, plank.ClusterStatusError),
 		},
 		{
 			name: "cluster fails validation with multiple clusters, specified is unrecognized",
@@ -1888,7 +1888,7 @@ func TestValidateClusterField(t *testing.T) {
 									Cluster: "build3",
 								},
 							}}}}},
-			clusterStatusFile: fmt.Sprintf(`{"default": %q, "build1": %q, "build2": %q}`, plank.ClusterStatusReachable, plank.ClusterStatusReachable, plank.ClusterStatusUnreachable),
+			clusterStatusFile: fmt.Sprintf(`{"default": %q, "build1": %q, "build2": %q}`, plank.ClusterStatusReachable, plank.ClusterStatusReachable, plank.ClusterStatusError),
 			expectedError:     "org1/repo1: job configuration for \"my-job\" specifies unknown 'cluster' value \"build3\"",
 		},
 		{

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -258,14 +258,7 @@ func (r *reconciler) syncMetrics(ctx context.Context) error {
 
 type ClusterStatus string
 
-// FIXME(listx): ClusterStatusUnreachable is no longer used here. It was used
-// previously when we used to list pods directly. However that code has been
-// deleted and replaced with flagutil.CheckAuthorizations.
-//
-// We should delete this status value sometime after
-// https://github.com/kubernetes/test-infra/pull/29282 is merged.
 const (
-	ClusterStatusUnreachable        ClusterStatus = "Unreachable"
 	ClusterStatusReachable          ClusterStatus = "Reachable"
 	ClusterStatusNoManager          ClusterStatus = "No-Manager"
 	ClusterStatusError              ClusterStatus = "Error"


### PR DESCRIPTION
When going through the code saw the message about removing ClusterStatusUnreachable once this https://github.com/kubernetes/test-infra/pull/29282 is merged. Updated the tests to use a different error, but would like some additional confirmation that the tests were updated to the correct error or if they need to be fully replaced.