### PR TITLE
capz: enable release-1.11 branch for v1.25 cloud-provider-azure tests

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -516,6 +516,7 @@ milestone_applier:
     main: v1.14
     release-1.13: v1.13
     release-1.12: v1.12
+    release-1.11: v1.11 # needed for v1.25 cloud-provider-azure tests
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0


### PR DESCRIPTION
There are 2 cloud-provider-azure jobs that still refer to "release-1.11". It seems that those jobs won't work based on the recent removal of that reference? This PR adds them back.

Ref:

- https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml#L103
- https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.25.yaml#L166