### PR TITLE
Fix the prowjob regex for variants.yaml

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -173,7 +173,7 @@ postsubmits:
           - images/builder/
     - name: post-test-infra-push-krte
       cluster: k8s-infra-prow-build-trusted
-      run_if_changed: '^images/(krte/|kubekins-e2e/variants.yaml)'
+      run_if_changed: '^images/(krte/|kubekins-e2e-v2/variants.yaml)'
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
         testgrid-tab-name: krte
@@ -203,7 +203,7 @@ postsubmits:
         testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
         testgrid-num-failures-to-alert: '1'
         description: builds and pushes the kubekins-e2e image
-      run_if_changed: '^(images/kubekins-e2e|kubetest|boskos|logexporter)/'
+      run_if_changed: '^(images/(kubekins-e2e/|kubekins-e2e-v2/variants.yaml)|kubetest|boskos|logexporter)'
       decorate: true
       decoration_config:
         timeout: 180m


### PR DESCRIPTION
When I tweaked the variants.yaml in #31912 I forgot to update the prowjob regexes.

Also, there was a typo in the golang PR #31940 and kubekins-e2e-v2 failed to build the images with 1.22. kubekins-e2e wasn't built because of the regex mismatch

/cc @dims @cpanato

<img width="1224" alt="image" src="https://github.com/kubernetes/test-infra/assets/25100905/3b931525-e0cb-47e0-8871-033ba4297389">
