### PR TITLE
Resume Resultstore uploads

### DIFF
--- a/prow/resultstore/uploader.go
+++ b/prow/resultstore/uploader.go
@@ -62,10 +62,13 @@ func (u *Uploader) Upload(ctx context.Context, log *logrus.Entry, p *Payload) er
 	w.WriteTarget(ctx, p.OverallTarget())
 	w.WriteConfiguredTarget(ctx, p.ConfiguredTarget())
 	w.WriteAction(ctx, p.OverallAction())
-	// TODO: When writer.New() is emended to resume uploads (see TODO there),
-	// return non-permanent errors from Finalize(). Doing this now is futile,
-	// since attempting to upload an existing invocation is a permanent error.
-	w.Finalize(ctx)
+
+	if err := w.Finalize(ctx); err != nil {
+		if writer.PermanentError(err) {
+			return nil
+		}
+		return err
+	}
 	return nil
 }
 

--- a/prow/resultstore/uploader.go
+++ b/prow/resultstore/uploader.go
@@ -17,8 +17,12 @@ limitations under the License.
 package resultstore
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"sync"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/resultstore/writer"
 )
@@ -44,7 +48,7 @@ func (u *Uploader) Upload(ctx context.Context, log *logrus.Entry, p *Payload) er
 		log.Errorf("p.Invocation: %v", err)
 		return nil
 	}
