### PR TITLE
Add config to autobump k8s-staging-apisnoop

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -39,3 +39,13 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false
+  - name: "k8s-staging-apisnoop-test-infra"
+    prefix: "gcr.io/k8s-staging-apisnoop/"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: false
+  - name: "k8s-staging-apisnoop-apisnoop"
+    prefix: "gcr.io/k8s-staging-apisnoop/"
+    repo: "https://github.com/kubernetes-sigs/apisnoop"
+    summarise: false
+    consistentImages: false


### PR DESCRIPTION
auto update snoopdb image for conformance gate (https://git.k8s.io/test-infra/config/jobs/kubernetes/sig-arch/conformance-gate.yaml)

depends on: https://github.com/ii/cncf-okrs/issues/7#issuecomment-1908643238, https://github.com/ii/cncf-okrs/issues/6

/hold
/assign