### PR TITLE
disable EventedPLEG for kind CI on allalpha enabling

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -459,7 +459,7 @@ periodics:
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: FEATURE_GATES
-        value: '{"AllAlpha":true}'
+        value: '{"AllAlpha":true,"EventedPLEG": false}'
       - name: RUNTIME_CONFIG
         value: '{"api/alpha":"true", "api/ga":"true"}'
       - name: FOCUS
@@ -563,7 +563,7 @@ periodics:
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: FEATURE_GATES
-        value: '{"AllAlpha":true,"AllBeta":true}'
+        value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG": false}'
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: FOCUS


### PR DESCRIPTION
As we discussed in sig node weekly meeting, https://github.com/kubernetes/kubernetes/issues/122721 is not a blocker for the next alpha release cut and it probably is a blocker for v1.30, and we will fix it in a high priority later. 

- https://github.com/kubernetes/kubernetes/issues/122721 which may be fixed by https://github.com/kubernetes/kubernetes/pull/122778


Slack discussion: https://kubernetes.slack.com/archives/C0BP8PW9G/p1706638623162379?thread_ts=1706055745.168469&cid=C0BP8PW9G
