### PR TITLE
job: migrate pull-cadvisor-e2e-kubernetes into community cluster

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -65,6 +65,7 @@ presubmits:
 
   kubernetes/kubernetes: # Temporary test for https://github.com/kubernetes/kubernetes/pull/116517
   - name: pull-cadvisor-e2e-kubernetes
+    cluster: k8s-infra-prow-build
     always_run: false
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Migrate pull-cadvisor-e2e-kubernetes job to community cluster. (resources already set)

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam