### PR TITLE
k8s-infra: disable aws-node-termination-handler for kops-mirror-canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -106,7 +106,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cloudProvider.aws.nodeTerminationHandler.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \


### PR DESCRIPTION
No need for the scope of the test.