### PR TITLE
capz: update maintainers and reviewers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -1,11 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- CecileRobertMichon
 - jackfrancis
 - mboersma
 - nojnhuh
-- sonasingh46
 reviewers:
 - Jont828
 - jsturtevant


### PR DESCRIPTION
Updates maintainers and reviewers of the cluster-api-provider-azure (CAPZ) project to match its current [`OWNERS_ALIASES`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES).

Specifically, removes @CecileRobertMichon and @sonasingh46, since they have moved on to emeritus status on the CAPZ project. Thanks again Cecile and Ashutosh! ❤️ 