### PR TITLE
Always run CAPI e2e tests in CAAPH presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
@@ -139,10 +139,11 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    path_alias: sigs.k8s.io/cluster-api-addon-provider-helm
+    always_run: true
     branches:
     # The script this job runs is not in all branches.
     - ^main$
-    path_alias: sigs.k8s.io/cluster-api-addon-provider-helm
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.29


### PR DESCRIPTION
Fix bug where e2e job doesn't run by default on PRs.