### PR TITLE
Migrate cluster-api-provider-cloudstack jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -111,6 +111,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
   - name: capi-provider-cloudstack-presubmit-e2e-smoke-test
+    cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR migrates `capi-provider-cloudstack-presubmit-e2e-smoke-test` jobs to community cluster.
This is part of the issue #31791
/cc @rjsadow @ameukam 