### PR TITLE
Add CI for knftables

### DIFF
--- a/config/jobs/kubernetes-sigs/knftables/OWNERS
+++ b/config/jobs/kubernetes-sigs/knftables/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- aojea
+- danwinship
+approvers:
+- aojea
+- danwinship

--- a/config/jobs/kubernetes-sigs/knftables/knftables-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/knftables/knftables-presubmits.yaml
@@ -1,0 +1,39 @@
+# sigs.k8s.io/knftables presubmits
+presubmits:
+  kubernetes-sigs/knftables:
+  - name: pull-kind-test
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/knftables
+    always_run: true
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/golang:1.20
+        command:
+        - make
+        - test
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 4Gi
+  - name: pull-kind-verify
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/kind
+    always_run: true
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/golang:1.20
+        command:
+        - make
+        - verify
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 4Gi


### PR DESCRIPTION
@aojea suggested "copy the CI config from kind", but of course that's set up to do all sorts of stuff with kind and doesn't seem to match how other repos are configured so I copied the `cluster` and `image` from other repos...

/hold
requires https://github.com/kubernetes-sigs/knftables/pull/3