### PR TITLE
verify: make pull-kubernetes-verify-lint required

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -28,6 +28,8 @@ presubmits:
           value: "y"
         - name: EXCLUDE_GODEP
           value: "y"
+        - name: EXCLUDE_GOLANGCI_LINT
+          value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
           value: master
         - name: REPO_DIR
@@ -56,7 +58,7 @@ presubmits:
     # for example, a linter config change or tool update might cause
     # failures in existing, unmodified code.
     always_run: true
-    optional: true
+    optional: false
     skip_branches:
     - release-\d+.\d+ # per-release job
     annotations:

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -42,6 +42,9 @@ dashboards:
   - name: pull-kubernetes-verify
     test_group_name: pull-kubernetes-verify
     base_options: width=10
+  - name: pull-kubernetes-verify-lint
+    test_group_name: pull-kubernetes-verify-lint
+    base_options: width=10
   - name: pull-kubernetes-typecheck
     test_group_name: pull-kubernetes-typecheck
     base_options: width=10


### PR DESCRIPTION
The EKS cluster can now be used for merge-blocking jobs. The pull-kubernetes-verify-lint job has been running smoothly on the EKS cluster for a while now and is ready to replace linting in pull-kubernetes-verify.

Because it runs verify-golangci.sh, we don't need to run that also in pull-kubernetes-verify.

Related-to: https://github.com/kubernetes/kubernetes/pull/123269