### PR TITLE
job: migrate ci-kubernetes-e2e-scalability-cleanup to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 24h
   name: ci-kubernetes-e2e-scalability-cleanup
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
   decorate: true
@@ -35,6 +36,13 @@ periodics:
       - scalability-project
       # File with boskos resource definitions
       - $(GOPATH)/src/k8s.io/test-infra/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
+      resources:
+        requests:
+          memory: "2000Mi"
+          cpu: 4000m
+        limits:
+          memory: "2000Mi"
+          cpu: 4000m
 
 - name: ci-kubernetes-scalability-cleanup-golang-builds-canary
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
This PR moves `ci-kubernetes-e2e-scalability-cleanup` to the community cluster

Ref: #31789 