### PR TITLE
Update CRI-O and configs for evented pleg tests

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign
@@ -29,26 +29,10 @@
         "mode": 420
       },
       {
-        "path": "/etc/crio/crio.conf.d/10-log-level.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Alog_level%20%3D%20%22debug%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/20-runtimes.conf",
+        "path": "/etc/crio/crio.conf.d/crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/4pOLsrM1ysqzSvJzE2N5UpJTUsszSmJhwoo2CooFZXmJStxcaEohNHFIEZyLE7ZktTiEt2MxLyUnNSiWC6ocHxBYkkGyGT90uIi/Zz85MQc/aTMPH2IRYAAAAD//zwQewWRAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/30-infra-container.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adrop_infra_ctr%20%3D%20false%0A"
+          "source": "data:;base64,H4sIAAAAAAAC/7SPQWrEMAxF9z5FyH7iE8xJSjAaR8moyFKQ5UJvXzxJKbRQuuisjMX/ek8v2UgnKrDhHCptAt4M065M+X24DmNEz7GH4jGbXqvKGMJRtCZOBefAuiXGN+TeWfDWtjEspnsiWQ1SdhuuwwpcMSy4QmNPZ7cXrEn+vvPzrVO2JnM4v2kHvz/EWrXImoHjjeSheOnJMRQVcrXfkyrl5x1fzG70N+bh/h9Mx+qXO8jCaM9ifwQAAP//eNRpfPABAAA="
         },
         "mode": 420
       },
@@ -95,7 +79,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=2ecbfb31ab8451345552e861fe6b0a961694bd29\"\nEnvironment=\"CRIO_COMMIT=4e230f28c6e3dd9bca81b67c0bb6ca9316f25743\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=rm -f /usr/bin/runc\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crun.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=85f0d4175e1abce29dc9f6efbd45fb235df86c3d\"\nEnvironment=\"CRIO_COMMIT=efff37a2900e5039e5af554c3196633df25890dc\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/templates/base/crio.conf
+++ b/jobs/e2e_node/crio/templates/base/crio.conf
@@ -1,0 +1,19 @@
+[crio.image]
+signature_policy = "/etc/crio/policy.json"
+
+[crio.runtime]
+log_level = "debug"
+drop_infra_ctr = false
+default_runtime = "runc"
+
+[crio.runtime.runtimes.crun]
+runtime_path = "/usr/local/bin/crio-crun"
+monitor_path = "/usr/local/bin/crio-conmon"
+
+[crio.runtime.runtimes.runc]
+runtime_path = "/usr/local/bin/crio-runc"
+monitor_path = "/usr/local/bin/crio-conmon"
+
+[crio.runtime.runtimes.test-handler]
+runtime_path = "/usr/local/bin/crio-runc"
+monitor_path = "/usr/local/bin/crio-conmon"

--- a/jobs/e2e_node/crio/templates/base/root-v2.yaml
+++ b/jobs/e2e_node/crio/templates/base/root-v2.yaml
@@ -4,8 +4,6 @@ version: 1.4.0
 kernel_arguments:
   should_not_exist:
     - mitigations=auto,nosmt
-  should_exist:
-    - systemd.unified_cgroup_hierarchy=0
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml
@@ -29,10 +27,6 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
-    - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
-      contents:
-        local: 40-evented-pleg.conf
-      mode: 0644
 systemd:
   units:
     - name: configure-sysctl.service
@@ -47,6 +41,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: tools-install.service
       enabled: true
       contents: |
@@ -66,6 +61,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: selinux-install.service
       enabled: true
       contents: |
@@ -84,6 +80,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: crio-install.service
       enabled: true
       contents: |
@@ -108,6 +105,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: authorized-key.service
       enabled: true
       contents: |

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -26,7 +26,7 @@ fi
 # Change the following configurations to adapt the resulting ignitions files.
 declare -A CONFIGURATIONS=(
     ["crio_cgroupsv1"]="root cgroups-v1"
-    ["crio_cgroupsv1_eventedpleg"]="root cgroups-v1 eventedpleg"
+    ["crio_cgroupsv1_eventedpleg"]="root-v2 cgroups-v1 eventedpleg"
     ["crio_cgroupsv1_hugepages"]="root cgroups-v1 hugepages"
     ["crio_cgroupsv2"]="root"
     ["crio_cgroupsv2_swap1g"]="root swap-1G"


### PR DESCRIPTION
I'm going to migrate the rest of the jobs as well if everything stays green. This patch updates CRI-O to the latest `main` commit and uses the new configuration approach to live side by side to Podman.

cc @sairameshv @harche @haircommander @kannon92 