-	w, err := writer.New(ctx, log, u.client, inv)
+	w, err := writer.New(ctx, log, u.client, inv, authToken.From(inv.Id.InvocationId))
 	if err != nil {
 		if writer.PermanentError(err) {
 			return nil
@@ -63,4 +67,47 @@ func (u *Uploader) Upload(ctx context.Context, log *logrus.Entry, p *Payload) er
 	// since attempting to upload an existing invocation is a permanent error.
 	w.Finalize(ctx)
 	return nil
+}
+
+type tokenGenerator struct {
+	mu   sync.Mutex
+	seed []byte
+}
+
+func (g *tokenGenerator) From(id string) string {
+	g.mu.Lock()
+	seed := g.seed
+	g.mu.Unlock()
+
+	digest := sha256.New()
+	digest.Write(seed)
+	digest.Write([]byte(id))
+	r := bytes.NewReader(digest.Sum(nil))
+	// error cannot occur since we read from a 256-bit digest.
+	u, _ := uuid.NewRandomFromReader(r)
+	return u.String()
+}
+
+func (g *tokenGenerator) Reseed(seed string) {
+	digest := sha256.New()
+	digest.Write([]byte(seed))
+
+	g.mu.Lock()
+	g.seed = digest.Sum(nil)
+	g.mu.Unlock()
+}
+
+var authToken *tokenGenerator
+
+func init() {
+	authToken = &tokenGenerator{}
+	SeedAuthToken("Avast ye, Matey!")
+}
+
+// SeedAuthToken sets the seed for computing AuthenticationToken values for
+// ResultStore uploads. This is just one of many layers of protection, but if
+// ever needed, a Crier secret string could be used to rule out unintended
+// writers from interfering with in-progress uploads.
+func SeedAuthToken(seed string) {
+	authToken.Reseed(seed)
 }

--- a/prow/resultstore/uploader_test.go
+++ b/prow/resultstore/uploader_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resultstore
+
+import "testing"
+
+func TestTokener(t *testing.T) {
+
+	for _, tc := range []struct {
+		desc string
+		seed string
+		id   string
+		want string
+	}{
+		{
+			desc: "normal",
+			seed: "Test Seed",
+			id:   "2cf762a1-e2ff-4c09-a45c-96ace79c0080",
+			want: "a6ca96c8-5411-4767-8cde-2e886cea8fea",
+		},
+		{
+			desc: "empty id",
+			seed: "Test Seed",
+			id:   "",
+			want: "dd84c04e-5803-447b-b2dd-cc85c6d01281",
+		},
+		{
+			desc: "empty seed",
+			seed: "",
+			id:   "2cf762a1-e2ff-4c09-a45c-96ace79c0080",
+			want: "35f1d874-5264-4b2d-afd5-cbbcfd43be37",
+		},
+		{
+			desc: "non uuid ok",
+			seed: "Test Seed",
+			id:   "non-uuid-value",
+			want: "c89d28cc-0f73-43c1-ba3a-695570eb3546",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			tg := tokenGenerator{}
+			tg.Reseed(tc.seed)
+			if got, want := tg.From(tc.id), tc.want; got != want {
+				t.Errorf("tokener.For() got %q, want %q", got, want)
+			}
+			// Ensure repeatable values.
+			if got, want := tg.From(tc.id), tc.want; got != want {
+				t.Errorf("Second tokener.For() got %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/prow/resultstore/writer/writer.go
+++ b/prow/resultstore/writer/writer.go
@@ -61,6 +61,8 @@ func resumeToken() string {
 
 type ResultStoreBatchClient interface {
 	CreateInvocation(context.Context, *resultstore.CreateInvocationRequest, ...grpc.CallOption) (*resultstore.Invocation, error)
+	GetInvocationUploadMetadata(context.Context, *resultstore.GetInvocationUploadMetadataRequest, ...grpc.CallOption) (*resultstore.UploadMetadata, error)
+	TouchInvocation(context.Context, *resultstore.TouchInvocationRequest, ...grpc.CallOption) (*resultstore.TouchInvocationResponse, error)
 	UploadBatch(ctx context.Context, in *resultstore.UploadBatchRequest, opts ...grpc.CallOption) (*resultstore.UploadBatchResponse, error)
 }
 
@@ -99,8 +101,16 @@ func PermanentError(err error) bool {
 	return false
 }
 
+// IsAlreadyExistsErr returns whether the error status code is AlreadyExists.
+func IsAlreadyExistsErr(err error) bool {
+	status, _ := status.FromError(err)
+	return status.Code() == codes.AlreadyExists
+}
+
 // New creates Invocation inv in ResultStore and returns a writer to add
-// resource protos and finalize the Invocation. The create is retried with
+// resource protos and finalize the Invocation. If the Invocation already
+// exists and is finalized, a permanent error is returned. Otherwise, the
+// writer syncs with ResultStore to resume writing. RPCs are retried with
 // exponential backoff unless there is a permanent error, which is returned
 // immediately. The caller should check whether a returned error is permanent
 // using PermanentError() and only retry transient errors. The authToken is a
@@ -117,26 +127,71 @@ func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, 
 	}
 	ctx, cancel := context.WithTimeout(ctx, rpcRetryDuration)
 	defer cancel()
-	err := wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
+
+	err := w.createInvocation(ctx, inv, invID)
+	if err == nil {
+		return w, nil
+	}
+	if !IsAlreadyExistsErr(err) {
+		return nil, err
+	}
+
+	if touchErr := w.touchInvocation(ctx, invID); PermanentError(touchErr) {
+		// Since it was confirmed above that the Invocation exists, a
+		// permanent error here indicates the Invocation is finalized.
+		return nil, err
+	}
+
+	if err = w.retrieveResumeToken(ctx, invID); err != nil {
+		return nil, err
+	}
+
+	log.Info("Resuming upload for unfinalized invocation")
+	return w, nil
+}
+
+func (w *writer) createInvocation(ctx context.Context, inv *resultstore.Invocation, invID string) error {
+	return wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
 		inv, err := w.client.CreateInvocation(ctx, w.createInvocationRequest(invID, inv))
 		if err != nil {
-			log.Errorf("resultstore.CreateInvocation: %v", err)
-			// TODO: In the event codes.AlreadyExists is returned, fall back
-			// to UpdateInvocation(). If that succeeds, we should be able to
-			// repeat the batch since resource Updates are idempotent.
+			w.log.Errorf("resultstore.CreateInvocation: %v", err)
 			if PermanentError(err) {
-				// End retries by returning error.
-				return false, err
+				return false, err // End retries.
 			}
 			return false, nil
 		}
 		w.retInv = inv
 		return true, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return w, nil
+}
+
+func (w *writer) touchInvocation(ctx context.Context, invID string) error {
+	return wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
+		_, err := w.client.TouchInvocation(ctx, w.touchInvocationRequest(invID))
+		if err != nil {
+			w.log.Errorf("resultstore.TouchInvocation: %v", err)
+			if PermanentError(err) {
+				return false, err // End retries.
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func (w *writer) retrieveResumeToken(ctx context.Context, invID string) error {
+	return wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
+		meta, err := w.client.GetInvocationUploadMetadata(ctx, w.getInvocationUploadMetadataRequest(invID))
+		if err != nil {
+			w.log.Errorf("resultstore.GetInvocationUploadMetadata: %v", err)
+			if PermanentError(err) {
+				return false, err // End retries.
+			}
+			return false, nil
+		}
+		w.resumeToken = meta.ResumeToken
+		return true, nil
+	})
 }
 
 func (w *writer) WriteConfiguration(ctx context.Context, c *resultstore.Configuration) error {
@@ -165,6 +220,28 @@ func (w *writer) createInvocationRequest(invID string, inv *resultstore.Invocati
 		Invocation:         inv,
 		AuthorizationToken: w.authToken,
 		InitialResumeToken: w.resumeToken,
+	}
+}
+
+func invocationName(invID string) string {
+	return fmt.Sprintf("invocations/%s", invID)
+}
+
+func (w *writer) touchInvocationRequest(invID string) *resultstore.TouchInvocationRequest {
+	return &resultstore.TouchInvocationRequest{
+		Name:               invocationName(invID),
+		AuthorizationToken: w.authToken,
+	}
+}
+
+func uploadMetadataName(invID string) string {
+	return fmt.Sprintf("invocations/%s/uploadMetadata", invID)
+}
+
+func (w *writer) getInvocationUploadMetadataRequest(invID string) *resultstore.GetInvocationUploadMetadataRequest {
+	return &resultstore.GetInvocationUploadMetadataRequest{
+		Name:               uploadMetadataName(invID),
+		AuthorizationToken: w.authToken,
 	}
 }
 

--- a/prow/resultstore/writer/writer.go
+++ b/prow/resultstore/writer/writer.go
@@ -53,12 +53,6 @@ var (
 	rpcRetryDuration = 5 * time.Minute
 )
 
-func authorizationToken() string {
-	// ResultStore authorization tokens "must be set to a RFC 4122-
-	// compliant v3, v4, or v5 UUID."
-	return uuid.New().String()
-}
-
 func resumeToken() string {
 	// ResultStore resume tokens must be unique and be "web safe
 	// Base64 encoded bytes."
@@ -109,14 +103,15 @@ func PermanentError(err error) bool {
 // resource protos and finalize the Invocation. The create is retried with
 // exponential backoff unless there is a permanent error, which is returned
 // immediately. The caller should check whether a returned error is permanent
-// using PermanentError() and only retry transient errors.
-func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, inv *resultstore.Invocation) (*writer, error) {
+// using PermanentError() and only retry transient errors. The authToken is a
+// UUID and must be identical across all calls for the same Invocation.
+func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, inv *resultstore.Invocation, authToken string) (*writer, error) {
 	invID := inv.Id.InvocationId
 	inv.Id = nil
 	w := &writer{
 		log:         log,
 		client:      client,
-		authToken:   authorizationToken(),
+		authToken:   authToken,
 		resumeToken: resumeToken(),
 		updates:     []*resultstore.UploadRequest{},
 	}


### PR DESCRIPTION
When Crier is restarted, it is possible for the ResultStore reporter to fail to record reconciliation state for successful uploads. When the reporter attempts to upload them again a permanent error is returned by ResultStore because the Invocation already exists. The existing code assumes the result is complete in that case and marks it as reconciled.

There is a chance however that the Invocation is not yet finalized, and could be missing the resource protos (Targets, etc.) that are uploaded subsequent to the Invocation itself. This change addresses that case, confirming that the Invocation is finalized, and if not, attempting to re-upload the resource protos and finalize the Invocation.