### PR TITLE
Adding test to release informing

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws, sig-release-master-informing
     testgrid-tab-name: ec2-master-scale-performance
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com
   spec:


### PR DESCRIPTION
We seemed to have resolved all the flakiness etc that we have encountered recently
- https://github.com/kubernetes/test-infra/issues/31459 
- https://github.com/kubernetes/k8s.io/issues/6303
- https://github.com/kubernetes/test-infra/issues/31755
etc

Tests seems to succeed now for last few runs after above issues and more was fixed. All the last 10 recent failures are attributed to above two issues.

So, wanting to move this to release-informing dashboard to keep an eye out on these tests from release perspective.  At the very least we can use this PR to serve the discussion to understand what more is needed to add this to `release-informing`.
