### PR TITLE
Add a dashboard for release related jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -663,7 +663,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-ec2-conformance-latest
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2, sig-release-master-informing
+    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2, sig-release-master-informing, amazon-ec2-release
     testgrid-tab-name: Conformance - EC2 - master
     description: Runs conformance tests using kubetest against kubernetes master on EC2
   labels:
@@ -1052,7 +1052,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-ec2-arm64-conformance-latest
   annotations:
-    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2, sig-release-master-informing
+    testgrid-dashboards: amazon-ec2, conformance-all, conformance-ec2, sig-release-master-informing, amazon-ec2-release
     testgrid-tab-name: Conformance - EC2 - arm64 - master
     description: Runs conformance tests using kubetest against kubernetes master on EC2 (arm64)
   labels:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws, sig-release-master-informing
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws, sig-release-master-informing, amazon-ec2-release
     testgrid-tab-name: ec2-master-scale-performance
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com
   spec:

--- a/config/testgrids/amazon/amazon.yaml
+++ b/config/testgrids/amazon/amazon.yaml
@@ -6,6 +6,7 @@ dashboards:
 - name: amazon-ec2-node
 - name: amazon-ec2-al2023
 - name: amazon-ec2-provider
+- name: amazon-ec2-release
 
 #
 # Start dashboard groups
@@ -17,3 +18,4 @@ dashboard_groups:
   - amazon-ec2-node
   - amazon-ec2-al2023
   - amazon-ec2-provider
+  - amazon-ec2-release


### PR DESCRIPTION
3 jobs are release-informing, highlighting them in one spot under `amazon` on the first page