### PR TITLE
[cloud-provider-azure] Update IPv6 and dualstack jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -122,7 +122,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.28.4"
+              value: "v1.29.0"
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -174,7 +174,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.28.4"
+              value: "v1.29.0"
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -411,7 +411,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.28.4"
+              value: "v1.29.0"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
@@ -464,7 +464,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.28.4"
+              value: "v1.29.0"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
@@ -751,7 +751,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.28.4"
+          value: "v1.29.0"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -806,7 +806,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.28.4"
+          value: "v1.29.0"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -861,7 +861,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.28.4"
+          value: "v1.29.0"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -916,7 +916,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.28.4"
+          value: "v1.29.0"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -25,7 +25,7 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
         testgrid-tab-name: pr-cloud-provider-azure-check-1-26
         description: "Run lint check tests for cloud-provider-azure release-1.26."
         testgrid-num-columns-recent: "30"
@@ -78,7 +78,7 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-26
         description: "Runs Azure specific tests with cloud-provider-azure release-1.26 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -139,7 +139,7 @@ presubmits:
               - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
                 value: "30"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
         testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-26
         description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.26 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -188,7 +188,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-26
         description: "Runs Azure specific tests with cloud-provider-azure release-1.26 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -217,7 +217,7 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-26
         description: "Run unit tests for cloud-provider-azure release-1.26."
         testgrid-num-columns-recent: "30"
@@ -284,7 +284,116 @@ presubmits:
               - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
                 value: "false"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-26
         description: "Runs Azure specific e2e tests with cloud controller manager v1.26 and IP-based load balancer backend pools."
         testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 21 * * *'  # Run at 21:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-26
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.26
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.26.13"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-26
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster."
+- cron: '0 21 * * *'  # Run at 21:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-vmss-capz-1-26
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.26
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.26.13"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-26
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster with vmss."

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -25,7 +25,7 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-check-1-27
         description: "Run lint check tests for cloud-provider-azure release-1.27."
         testgrid-num-columns-recent: "30"
@@ -78,7 +78,7 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
         description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -139,7 +139,7 @@ presubmits:
               - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
                 value: "30"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-27
         description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -188,7 +188,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-27
         description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -217,7 +217,7 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-27
         description: "Run unit tests for cloud-provider-azure release-1.27."
         testgrid-num-columns-recent: "30"
@@ -268,7 +268,7 @@ presubmits:
               - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27-presubmit
         description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
@@ -319,7 +319,7 @@ presubmits:
               - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27-presubmit
         description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
@@ -371,7 +371,7 @@ presubmits:
               - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27-presubmit
         description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
@@ -423,7 +423,7 @@ presubmits:
               - name: CLUSTER_TEMPLATE # CAPZ config
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27-presubmit
         description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
@@ -490,7 +490,224 @@ presubmits:
               - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
                 value: "false"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27
         description: "Runs Azure specific e2e tests with cloud controller manager v1.27 and IP-based load balancer backend pools."
         testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-27
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.27
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.27.10"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-27
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster."
+- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-vmss-capz-1-27
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.27
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.27.10"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-27
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster with vmss."
+- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-capz-1-27
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.27
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.27.10"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-27
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster."
+- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-vmss-capz-1-27
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.27
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.27.10"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-27
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster with vmss."

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -25,7 +25,7 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-check-1-28
         description: "Run lint check tests for cloud-provider-azure release-1.28."
         testgrid-num-columns-recent: "30"
@@ -78,7 +78,7 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
         description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -139,7 +139,7 @@ presubmits:
               - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
                 value: "30"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-28
         description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -188,7 +188,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-28
         description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -255,7 +255,7 @@ presubmits:
               - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
                 value: "false"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
         description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools."
         testgrid-num-columns-recent: '30'
@@ -320,7 +320,7 @@ presubmits:
               - name: WINDOWS_WORKER_MACHINE_COUNT
                 value: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
         description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers."
         testgrid-num-columns-recent: '30'
