### PR TITLE
Enable checkpoint support in CRI-O

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1.ign
@@ -50,6 +50,14 @@
           "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/42-checkpoint-enabled.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Aenable_criu_support%20%3D%20true%0A"
+        },
+        "mode": 420
       }
     ]
   },

--- a/jobs/e2e_node/crio/templates/base/42-checkpoint-enabled.conf
+++ b/jobs/e2e_node/crio/templates/base/42-checkpoint-enabled.conf
@@ -1,0 +1,2 @@
+[crio.runtime]
+enable_criu_support = true

--- a/jobs/e2e_node/crio/templates/base/criu-enabled.yaml
+++ b/jobs/e2e_node/crio/templates/base/criu-enabled.yaml
@@ -1,0 +1,7 @@
+---
+storage:
+  files:
+    - path: /etc/crio/crio.conf.d/42-checkpoint-enabled.conf
+      contents:
+        local: 42-checkpoint-enabled.conf
+      mode: 0644

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv1.yaml
@@ -29,6 +29,10 @@ storage:
         # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
         source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
       mode: 0644
+    - path: /etc/crio/crio.conf.d/42-checkpoint-enabled.conf
+      contents:
+        local: 42-checkpoint-enabled.conf
+      mode: 0644
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -25,7 +25,7 @@ fi
 
 # Change the following configurations to adapt the resulting ignitions files.
 declare -A CONFIGURATIONS=(
-    ["crio_cgroupsv1"]="root cgroups-v1"
+    ["crio_cgroupsv1"]="root cgroups-v1 criu-enabled"
     ["crio_cgroupsv1_eventedpleg"]="root cgroups-v1 eventedpleg"
     ["crio_cgroupsv1_hugepages"]="root cgroups-v1 hugepages"
     ["crio_cgroupsv2"]="root"


### PR DESCRIPTION
With the upcoming Alpha to Beta graduation of "Forensic Container Checkpointing" (KEP #2008) having checkpoint support enabled in CRI-O is important to run the checkpoint tests in Kubernetes.

I just enabled it in one of the CRI-O test runs for now.

@saschagrunert PTAL