### PR TITLE
job: migrate sig-scalability presubmit jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -88,6 +88,7 @@ presubmits:
           privileged: true
 
   - name: pull-kubernetes-e2e-gce-big-performance
+    cluster: k8s-infra-prow-build
     always_run: false
     max_concurrency: 1
     branches:
@@ -221,6 +222,7 @@ presubmits:
           privileged: true
 
   - name: pull-kubernetes-e2e-gce-scale-performance-manual
+    cluster: k8s-infra-prow-build
     always_run: false
     max_concurrency: 1
     branches:


### PR DESCRIPTION
This PR migrate sig-scalability presubmit jobs to community maintained cluster.
- [x] `pull-kubernetes-e2e-gce-big-performance`
- [x] `pull-kubernetes-e2e-gce-scale-performance-manual`
 
Ref: https://github.com/kubernetes/kubernetes/issues/123079
/cc @rjsadow @ameukam