### PR TITLE
Migrate release-secrets-store-csi-driver-e2e-vault to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -634,6 +634,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: release-secrets-store-csi-driver-e2e-vault
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m


### PR DESCRIPTION
Migrate `release-secrets-store-csi-driver-e2e-vault` to community clusters
https://github.com/kubernetes/test-infra/issues/31792
/cc @rjsadow @ameukam