### PR TITLE
updateconfig: remove spurious debug statement

### DIFF
--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -254,7 +254,6 @@ func MarkStaleKeysForDeletion(
 
 	// Add deletion entries for stale keys there were missing from the updates.
 	toDelete := []ConfigMapUpdate{}
-	fmt.Printf("configMap is %v", configMap)
 	for key := range configMap.Data {
 		if updatedKeys.Has(key) {
 			continue


### PR DESCRIPTION
When we added MarkStaleKeysForDeletion() in 27b33826e4 (Merge pull request #31644 from
listx/teach-config-bootstrapper-to-delete-stale-keys, 2024-01-30), we forgot to remove this line.