### PR TITLE
jobs: migrate pull-kubernetes-e2e-containerd-gce to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-containerd-gce
+    cluster: k8s-infra-prow-build
     always_run: false
     optional: true
     decorate: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -987,6 +987,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
+    cluster: k8s-infra-prow-build
     optional: true
     decorate: true
     decoration_config:
@@ -1017,8 +1018,12 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.26
         name: ""
         resources:
+          limits:
+            cpu: "4"
+            memory: "6Gi"
           requests:
-            memory: 6Gi
+            cpu: "4"
+            memory: "6Gi"
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -942,6 +942,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
+    cluster: k8s-infra-prow-build
     optional: true
     decorate: true
     decoration_config:
@@ -973,7 +974,11 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 6Gi
+            cpu: 4
+            memory: "6Gi"
+          limits:
+            cpu: 4
+            memory: "6Gi"
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -939,6 +939,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
+    cluster: k8s-infra-prow-build
     optional: true
     decorate: true
     decoration_config:
@@ -970,7 +971,11 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 6Gi
+            cpu: 4
+            memory: "6Gi"
+          limits:
+            cpu: 4
+            memory: "6Gi"
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1116,6 +1116,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     name: pull-kubernetes-e2e-containerd-gce
+    cluster: k8s-infra-prow-build
     optional: true
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
This PR moves `pull-kubernetes-e2e-containerd-gce` to community-owned cluster

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789