### PR TITLE
Improve Cluster API triage process

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -877,13 +877,11 @@ require_matching_label:
   repo: cluster-api
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
-    If CAPI contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
-
-    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+    CAPI contributors will take a look as soon as possible, apply one of the [`triage/*`](https://github.com/kubernetes-sigs/cluster-api/labels?q=triage%2F) labels and provide further guidance.
 - missing_label: needs-triage
   org: kubernetes-sigs
   repo: cluster-api-operator

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -227,6 +227,7 @@ larger set of contributors to apply/remove them.
 | <a id="kind/design" href="#kind/design">`kind/design`</a> | Categorizes issue or PR as related to design.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | Issues or PRs related to proposals.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/release-blocking" href="#kind/release-blocking">`kind/release-blocking`</a> | Issues or PRs that need to be closed before the next CAPI release| approvers |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="triage/needs-discussion" href="#triage/needs-discussion">`triage/needs-discussion`</a> | Indicates an issue or PR that needs further discussion before being actively worked on.| org members |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes-sigs/cluster-api, only for PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1686,6 +1686,12 @@ repos:
         addedBy: anyone
   kubernetes-sigs/cluster-api:
     labels:
+      - color: d455d0
+        description: Indicates an issue or PR that needs further discussion before being actively worked on.
+        name: triage/needs-discussion
+        target: both
+        prowPlugin: label
+        addedBy: org members
       - color: c7def8
         description: Issues or PRs related to proposals.
         name: kind/proposal


### PR DESCRIPTION
Improve the cluster API triage process by:
- Ensure the `needs-triage` label is applied only when there is not yet a `triage/*` label applied (currently `needs-triage` goes away only when it is applied `triage/accepted`
- Introduces a new `triage/needs-discussion` label to be applied to issues being triaged but not yet in the state to be actively worked on, which is the current meaning of `triage/accepted`

cc @sbueringer @chrischdi 