### PR TITLE
capv: fix janitor job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -281,8 +281,11 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.28
       command:
       - runner.sh
+      - bash
       args:
-      - make clean-ci
+      - -c
+      - |
+        make clean-ci
       env:
       resources:
         requests:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -285,8 +285,11 @@ periodics:
     - image: {{ $.config.TestImage }}
       command:
       - runner.sh
+      - bash
       args:
-      - make clean-ci
+      - -c
+      - |
+        make clean-ci
       env:
       resources:
         requests:


### PR DESCRIPTION
/assign sbueringer 

Run failed:

```
+ WRAPPED_COMMAND_PID=18
+ wait 18
+ 'make clean-ci'
/usr/local/bin/runner.sh: line 115: make clean-ci: command not found
+ EXIT_VALUE=1[2](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-janitor/1754865849526652928#1:build-log.txt%3A2)7
+ set +o xtrace
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-janitor/1754865849526652928