### PR TITLE
Add building of verify conformance image

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -44,3 +44,26 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
               - apps/snoopdb
+  kubernetes-sigs/verify-conformance:
+    - name: post-verify-conformance-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: conformance-apisnoop, sig-k8s-infra-gcb
+        testgrid-tab-name: verify-conformance-image
+        testgrid-alert-email: apisnoop@ii.coop
+        description: Builds the verify-conformance image
+      decorate: true
+      branches:
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20230711-e33377c2b4
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-apisnoop
+              - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
Build verify-conformance

depends on: migration of cncf-infra/verify-conformance to kubernetes-sigs/verify-conformance (https://github.com/orgs/ii/projects/11/views/2?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status&pane=issue&itemId=51693001)
depends on: https://github.com/kubernetes/test-infra/pull/31777

/assign
/hold