### PR TITLE
job: migrate cluster-api-provider-azure jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -151,6 +151,7 @@ periodics:
     testgrid-tab-name: capz-periodic-apiversion-upgrade-main
     description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
 - name: periodic-cluster-api-provider-azure-coverage
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -181,6 +182,13 @@ periodics:
           ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
           ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
           exit $result
+      resources:
+        limits:
+          cpu: 2
+          memory: "9Gi"
+        requests:
+          cpu: 2
+          memory: "9Gi"
       securityContext:
         privileged: true
 - name: periodic-cluster-api-provider-azure-e2e-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -498,6 +498,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-upstream-k8s-ci-windows-containerd-serial-slow-main
   - name: pull-cluster-api-provider-azure-apidiff
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     always_run: true
@@ -512,6 +513,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: "9Gi"
+          requests:
+            cpu: 2
+            memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -286,6 +286,7 @@ presubmits:
       testgrid-tab-name: capz-pr-conformance-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-apidiff-v1beta1
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     always_run: true
@@ -301,6 +302,13 @@ presubmits:
           - runner.sh
         args:
           - ./scripts/ci-apidiff.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: "9Gi"
+          requests:
+            cpu: 2
+            memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-v1beta1


### PR DESCRIPTION
This PR migrate `cluster-api-provider-azure` jobs to community cluster.
Fixes part of https://github.com/kubernetes/test-infra/issues/31791