### PR TITLE
sig-cluster-lifecycle/cluster-api: add chrischdi to maintainers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api/OWNERS
@@ -2,6 +2,7 @@
 
 reviewers:
 - CecileRobertMichon
+- chrischdi
 - fabriziopandini
 - JoelSpeed
 - justinsb
@@ -11,6 +12,7 @@ reviewers:
 - vincepri
 approvers:
 - CecileRobertMichon
+- chrischdi
 - fabriziopandini
 - justinsb
 - sbueringer


### PR DESCRIPTION
Adding myself to the approvers for cluster-api relevant staging images.

xref:

https://github.com/kubernetes-sigs/cluster-api/pull/9997

/assign sbueringer 