### PR TITLE
Fix milestone applier config for kubernetes/website

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -537,7 +537,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.30: 1.30
+    dev-1.30: v1.30
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Milestone applier config was incorrectly configured for `kubernetes/website`

cc @kubernetes/release-team-docs 