### PR TITLE
migrate ci-kubernetes-e2e-node-canary to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -91,11 +91,11 @@ periodics:
         value: /go
       resources:
         limits:
-          cpu: 4
-          memory: 16Gi
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: 4
-          memory: 16Gi
+          cpu: 2
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: node

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -55,6 +55,7 @@ periodics:
     testgrid-tab-name: gce
 
 - name: ci-kubernetes-e2e-node-canary
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -88,6 +89,13 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+      resources:
+        limits:
+          cpu: 4
+          memory: 16Gi
+        requests:
+          cpu: 4
+          memory: 16Gi
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: node


### PR DESCRIPTION
Migrating one of the jobs from the list in https://github.com/kubernetes/test-infra/issues/31793

/cc @ameukam @rjsadow