### PR TITLE
job: migrate pull-kubernetes-e2e-gce-device-plugin-gpu jobs into community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -889,6 +889,7 @@ presubmits:
     branches:
     - release-1.26
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -930,7 +931,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.26
         name: ""
         resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
           requests:
+            cpu: 2
             memory: 6Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -885,6 +885,7 @@ presubmits:
     branches:
     - release-1.27
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -927,7 +928,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.27
         name: ""
         resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
           requests:
+            cpu: 2
             memory: 6Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -885,6 +885,7 @@ presubmits:
     branches:
     - release-1.28
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    cluster: k8s-infra-prow-build
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -924,7 +925,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240111-cf1d81388e-1.28
         name: ""
         resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
           requests:
+            cpu: 2
             memory: 6Gi
         securityContext:
           privileged: true


### PR DESCRIPTION
Migrate pull-kubernetes-e2e-gce-device-plugin-gpu job to community cluster.
(Resources are the same of already running jobs)

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam