### PR TITLE
[cloud-provider-azure] Add pr IPv6 & dualstack jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.26.yaml
@@ -288,6 +288,109 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-26
         description: "Runs Azure specific e2e tests with cloud controller manager v1.26 and IP-based load balancer backend pools."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-26
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.26
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            args:
+            - ./scripts/ci-entrypoint.sh
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.26.13"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "Standard"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-26-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-26
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.26
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e &&
+              popd
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "standard"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.26.13"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-26
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-26-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
 periodics:
 - cron: '0 21 * * *'  # Run at 21:00 UTC everyday
   name: cloud-provider-azure-master-ipv6-capz-1-26

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -260,7 +260,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.1"
+                value: "v1.27.10"
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -311,7 +311,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.1"
+                value: "v1.27.10"
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -365,7 +365,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.1"
+                value: "v1.27.10"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
@@ -417,7 +417,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.1"
+                value: "v1.27.10"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -353,6 +353,212 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-28
         description: "Run unit tests for cloud-provider-azure release-1.28."
         testgrid-num-columns-recent: "30"
+    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.28
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            args:
+            - ./scripts/ci-entrypoint.sh
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.28.5"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "Standard"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.28
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            args:
+            - ./scripts/ci-entrypoint.sh
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.28.5"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "Standard"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.28
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e &&
+              popd
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "standard"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.28.5"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.28
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e &&
+              popd
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "standard"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.28.5"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
 periodics:
 - cron: '0 22 * * *'  # Run at 22:00 UTC everyday
   name: cloud-provider-azure-master-ipv6-capz-1-28

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
@@ -353,6 +353,212 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-unit-1-29
         description: "Run unit tests for cloud-provider-azure release-1.29."
         testgrid-num-columns-recent: "30"
+    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-29
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.29
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            args:
+            - ./scripts/ci-entrypoint.sh
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.29.0"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "Standard"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-29-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-29
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.29
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            args:
+            - ./scripts/ci-entrypoint.sh
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.29.0"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "Standard"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-29-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-29
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.29
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e &&
+              popd
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "standard"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.29.0"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-29-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-29
+      always_run: false
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.29
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.12
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e &&
+              popd
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM # CAPZ config
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
+                value: "standard"
+              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+                value: "1"
+              - name: KUBERNETES_VERSION # CAPZ config
+                value: "v1.29.0"
+              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+                value: "capz"
+              - name: CLUSTER_TEMPLATE # CAPZ config
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-29-presubmit
+        description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
 periodics:
 - cron: '0 23 * * *'  # Run at 23:00 UTC everyday
   name: cloud-provider-azure-master-ipv6-capz-1-29


### PR DESCRIPTION
* release-1.27 to 1.29: Both
* release-1.26: IPv6 only