### PR TITLE
🌱 Kubebuilder - Bump golang version from 1.20 to 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - ./test.sh
         resources:


### PR DESCRIPTION
**Description**

Bump golang version from 1.20 to 1.21 for Kubebuilder