### PR TITLE
Use n2 also for kubemark presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -367,6 +367,7 @@ presubmits:
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=500
+        - --kubemark-master-size=n2-standard-16
         - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=160 --max-mutating-requests-inflight=0 --profiling --contention-profiling
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-big
@@ -455,6 +456,7 @@ presubmits:
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=5000
+        - --kubemark-master-size=n2-standard-64
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-scale
         # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
@@ -657,6 +659,7 @@ presubmits:
         - --gcp-zone=us-east1-b
         - --kubemark
         - --kubemark-nodes=100
+        - --kubemark-master-size=n2-standard-8
         - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
         - --provider=gce
         - --tear-down-previous


### PR DESCRIPTION
Kubemark presubmits are failing with error like
```
 - Setting minimum CPU platform is not supported for the selected machine type e2-standard-8.
Failed to create master instance due to non-retryable error
2024/01/30 13:18:34 process.go:155: Step 'test/kubemark/start-kubemark.sh' finished in 1m20.74023594s
```

Link: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/perf-tests/2533/pull-perf-tests-clusterloader2-kubemark/1752317274120785920

This is follow up to https://github.com/kubernetes/test-infra/pull/31609, but for presubmits.