### PR TITLE
Fix defaults repo matching for presubmits

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -757,9 +757,17 @@ type DefaultDecorationConfigEntry struct {
 // TODO(mpherman): Make a Matcher struct embedded in both ProwJobDefaultEntry and
 // DefaultDecorationConfigEntry and DefaultRerunAuthConfigEntry.
 func matches(givenOrgRepo, givenCluster, orgRepo, cluster string) bool {
-	orgRepoMatch := givenOrgRepo == "" || givenOrgRepo == "*" || givenOrgRepo == strings.Split(orgRepo, "/")[0] || givenOrgRepo == orgRepo
-	clusterMatch := givenCluster == "" || givenCluster == "*" || givenCluster == cluster
-	return orgRepoMatch && clusterMatch
+	if givenCluster != "" && givenCluster != "*" && givenCluster != cluster {
+		return false
+	}
+	if givenOrgRepo == "" || givenOrgRepo == "*" || givenOrgRepo == orgRepo {
+		return true
+	}
+	// Ensure a bare given repo name matches the http-prefixed repo
+	// that arises in pre/postsubmit jobs.
+	orgRepo = strings.TrimPrefix(orgRepo, "https://")
+	orgRepo = strings.TrimPrefix(orgRepo, "http://")
+	return givenOrgRepo == orgRepo || givenOrgRepo == strings.Split(orgRepo, "/")[0]
 }
 
 // matches returns true iff all the filters for the entry match a job.

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -422,6 +422,129 @@ func TestGetGCSBrowserPrefix(t *testing.T) {
 	}
 }
 
+func TestDefaultMatches(t *testing.T) {
+	for _, tc := range []struct{
+		desc string
+		givenOrgRepo string
+		givenCluster string
+		orgRepo string
+		cluster string
+		want bool
+	}{
+		{
+			desc: "empty",
+			orgRepo: "org/repo",
+			cluster: "cluster",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo empty",
+			givenOrgRepo: "",
+			orgRepo: "org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo star",
+			givenOrgRepo: "*",
+			orgRepo: "org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo org match",
+			givenOrgRepo: "org",
+			orgRepo: "org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo full match",
+			givenOrgRepo: "org/repo",
+			orgRepo: "org/repo",
+			want: true,
+		},
+		// The following two cases cover an unexpected existing configuration
+		// that matches a literal http/s prefix. Though unadvised, it should
+		// not be broken by fuzz matching http prefixes.
+		{
+			desc: "givenOrgRepo http full match",
+			givenOrgRepo: "http://org/repo",
+			orgRepo: "http://org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo https full match",
+			givenOrgRepo: "https://org/repo",
+			orgRepo: "https://org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo http fuzz org match",
+			givenOrgRepo: "org",
+			orgRepo: "http://org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo https fuzz org match",
+			givenOrgRepo: "org",
+			orgRepo: "https://org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo http fuzz full match",
+			givenOrgRepo: "org/repo",
+			orgRepo: "http://org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo https fuzz full match",
+			givenOrgRepo: "org/repo",
+			orgRepo: "https://org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo org mismatch",
+			givenOrgRepo: "org2",
+			orgRepo: "org/repo",
+			want: false,
+		},
+		{
+			desc: "givenOrgRepo repo mismatch",
+			givenOrgRepo: "org/repo2",
+			orgRepo: "org/repo",
+			want: false,
+		},
+		{
+			desc: "givenCluster empty",
+			givenCluster: "",
+			cluster: "cluster",
+			want: true,
+		},
+		{
+			desc: "givenCluster star",
+			givenCluster: "*",
+			cluster: "cluster",
+			want: true,
+		},
+		{
+			desc: "givenCluster match",
+			givenCluster: "cluster",
+			cluster: "cluster",
+			want: true,
+		},
+		{
+			desc: "givenCluster mismatch",
+			givenCluster: "cluster2",
+			cluster: "cluster",
+			want: false,
+		},
+	}{
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := matches(tc.givenOrgRepo, tc.givenCluster, tc.orgRepo, tc.cluster); got != tc.want {
+				t.Errorf("matches() got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDecorationRawYaml(t *testing.T) {
 	t.Parallel()
 	var testCases = []struct {


### PR DESCRIPTION
repo values in prowjob_default_entries and other defaulting configs do not match repos for presubmits as expected with Gerrit (at least). With presumit jobs, the orgRepo value encountered has an "https://" prefix, so e.g. "repo: some.org/some-repo" fails to match the repo value "https://some.org/some-repo".

Note that the matches() function in config.go doesn't consider the possibility of http prefixes, as it splits on "/" to match the org; with these prefixes the repo "https:" arises.

Despite the unlikelyhood of such a configuration, this change supports (and tests) a literal full match with the http prefix in givenOrgRepo, in case any exist.

The matches() function is equipped with a full suite of tests for matching conditions, and the function itself is refactored to short circuit cheap cases before more expensive string operations.