### PR TITLE
Updating windows v1.26 jobs to use containerd 1.7

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
@@ -9,11 +9,6 @@ presets:
   - name: K8S_SSH_PRIVATE_KEY_PATH
     value: /etc/ssh-key-secret/ssh-private # from preset-k8s-ssh label
 - labels:
-    preset-capz-containerd-1-6-latest: "true"
-  env:
-  - name: WINDOWS_CONTAINERD_URL
-    value: "https://github.com/containerd/containerd/releases/download/v1.6.25/containerd-1.6.25-windows-amd64.tar.gz"
-- labels:
     preset-capz-containerd-1-7-latest: "true"
   env:
   - name: WINDOWS_CONTAINERD_URL

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2019: "true"
-      preset-capz-containerd-1-6-latest: "true"
+      preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.26-windows.yaml
@@ -38,7 +38,7 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
     preset-azure-cred-only: "true"
-    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-containerd-1-7-latest: "true"
     preset-capz-windows-2019: "true"
     preset-capz-windows-common-126: "true"
     preset-dind-enabled: "true"
@@ -76,7 +76,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-    preset-capz-containerd-1-6-latest: "true"
+    preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
     preset-capz-windows-common-126: "true"


### PR DESCRIPTION
fixes an issue where Windows nodes in this branch were not coming online due to https://github.com/kubernetes-sigs/windows-testing/pull/421 (the new flag is only available in containerd v1.7+)

/sig windows
/assign @jsturtevant @aravindhp 