### PR TITLE
job: migrate pull-kubernetes-e2e-gci-gce-ipvs into community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -140,6 +140,7 @@ presubmits:
       description: Uses kubetest to run e2e Conformance, SIG-Network or Network Policy tests against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
 
   - name: pull-kubernetes-e2e-gci-gce-ipvs
+    cluster: k8s-infra-prow-build
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
     - master
@@ -193,7 +194,11 @@ presubmits:
         - --timeout=80m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-master
         resources:
+          limits:
+            cpu: 2
+            memory: "6Gi"
           requests:
+            cpu: 2
             memory: "6Gi"
         securityContext:
           privileged: true


### PR DESCRIPTION
Migrate pull-kubernetes-e2e-gci-gce-ipvs job to community cluster.

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam