### PR TITLE
Deflake `cherrypicker` tests

### DIFF
--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -31,7 +31,10 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
-var commentFormat = "%s/%s#%d %s"
+var (
+	commentFormat = "%s/%s#%d %s"
+	fakePR        prNumberGenerator
+)
 
 type fghc struct {
 	sync.Mutex
@@ -145,7 +148,13 @@ func (f *fghc) CreateIssue(org, repo, title, body string, milestone int, labels,
 	var ghLabels []github.Label
 	var ghAssignees []github.User
 
-	num := len(f.issues) + 1
+	var num int
+	for _, issue := range f.issues {
+		if issue.Number > num {
+			num = issue.Number
+		}
+	}
+	num++
 
 	for _, label := range labels {
 		ghLabels = append(ghLabels, github.Label{Name: label})
@@ -169,7 +178,13 @@ func (f *fghc) CreateIssue(org, repo, title, body string, milestone int, labels,
 func (f *fghc) CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error) {
 	f.Lock()
 	defer f.Unlock()
-	num := len(f.prs) + 1
+	var num int
+	for _, pr := range f.prs {
+		if pr.Number > num {
+			num = pr.Number
+		}
+	}
+	num++
 	f.prs = append(f.prs, github.PullRequest{
 		Title:  title,
 		Body:   body,
@@ -269,6 +284,7 @@ func TestCherryPickICV2(t *testing.T) {
 }
 
 func testCherryPickIC(clients localgit.Clients, t *testing.T) {
+	iNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
 	if err := lg.CheckoutNewBranch("foo", "bar", "stage"); err != nil {
 		t.Fatalf("Checking out pull branch: %v", err)
@@ -296,7 +312,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 			FullName: "foo/bar",
 		},
 		Issue: github.Issue{
-			Number:      2,
+			Number:      iNumber,
 			State:       "closed",
 			PullRequest: &struct{}{},
 		},
@@ -310,9 +326,9 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 
 	botUser := &github.UserData{Login: "ci-robot", Email: "ci-robot@users.noreply.github.com"}
 	expectedTitle := "[stage] This is a fix for X"
-	expectedBody := "This is an automated cherry-pick of #2\n\n/assign wiseguy\n\n```release-note\nUpdate the magic number from 42 to 49\n```"
+	expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d\n\n/assign wiseguy\n\n```release-note\nUpdate the magic number from 42 to 49\n```", iNumber)
 	expectedBase := "stage"
-	expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, 2, expectedBase)
+	expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, iNumber, expectedBase)
 	expectedLabels := []string{}
 	expected := fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, expectedBase, expectedLabels)
 
@@ -347,6 +363,7 @@ func TestCherryPickPRV2(t *testing.T) {
 }
 
 func testCherryPickPR(clients localgit.Clients, t *testing.T) {
+	prNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
 	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8"}
 	for _, branch := range expectedBranches {
@@ -354,7 +371,7 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 			t.Fatalf("Checking out pull branch: %v", err)
 		}
 	}
-	if err := lg.CheckoutNewBranch("foo", "bar", "cherry-pick-2-to-release-1.5"); err != nil {
+	if err := lg.CheckoutNewBranch("foo", "bar", fmt.Sprintf("cherry-pick-%d-to-release-1.5", prNumber)); err != nil {
 		t.Fatalf("Checking out existing PR branch: %v", err)
 	}
 
@@ -408,12 +425,12 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 		prs: []github.PullRequest{
 			{
 				Title: "[release-1.5] This is a fix for Y",
-				Body:  "This is an automated cherry-pick of #2",
+				Body:  fmt.Sprintf("This is an automated cherry-pick of #%d", prNumber),
 				Base: github.PullRequestBranch{
 					Ref: "release-1.5",
 				},
 				Head: github.PullRequestBranch{
-					Ref: "ci-robot:cherry-pick-2-to-release-1.5",
+					Ref: fmt.Sprintf("ci-robot:cherry-pick-%d-to-release-1.5", prNumber),
 				},
 			},
 		},
@@ -432,7 +449,7 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 					Name: "bar",
 				},
 			},
-			Number:   2,
+			Number:   prNumber,
 			Merged:   true,
 			MergeSHA: new(string),
 			Title:    "This is a fix for Y",
@@ -463,8 +480,8 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 
 	var expectedFn = func(branch string) string {
 		expectedTitle := fmt.Sprintf("[%s] This is a fix for Y", branch)
-		expectedBody := "This is an automated cherry-pick of #2"
-		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, 2, branch)
+		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d", prNumber)
+		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, prNumber, branch)
 		expectedLabels := s.labels
 		return fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, branch, expectedLabels)
 	}
