### PR TITLE
Increase max rate limit for crier controller rate limiter

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -163,7 +163,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *logrus.Entry, req recon
 	for _, pjob := range pjs {
 		if err := criercommonlib.UpdateReportStateWithRetries(ctx, pjob, log, r.pjclientset, r.reporter.GetName()); err != nil {
 			log.WithError(err).Error("Failed to update report state on prowjob")
-			// The error above is alreay logged, so it would be duplicated
+			// The error above is already logged, so it would be duplicated
 			// effort to combine all errors to return, only capture the last
 			// error should be sufficient.
 			lastErr = err


### PR DESCRIPTION
We observe cases where k8s API controller throttling requests from crier controller. 

Previously we were using the `workqueue.DefaultControllerRateLimiter()`, which is calling `workqueue.NewMaxOfRateLimiter` internally with rate.Limit set to 10 and bucket size set to 100. And the setting for `NewItemExponentialFailureRateLimiter` is 5ms for base delay and 1000 seconds for max delay.

In this change, we double the QPS and bucket size and decrease max delay by half to 500 seconds and keep the base delay intact.

/cc @listx 