### PR TITLE
migrate `cadvisor` job to community cluster

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -65,6 +65,7 @@ presubmits:
 
   kubernetes/kubernetes: # Temporary test for https://github.com/kubernetes/kubernetes/pull/116517
   - name: pull-cadvisor-e2e-kubernetes
+    cluster: k8s-infra-prow-build
     always_run: false
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
This PR moves `pull-cadvisor-e2e-kubernetes`  to the community owned cluster gke cluster

Ref: https://github.com/kubernetes/test-infra/issues/31789, https://github.com/kubernetes/kubernetes/issues/123079