### PR TITLE
Fix more typos in kubekins-e2e-v2 image

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -242,7 +242,6 @@ postsubmits:
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
-          - --build-dir=.
           - images/kubekins-e2e-v2/
     #
     # components, e.g. kettle/, triage/

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -12,12 +12,12 @@ steps:
     - --build-arg=KIND_VERSION=$_KIND_VERSION
     - --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION
     - --build-arg=YQ_VERSION=$_YQ_VERSION
+    - --push
     - .
     dir: .
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: gcloud
     args:
-    - tag
     - container
     - images
     - add-tag


### PR DESCRIPTION
I'll rerun the job on merge with the updated config

Copying the entire` k/test-infra` repo doesn't make sense when this job doesn't use any files outside of the images/kubekins-e2e-v2 folder

/cc @dims @ameukam 