@@ -349,7 +349,224 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-28
         description: "Run unit tests for cloud-provider-azure release-1.28."
         testgrid-num-columns-recent: "30"
+periodics:
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-28
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.28
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.28.5"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster."
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-vmss-capz-1-28
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.28
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.28.5"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster with vmss."
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-capz-1-28
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.28
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.28.5"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster."
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-vmss-capz-1-28
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.28
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.28.5"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster with vmss."

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
@@ -25,7 +25,7 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-check-1-29
         description: "Run lint check tests for cloud-provider-azure release-1.29."
         testgrid-num-columns-recent: "30"
@@ -78,7 +78,7 @@ presubmits:
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-29
         description: "Runs Azure specific tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -139,7 +139,7 @@ presubmits:
               - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
                 value: "30"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-29
         description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -188,7 +188,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-29
         description: "Runs Azure specific tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: "30"
@@ -255,7 +255,7 @@ presubmits:
               - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
                 value: "false"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29
         description: "Runs Azure specific e2e tests with cloud controller manager v1.29 and IP-based load balancer backend pools."
         testgrid-num-columns-recent: '30'
@@ -320,7 +320,7 @@ presubmits:
               - name: WINDOWS_WORKER_MACHINE_COUNT
                 value: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29
         description: "Runs Azure specific e2e tests with cloud controller manager v1.29 and multiple standard load balancers."
         testgrid-num-columns-recent: '30'
@@ -349,7 +349,224 @@ presubmits:
                 memory: "9Gi"
                 cpu: "2"
       annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29-presubmit
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-29
         description: "Run unit tests for cloud-provider-azure release-1.29."
         testgrid-num-columns-recent: "30"
+periodics:
+- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-29
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.29
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.29.0"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-29
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster."
+- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-vmss-capz-1-29
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.29
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.29.0"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-29
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster with vmss."
+- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-capz-1-29
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.29
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.29.0"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-29
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster."
+- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-vmss-capz-1-29
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.12
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: release-1.29
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION # CAPZ config
+          value: "v1.29.0"
+        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-29
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster with vmss."

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -6,10 +6,10 @@ dashboard_groups:
       - provider-azure-blobfuse-csi-driver
       - provider-azure-cloud-provider-azure
       - provider-azure-cloud-provider-azure-1-25-presubmit
-      - provider-azure-cloud-provider-azure-1-26-presubmit
-      - provider-azure-cloud-provider-azure-1-27-presubmit
-      - provider-azure-cloud-provider-azure-1-28-presubmit
-      - provider-azure-cloud-provider-azure-1-29-presubmit
+      - provider-azure-cloud-provider-azure-1-26
+      - provider-azure-cloud-provider-azure-1-27
+      - provider-azure-cloud-provider-azure-1-28
+      - provider-azure-cloud-provider-azure-1-29
       - provider-azure-presubmit
       - provider-azure-master-signal
       - provider-azure-1.28-signal
@@ -22,10 +22,10 @@ dashboards:
   - name: provider-azure-blobfuse-csi-driver
   - name: provider-azure-cloud-provider-azure
   - name: provider-azure-cloud-provider-azure-1-25-presubmit
-  - name: provider-azure-cloud-provider-azure-1-26-presubmit
-  - name: provider-azure-cloud-provider-azure-1-27-presubmit
-  - name: provider-azure-cloud-provider-azure-1-28-presubmit
-  - name: provider-azure-cloud-provider-azure-1-29-presubmit
+  - name: provider-azure-cloud-provider-azure-1-26
+  - name: provider-azure-cloud-provider-azure-1-27
+  - name: provider-azure-cloud-provider-azure-1-28
+  - name: provider-azure-cloud-provider-azure-1-29
   - name: provider-azure-presubmit
   - name: provider-azure-master-signal
   - name: provider-azure-1.28-signal


### PR DESCRIPTION
* master: bump IPv6 and dualstack k8s version
* release-1.27 to 1.29: Add IPv6 and dualstack cron jobs
* release-1.26: Add IPv6 cron jobs