### PR TITLE
Migrate pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-3 to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -388,6 +388,7 @@ presubmits:
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.24.7"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-3
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -420,6 +421,9 @@ presubmits:
           value: "1.25.3"
         resources:
           requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
             cpu: "4"
             memory: "4Gi"
     annotations:


### PR DESCRIPTION
Migrate pull-secrets-store-csi-driver-e2e-provider-k8s-1-25-3 to community clusters
https://github.com/kubernetes/test-infra/issues/31792
/cc @rjsadow @ameukam