### PR TITLE
job: migrate pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2 to community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2434,6 +2434,7 @@ presubmits:
   #     Until then, this job complements pull-kubernetes-e2e-gce-cos-alpha-features by running inplace pod resize e2e tests
   #     full-spectrum against containerd/main which has the necessary CRI support.
   - name: pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false
     run_if_changed: 'test/e2e/node/pod_resize.go|pkg/kubelet/kubelet.go|pkg/kubelet/kubelet_pods.go|pkg/kubelet/kuberuntime/kuberuntime_manager.go'


### PR DESCRIPTION
This PR migrate `pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2` to community maintained cluster
Part of https://github.com/kubernetes/kubernetes/issues/123079
/cc @rjsadow @ameukam