### PR TITLE
ResultStore reporter finished.json default upload

### DIFF
--- a/prow/crier/reporters/resultstore/reporter.go
+++ b/prow/crier/reporters/resultstore/reporter.go
@@ -158,11 +158,17 @@ func defaultFiles(pj *v1.ProwJob) []resultstore.DefaultFile {
 	var fs []resultstore.DefaultFile
 
 	// There is a race with the GCS reporter writing prowjob.json and
-	// in practice, it is generally not written yet. In the unlikely
+	// finished.json, so provide these as defaults. In the unlikely
 	// case of error, skip it since the GCS reporter won't write it.
 	if bs, err := util.MarshalProwJob(pj); err == nil {
 		fs = append(fs, resultstore.DefaultFile{
 			Name: "prowjob.json",
+			Size: int64(len(bs)),
+		})
+	}
+	if bs, err := util.MarshalFinishedJSON(pj); err == nil {
+		fs = append(fs, resultstore.DefaultFile{
+			Name: "finished.json",
 			Size: int64(len(bs)),
 		})
 	}


### PR DESCRIPTION
Due to a race between the gcs and resultstore reporters, the finished.json file is often missing from the uploaded files. Apply the same treatment as was done for prowjob.json to compute the size from the JSON-marshaled metadata.