### PR TITLE
Migrate two csi periodic jobs to community clusters

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -924,6 +924,7 @@ postsubmits:
 periodics:
 - interval: 24h
   name: periodic-secrets-store-csi-driver-image-scan
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 10m
@@ -947,6 +948,13 @@ periodics:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-image-scan
@@ -991,6 +999,7 @@ periodics:
     testgrid-num-columns-recent: '30'
 - interval: 12h
   name: periodic-secrets-store-csi-driver-inplace-upgrade-test-e2e-provider
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 30m
@@ -1017,6 +1026,13 @@ periodics:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-inplace-upgrade-test-e2e-provider


### PR DESCRIPTION
Migrate two jobs to community clusters

- `periodic-secrets-store-csi-driver-image-scan`
- `periodic-secrets-store-csi-driver-inplace-upgrade-test-e2e-provider`

https://github.com/kubernetes/test-infra/issues/31792
/cc @rjsadow @ameukam