### PR TITLE
align runtime config of evented pleg job with alpha features job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -453,7 +453,7 @@ presubmits:
         - name: FEATURE_GATES
           value: '{"EventedPLEG":true}'
         - name: RUNTIME_CONFIG
-          value: '{"api/all":"true"}'
+          value: '{"api/alpha":"true", "api/ga":"true"}'
         - name: FOCUS
           value: "."
         - name: SKIP


### PR DESCRIPTION
Evented PLEG feature is still in the alpha, so this PR tweaks the `pull-kubernetes-e2e-kind-evented-pleg` to align more with `pull-kubernetes-e2e-kind-alpha-features`. 

With the help of @pacoxu's  https://github.com/kubernetes/kubernetes/pull/122778 the remaining issues are hopefully going to get fixed. And once we have that, it would be make sense to revert https://github.com/kubernetes/test-infra/pull/31647 which disabled Evented PLEG for  `pull-kubernetes-e2e-kind-alpha-features`. 

By aligning `pull-kubernetes-e2e-kind-evented-pleg` more closely with `pull-kubernetes-e2e-kind-alpha-features` it would help us get a right signal on the stability of the Evented PLEG from the perspective of `pull-kubernetes-e2e-kind-alpha-features` 

/cc @pacoxu 
/cc @dims 
 