### PR TITLE
Migrate secrets-store-csi-driver-e2e-vault-postsubmit job to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -760,6 +760,7 @@ presubmits:
 postsubmits:
   kubernetes-sigs/secrets-store-csi-driver:
   - name: secrets-store-csi-driver-e2e-vault-postsubmit
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -786,6 +787,9 @@ postsubmits:
           privileged: true
         resources:
           requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
             cpu: "4"
             memory: "4Gi"
     annotations:


### PR DESCRIPTION
Migrate `secrets-store-csi-driver-e2e-vault-postsubmit` to community clusters
https://github.com/kubernetes/test-infra/issues/31792
/cc @rjsadow @ameukam