### PR TITLE
Set timeouts for the EKS node e2e jobs explicitly

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -23,6 +23,8 @@ periodics:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -66,6 +68,8 @@ periodics:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -114,6 +118,8 @@ periodics:
       preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -170,6 +176,8 @@ periodics:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -220,6 +228,8 @@ periodics:
       preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -279,6 +289,8 @@ periodics:
       preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -329,6 +341,8 @@ periodics:
       preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -380,6 +394,8 @@ periodics:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -421,12 +437,12 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv1-containerd-node-e2e-serial-ec2-eks
-    decoration_config:
-      timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -469,13 +485,13 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv1-containerd-node-arm64-e2e-serial-ec2-eks
-    decoration_config:
-      timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -527,12 +543,12 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node,amazon-ec2-al2023
       testgrid-tab-name: ci-cgroupv2-containerd-node-al2023-e2e-serial-ec2-eks
-    decoration_config:
-      timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra
@@ -577,13 +593,13 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node,amazon-ec2-al2023
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-al2023-e2e-serial-ec2-eks
-    decoration_config:
-      timeout: 240m
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 240m
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra


### PR DESCRIPTION
- Add timeouts where missing
- Move `decoration_config` right after `decorate`