### PR TITLE
Bump timeout for post-test-infra-push-kubekins-e2e v1 and v2 CI jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -205,6 +205,9 @@ postsubmits:
         description: builds and pushes the kubekins-e2e image
       run_if_changed: '^(images/kubekins-e2e|kubetest|boskos|logexporter)/'
       decorate: true
+      decoration_config:
+        timeout: 180m
+        grace_period: 10m
       branches:
       - ^master$
       max_concurrency: 1
@@ -230,6 +233,9 @@ postsubmits:
         description: builds and pushes the kubekins-e2e-v2 image
       run_if_changed: '^images/kubekins-e2e-v2/'
       decorate: true
+      decoration_config:
+        timeout: 180m
+        grace_period: 10m
       branches:
       - ^master$
       max_concurrency: 1

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -47,7 +47,7 @@ substitutions:
   _KIND_VERSION: ''
   _KUBETEST2_VERSION: 'master'
   _YQ_VERSION: v4.23.1
-timeout: 1800s  
+timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
   # this is a large and critical CI image, builds are slow on the default 1 core


### PR DESCRIPTION
pretty bad track record ... let's see if we can give it a bit more room

- https://prow.k8s.io/?job=post-test-infra-push-kubekins-e2e-v2
- https://prow.k8s.io/?job=post-test-infra-push-kubekins-e2e