### PR TITLE
Migrate pull-secrets-store-csi-driver-e2e-provider-k8s-1-27-1 to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -468,6 +468,7 @@ presubmits:
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.26.0"
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-27-1
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -500,6 +501,9 @@ presubmits:
           value: "1.27.1"
         resources:
           requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
             cpu: "4"
             memory: "4Gi"
     annotations:


### PR DESCRIPTION
Migrate pull-secrets-store-csi-driver-e2e-provider-k8s-1-27-1 to community clusters
https://github.com/kubernetes/test-infra/issues/31792
/cc @rjsadow @ameukam