### PR TITLE
Do not retry permanent ResultStore upload errors

### DIFF
--- a/prow/resultstore/uploader.go
+++ b/prow/resultstore/uploader.go
@@ -35,19 +35,32 @@ func NewUploader(client *Client) *Uploader {
 
 // Upload uploads a completed Prow job's results to ResultStore's API:
 // https://github.com/googleapis/googleapis/blob/master/google/devtools/resultstore/v2/resultstore_upload.proto
+// This function distinguishes between transient and permanent errors; only
+// transient errors from ResultStore are returned, in which case the call
+// should be retried later.
 func (u *Uploader) Upload(ctx context.Context, log *logrus.Entry, p *Payload) error {
 	inv, err := p.Invocation()
 	if err != nil {
-		return err
+		log.Errorf("p.Invocation: %v", err)
+		return nil
 	}
 	w, err := writer.New(ctx, log, u.client, inv)
 	if err != nil {
+		if writer.PermanentError(err) {
+			return nil
+		}
 		return err
 	}
+	// While the resource proto write methods could theoretically return error,
+	// because we presently create fewer than writer.batchSize updates, they
+	// are all batched and no I/O occurs until the Finalize() call.
 	w.WriteConfiguration(ctx, p.DefaultConfiguration())
 	w.WriteTarget(ctx, p.OverallTarget())
 	w.WriteConfiguredTarget(ctx, p.ConfiguredTarget())
 	w.WriteAction(ctx, p.OverallAction())
+	// TODO: When writer.New() is emended to resume uploads (see TODO there),
+	// return non-permanent errors from Finalize(). Doing this now is futile,
+	// since attempting to upload an existing invocation is a permanent error.
 	w.Finalize(ctx)
 	return nil
 }


### PR DESCRIPTION
If the error returned by the invocation is a permanent error, don't return an error to the caller; this results in indefinite retries. Return no error so that the Crier controller considers it done.

Clarify documentation to uploader.Upload() to improve readability.

Log errors from payload.Invocation() but do not return them, as they are also permanent.