### PR TITLE
chore: ensure apisnoop-gate loads k8s data

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -13,6 +13,9 @@ periodics:
     containers:
     - name: apisnoop-gate
       image: gcr.io/k8s-staging-apisnoop/snoopdb:v20240121-auditlogger-1.2.11-4-gb17b29c
+      env:
+        - name: LOAD_K8S_DATA
+          value: "true"
       command:
       - /usr/local/bin/docker-entrypoint.sh
       - postgres


### PR DESCRIPTION
checking of untested endpoints requires k8s data to be loaded

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/apisnoop-conformance-gate/1749578868831817728#1:build-log.txt%3A468