### PR TITLE
Add CAPI e2e test job for CAAPH

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-periodics-main.yaml
@@ -1,0 +1,33 @@
+periodics:
+- name: periodic-cluster-api-addon-provider-helm-capi-e2e-main
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-addon-provider-helm
+      base_ref: main
+      path_alias: "sigs.k8s.io/cluster-api-addon-provider-helm"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.29
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Cluster API E2E tests"
+        - name: GINKGO_SKIP
+          value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
+    testgrid-tab-name: caaph-periodic-capi-e2e-main
+    testgrid-alert-email: k8s-infra-staging-cluster-api-helm@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
@@ -133,3 +133,35 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-test-mink8s-main
+  - name: pull-cluster-api-addon-provider-helm-capi-e2e-main
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: sigs.k8s.io/cluster-api-addon-provider-helm
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.29
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "Cluster API E2E tests"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+            memory: 32Gi
+          limits:
+            cpu: 7300m
+            memory: 32Gi
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
+      testgrid-tab-name: caaph-pr-capi-e2e-main


### PR DESCRIPTION
Hold until [this PR](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/147) merges.