### PR TITLE
tide, Fix require_manually_triggered_jobs tide handling

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -861,7 +861,7 @@ func mergeTideContextPolicy(a, b TideContextPolicy) TideContextPolicy {
 	return c
 }
 
-func parseTideContextPolicyOptions(org, repo, branch string, options TideContextPolicyOptions) TideContextPolicy {
+func ParseTideContextPolicyOptions(org, repo, branch string, options TideContextPolicyOptions) TideContextPolicy {
 	option := options.TideContextPolicy
 	if o, ok := options.Orgs[org]; ok {
 		option = mergeTideContextPolicy(option, o.TideContextPolicy)
@@ -880,7 +880,7 @@ func parseTideContextPolicyOptions(org, repo, branch string, options TideContext
 // Otherwise if set it will use the branch protection setting, or the listed jobs.
 func (c Config) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, branch string, baseSHAGetter RefGetter, headSHA string) (*TideContextPolicy, error) {
 	var requireManuallyTriggeredJobs *bool
-	options := parseTideContextPolicyOptions(org, repo, branch, c.Tide.ContextOptions)
+	options := ParseTideContextPolicyOptions(org, repo, branch, c.Tide.ContextOptions)
 	// Adding required and optional contexts from options
 	required := sets.New[string](options.RequiredContexts...)
 	requiredIfPresent := sets.New[string](options.RequiredIfPresentContexts...)

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -1284,7 +1284,7 @@ func TestParseTideContextPolicyOptions(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		policy := parseTideContextPolicyOptions(org, repo, branch, tc.config)
+		policy := ParseTideContextPolicyOptions(org, repo, branch, tc.config)
 		if !reflect.DeepEqual(policy, tc.expected) {
 			t.Errorf("%s - did not get expected policy: %s", tc.name, diff.ObjectReflectDiff(tc.expected, policy))
 		}


### PR DESCRIPTION
When `require_manually_triggered_jobs` is used, tide doesn't wait for the jobs
that require manual trigger, nor adds them to batches.
This PR fix it, by checking the bp settings, and if the `require_manually_triggered_jobs` feature is enabled
for the branch, then force the jobs that have the following settings:
* `always_run=false`
* `optional=false`
* `skip_report=false`
* `run_if_changed` and `skip_if_only_changed` are empty

or has `run_before_merge=true` (as was already before this PR).

Fixes: https://github.com/kubernetes/test-infra/issues/31686
Fixes: https://github.com/kubernetes/test-infra/issues/31050