### PR TITLE
Increase Tekton pipeline creation timeout

### DIFF
--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -350,7 +350,7 @@ func (c *controller) createPipelineRun(pContext, namespace string, p *pipelinev1
 	}
 	// Block until the pipelinerun is in the lister, otherwise we may attempt to create it again
 	var errOut error
-	wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+	wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
 		_, errOut = c.getPipelineRun(pContext, namespace, p.Name)
 		return errOut == nil, nil
 	})


### PR DESCRIPTION
Current timeout (3secs) is too short to catch PipelineRun creation in several cases (e.g. PVC bound). Increase 10secs to cover common cases.