### PR TITLE
Allow GH action to update branches for hydrophone and provider-aws-test-infra

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -564,6 +564,9 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        hydrophone:
+          exclude:
+            - "^dependencies/" # don't protect branches created by github action that updates dependencies
         kernel-module-management:
           required_status_checks:
             contexts:
@@ -608,6 +611,9 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        provider-aws-test-infra:
+          exclude:
+            - "^dependencies/" # don't protect branches created by github action that updates dependencies
         secrets-store-csi-driver:
           branches:
             gh-pages:


### PR DESCRIPTION
These GH actions update the go.mod/sum

- https://github.com/kubernetes-sigs/hydrophone/blob/main/.github/workflows/update-deps.yml
- https://github.com/kubernetes-sigs/provider-aws-test-infra/blob/main/.github/workflows/update-deps.yml