### PR TITLE
Migrate pull-secrets-store-csi-driver-build job to community clusters

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -321,6 +321,7 @@ presubmits:
       description: "Run e2e test with aws provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-build
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 10m
@@ -342,6 +343,13 @@ presubmits:
             make build build-windows
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-build


### PR DESCRIPTION
Migrate a csi job (pull-secrets-store-csi-driver-build) to community cluster
https://github.com/kubernetes/test-infra/issues/31792