### PR TITLE
branchprotector: Accept 'required_approving_review_count: 0' as valid option

### DIFF
--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -129,15 +129,13 @@ func makeRestrictions(rp *branchprotection.Restrictions, enableAppsRestrictions 
 
 // makeReviews renders review policy into the corresponding GitHub api object.
 //
-// Returns nil if the policy is nil, or approvals is nil or 0.
+// Returns nil if the policy is nil, or approvals is nil.
 func makeReviews(rp *branchprotection.ReviewPolicy) *github.RequiredPullRequestReviewsRequest {
 	switch {
 	case rp == nil:
 		return nil
 	case rp.Approvals == nil:
 		logrus.Warn("WARNING: required_pull_request_reviews policy does not specify required_approving_review_count, disabling")
-		return nil
-	case *rp.Approvals == 0:
 		return nil
 	}
 	rprr := github.RequiredPullRequestReviewsRequest{

--- a/prow/cmd/branchprotector/request_test.go
+++ b/prow/cmd/branchprotector/request_test.go
@@ -71,9 +71,12 @@ func TestMakeReviews(t *testing.T) {
 			},
 		},
 		{
-			name: "0 approvals returns nil",
+			name: "0 approvals set",
 			input: &branchprotection.ReviewPolicy{
 				Approvals: &zero,
+			},
+			expected: &github.RequiredPullRequestReviewsRequest{
+				RequiredApprovingReviewCount: 0,
 			},
 		},
 		{

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -89,7 +89,7 @@ type ReviewPolicy struct {
 	DismissStale *bool `json:"dismiss_stale_reviews,omitempty"`
 	// RequireOwners overrides whether CODEOWNERS must approve PRs if set
 	RequireOwners *bool `json:"require_code_owner_reviews,omitempty"`
-	// Approvals overrides the number of approvals required if set (set to 0 to disable)
+	// Approvals overrides the number of approvals required if set
 	Approvals *int `json:"required_approving_review_count,omitempty"`
 	// BypassRestrictions appends users/teams that are allowed to bypass PR restrictions
 	BypassRestrictions *BypassRestrictions `json:"bypass_pull_request_allowances,omitempty"`

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -85,7 +85,7 @@ branch-protection:
                                         - ""
                                 # RequireOwners overrides whether CODEOWNERS must approve PRs if set
                                 require_code_owner_reviews: false
-                                # Approvals overrides the number of approvals required if set (set to 0 to disable)
+                                # Approvals overrides the number of approvals required if set
                                 required_approving_review_count: 0
                             # RequiredStatusChecks configures github contexts
                             required_status_checks:
@@ -139,7 +139,7 @@ branch-protection:
                                 - ""
                         # RequireOwners overrides whether CODEOWNERS must approve PRs if set
                         require_code_owner_reviews: false
-                        # Approvals overrides the number of approvals required if set (set to 0 to disable)
+                        # Approvals overrides the number of approvals required if set
                         required_approving_review_count: 0
                     # RequiredStatusChecks configures github contexts
                     required_status_checks:
@@ -181,7 +181,7 @@ branch-protection:
                         - ""
                 # RequireOwners overrides whether CODEOWNERS must approve PRs if set
                 require_code_owner_reviews: false
-                # Approvals overrides the number of approvals required if set (set to 0 to disable)
+                # Approvals overrides the number of approvals required if set
                 required_approving_review_count: 0
             # RequiredStatusChecks configures github contexts
             required_status_checks:
@@ -232,7 +232,7 @@ branch-protection:
                 - ""
         # RequireOwners overrides whether CODEOWNERS must approve PRs if set
         require_code_owner_reviews: false
-        # Approvals overrides the number of approvals required if set (set to 0 to disable)
+        # Approvals overrides the number of approvals required if set
         required_approving_review_count: 0
     # RequiredStatusChecks configures github contexts
     required_status_checks:

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2683,7 +2683,6 @@ func (c *client) UpdateBranchProtection(org, repo, branch string, config BranchP
 	defer durationLogger()
 
 	_, err := c.request(&request{
-		accept:      "application/vnd.github.luke-cage-preview+json", // for required_approving_review_count
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("/repos/%s/%s/branches/%s/protection", org, repo, branch),
 		org:         org,


### PR DESCRIPTION
We would like to make the branchprotector configure the following configuration:
<img width="601" alt="image" src="https://github.com/kubernetes/test-infra/assets/42113979/3e7ff5ed-f41d-4826-a079-036ec53fab8f">

This corresponds to the following config in the REST API:
```console
$ gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/cert-manager/cert-manager/branches/master/protection
...
"required_pull_request_reviews": {
    "url": "https://api.github.com/repos/cert-manager/cert-manager/branches/master/protection/required_pull_request_reviews",
    "dismiss_stale_reviews": false,
    "require_code_owner_reviews": false,
    "require_last_push_approval": false,
    "required_approving_review_count": 0
  },
...
```

Currently we cannot make prow configure that setup, because it skips `required_pull_request_reviews` if `required_approving_review_count` is `0`.
We would like to make this change to improve the security of our repo as advised by our security audit.