### PR TITLE
capz: run periodic jobs less frequently

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -3,7 +3,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -37,7 +37,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -81,7 +81,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -116,7 +116,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -187,7 +187,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -222,7 +222,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 12h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.12.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.12.yaml
@@ -3,7 +3,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -38,7 +38,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -73,7 +73,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.13.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.13.yaml
@@ -3,7 +3,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -37,7 +37,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -81,7 +81,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -116,7 +116,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -151,7 +151,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 24h
+  interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
This PR reduces the frequency of CAPZ periodic jobs now that the project, and those jobs, have matured.

In practice these jobs inform release decisions, which do not happen frequently enough for the current periodic frequency: we don't need needing dozens (or hundreds) or inter-release-cycle historical test data dating back weeks or months to inform pre-release hygiene.