### PR TITLE
build cluster DaemonSets: let RollingUpdate tolerate unavailable nodes

### DIFF
--- a/config/prow/cluster/build/create-loop-devs_daemonset.yaml
+++ b/config/prow/cluster/build/create-loop-devs_daemonset.yaml
@@ -18,6 +18,10 @@ spec:
   selector:
     matchLabels:
       name: create-loop-devs
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   template:
     metadata:
       labels:

--- a/config/prow/cluster/build/tune-sysctls_daemonset.yaml
+++ b/config/prow/cluster/build/tune-sysctls_daemonset.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       name: tune-sysctls
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Although we pinned these images in f97d3842f2 (Merge pull request #31704 from listx/pin-daemonset-images, 2024-01-23), the update of the images did not trigger an actual update of the pods managed by these DaemonSets, because although a RollingUpdate strategy is already the default [1], the default `maxUnavailable: 1` setting stops the update if just 1 pod is unavailable. So it was basically stuck (rolling updates getting stuck is a common issue [3]). Currently the k8s-prow-cluster has 164 nodes, of which 3 are listed as "Unknown" status. These 3 were blocking the RolllingUpdate from happening, because 3 > 1.

Explicitly set a RollingUpdate strategy [2] with `maxUnavailble` to 10%, so that updating the image version will force all existing pods to update to the newer image version even if 10% of nodes are unavailable.

These settings have already been applied manually, and will be a NOP when merged to our declarative config.

We can look into deleting the nodes with "Unknown" status later, if only to cut costs as they are not being used by the cluster (as these DaemonSets, much less Prow, are not able to schedule pods into them anyway).

[1] https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
[2] https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
[3] https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-rolling-update-is-stuck

/cc @airbornepony @cjwagner @timwangmusic 