### PR TITLE
Fix ci-aws-ebs-csi-driver-unit-test periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -7,8 +7,6 @@ periodics:
   interval: 6h
   labels:
     preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-aws-credential-aws-shared-testing: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: aws-ebs-csi-driver
@@ -21,8 +19,6 @@ periodics:
       args:
       - make
       - test
-      securityContext:
-        privileged: true
       resources:
         limits:
           cpu: "2"


### PR DESCRIPTION
This PR fixes the `ci-aws-ebs-csi-driver-unit-test` periodic, see https://testgrid.k8s.io/amazon-ec2-periodics#ci-unit-test&width=20