### PR TITLE
migrate ci-kubernetes-e2e-snapshot job to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -258,6 +258,7 @@ periodics:
     testgrid-num-columns-recent: '20'
 - interval: 24h
   name: ci-kubernetes-e2e-snapshot
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
ref #31789
migrate remaining [ci-kubernetes-e2e-snapshot](https://cs.k8s.io/?q=ci-kubernetes-e2e-snapshot) job to community cluster
