### PR TITLE
Fix `ulimit` error in `krte` image

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -96,6 +96,7 @@ RUN echo "Installing Packages ..." \
         && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+        && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
     && echo "Ensuring Legacy Iptables ..." \
         && update-alternatives --set iptables /usr/sbin/iptables-legacy \
         && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy


### PR DESCRIPTION
`krte` image is broken with `docker-ce 25.0.0` and fails when executing an `ulimit` command ([see my comment](https://github.com/kubernetes/test-infra/pull/31774#issuecomment-1919702745)).
This PR implements a fix for it similar to how we did it for our own version of `krte` image (https://github.com/gardener/ci-infra/pull/1108).

The idea for the fix was taken from a docker issue: https://github.com/docker/cli/issues/4807#issuecomment-1903950217