### PR TITLE
migrate `kind` postsubmit to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -2,6 +2,7 @@
 postsubmits:
   kubernetes-sigs/kind:
   - name: ci-kind-test
+    cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -17,6 +18,13 @@ postsubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 6Gi
+          requests:
+            cpu: "4"
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-testing-kind
       testgrid-tab-name: ci unit test


### PR DESCRIPTION
This PR moves kind-postsubmit job to the community owned cluster eks cluster

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @bentheelder @munnerz @neolit123 @aojea