### PR TITLE
Migrate one test job to use containerd registry config_path

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -585,7 +585,7 @@ periodics:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config-v2.yaml
       - --deployment=node
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-driver=systemd --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'

--- a/jobs/e2e_node/containerd/config-v2.toml
+++ b/jobs/e2e_node/containerd/config-v2.toml
@@ -1,0 +1,27 @@
+version = 2
+required_plugins = ["io.containerd.grpc.v1.cri"]
+# Kubernetes doesn't use containerd restart manager.
+disabled_plugins = ["io.containerd.internal.v1.restart"]
+oom_score = -999
+
+[debug]
+  level = "debug"
+
+[plugins."io.containerd.grpc.v1.cri"]
+  stream_server_address = "127.0.0.1"
+  max_container_log_line_size = 262144
+[plugins."io.containerd.grpc.v1.cri".cni]
+  bin_dir = "/home/containerd/"
+  conf_dir = "/etc/cni/net.d"
+  conf_template = "/home/containerd/cni.template"
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+
+# Runtime handler used for runtime class test.
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runc.v2"
+

--- a/jobs/e2e_node/containerd/hosts-docker.toml
+++ b/jobs/e2e_node/containerd/hosts-docker.toml
@@ -1,0 +1,4 @@
+server = "https://registry-1.docker.io"
+
+[host."https://mirror.gcr.io"]
+  capabilities = ["pull", "resolve"]

--- a/jobs/e2e_node/containerd/image-config-v2.yaml
+++ b/jobs/e2e_node/containerd/image-config-v2.yaml
@@ -1,0 +1,10 @@
+images:
+  ubuntu:
+    image_family: pipeline-1-29
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-v2.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
+  cos-stable:
+    image_family: cos-stable
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-v2.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
+ 

--- a/jobs/e2e_node/containerd/init-v2.yaml
+++ b/jobs/e2e_node/containerd/init-v2.yaml
@@ -1,0 +1,31 @@
+#cloud-config
+
+runcmd:
+  - echo "Test run from /tmp folder, remounting it"
+  - mount /tmp /tmp -o remount,exec,suid
+
+  - echo "This will configure built-in containerd for k8s tests. Containerd version is:"
+  - ctr version # current version of containerd
+
+  - echo "Download and install CNI configuration to /home/containerd"
+  - mkdir -p /home/containerd
+  - mount --bind /home/containerd /home/containerd
+  - mount -o remount,exec /home/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
+
+  - echo "Download and install CNI to /home/containerd"
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
+
+  - echo "Set containerd configuration"
+  - mkdir -p /etc/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
+
+  - echo "Set containerd registry configurations"
+  - mkdir -p /etc/containerd/certs.d/docker.io
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/certs.d/docker.io/hosts.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/registry-config-docker'
+  
+  - echo "Restarting containerd"
+  - systemctl restart containerd
+
+  - echo "Configuration complete"


### PR DESCRIPTION
All k8s node jobs using containerd deprecated registry options, which is going to be removed soon. Migrating one job node-e2e-features to test the new configurations

Issue: https://github.com/kubernetes/test-infra/issues/31851