### PR TITLE
Job: migrate ci-kubernetes-e2e-gci-gce-statefulset job to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -21,6 +21,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-statefulset

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-statefulset
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
This PR moves ci-kubernetes-e2e-gci-gce-statefulset to community-owned cluster
ref.   #31789
@ameukam