### PR TITLE
chore(deps): bump client-go to use golang 1.21.x

### DIFF
--- a/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
+++ b/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: k8s.io/client-go
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.15.8
+      - image: public.ecr.aws/docker/library/golang:1.21
         env:
         - name: GO111MODULE
           value: "on"


### PR DESCRIPTION
The pull-client-go-build prow jobs fail at the moment because the master branch of client-go depends on apimachinery that depends on io/fs (Go 1.17 or newer) and cmp (Go 1.21 or newer) so we need to bump the image to be at least 1.21 now