### PR TITLE
switch pull-containerd-node-e2e-1-6 to k8s master

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -138,7 +138,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: release-1.26
+      base_ref: master
       path_alias: k8s.io/kubernetes
     - org: kubernetes
       repo: test-infra


### PR DESCRIPTION
`pull-containerd-node-e2e-1-6` is testing against `release-1.26` branch of kubernetes. switch it to test against master branch of kubernetes

/cc @dims 
The job was switched to use 1.26 release branch https://github.com/kubernetes/test-infra/commit/e69360aac36656ad6ef4947399f60dde4d027c0c as part of https://github.com/kubernetes/test-infra/pull/28992. 