### PR TITLE
Revert "bump timeout value for pull-kubernetes-e2e-kind-evented-pleg"

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -438,7 +438,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decoration_config:
-      timeout: 180m
+      timeout: 60m
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
This reverts commit f8210e64d6bb6ab93bad31bc73e45b95624fb584.

The job now passes in around 30min. - https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kind-evented-pleg

/cc @pacoxu @dims 