### PR TITLE
Make prowimagebuilder use a consistent date when creating image tags.

### DIFF
--- a/hack/prowimagebuilder/main.go
+++ b/hack/prowimagebuilder/main.go
@@ -186,17 +186,24 @@ func allTags(arch string) ([]string, error) {
 	return allTags, nil
 }
 
+var datePrefix string
+
 // gitTag returns YYYYMMDD-<GIT_TAG>
+// In order to ensure a consistent date value across the runtime of this process
+// when run near midnight UTC, we cache the value of date.
+// We don't cache the git SHA since a change in that would be meaningful.
 func gitTag() (string, error) {
-	prefix, err := runCmd(nil, "date", "+v%Y%m%d")
-	if err != nil {
-		return "", err
+	var err error
+	if datePrefix == "" {
+		if datePrefix, err = runCmd(nil, "date", "+v%Y%m%d"); err != nil {
+			return "", err
+		}
 	}
 	postfix, err := runCmd(nil, "git", "describe", "--always", "--dirty")
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s-%s", prefix, postfix), nil
+	return fmt.Sprintf("%s-%s", datePrefix, postfix), nil
 }
 
 func runGatherStaticScript(id *imageDef, args ...string) error {


### PR DESCRIPTION
If the `prowimagebuilder` runs across midnight UTC it can generate images with inconsistent tags which our autobumper is configured to reject.

The fix for the [last occurence](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-autobump-prow/1758555813540007936):
> I fixed this occurrence by rerunning the [publishing job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-prow/1758561761411207168) and then the [autobump job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-autobump-prow/1758568462977863680). New bump PR: https://github.com/kubernetes/test-infra/pull/32020

This PR makes us use a fixed date across the runtime of the process.

/assign @listx 