### PR TITLE
[sig-storage-lib-external-provisioner] Remove an unnecessary job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
@@ -22,27 +22,3 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-
-  - name: pull-sig-storage-lib-external-provisioner-unit
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/sig-storage-lib-external-provisioner
-    annotations:
-      testgrid-dashboards: sig-storage-lib-external-provisioner
-      testgrid-tab-name: unit
-      description: Unit tests in sig-storage-lib-external-provisioner repo.
-    spec:
-      containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
-        command:
-        - make
-        args:
-        - test
-        resources:
-          limits:
-            cpu: 2
-            memory: 4Gi
-          requests:
-            cpu: 2
-            memory: 4Gi


### PR DESCRIPTION
Currently, in the [sig-storage-lib-external-provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner) repository, there are two jobs configured. However, upon reviewing the [Makefile]((https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/v9.0.3/Makefile)), it seems that [the first job (pull-sig-storage-lib-external-provisioner-build)](https://github.com/bells17/test-infra/blob/2cd3c3b207f9287a7796e21f4a0d685b23818204/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml#L2-L24) is also executing the tests run by [the second job(pull-sig-storage-lib-external-provisioner-unit)](https://github.com/bells17/test-infra/blob/2cd3c3b207f9287a7796e21f4a0d685b23818204/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml#L26-L48).

Therefore, the second job appears to be unnecessary and I am proposing its removal.

/sig storage