### PR TITLE
Revert ci-ingress-gce-e2e job

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -145,7 +145,7 @@ presubmits:
       testgrid-tab-name: pull-ingress-gce-verify
 
   - name: pull-ingress-gce-e2e
-    cluster: k8s-infra-prow-build
+    cluster: default # https://github.com/kubernetes/test-infra/pull/31681d
     always_run: true
     optional: false
     decorate: true


### PR DESCRIPTION
Revert `ci-ingress-gce-e2e` job as it began failing when moved to community cluster