### PR TITLE
migrate ci-kubernetes-e2e-prow-canary to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -24,11 +24,11 @@ periodics:
       - --timeout=65m
       resources:
         limits:
-          cpu: 4
-          memory: 16Gi
+          cpu: 2
+          memory: 4Gi
         requests:
-          cpu: 4
-          memory: 16Gi  
+          cpu: 2
+          memory: 4Gi  
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: prow

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -30,7 +30,6 @@ periodics:
           cpu: 4
           memory: 16Gi  
   annotations:
-  annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: prow
 - name: ci-kubernetes-e2e-node-canary

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -17,7 +17,6 @@ periodics:
       - --check-leaked-resources
       - --cluster=canary-e2e-prow
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
       - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -28,7 +28,7 @@ periodics:
           memory: 4Gi
         requests:
           cpu: 2
-          memory: 4Gi  
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: prow

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-prow-canary
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-service-account: "true"
@@ -21,6 +22,14 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=65m
+      resources:
+        limits:
+          cpu: 4
+          memory: 16Gi
+        requests:
+          cpu: 4
+          memory: 16Gi  
+  annotations:
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: prow


### PR DESCRIPTION
migrate job listed in https://github.com/kubernetes/test-infra/issues/31793
@ameukam 