### PR TITLE
Self nominate to be a sig-node reviewer for test configurations

### DIFF
--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -8,6 +8,7 @@ reviewers:
   - pacoxu
   - sjenning
   - SergeyKanzhelev
+  - kannon92
 approvers:
   - yujuhong
   - Random-Liu


### PR DESCRIPTION
Self nominating to be a reviewer for sig-node test-infra.

I am an active attendee in sig-node-ci and a maintainer of the crio code in this repo.

Issues completed:
- https://github.com/kubernetes/test-infra/issues/30888
PRs started/completed:
- https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+author%3Akannon92

Generally I have been working on improving test coverage for features and monitoring these tests to detect failures. I have good knowledge of the configurations and I feel that I am ready to be a reviewer of this code.

Will also open up a k/k issue so I can present this at the next sig-node meeting if async is not sufficient.