### PR TITLE
images: Bump aws-iam-authenticator to 5.21

### DIFF
--- a/images/git-custom-k8s-auth/cloudbuild.yaml
+++ b/images/git-custom-k8s-auth/cloudbuild.yaml
@@ -20,4 +20,4 @@ steps:
     - gcr.io/$PROJECT_ID/git-custom-k8s-auth:latest
 substitutions:
   _GIT_TAG: '12345'
-  _AWS_IAM_AUTHENTICATOR_VERSION: '0.5.12'
+  _AWS_IAM_AUTHENTICATOR_VERSION: '0.5.21'


### PR DESCRIPTION
Bumping aws-iam-authenticator to the latest minor.
This will also bump the image to Alpine 3.19.0