### PR TITLE
job: migrate pull-kubernetes-e2e-gci-gce-ingress to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -4,6 +4,7 @@ presubmits:
   kubernetes/kubernetes:
 
   - name: pull-kubernetes-e2e-gci-gce-ingress
+    cluster: k8s-infra-prow-build
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
     - master
@@ -60,6 +61,10 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
         resources:
           requests:
+            cpu: 4
+            memory: "6Gi"
+          limits:
+            cpu: 4
             memory: "6Gi"
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR moves `pull-kubernetes-e2e-gci-gce-ingress` to community-owned cluster

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam