### PR TITLE
When dumping logs from nodes, do it only for ready nodes.

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -843,7 +843,7 @@ function dump_node_info() {
   kubectl get nodes -o yaml > "${nodes_dir}/kubectl_get_nodes.yaml"
 
   api_node_names=()
-  api_node_names+=($( kubectl get nodes -o 'template={{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' ))
+  api_node_names+=($( kubectl get nodes -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status=="True"}{.metadata.name}{ "\n"}{end}' ))
   if [[ "${#api_node_names[@]}" -le 5 ]]; then
     for node_name in "${api_node_names[@]}"; do
       mkdir -p "${nodes_dir}/${node_name}"


### PR DESCRIPTION
When dumping logs from nodes, do it only for ready nodes.

This will avoid scenarios where one of the nodes is unready and we fail to dump the logs.