### PR TITLE
Setting timeout for pull-kubernetes-e2e-capz-windows-serial-slow to 4hours

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -68,6 +68,8 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-serial-slow
     decorate: true
+    decoration_config:
+      timeout: 4h
     always_run: false
     optional: true
     path_alias: k8s.io/kubernetes


### PR DESCRIPTION
E2e tests added by https://github.com/kubernetes/kubernetes/pull/122922 are causing the PR job to take more than the default time of 2 hours.
The periodic jobs have a timeout of 5 hours already so no updates are needed there.

/sig windows
/assign @jsturtevant 