### PR TITLE
Downgrade release branch K8s version

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -121,8 +121,9 @@ presubmits:
               value: "true"
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
+            # TODO: Should use a 1.29 K8s version
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.29.0"
+              value: "v1.28.5"
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -174,7 +175,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.29.0"
+              value: "v1.28.5"
             - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
               value: "Standard"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -411,7 +412,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.29.0"
+              value: "v1.28.5"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
@@ -464,7 +465,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
               value: "1"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.29.0"
+              value: "v1.28.5"
             - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
               value: "capz"
             - name: CLUSTER_TEMPLATE # CAPZ config
@@ -751,7 +752,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -806,7 +807,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -861,7 +862,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -916,7 +917,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -260,7 +260,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.10"
+                value: "v1.27.9"
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -311,7 +311,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.10"
+                value: "v1.27.9"
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -365,7 +365,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.10"
+                value: "v1.27.9"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
@@ -417,7 +417,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.27.10"
+                value: "v1.27.9"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
@@ -539,7 +539,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.27.10"
+          value: "v1.27.9"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -593,7 +593,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.27.10"
+          value: "v1.27.9"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -647,7 +647,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.27.10"
+          value: "v1.27.9"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -701,7 +701,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.27.10"
+          value: "v1.27.9"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
@@ -67,6 +67,7 @@ presubmits:
             env:
               - name: TEST_CCM # CAPZ config
                 value: "true"
+              # TODO: Should use a 1.29 K8s version
               - name: KUBERNETES_VERSION # CAPZ config
                 value: "latest-1.29"
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
@@ -392,7 +393,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.29.0"
+                value: "v1.28.5"
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -443,7 +444,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.29.0"
+                value: "v1.28.5"
               - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
                 value: "Standard"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
@@ -497,7 +498,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.29.0"
+                value: "v1.28.5"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
@@ -549,7 +550,7 @@ presubmits:
               - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
                 value: "1"
               - name: KUBERNETES_VERSION # CAPZ config
-                value: "v1.29.0"
+                value: "v1.28.5"
               - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
                 value: "capz"
               - name: CLUSTER_TEMPLATE # CAPZ config
@@ -604,7 +605,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -658,7 +659,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -712,7 +713,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config
@@ -766,7 +767,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
           value: "1"
         - name: KUBERNETES_VERSION # CAPZ config
-          value: "v1.29.0"
+          value: "v1.28.5"
         - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE # CAPZ config


### PR DESCRIPTION
Curret ones are latest K8s version but actually provided VM images are 1 patch version older.

az vm image list -p cncf-upstream --all -o table