### PR TITLE
Resultstore upload resume fixes and cleanup

### DIFF
--- a/prow/resultstore/payload.go
+++ b/prow/resultstore/payload.go
@@ -41,13 +41,21 @@ type Payload struct {
 	ProjectID string
 }
 
+// InvocationID returns the ResultStore InvocationId.
+func (p *Payload) InvocationID() (string, error) {
+	if p.Job == nil {
+		return "", errors.New("internal error: pj is nil")
+	}
+	// Name is a v4 UUID set in pjutil.go.
+	return p.Job.Name, nil
+}
+
+// Invocation returns an Invocation suitable to upload to ResultStore.
 func (p *Payload) Invocation() (*resultstore.Invocation, error) {
-	id, err := invocationID(p.Job)
-	if err != nil {
-		return nil, err
+	if p.Job == nil {
+		return nil, errors.New("internal error: pj is nil")
 	}
 	i := &resultstore.Invocation{
-		Id:                   id,
 		StatusAttributes:     invocationStatusAttributes(p.Job),
 		Timing:               invocationTiming(p.Job),
 		InvocationAttributes: invocationAttributes(p.ProjectID, p.Job),
@@ -56,16 +64,6 @@ func (p *Payload) Invocation() (*resultstore.Invocation, error) {
 		Files:                p.Files,
 	}
 	return i, nil
-}
-
-func invocationID(pj *v1.ProwJob) (*resultstore.Invocation_Id, error) {
-	if pj == nil {
-		return nil, errors.New("internal error: pj is nil")
-	}
-	return &resultstore.Invocation_Id{
-		// Name is a v4 UUID set in pjutil.go.
-		InvocationId: pj.Name,
-	}, nil
 }
 
 func invocationStatusAttributes(job *v1.ProwJob) *resultstore.StatusAttributes {

--- a/prow/resultstore/payload_test.go
+++ b/prow/resultstore/payload_test.go
@@ -32,6 +32,49 @@ import (
 	"k8s.io/test-infra/prow/kube"
 )
 
+func TestInvocationID(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		payload Payload
+		want    string
+		wantErr bool
+	}{
+		{
+			desc: "success",
+			payload: Payload{
+				Job: &v1.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job-name",
+					},
+				},
+			},
+			want: "job-name",
+		},
+		{
+			desc:    "nil job",
+			payload: Payload{},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := tc.payload.InvocationID()
+			if err != nil {
+				if tc.wantErr {
+					t.Logf("got expected error: %v", err)
+					return
+				}
+				t.Fatal("got unexpected error")
+			}
+			if tc.wantErr {
+				t.Fatal("want error, got nil")
+			}
+			if got != tc.want {
+				t.Errorf("InvocationID got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func int64Pointer(v int64) *int64 {
 	return &v
 }
@@ -101,9 +144,6 @@ func TestInvocation(t *testing.T) {
 				ProjectID: "project-id",
 			},
 			want: &resultstore.Invocation{
-				Id: &resultstore.Invocation_Id{
-					InvocationId: "job-name",
-				},
 				InvocationAttributes: &resultstore.InvocationAttributes{
 					ProjectId: "project-id",
 					Labels: []string{
@@ -213,9 +253,6 @@ func TestInvocation(t *testing.T) {
 				ProjectID: "project-id",
 			},
 			want: &resultstore.Invocation{
-				Id: &resultstore.Invocation_Id{
-					InvocationId: "job-name",
-				},
 				InvocationAttributes: &resultstore.InvocationAttributes{
 					ProjectId: "project-id",
 					Labels: []string{
@@ -287,49 +324,6 @@ func TestInvocation(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
 				t.Errorf("invocation differs (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestInvocationId(t *testing.T) {
-	for _, tc := range []struct {
-		desc    string
-		job     *v1.ProwJob
-		want    *resultstore.Invocation_Id
-		wantErr bool
-	}{
-		{
-			desc: "success",
-			job: &v1.ProwJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "job-name",
-				},
-			},
-			want: &resultstore.Invocation_Id{
-				InvocationId: "job-name",
-			},
-		},
-		{
-			desc:    "nil",
-			job:     nil,
-			wantErr: true,
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			got, err := invocationID(tc.job)
-			if err != nil {
-				if tc.wantErr {
-					t.Logf("got expected error: %v", err)
-					return
-				}
-				t.Fatal("got unexpected error")
-			}
-			if tc.wantErr {
-				t.Fatal("want error, got nil")
-			}
-			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
-				t.Errorf("invocation id differs (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/prow/resultstore/uploader.go
+++ b/prow/resultstore/uploader.go
@@ -52,12 +52,16 @@ func onlyTransientError(err error) error {
 // transient errors from ResultStore are returned, in which case the call
 // should be retried later.
 func (u *Uploader) Upload(ctx context.Context, log *logrus.Entry, p *Payload) error {
+	invID, err := p.InvocationID()
+	if err != nil {
+		log.Errorf("p.InvocationID: %v", err)
+	}
 	inv, err := p.Invocation()
 	if err != nil {
 		log.Errorf("p.Invocation: %v", err)
 		return nil
 	}
-	w, err := writer.New(ctx, log, u.client, inv, authToken.From(inv.Id.InvocationId))
+	w, err := writer.New(ctx, log, u.client, inv, invID, authToken.From(invID))
 	if err != nil {
 		return onlyTransientError(err)
 	}

--- a/prow/resultstore/uploader_test.go
+++ b/prow/resultstore/uploader_test.go
@@ -18,7 +18,7 @@ package resultstore
 
 import "testing"
 
-func TestTokener(t *testing.T) {
+func TestTokenGenerator(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc string

--- a/prow/resultstore/writer/writer.go
+++ b/prow/resultstore/writer/writer.go
@@ -70,9 +70,9 @@ type ResultStoreBatchClient interface {
 type writer struct {
 	log         *logrus.Entry
 	client      ResultStoreBatchClient
+	invID       string
 	authToken   string
 	resumeToken string
-	retInv      *resultstore.Invocation
 	updates     []*resultstore.UploadRequest
 	finalized   bool
 }
@@ -121,6 +121,7 @@ func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, 
 	w := &writer{
 		log:         log,
 		client:      client,
+		invID:       invID,
 		authToken:   authToken,
 		resumeToken: resumeToken(),
 		updates:     []*resultstore.UploadRequest{},
@@ -128,7 +129,7 @@ func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, 
 	ctx, cancel := context.WithTimeout(ctx, rpcRetryDuration)
 	defer cancel()
 
-	err := w.createInvocation(ctx, inv, invID)
+	err := w.createInvocation(ctx, inv)
 	if err == nil {
 		return w, nil
 	}
@@ -136,13 +137,13 @@ func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, 
 		return nil, err
 	}
 
-	if touchErr := w.touchInvocation(ctx, invID); IsPermanentError(touchErr) {
+	if touchErr := w.touchInvocation(ctx); IsPermanentError(touchErr) {
 		// Since it was confirmed above that the Invocation exists, a
 		// permanent error here indicates the Invocation is finalized.
 		return nil, err
 	}
 
-	if err = w.retrieveResumeToken(ctx, invID); err != nil {
+	if err = w.retrieveResumeToken(ctx); err != nil {
 		return nil, err
 	}
 
@@ -159,21 +160,20 @@ func onlyPermanentError(err error) error {
 	return nil
 }
 
-func (w *writer) createInvocation(ctx context.Context, inv *resultstore.Invocation, invID string) error {
+func (w *writer) createInvocation(ctx context.Context, inv *resultstore.Invocation) error {
 	return wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
-		inv, err := w.client.CreateInvocation(ctx, w.createInvocationRequest(invID, inv))
+		_, err := w.client.CreateInvocation(ctx, w.createInvocationRequest(inv))
 		if err != nil {
 			w.log.Errorf("resultstore.CreateInvocation: %v", err)
 			return false, onlyPermanentError(err)
 		}
-		w.retInv = inv
 		return true, nil
 	})
 }
 
-func (w *writer) touchInvocation(ctx context.Context, invID string) error {
+func (w *writer) touchInvocation(ctx context.Context) error {
 	return wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
-		_, err := w.client.TouchInvocation(ctx, w.touchInvocationRequest(invID))
+		_, err := w.client.TouchInvocation(ctx, w.touchInvocationRequest())
 		if err != nil {
 			w.log.Errorf("resultstore.TouchInvocation: %v", err)
 			return false, onlyPermanentError(err)
@@ -182,9 +182,9 @@ func (w *writer) touchInvocation(ctx context.Context, invID string) error {
 	})
 }
 
-func (w *writer) retrieveResumeToken(ctx context.Context, invID string) error {
+func (w *writer) retrieveResumeToken(ctx context.Context) error {
 	return wait.ExponentialBackoffWithContext(ctx, rpcRetryBackoff, func() (bool, error) {
-		meta, err := w.client.GetInvocationUploadMetadata(ctx, w.getInvocationUploadMetadataRequest(invID))
+		meta, err := w.client.GetInvocationUploadMetadata(ctx, w.getInvocationUploadMetadataRequest())
 		if err != nil {
 			w.log.Errorf("resultstore.GetInvocationUploadMetadata: %v", err)
 			return false, onlyPermanentError(err)
@@ -214,33 +214,33 @@ func (w *writer) Finalize(ctx context.Context) error {
 	return w.addUploadRequest(ctx, w.finalizeRequest())
 }
 
-func (w *writer) createInvocationRequest(invID string, inv *resultstore.Invocation) *resultstore.CreateInvocationRequest {
+func (w *writer) createInvocationRequest(inv *resultstore.Invocation) *resultstore.CreateInvocationRequest {
 	return &resultstore.CreateInvocationRequest{
-		InvocationId:       invID,
+		InvocationId:       w.invID,
 		Invocation:         inv,
 		AuthorizationToken: w.authToken,
 		InitialResumeToken: w.resumeToken,
 	}
 }
 
-func invocationName(invID string) string {
-	return fmt.Sprintf("invocations/%s", invID)
+func (w *writer) invocationName() string {
+	return fmt.Sprintf("invocations/%s", w.invID)
 }
 
-func (w *writer) touchInvocationRequest(invID string) *resultstore.TouchInvocationRequest {
+func (w *writer) touchInvocationRequest() *resultstore.TouchInvocationRequest {
 	return &resultstore.TouchInvocationRequest{
-		Name:               invocationName(invID),
+		Name:               w.invocationName(),
 		AuthorizationToken: w.authToken,
 	}
 }
 
-func uploadMetadataName(invID string) string {
-	return fmt.Sprintf("invocations/%s/uploadMetadata", invID)
+func (w *writer) uploadMetadataName() string {
+	return fmt.Sprintf("invocations/%s/uploadMetadata", w.invID)
 }
 
-func (w *writer) getInvocationUploadMetadataRequest(invID string) *resultstore.GetInvocationUploadMetadataRequest {
+func (w *writer) getInvocationUploadMetadataRequest() *resultstore.GetInvocationUploadMetadataRequest {
 	return &resultstore.GetInvocationUploadMetadataRequest{
-		Name:               uploadMetadataName(invID),
+		Name:               w.uploadMetadataName(),
 		AuthorizationToken: w.authToken,
 	}
 }
@@ -280,7 +280,7 @@ func (w *writer) flushUpdates(ctx context.Context) error {
 func (w *writer) uploadBatchRequest(reqs []*resultstore.UploadRequest) *resultstore.UploadBatchRequest {
 	nextToken := resumeToken()
 	req := &resultstore.UploadBatchRequest{
-		Parent:             w.retInv.Name,
+		Parent:             w.invocationName(),
 		ResumeToken:        w.resumeToken,
 		NextResumeToken:    nextToken,
 		AuthorizationToken: w.authToken,

--- a/prow/resultstore/writer/writer.go
+++ b/prow/resultstore/writer/writer.go
@@ -113,8 +113,8 @@ func IsAlreadyExistsErr(err error) bool {
 // writer syncs with ResultStore to resume writing. RPCs are retried with
 // exponential backoff unless there is a permanent error, which is returned
 // immediately. The caller should check whether a returned error is permanent
-// using PermanentError() and only retry transient errors. The authToken is a
-// UUID and must be identical across all calls for the same Invocation.
+// using IsPermanentError() and only retry transient errors. The authToken is
+// a UUID and must be identical across all calls for the same Invocation.
 func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, inv *resultstore.Invocation, invID, authToken string) (*writer, error) {
 	w := &writer{
 		log:         log,

--- a/prow/resultstore/writer/writer.go
+++ b/prow/resultstore/writer/writer.go
@@ -115,9 +115,7 @@ func IsAlreadyExistsErr(err error) bool {
 // immediately. The caller should check whether a returned error is permanent
 // using PermanentError() and only retry transient errors. The authToken is a
 // UUID and must be identical across all calls for the same Invocation.
-func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, inv *resultstore.Invocation, authToken string) (*writer, error) {
-	invID := inv.Id.InvocationId
-	inv.Id = nil
+func New(ctx context.Context, log *logrus.Entry, client ResultStoreBatchClient, inv *resultstore.Invocation, invID, authToken string) (*writer, error) {
 	w := &writer{
 		log:         log,
 		client:      client,


### PR DESCRIPTION
1. Fixes a bug where the returned invocation was assumed to exist when resuming uploads.
2. Cleans up the handling of invocation ID, avoiding setting then unsetting in Invocation.
3. A couple of trivial fixes from recent changes.