### PR TITLE
Add a kind job for evented pleg

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -427,7 +427,53 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
-
+  - name: pull-kubernetes-e2e-kind-evented-pleg
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20240111-cf1d81388e-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"EventedPLEG":true}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: FOCUS
+          value: "."
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 7
+            memory: 9000Mi
+          requests:
+            cpu: 7
+            memory: 9000Mi
+    annotations:
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
 periodics:
 - interval: 24h
   cluster: k8s-infra-prow-build

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -107,6 +107,9 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-alpha-features
     test_group_name: pull-kubernetes-e2e-kind-alpha-features
     base_options: width=10
+  - name: pull-kubernetes-e2e-kind-evented-pleg
+    test_group_name: pull-kubernetes-e2e-kind-evented-pleg
+    base_options: width=10
   - name: pull-kubernetes-e2e-kind-beta-features
     test_group_name: pull-kubernetes-e2e-kind-beta-features
     base_options: width=10


### PR DESCRIPTION
After https://github.com/kubernetes/test-infra/pull/31647 and https://github.com/kubernetes/test-infra/pull/31767 are merged there isn't a job that uses kind cluster with `Evented PLEG`. 

This PR adds a non-blocking pre-submit job that uses kind cluster for Evented PLEG. Apart from helping in debugging issues related Evented PLEG, this job also enhances Evented PLEG testing beyond existing node e2e jobs. 


/cc @pacoxu 
