### PR TITLE
CAPZ: better ci-entrypoint.sh test triggers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -599,7 +599,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
-    skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
+    run_if_changed: 'scripts\/ci-entrypoint.sh|scripts\/ci-build-azure-ccm.sh|scripts\/ci-build-kubernetes.sh|^hack/|templates\/test'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR sets more specific test run triggers for CAPZ's ci-entrypoint.sh script test job, and makes the test optional.

This test job remains required for release branches, which is where downstream tests source CAPZ from.