### PR TITLE
Apply blobless_fetch to extra_refs

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -490,7 +490,8 @@ spec:
                       type: string
                     blobless_fetch:
                       description: BloblessFetch tells prow to avoid fetching objects
-                        when cloning using the --filter=blob:none flag.
+                        when cloning using the --filter=blob:none flag. If unspecified,
+                        defaults to DecorationConfig.BloblessFetch.
                       type: boolean
                     clone_depth:
                       description: CloneDepth is the depth of the clone that will
@@ -29348,7 +29349,8 @@ spec:
                     type: string
                   blobless_fetch:
                     description: BloblessFetch tells prow to avoid fetching objects
-                      when cloning using the --filter=blob:none flag.
+                      when cloning using the --filter=blob:none flag. If unspecified,
+                      defaults to DecorationConfig.BloblessFetch.
                     type: boolean
                   clone_depth:
                     description: CloneDepth is the depth of the clone that will be

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -1156,7 +1156,7 @@ type Refs struct {
 	SkipFetchHead bool `json:"skip_fetch_head,omitempty"`
 	// BloblessFetch tells prow to avoid fetching objects when cloning
 	// using the --filter=blob:none flag.
-	BloblessFetch bool `json:"blobless_fetch,omitempty"`
+	BloblessFetch *bool `json:"blobless_fetch,omitempty"`
 }
 
 func (r Refs) String() string {

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -1155,7 +1155,8 @@ type Refs struct {
 	// The git fetch <remote> <BaseRef> call occurs regardless.
 	SkipFetchHead bool `json:"skip_fetch_head,omitempty"`
 	// BloblessFetch tells prow to avoid fetching objects when cloning
-	// using the --filter=blob:none flag.
+	// using the --filter=blob:none flag. If unspecified, defaults to
+	// DecorationConfig.BloblessFetch.
 	BloblessFetch *bool `json:"blobless_fetch,omitempty"`
 }
 

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -547,6 +547,11 @@ func (in *Refs) DeepCopyInto(out *Refs) {
 		*out = make([]Pull, len(*in))
 		copy(*out, *in)
 	}
+	if in.BloblessFetch != nil {
+		in, out := &in.BloblessFetch, &out.BloblessFetch
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -231,8 +231,12 @@ func DecorateExtraRefs(refs []prowapi.Refs, jb config.JobBase) []prowapi.Refs {
 }
 
 func DecorateRefs(refs prowapi.Refs, jb config.JobBase) *prowapi.Refs {
-	if dc := jb.DecorationConfig; dc != nil && dc.BloblessFetch != nil {
-		refs.BloblessFetch = *dc.BloblessFetch
+	dc := jb.DecorationConfig
+	if dc == nil {
+		return &refs
+	}
+	if refs.BloblessFetch == nil {
+		refs.BloblessFetch = dc.BloblessFetch
 	}
 	return &refs
 }

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -326,7 +326,7 @@ func TestCompletePrimaryRefs(t *testing.T) {
 				SkipSubmodules: true,
 				CloneDepth:     2,
 				SkipFetchHead:  true,
-				BloblessFetch:  true,
+				BloblessFetch:  boolPtr(true),
 			},
 		},
 		{
@@ -1219,19 +1219,25 @@ func TestSpecFromJobBase(t *testing.T) {
 					ExtraRefs: []prowapi.Refs{
 						{
 							Org:           "true-org",
-							BloblessFetch: true,
+							BloblessFetch: boolPtr(true),
 						},
 						{
 							Org:           "false-org",
-							BloblessFetch: false,
+							BloblessFetch: boolPtr(false),
+						},
+						{
+							Org: "default-org",
+							BloblessFetch: nil,
 						},
 					},
 				},
 			},
 			verify: func(pj prowapi.ProwJobSpec) error {
 				for _, r := range pj.ExtraRefs {
-					if !r.BloblessFetch {
-						return fmt.Errorf("ExtraRefs BloblessFetch for %s got false, want true", r.Org)
+					got := r.BloblessFetch
+					want := boolPtr(r.Org != "false-org")
+					if diff := cmp.Diff(want, got); diff != "" {
+						return fmt.Errorf("ExtraRefs BloblessFetch for %s differs (-want +got)\n%s", r.Org, diff)
 					}
 				}
 				return nil
@@ -1247,19 +1253,25 @@ func TestSpecFromJobBase(t *testing.T) {
 					ExtraRefs: []prowapi.Refs{
 						{
 							Org:           "true-org",
-							BloblessFetch: true,
+							BloblessFetch: boolPtr(true),
 						},
 						{
 							Org:           "false-org",
-							BloblessFetch: false,
+							BloblessFetch: boolPtr(false),
+						},
+						{
+							Org: "default-org",
+							BloblessFetch: nil,
 						},
 					},
 				},
 			},
 			verify: func(pj prowapi.ProwJobSpec) error {
 				for _, r := range pj.ExtraRefs {
-					if r.BloblessFetch {
-						return fmt.Errorf("ExtraRefs BloblessFetch for %s got true, want false", r.Org)
+					got := r.BloblessFetch
+					want := boolPtr(r.Org == "true-org")
+					if diff := cmp.Diff(want, got); diff != "" {
+						return fmt.Errorf("ExtraRefs BloblessFetch for %s differs (-want +got)\n%s", r.Org, diff)
 					}
 				}
 				return nil
@@ -1272,19 +1284,34 @@ func TestSpecFromJobBase(t *testing.T) {
 					ExtraRefs: []prowapi.Refs{
 						{
 							Org:           "true-org",
-							BloblessFetch: true,
+							BloblessFetch: boolPtr(true),
 						},
 						{
 							Org:           "false-org",
-							BloblessFetch: false,
+							BloblessFetch: boolPtr(false),
+						},
+						{
+							Org: "default-org",
+							BloblessFetch: nil,
 						},
 					},
 				},
 			},
 			verify: func(pj prowapi.ProwJobSpec) error {
 				for _, r := range pj.ExtraRefs {
-					if got, want := r.BloblessFetch, r.Org == "true-org"; got != want {
-						return fmt.Errorf("ExtraRefs BloblessFetch for %s got %v, want %v", r.Org, got, want)
+					got := r.BloblessFetch
+					var want *bool
+					switch r.Org {
+					case "true-org":
+						want = boolPtr(true)
+					case "false-org":
+						want = boolPtr(false)
+					case "default-org":
+						// Keep the unset default value.
+						want = nil
+					}
+					if diff := cmp.Diff(want, got); diff != "" {
+						return fmt.Errorf("ExtraRefs BloblessFetch for %s differs (-want +got)\n%s", r.Org, diff)
 					}
 				}
 				return nil

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -280,8 +280,6 @@ func TestBatchSpec(t *testing.T) {
 }
 
 func TestCompletePrimaryRefs(t *testing.T) {
-	trueVar := true
-
 	cases := []struct {
 		name     string
 		refs     prowapi.Refs
@@ -318,7 +316,7 @@ func TestCompletePrimaryRefs(t *testing.T) {
 					CloneDepth:     2,
 					SkipFetchHead:  true,
 					DecorationConfig: &prowapi.DecorationConfig{
-						BloblessFetch: &trueVar,
+						BloblessFetch: boolPtr(true),
 					},
 				},
 			},
@@ -1150,8 +1148,6 @@ func TestSpecFromJobBase(t *testing.T) {
 		GitHubUsers:   permittedUsers,
 		GitHubOrgs:    permittedOrgs,
 	}
-	falseVar := false
-	trueVar := true
 	testCases := []struct {
 		name    string
 		jobBase config.JobBase
@@ -1218,7 +1214,7 @@ func TestSpecFromJobBase(t *testing.T) {
 			jobBase: config.JobBase{
 				UtilityConfig: config.UtilityConfig{
 					DecorationConfig: &prowapi.DecorationConfig{
-						BloblessFetch: &trueVar,
+						BloblessFetch: boolPtr(true),
 					},
 					ExtraRefs: []prowapi.Refs{
 						{
@@ -1246,7 +1242,7 @@ func TestSpecFromJobBase(t *testing.T) {
 			jobBase: config.JobBase{
 				UtilityConfig: config.UtilityConfig{
 					DecorationConfig: &prowapi.DecorationConfig{
-						BloblessFetch: &falseVar,
+						BloblessFetch: boolPtr(false),
 					},
 					ExtraRefs: []prowapi.Refs{
 						{

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -244,7 +244,7 @@ func (g *gitCtx) commandsForBaseRef(refs prowapi.Refs, gitUserName, gitUserEmail
 		depthArgs = append(depthArgs, "--depth", strconv.Itoa(d))
 	}
 	var filterArgs []string
-	if refs.BloblessFetch {
+	if refs.BloblessFetch != nil && *refs.BloblessFetch {
 		filterArgs = append(filterArgs, "--filter=blob:none")
 	}
 
@@ -337,7 +337,7 @@ func (g *gitCtx) commandsForPullRefs(refs prowapi.Refs, fakeTimestamp int) []run
 	var commands []runnable
 	for _, prRef := range refs.Pulls {
 		var fetchArgs []string
-		if refs.BloblessFetch {
+		if refs.BloblessFetch != nil && *refs.BloblessFetch {
 			fetchArgs = append(fetchArgs, "--filter=blob:none")
 		}
 		ref := fmt.Sprintf("pull/%d/head", prRef.Number)

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -59,6 +59,10 @@ func TestPathForRefs(t *testing.T) {
 	}
 }
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func TestCommandsForRefs(t *testing.T) {
 	fakeTimestamp := 100200300
 	var testCases = []struct {
@@ -579,7 +583,7 @@ func TestCommandsForRefs(t *testing.T) {
 				Pulls: []prowapi.Pull{
 					{Number: 1, Ref: "pull-me"},
 				},
-				BloblessFetch: true,
+				BloblessFetch: boolPtr(true),
 			},
 			dir: "/go",
 			expectedBase: []runnable{


### PR DESCRIPTION
Set BloblessFetch in ExtraRefs based on the DecorationConfig. This ensures that periodic jobs (which only specify ExtraRefs) and any presubmit, etc. jobs that happen to specify extra_refs use blobless clones consistently.

Setting BloblessFetch in ExtraRefs takes preference over the default config. This is done by making that field a pointer to boolean; only nil values are replaced by the default.
