### PR TITLE
Reapply "pin alpine image to latest (specific) tag"

### DIFF
--- a/config/prow/cluster/build/create-loop-devs_daemonset.yaml
+++ b/config/prow/cluster/build/create-loop-devs_daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             done
             sleep 100000000
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: alpine:20231219
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:

--- a/config/prow/cluster/build/tune-sysctls_daemonset.yaml
+++ b/config/prow/cluster/build/tune-sysctls_daemonset.yaml
@@ -32,7 +32,7 @@ spec:
             sysctl -w fs.inotify.max_user_watches=524288
             sleep 10
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: alpine:20231219
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:


### PR DESCRIPTION
This is a second attempt of 8f2aaeb70a (pin alpine image to latest (specific) tag, 2024-01-17), which was reverted in 40c1278487 (Revert "pin alpine image to latest (specific) tag", 2024-01-22).

The first attempt ran afoul of the autobumper, because the usage of the `gcr.io/k8s-prow/` prefix in this patch brought it in scope of the autobumper's purview. In our autobumper job we have a flag enabled that checks that the old version we are bumping away from must also look like `v<DATE>-<SHA>`. In our case we were moving away from `latest`, so the autobumper concluded that it was previously bumped to `latest`, a non-conforming tag that the autobumper is not responsible for, indicating that the tag must have been bumped outside of the autobumper (which is not allowed).

The fix is to just use a different prefix altogether, so use the official Alpine image instead, pinned to the latest tag. We could alternatively use `alpine:latest` but pinning is a best practice here (and currently without a RollingUpdate strategy the DaemonSet won't go to each node to actually pull the latest tag if the image was already pulled some time ago).

Whether or not the autobumper should allow bumps from `latest` to `v20240108-a28886d2bd` is another matter. Given the ease of fixing it in the way here, that's probably not worth looking into. For the sake of argument if we did allow it, then ultimately that would encourage the use of gcr.io/k8s-prow images in places that are external the Prow service components (as in this PR, where we tried to bump DaemonSets for build clusters external to the Prow service cluster), because the autobumper won't complain as it did in our first attempt. We don't want to encourage this behavior, so the better fix is to stop using `gcr.io/k8s-prow/` as discussed above. IOW, seeing the autobumper break when non-Prow component files get bumped with Prow-component images is actually a good thing.

/cc @airbornepony @cjwagner @timwangmusic 