### PR TITLE
Add area/{node,pod}-lifecycle labels

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -449,6 +449,8 @@ larger set of contributors to apply/remove them.
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
 | <a id="area/network-policy" href="#area/network-policy">`area/network-policy`</a> | Issues or PRs related to Network Policy subproject| label | |
+| <a id="area/node-lifecycle" href="#area/node-lifecycle">`area/node-lifecycle`</a> | Issues or PRs related to Node lifecycle| label | |
+| <a id="area/pod-lifecycle" href="#area/pod-lifecycle">`area/pod-lifecycle`</a> | Issues or PRs related to Pod lifecycle| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="area/stable-metrics" href="#area/stable-metrics">`area/stable-metrics`</a> | Issues or PRs involving stable metrics| label | |
 | <a id="official-cve-feed" href="#official-cve-feed">`official-cve-feed`</a> | Issues or PRs related to CVEs officially announced by Security Response Committee (SRC)| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1142,6 +1142,16 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to Node lifecycle
+        name: area/node-lifecycle
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to Pod lifecycle
+        name: area/pod-lifecycle
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to the Release Engineering subproject
         name: area/release-eng
         previously:


### PR DESCRIPTION
Apparently node-lifecycle exists but was defined out-of-band (oops!)