### PR TITLE
Kops - Include default state store env var in upgrade tests

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -157,6 +157,8 @@ def build_test(cloud='aws',
         env['DISCOVERY_STORE'] = "s3://k8s-kops-ci-prow"
         env['KOPS_DNS_DOMAIN'] = "tests-kops-aws.k8s.io"
         env['KUBE_SSH_USER'] = kops_ssh_user
+        if 'KOPS_STATE_STORE' not in env and cloud == "aws":
+            env['KOPS_STATE_STORE'] = 's3://k8s-kops-prow'
         if extra_flags:
             env['KOPS_EXTRA_FLAGS'] = " ".join(extra_flags)
         if irsa and cloud == "aws":

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -46,6 +46,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -120,6 +122,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -188,6 +192,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -262,6 +268,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -330,6 +338,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -404,6 +414,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -472,6 +484,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -546,6 +560,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -614,6 +630,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -688,6 +706,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -756,6 +776,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -830,6 +852,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -898,6 +922,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -972,6 +998,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1040,6 +1068,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1114,6 +1144,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1182,6 +1214,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1256,6 +1290,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1324,6 +1360,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1398,6 +1436,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1466,6 +1506,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1540,6 +1582,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1608,6 +1652,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1682,6 +1728,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1750,6 +1798,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1824,6 +1874,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1892,6 +1944,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -1966,6 +2020,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2034,6 +2090,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2108,6 +2166,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2176,6 +2236,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2250,6 +2312,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2318,6 +2382,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2392,6 +2458,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2460,6 +2528,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2534,6 +2604,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2602,6 +2674,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2676,6 +2750,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2744,6 +2820,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2818,6 +2896,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2886,6 +2966,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -2960,6 +3042,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -3028,6 +3112,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
@@ -3096,6 +3182,8 @@ periodics:
         value: "tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/32005. We still need the env var set, just set it to the original default value. 

This condition is copied from the presubmit job setup code:

https://github.com/kubernetes/test-infra/blob/8da62ba705ce4aa2ddecb2357b0cd582b32c4a6d/config/jobs/kubernetes/kops/build_jobs.py#L323-L324

Fixes: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k124-ko128-to-k125-kolatest/1758262792529383424

`W0215 22:55:57.388881   14803 state.go:46] failed to run /tmp/kops.Ppr5Pd8E8 get cluster e2e-91780086ad-c0835.tests-kops-aws.k8s.io -ojson; stderr=Error: State Store: Required value: Please set the --state flag or export KOPS_STATE_STORE.`