### PR TITLE
sig-windows: Use containerd 1.7.x for NLQ periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -501,6 +501,7 @@ periodics:
     preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
     preset-windows-private-registry-cred: "true"
+    preset-capz-containerd-1-7-latest: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -537,8 +538,6 @@ periodics:
             value: \[Serial\]|\[Slow\]
           - name: NODE_FEATURE_GATES
             value: "NodeLogQuery=true"
-          - name: WINDOWS_CONTAINERD_URL
-            value: "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz"
   annotations:
     testgrid-alert-email: sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release


### PR DESCRIPTION
Using containerd nightly is resulting in the job failing similar to the ci-kubernetes-e2e-capz-master-containerd-nightly-windows job. Switch to using containerd 1.7 given that the NodeLogQuery job does not require the latest containerd.