### PR TITLE
Use default controller rate limiter in Crier reconciler

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -66,7 +67,8 @@ func New(
 		// Is used for metrics, hence must be unique per controller instance
 		Named(fmt.Sprintf("crier_%s", reporter.GetName())).
 		For(&prowv1.ProwJob{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: numWorkers}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: numWorkers,
+			RateLimiter: workqueue.DefaultControllerRateLimiter()}).
 		Complete(&reconciler{
 			pjclientset:       mgr.GetClient(),
 			reporter:          reporter,


### PR DESCRIPTION
We observe that the k8s API server is rate limiting crier reporter to GCS. Previously the Crier reconciler does not specify a rate limiter. In this change, we use the default rate limiter which combines exponential backoff for new items and bucket rate limiter which should help with clusters handling a large number of objects.