### PR TITLE
skip attesting docker images and bump buildx and go

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -56,6 +56,6 @@ ADD ./buildx-entrypoint.sh /buildx-entrypoint
 RUN apk add qemu
 
 # Install buildx system-wide for fast docker builds
-COPY --from=docker/buildx-bin:0.10.4 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker/buildx-bin:0.12.1 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 ENTRYPOINT ["/bin/bash"]

--- a/images/gcb-docker-gcloud/buildx-entrypoint.sh
+++ b/images/gcb-docker-gcloud/buildx-entrypoint.sh
@@ -16,5 +16,8 @@
 set -euo pipefail
 
 /register --reset -p yes
+if [ -z "${BUILDX_NO_DEFAULT_ATTESTATIONS}" ]; then
+    export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+fi
 docker buildx create --use
 docker buildx "$@"

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.21.5
+  _GO_VERSION: 1.21.6
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest'


### PR DESCRIPTION
buildx keeps adding extra layers with unhelpful manifests so I'm disabling that feature as these are CI images.

https://docs.docker.com/build/attestations/


```
 mahamed  MAHAALI-M-2PY9  tmp  $  gcrane manifest us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-go-canary
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4fd75c9f840f91e3efbbb14429c0165f02110c8071ef4e48f01a0b4077761013",
      "size": 3726,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4760b108818827dcad8d5a884204d9c0ec6ef55184380bd3757f28974a8ae15f",
      "size": 3726,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:151eac049af76314eb275e3485285613f4c059582c483a1af04e4684ccb32f34",
      "size": 566,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:4fd75c9f840f91e3efbbb14429c0165f02110c8071ef4e48f01a0b4077761013",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:a363e5745814630c30e80c5cb8506cac640f6704305b8beafd01181b47459d24",
      "size": 566,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:4760b108818827dcad8d5a884204d9c0ec6ef55184380bd3757f28974a8ae15f",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
  ]
}
```