### PR TITLE
Update OWNERS for CAAPH

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/OWNERS
@@ -3,8 +3,13 @@
 approvers:
 - Jont828
 - fabriziopandini
-- CecileRobertMichon
 - jackfrancis
+
+reviewers:
+- mboersma
+
+emeritus_approvers:
+- CecileRobertMichon
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up the `OWNERS` file with current reality in [cluster-api-addon-provider-helm](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/OWNERS_ALIASES).

/cc @jackfrancis @Jont828 