### PR TITLE
job: migrate cluster-api-provider-ibmcloud job to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-ibmcloud-coverage
+  cluster: eks-prow-build-cluster
   interval: 12h
   decorate: true
   extra_refs:
@@ -29,3 +30,10 @@ periodics:
           ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
           ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
           exit $result
+      resources:
+        limits:
+          cpu: "2"
+          memory: "6Gi"
+        requests:
+          cpu: "2"
+          memory: "6Gi"


### PR DESCRIPTION
This PR migrate `cluster-api-provider-ibmcloud` jobs to community cluster.
Fixes part of https://github.com/kubernetes/test-infra/issues/31791