### PR TITLE
Bump and pin base images

### DIFF
--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:latest
+# Update the date below (check https://hub.docker.com/_/alpine/tags) to get the
+# alpine edge base image, which has a faster release cadence than alpine:latest
+# (which tracks alpine stable), to pick up security patches more quickly.
+FROM alpine:20231219
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/git-custom-k8s-auth/Dockerfile
+++ b/images/git-custom-k8s-auth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:latest as builder
+FROM google/cloud-sdk:461.0.0 as builder
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/Dockerfile
 
 ARG AWS_IAM_AUTHENTICATOR_VERSION

--- a/images/git-custom-k8s-auth/Dockerfile
+++ b/images/git-custom-k8s-auth/Dockerfile
@@ -21,7 +21,10 @@ RUN curl -fsSL \
     chmod +x /aws-iam-authenticator
 
 
-FROM alpine:latest
+# Update the date below (check https://hub.docker.com/_/alpine/tags) to get the
+# alpine edge base image, which has a faster release cadence than alpine:latest
+# (which tracks alpine stable), to pick up security patches more quickly.
+FROM alpine:20231219
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/git-custom-k8s-auth/cloudbuild.yaml
+++ b/images/git-custom-k8s-auth/cloudbuild.yaml
@@ -20,4 +20,5 @@ steps:
     - gcr.io/$PROJECT_ID/git-custom-k8s-auth:latest
 substitutions:
   _GIT_TAG: '12345'
+  # Prefer 0.5.x series (not 0.6.x) for now.
   _AWS_IAM_AUTHENTICATOR_VERSION: '0.5.21'

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+# Update the date below (check https://hub.docker.com/_/alpine/tags) to get the
+# alpine edge base image, which has a faster release cadence than alpine:latest
+# (which tracks alpine stable), to pick up security patches more quickly.
+FROM alpine:20231219
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 RUN apk add --no-cache git git-daemon openssh
 
 COPY github-known-hosts /github_known_hosts


### PR DESCRIPTION
Notably, this starts using Alpine Edge which has a faster release cadence for security fixes. For example, the version of Git from Edge builds with libcurl 8.5.0, which was released last month.

As a follow-up, we'll need to bump our `.ko.yaml` file  so that our Prow components will start using these base images.

/cc @airbornepony @cjwagner @timwangmusic 