### PR TITLE
bump Prow base images

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,56 +1,56 @@
 # Distroless images:
 # defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
-  k8s.io/test-infra/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git-custom-k8s-auth:v20240125-32d3286cca
-  k8s.io/test-infra/prow/cmd/deck: gcr.io/k8s-prow/git-custom-k8s-auth:v20240125-32d3286cca
-  k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git-custom-k8s-auth:v20240125-32d3286cca
-  k8s.io/test-infra/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/gangway: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20230817-0485b825c2
+  k8s.io/test-infra/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/deck: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/gangway: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   k8s.io/test-infra/prow/cmd/grandmatriarch: gcr.io/cloud-builders/gcloud@sha256:5b49dfb5e366dd75a5fc6d5d447be584f8f229c5a790ee0c3b0bd0cf70ec41dd
-  k8s.io/test-infra/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/hook: gcr.io/k8s-prow/git-custom-k8s-auth:v20240125-32d3286cca
-  k8s.io/test-infra/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/initupload: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/invitations-accepter: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/moonraker: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20240125-32d3286cca
-  k8s.io/test-infra/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/sub: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/tide: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/cmd/tot: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-custom-k8s-auth:v20240125-32d3286cca
-  k8s.io/test-infra/prow/cmd/admission: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+  k8s.io/test-infra/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/hook: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/initupload: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/invitations-accepter: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/moonraker: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/sub: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/tide: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/tot: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/admission: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   k8s.io/test-infra/prow/cmd/webhook-server: gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
-  k8s.io/test-infra/prow/cmd/mkpj: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/mkpod: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/cmd/pipeline: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/external-plugins/needs-rebase: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+  k8s.io/test-infra/prow/cmd/mkpj: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/mkpod: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/cmd/pipeline: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/external-plugins/needs-rebase: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   # external
-  k8s.io/test-infra/prow/external-plugins/cherrypicker: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/prow/external-plugins/refresh: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/ghproxy: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/label_sync: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/robots/commenter: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-prow/git:v20230817-0485b825c2
-  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/gencred: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+  k8s.io/test-infra/prow/external-plugins/cherrypicker: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/external-plugins/refresh: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/ghproxy: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/label_sync: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/robots/commenter: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/gencred: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   # prow integration test
-  k8s.io/test-infra/prow/test/integration/cmd/fakeghserver: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
-  k8s.io/test-infra/prow/test/integration/cmd/fakegitserver: gcr.io/k8s-prow/git:v20220523-6026203ca9
+  k8s.io/test-infra/prow/test/integration/cmd/fakeghserver: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/prow/test/integration/cmd/fakegitserver: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   k8s.io/test-infra/prow/test/integration/cmd/fakepubsub: google/cloud-sdk:389.0.0
-  k8s.io/test-infra/prow/test/integration/cmd/fakegcsserver: gcr.io/k8s-prow/alpine:v20240108-a28886d2bd
+  k8s.io/test-infra/prow/test/integration/cmd/fakegcsserver: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
 
 # https://pkg.go.dev/cmd/link
 # -s: omit symbol/debug info


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/test-infra/pull/31745. This picks up Alpine Edge for external dependencies outside of our Go-based binaries. For example, for the `git` base image, this brings in libcurl 8.5.0 which addresses several CVEs for curl's dependencies.

In the future we can move away from alpine (to distroless) for those images that don't depend on any additional Alpine packages (these are all the ones that just use plain "alpine" as the base image).

/cc @ameukam @airbornepony @cjwagner @timwangmusic 