### PR TITLE
Pick up latest runner.sh with ulimit changes - needed to rebuilt kubekins-e2e image

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-staging-test-infra/bootstrap:v20240205-69ac5748ba
+FROM gcr.io/k8s-staging-test-infra/bootstrap:v20240209-223676d605
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
This bootstrap image just got built:
https://explore.ggcr.dev/?image=gcr.io%2Fk8s-staging-test-infra%2Fbootstrap:v20240209-223676d605

verified that the ulimit changes are present:
```
root@74b72e5b3c67:/go/src/k8s.io/kubernetes# find / -name runner.sh | xargs grep ulimit
/usr/local/bin/runner.sh:    # Fix ulimit issue
/usr/local/bin/runner.sh:    sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true
/workspace/test-infra/images/bootstrap/runner.sh:    # Fix ulimit issue
/workspace/test-infra/images/bootstrap/runner.sh:    sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true
/workspace/test-infra/images/kubekins-e2e-v2/runner.sh:    # Fix ulimit issue
/workspace/test-infra/images/kubekins-e2e-v2/runner.sh:    sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true
```

