### PR TITLE
migrate ci-kubernetes-e2e-gce-canary to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -27,6 +27,7 @@ periodics:
 
 - interval: 30m
   name: ci-kubernetes-e2e-gce-canary
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -51,6 +51,13 @@ periodics:
       - --timeout=40m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: 4
+          memory: 16Gi
+        requests:
+          cpu: 4
+          memory: 16Gi
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: gce


### PR DESCRIPTION
Migrating one of the jobs from the list in https://github.com/kubernetes/test-infra/issues/31793

/cc @ameukam @rjsadow