### PR TITLE
Deck: Always show horizontal scroll bars when required

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -485,6 +485,7 @@ span.label:not(.merge-table-label):hover {
 
 .table-container {
     overflow-x: auto;
+    height: 100%;
 }
 
 /**


### PR DESCRIPTION
When the browser window is narrow enough to require horizontal scrolling in a table, the scroll bar was only visible at the very bottom of the table. i.e. it was necessary to scroll to the bottom before scrolling across. This made it impossible to follow a row across, unless that row happened to be near the bottom.

This change shows the horizontal scroll bar at the bottom of the browser window instead of at the bottom of the table, so both scroll bars can be used at all times.