### PR TITLE
npd: Always verify go.mod

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -70,8 +70,7 @@ presubmits:
     cluster: k8s-infra-prow-build
     branches:
     - master
-    always_run: false
-    optional: true
+    always_run: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:


### PR DESCRIPTION
The job is working as expected, time to make it official:
https://github.com/kubernetes/node-problem-detector/pull/858

/cc @vteratipally @MartinForReal @vteratipally 