### PR TITLE
Add in eligible and ineligible reports

### DIFF
--- a/hack/cluster-migration/main_test.go
+++ b/hack/cluster-migration/main_test.go
@@ -62,7 +62,7 @@ func TestGetJobStatus_NonDefaultCluster(t *testing.T) {
 		Cluster: "test-infra-trusted",
 	}
 
-	cluster, eligible := getJobStatus(job)
+	cluster, eligible, _ := getJobStatus(job)
 	if cluster != "test-infra-trusted" || !eligible {
 		t.Errorf("Expected cluster 'test-infra-trusted' and eligible true, got cluster '%s' and eligible %v", cluster, eligible)
 	}
@@ -297,7 +297,7 @@ func TestGetJobStatus_DefaultClusterEligible(t *testing.T) {
 				},
 			},
 			expectedCluster:  "",
-			expectedEligible: false,
+			expectedEligible: true,
 		},
 		//
 		{
@@ -335,7 +335,7 @@ func TestGetJobStatus_DefaultClusterEligible(t *testing.T) {
 				},
 			},
 			expectedCluster:  "",
-			expectedEligible: false,
+			expectedEligible: true,
 		},
 		//
 		{
@@ -523,7 +523,7 @@ func TestGetJobStatus_DefaultClusterEligible(t *testing.T) {
 	}
 
 	for _, job := range jobs {
-		cluster, eligible := getJobStatus(job.job)
+		cluster, eligible, _ := getJobStatus(job.job)
 		if cluster != job.expectedCluster || eligible != job.expectedEligible {
 			t.Errorf("%v: Expected cluster '%s' and eligible %v, got cluster '%s' and eligible %v", job.name, job.expectedCluster, job.expectedEligible, cluster, eligible)
 		}


### PR DESCRIPTION
This change adds in a `--ineligible-repot` and `--eligible-report` flag to the cluster migration script. They will loop through each repo and find all jobs that are either ineligible (with a reason) or eligible respectively. 

/cc @ameukam 