### PR TITLE
bump kubekins-e2e v2 image build timeout

### DIFF
--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -32,7 +32,7 @@ substitutions:
   _KIND_VERSION: ''
   _KUBETEST2_VERSION: 'master'
   _YQ_VERSION: v4.40.4
-timeout: 1800s  
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   # this is a large and critical CI image, builds are slow on the default 1 core


### PR DESCRIPTION
canary was built successfully but the other variants needed a little bit more than 30min, bumping to 1h

https://console.cloud.google.com/cloud-build/builds?project=k8s-staging-test-infra

```
 mahamed  MAHAALI-M-2PY9  tmp  $  gcrane manifest us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-go-canary
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4fd75c9f840f91e3efbbb14429c0165f02110c8071ef4e48f01a0b4077761013",
      "size": 3726,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4760b108818827dcad8d5a884204d9c0ec6ef55184380bd3757f28974a8ae15f",
      "size": 3726,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:151eac049af76314eb275e3485285613f4c059582c483a1af04e4684ccb32f34",
      "size": 566,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:4fd75c9f840f91e3efbbb14429c0165f02110c8071ef4e48f01a0b4077761013",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:a363e5745814630c30e80c5cb8506cac640f6704305b8beafd01181b47459d24",
      "size": 566,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:4760b108818827dcad8d5a884204d9c0ec6ef55184380bd3757f28974a8ae15f",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
  ]
}
```
/cc @dims @ameukam 