### PR TITLE
Bump timeout for kubernetes-verify-go-licenses-periodical to 20 mins

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -216,7 +216,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
-    timeout: 10m
+    timeout: 20m
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"


### PR DESCRIPTION
test grid is 😢 and 🟥 🟥 🟥 🟥 ...

https://testgrid.k8s.io/sig-testing-misc#kubernetes-verify-go-licenses-periodical&width=20

verified that i can run the script locally and it works fine.