### PR TITLE
migrate `perf-tests` jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1766,6 +1766,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -1775,7 +1776,7 @@ presubmits:
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -1833,6 +1834,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -1843,7 +1845,7 @@ presubmits:
         - --gcp-master-size=n1-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=100

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -1727,6 +1727,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -1736,7 +1737,7 @@ presubmits:
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -1794,6 +1795,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -1804,7 +1806,7 @@ presubmits:
         - --gcp-master-size=n1-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=100

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1954,6 +1954,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -1963,7 +1964,7 @@ presubmits:
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -2021,6 +2022,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -2031,7 +2033,7 @@ presubmits:
         - --gcp-master-size=n1-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=100

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -2189,6 +2189,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -2198,7 +2199,7 @@ presubmits:
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -2256,6 +2257,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 3
     name: pull-perf-tests-clusterloader2-kubemark
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/perf-tests
     run_if_changed: ^clusterloader2/.*$
     spec:
@@ -2266,7 +2268,7 @@ presubmits:
         - --gcp-master-size=n1-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=100

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
@@ -9,6 +9,7 @@
 presubmits:
   kubernetes/perf-tests:
   - name: pull-perf-tests-100-adhoc
+    cluster: k8s-infra-prow-build
     always_run: false # This test needs to be triggered manually via `/test pull-perf-tests-100-adhoc`
     max_concurrency: 1 # Keep at 1 until we figure out a proper reservation system.
     skip_report: false # Report the status on github.
@@ -42,7 +43,7 @@ presubmits:
         - --cluster=
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -493,6 +493,7 @@ presubmits:
 
   kubernetes/perf-tests:
   - name: pull-perf-tests-benchmark-kube-dns
+    cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
     max_concurrency: 3
@@ -534,8 +535,16 @@ presubmits:
         - --test-cmd-args=$(ARTIFACTS)
         - --test-cmd-name=KubeDnsBenchmark
         - --timeout=120m
+        resources:
+          limits:
+            cpu: 4
+            memory: "12Gi"
+          requests:
+            cpu: 4
+            memory: "12Gi"
 
   - name: pull-perf-tests-clusterloader2
+    cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
     max_concurrency: 3
@@ -571,7 +580,7 @@ presubmits:
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -606,6 +615,7 @@ presubmits:
             memory: "6Gi"
 
   - name: pull-perf-tests-clusterloader2-kubemark
+    cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
     max_concurrency: 3
@@ -643,7 +653,7 @@ presubmits:
         - --gcp-master-size=n2-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=100
@@ -772,6 +782,7 @@ presubmits:
           privileged: true
 
   - name: pull-perf-tests-util-images
+    cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
     max_concurrency: 10
@@ -807,6 +818,7 @@ presubmits:
             memory: "2Gi"
 
   - name: pull-perf-tests-verify-all-python
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     skip_branches:
@@ -831,6 +843,7 @@ presubmits:
               memory: "2Gi"
 
   - name: pull-perf-tests-verify-test
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     skip_branches:
@@ -853,6 +866,7 @@ presubmits:
             memory: "2Gi"
 
   - name: pull-perf-tests-verify-dashboard
+    cluster: k8s-infra-prow-build
     decorate: true
     run_if_changed: ^clusterloader2/pkg/prometheus/manifests/dashboards/.*\.json$
     skip_branches:
@@ -877,6 +891,7 @@ presubmits:
             memory: "2Gi"
 
   - name: pull-perf-tests-verify-lint
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: true
     skip_branches:


### PR DESCRIPTION
This PR moves perf-tests jobs to the community owned cluster gke cluster

ref: https://github.com/kubernetes/test-infra/issues/30277

/cc @mm4tt @wojtek-t @cpanato @upodroid @puerco