### PR TITLE
Migrate remaining sig_node(node-problem-detector) jobs to community clusters

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: ci-npd-build
-  # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-  cluster: default
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -97,8 +97,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-node
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -152,8 +151,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -198,8 +196,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -284,8 +281,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -330,8 +326,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true


### PR DESCRIPTION
Migrate remaining `node-problem-detector` ci and presubmits jobs to `k8s-infra-prow-build` community cluster.
Fixes part of #31794 

/cc @rjsadow @ameukam 