### PR TITLE
migrate pull-ingress-gce-e2e to use community clusters

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -145,7 +145,7 @@ presubmits:
       testgrid-tab-name: pull-ingress-gce-verify
 
   - name: pull-ingress-gce-e2e
-    cluster: default # https://github.com/kubernetes/test-infra/pull/31681d
+    cluster: k8s-infra-prow-build
     always_run: true
     optional: false
     decorate: true


### PR DESCRIPTION
This PR moves pull-ingress-gce-e2e jobs to the community owned cluster gke cluster.

ref: #30277
parent: #31681 and #31736