### PR TITLE
presubmit that does the same as ci-cos-containerd-e2e-ubuntu-gce

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -65,6 +65,63 @@ presubmits:
             memory: 14Gi
         securityContext:
           privileged: true
+
+  - name: pull-cos-containerd-e2e-ubuntu-gce
+    always_run: false
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+\.\d+ # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    decorate: true
+    decoration_config:
+      timeout: 105m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: release
+      base_ref: master
+      path_alias: k8s.io/release
+    spec:
+      containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --build=quick
+        - --cluster=
+        - --extract=local
+        - --gcp-node-image=ubuntu
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --image-family=pipeline-1-29
+        - --image-project=ubuntu-os-gke-cloud
+        - --provider=gce
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        # Panic if anything mutates a shared informer cache
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-cos-containerd-e2e-ubuntu-gce
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+        - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
+        resources:
+          requests:
+            cpu: 4
+            memory: 14Gi
+          limits:
+            cpu: 4
+            memory: 14Gi
+        securityContext:
+          privileged: true
+
   - name: pull-kubernetes-e2e-gce-cos-no-stage
     always_run: false
     cluster: k8s-infra-prow-build

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -68,6 +68,9 @@ dashboards:
     base_options: width=10
 - name: presubmits-kubernetes-nonblocking
   dashboard_tab:
+  - name: pull-cos-containerd-e2e-ubuntu-gce
+    test_group_name: pull-cos-containerd-e2e-ubuntu-gce
+    base_options: width=10
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
     test_group_name: pull-kubernetes-e2e-gce-network-proxy-grpc
     base_options: width=10


### PR DESCRIPTION
need a presubmit to recreate the NFS problems that show up in:
- https://testgrid.k8s.io/sig-node-containerd#image-validation-ubuntu-e2e&width=20
- https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu&width=20

started by cloning pull-kubernetes-e2e-gce-cos and then overlaid with stuff from ci-cos-containerd-e2e-ubuntu-gce