### PR TITLE
Update kustomize presubmit to Go 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - make
         args:


### PR DESCRIPTION
Blocking https://github.com/kubernetes-sigs/kustomize/pull/5535 & https://github.com/kubernetes-sigs/kustomize/pull/5555