### PR TITLE
Migrate ci kubernetes e2e prow canary to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-prow-canary
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -88,6 +89,13 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+      resources:
+        limits:
+          cpu: 4
+          memory: 16Gi
+        requests:
+          cpu: 4
+          memory: 16Gi  
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: node


### PR DESCRIPTION
Migration of ci kubernetes e2e prow canary to community cluster in https://github.com/kubernetes/test-infra/issues/31793