### PR TITLE
CAPZ: improved triggers for CAPI E2E test jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -174,7 +174,7 @@ presubmits:
   - name: pull-cluster-api-provider-azure-capi-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
-    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-e2e.sh|Makefile'
+    run_if_changed: 'test\/e2e\/capi_test.go|scripts\/ci-e2e.sh|^go.mod'
     optional: true
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -190,7 +190,7 @@ presubmits:
   - name: pull-cluster-api-provider-azure-capi-e2e-v1beta1
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
-    run_if_changed: 'test\/e2e|templates\/test|scripts\/ci-e2e.sh|Makefile'
+    run_if_changed: 'test\/e2e\/capi_test.go|scripts\/ci-e2e.sh|^go.mod'
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
This PR sets more specific triggers for CAPZ's CAPI E2E test job, so that we don't run them unnecessarily on PRs.