### PR TITLE
bump timeout value for pull-kubernetes-e2e-kind-evented-pleg

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -438,7 +438,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decoration_config:
-      timeout: 60m
+      timeout: 180m
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
It seems we are reaching the [timeout value](https://github.com/kubernetes/kubernetes/pull/122778#issuecomment-1920179751) of the `pull-kubernetes-e2e-kind-evented-pleg`. This PR bumps it up to make sure the job completes running all test cases. 