### PR TITLE
Skip LoadBalancers on al2023 jobs for now

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/periodic-eks-e2e.yaml
@@ -51,7 +51,7 @@ periodics:
              --use-built-binaries true \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws" \
              --focus-regex="\[Slow\]" \
-             --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
+             --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|LoadBalancers" \
              --parallel=25
         env:
           - name: BUILD_EKS_AMI_OS
@@ -122,7 +122,7 @@ periodics:
              --use-built-binaries true \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws" \
              --focus-regex="\[Slow\]" \
-             --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
+             --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|LoadBalancers" \
              --parallel=25
         env:
           - name: BUILD_EKS_AMI_OS


### PR DESCRIPTION
- https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-eks-al2023-slow&width=20&include-filter-by-regex=LoadBalancers
- https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-eks-al2023-arm64-slow&width=20&include-filter-by-regex=LoadBalancers

Need to dig in.