### PR TITLE
update CAPZ periodic jobs as part of CAPZ v1.13 release

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.12.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.12.yaml
@@ -1,9 +1,9 @@
 periodics:
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-11
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-12
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -32,13 +32,13 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-11
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-12
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-11
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-12
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -67,13 +67,13 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-11
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-12
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-11
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-12
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -102,5 +102,5 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-11
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-12
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.13.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.13.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-12
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-13
   decorate: true
   decoration_config:
     timeout: 4h
@@ -12,7 +12,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.12
+      base_ref: release-1.13
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -30,10 +30,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-12
+    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-13
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.12 (v1beta1)
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-12
+    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.13 (v1beta1)
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-13
   decorate: true
   decoration_config:
     timeout: 4h
@@ -47,7 +47,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.12
+      base_ref: release-1.13
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -74,10 +74,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-12
+    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-13
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.12 (v1beta1)
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-12
+    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.13 (v1beta1)
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-13
   decorate: true
   decoration_config:
     timeout: 4h
@@ -91,7 +91,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.12
+      base_ref: release-1.13
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -110,9 +110,9 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-12
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-13
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-12
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-13
   decorate: true
   decoration_config:
     timeout: 4h
@@ -126,7 +126,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.12
+      base_ref: release-1.13
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -145,9 +145,9 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-12
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-13
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-12
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-13
   decorate: true
   decoration_config:
     timeout: 4h
@@ -161,7 +161,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.12
+      base_ref: release-1.13
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -180,5 +180,5 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-12
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-13
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
Update CAPZ periodic jobs as part of CAPZ v1.13 release
- release-1.11 test jobs are dropped
- release-1.11 become release-1.12 test jobs
- release-1.12 test jobs become release-1.13.

Note:
- Release-1.13 jobs contain `conformance` tests spec.
- Changes aren't squashed for easier review.