### PR TITLE
migrate capi-provider-cloudstack-presubmit-e2e-smoke-test to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -111,6 +111,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
   - name: capi-provider-cloudstack-presubmit-e2e-smoke-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
migrate one of the job from list in https://github.com/kubernetes/test-infra/issues/31791