### PR TITLE
capv: enable docker for janitor and use bash script

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -264,6 +264,7 @@ periodics:
 
 - name: periodic-cluster-api-provider-vsphere-janitor
   labels:
+    preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
   interval: 12h
   decorate: true
@@ -281,11 +282,8 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.28
       command:
       - runner.sh
-      - bash
       args:
-      - -c
-      - |
-        make clean-ci
+      - ./hack/clean-ci.sh
       env:
       resources:
         requests:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -268,6 +268,7 @@ periodics:
 
 - name: periodic-cluster-api-provider-vsphere-janitor
   labels:
+    preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
   interval: 12h
   decorate: true
@@ -285,11 +286,8 @@ periodics:
     - image: {{ $.config.TestImage }}
       command:
       - runner.sh
-      - bash
       args:
-      - -c
-      - |
-        make clean-ci
+      - ./hack/clean-ci.sh
       env:
       resources:
         requests:


### PR DESCRIPTION
Enables docker for capv janitor and makes use of the right script.