### PR TITLE
Config Gerrit review repo matches

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -763,6 +763,9 @@ func matches(givenOrgRepo, givenCluster, orgRepo, cluster string) bool {
 	if givenOrgRepo == "" || givenOrgRepo == "*" || givenOrgRepo == orgRepo {
 		return true
 	}
+	// For Gerrit use, the repo from the adapter probably contains the
+	// extra "-review" hostname; trim that away.
+	orgRepo = gerritsource.EnsureCodeURL(orgRepo)
 	// Ensure a bare given repo name matches the http-prefixed repo
 	// that arises in pre/postsubmit jobs.
 	orgRepo = strings.TrimPrefix(orgRepo, "https://")

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -461,6 +461,18 @@ func TestDefaultMatches(t *testing.T) {
 			orgRepo: "org/repo",
 			want: true,
 		},
+		{
+			desc: "givenOrgRepo gerrit review org match",
+			givenOrgRepo: "some.org",
+			orgRepo: "some-review.org/repo",
+			want: true,
+		},
+		{
+			desc: "givenOrgRepo gerrit review full match",
+			givenOrgRepo: "some.org/repo",
+			orgRepo: "some-review.org/repo",
+			want: true,
+		},
 		// The following two cases cover an unexpected existing configuration
 		// that matches a literal http/s prefix. Though unadvised, it should
 		// not be broken by fuzz matching http prefixes.
@@ -489,6 +501,12 @@ func TestDefaultMatches(t *testing.T) {
 			want: true,
 		},
 		{
+			desc: "givenOrgRepo https fuzz gerrit review org match",
+			givenOrgRepo: "some.org",
+			orgRepo: "https://some-review.org/repo",
+			want: true,
+		},
+		{
 			desc: "givenOrgRepo http fuzz full match",
 			givenOrgRepo: "org/repo",
 			orgRepo: "http://org/repo",
@@ -510,6 +528,12 @@ func TestDefaultMatches(t *testing.T) {
 			desc: "givenOrgRepo repo mismatch",
 			givenOrgRepo: "org/repo2",
 			orgRepo: "org/repo",
+			want: false,
+		},
+		{
+			desc: "givenOrgRepo gerrit review org mismatch",
+			givenOrgRepo: "some.other.org",
+			orgRepo: "some.other-review.org",
 			want: false,
 		},
 		{


### PR DESCRIPTION
Corrects matching Gerrit "-review" host names for config defaulting.

The first commit demonstrates the problem with failing unit tests.
The second commit corrects the matching, passing tests.