### PR TITLE
[ubuntu-os-gke-cloud] use pipeline corresponding to 1.29

### DIFF
--- a/jobs/e2e_node/containerd/image-config-systemd.yaml
+++ b/jobs/e2e_node/containerd/image-config-systemd.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-25
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix


### PR DESCRIPTION
pipeline-1-25 seems to have very old versions of containerd and runc which could be contributing to failures.

from [log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cos-containerd-node-e2e/1753883638342094848/artifacts/tmp-node-e2e-01675d27-ubuntu-gke-2204-1-25-v20240203/containerd.log)
```
Feb 03 21:02:34 tmp-node-e2e-01675d27-ubuntu-gke-2204-1-25-v20240203 containerd[556]: time="2024-02-03T21:02:34.849470136Z" level=info msg="starting containerd" revision= version="1.6.18-0ubuntu0~22.04.2~gke2"
```

Let's switch to pipeline-1-29 from the older one.