### PR TITLE
Migrate pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-7 to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -348,6 +348,7 @@ presubmits:
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-7
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -380,6 +381,9 @@ presubmits:
           value: "1.24.7"
         resources:
           requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
             cpu: "4"
             memory: "4Gi"
     annotations:


### PR DESCRIPTION
Migrate a csi job (pull-secrets-store-csi-driver-e2e-provider-k8s-1-24-7) to community cluster
https://github.com/kubernetes/test-infra/issues/31792
/cc @rjsadow @ameukam 