@@ -500,6 +517,7 @@ func TestCherryPickOfCherryPickPRV2(t *testing.T) {
 // function works as intended when the user performs a cherry-pick from
 // a branch that's already a cherry-pick branch
 func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
+	prNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
 	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8"}
 	for _, branch := range expectedBranches {
@@ -539,7 +557,7 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 					Name: "bar",
 				},
 			},
-			Number:   2,
+			Number:   prNumber,
 			Merged:   true,
 			MergeSHA: new(string),
 			Title:    "This is a fix for Y",
@@ -587,8 +605,8 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 
 	var expectedFn = func(branch string) string {
 		expectedTitle := fmt.Sprintf("[%s] This is a fix for Y", branch)
-		expectedBody := "This is an automated cherry-pick of #2"
-		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, 2, branch)
+		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d", prNumber)
+		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, prNumber, branch)
 		expectedLabels := s.labels
 		return fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, branch, expectedLabels)
 	}
@@ -621,6 +639,7 @@ func TestCherryPickPRWithLabelsV2(t *testing.T) {
 }
 
 func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
+	prNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
 	if err := lg.CheckoutNewBranch("foo", "bar", "release-1.5"); err != nil {
 		t.Fatalf("Checking out pull branch: %v", err)
@@ -645,7 +664,7 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 						Name: "bar",
 					},
 				},
-				Number:   2,
+				Number:   prNumber,
 				Merged:   true,
 				MergeSHA: new(string),
 				Title:    "This is a fix for Y",
@@ -758,8 +777,8 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 
 					expectedFn := func(branch string) string {
 						expectedTitle := fmt.Sprintf("[%s] This is a fix for Y", branch)
-						expectedBody := "This is an automated cherry-pick of #2"
-						expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, 2, branch)
+						expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d", prNumber)
+						expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, prNumber, branch)
 						expectedLabels := s.labels
 						return fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, branch, expectedLabels)
 					}
@@ -899,6 +918,7 @@ func TestCherryPickPRAssignmentsV2(t *testing.T) {
 }
 
 func testCherryPickPRAssignments(clients localgit.Clients, t *testing.T) {
+	iNumber := fakePR.GetPRNumber()
 	for _, prowAssignments := range []bool{true, false} {
 		lg, c := makeFakeRepoWithCommit(clients, t)
 		if err := lg.CheckoutNewBranch("foo", "bar", "stage"); err != nil {
@@ -930,7 +950,7 @@ func testCherryPickPRAssignments(clients localgit.Clients, t *testing.T) {
 				FullName: "foo/bar",
 			},
 			Issue: github.Issue{
-				Number:      2,
+				Number:      iNumber,
 				State:       "closed",
 				PullRequest: &struct{}{},
 			},
@@ -1071,4 +1091,16 @@ type threadUnsafeFGHC struct {
 func (tuf *threadUnsafeFGHC) EnsureFork(login, org, repo string) (string, error) {
 	tuf.orgRepoCountCalled++
 	return "", errors.New("that is enough")
+}
+
+type prNumberGenerator struct {
+	sync.Mutex
+	prNumber int
+}
+
+func (p *prNumberGenerator) GetPRNumber() int {
+	p.Lock()
+	defer p.Unlock()
+	p.prNumber = p.prNumber + 10
+	return p.prNumber
 }


### PR DESCRIPTION
I noticed that `cherrypicker` tests are sometime flaky ([ref](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/31774/pull-test-infra-unit-test/1753073579114631168)).
In the tests multiple issues and PRs are created with number 2. This might mess up `git` when tests are running in parallel because it uses the same path multiple times ([ref](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/31774/pull-test-infra-unit-test/1753073579114631168#1:build-log.txt%3A612-613)).

This PR introduces a small PR number generator for the tests to avoid this issue. We had a similar issue a while back in our fork of cherrypicker. They are gone now after a similar fix https://github.com/gardener/ci-infra/pull/366.