### PR TITLE
Revert "pin alpine image to latest (specific) tag"

### DIFF
--- a/config/prow/cluster/build/create-loop-devs_daemonset.yaml
+++ b/config/prow/cluster/build/create-loop-devs_daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             done
             sleep 100000000
           done
-        image: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+        image: gcr.io/k8s-prow/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:

--- a/config/prow/cluster/build/tune-sysctls_daemonset.yaml
+++ b/config/prow/cluster/build/tune-sysctls_daemonset.yaml
@@ -32,7 +32,7 @@ spec:
             sysctl -w fs.inotify.max_user_watches=524288
             sleep 10
           done
-        image: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+        image: gcr.io/k8s-prow/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:


### PR DESCRIPTION
Reverts kubernetes/test-infra#31653

For some reason, merging this broke the autobumper: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-test-infra-autobump-prow?buildId=1748061612272521216.

/cc @airbornepony @cjwagner @timwangmusic 