### PR TITLE
job: migrate ci-kubernetes-kubemark-100-gce-scheduler-highqps into community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -280,6 +280,7 @@ periodics:
           memory: "6Gi"
 
 - name: ci-kubernetes-kubemark-100-gce-scheduler-highqps
+  cluster: k8s-infra-prow-build
   tags:
   - "perfDashPrefix: kubemark-100Nodes-scheduler-highqps"
   - "perfDashJobType: performance"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -345,8 +345,6 @@ periodics:
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=150m
-      - --use-logexporter
-      - --logexporter-gcs-path=gs://sig-scalability-logs/$(JOB_NAME)/$(BUILD_ID)
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
This PR move the ci-kubernetes-kubemark-100-gce-scheduler-highqps job to community cluster 
(resources are already set)

@ameukam

Part of #31789