### PR TITLE
Enable blobless clones by global default

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -36,6 +36,7 @@ plank:
         sidecar:
           requests:
             cpu: 100m
+      blobless_fetch: true
   - cluster: gke_rules-k8s_us-central1-f_testing
     config:
       gcs_credentials_secret: ""


### PR DESCRIPTION
Enable blobless cloning using the feature added in https://github.com/kubernetes/test-infra/pull/31623.

This change is deemed safe since blobless fetches were rolled out in https://github.com/kubernetes/test-infra/pull/29548 without issues in github. (There were issues with Gerrit, which is why it was rolled back and made configurable instead.)

https://github.com/kubernetes/test-infra/issues/26590