### PR TITLE
Kops - update grid distros

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -411,7 +411,7 @@ networking_options = [
 ]
 
 distro_options = [
-    'amzn2',
+    'al2023',
     'deb12',
     'flatcar',
     'rhel8',

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -412,7 +412,7 @@ networking_options = [
 
 distro_options = [
     'amzn2',
-    'deb10',
+    'deb12',
     'flatcar',
     'rhel8',
     'u2004',

--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.29/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
@@ -98,7 +98,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.29/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
@@ -164,7 +164,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -230,7 +230,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -296,7 +296,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -362,7 +362,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --master-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -352,7 +352,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -416,7 +416,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -544,7 +544,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -608,7 +608,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -2125,7 +2125,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -2188,7 +2188,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -2252,7 +2252,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -2315,7 +2315,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -2378,7 +2378,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -2442,7 +2442,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -2505,7 +2505,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -2568,7 +2568,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
@@ -2632,7 +2632,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -2695,7 +2695,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -2758,7 +2758,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -3514,7 +3514,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -3577,7 +3577,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -3640,7 +3640,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -3703,7 +3703,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -3766,7 +3766,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -3829,7 +3829,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -3892,7 +3892,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -3955,7 +3955,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -4018,7 +4018,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -4081,7 +4081,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -4144,7 +4144,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -6300,7 +6300,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -6363,7 +6363,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -6427,7 +6427,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -6490,7 +6490,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -6553,7 +6553,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -6617,7 +6617,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -6680,7 +6680,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -6743,7 +6743,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
@@ -6807,7 +6807,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -6870,7 +6870,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -6933,7 +6933,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -7689,7 +7689,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -7752,7 +7752,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -7815,7 +7815,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -7878,7 +7878,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -7941,7 +7941,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -8004,7 +8004,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -8067,7 +8067,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -8130,7 +8130,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -8193,7 +8193,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -8256,7 +8256,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -8319,7 +8319,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -10475,7 +10475,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -10538,7 +10538,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -10602,7 +10602,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -10665,7 +10665,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -10728,7 +10728,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -10792,7 +10792,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -10855,7 +10855,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -10918,7 +10918,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
@@ -10982,7 +10982,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -11045,7 +11045,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -11108,7 +11108,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -11864,7 +11864,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -11927,7 +11927,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -11990,7 +11990,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -12053,7 +12053,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -12116,7 +12116,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -12179,7 +12179,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -12242,7 +12242,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -12305,7 +12305,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -12368,7 +12368,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -12431,7 +12431,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -12494,7 +12494,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -14650,7 +14650,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -14713,7 +14713,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -14777,7 +14777,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -14840,7 +14840,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -14903,7 +14903,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -14967,7 +14967,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -15030,7 +15030,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -15093,7 +15093,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
@@ -15157,7 +15157,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -15220,7 +15220,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -15283,7 +15283,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -16039,7 +16039,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -16102,7 +16102,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -16165,7 +16165,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -16228,7 +16228,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -16291,7 +16291,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -16354,7 +16354,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -16417,7 +16417,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -16480,7 +16480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -16543,7 +16543,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -16606,7 +16606,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -16669,7 +16669,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -18276,7 +18276,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -18340,7 +18340,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -18404,7 +18404,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -18468,7 +18468,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -18532,7 +18532,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -18596,7 +18596,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -18660,7 +18660,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -18724,7 +18724,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -19300,7 +19300,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -19364,7 +19364,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -19428,7 +19428,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -19492,7 +19492,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -19556,7 +19556,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -19620,7 +19620,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -19684,7 +19684,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -19748,7 +19748,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -21525,7 +21525,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -21588,7 +21588,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -21652,7 +21652,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -21715,7 +21715,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -21778,7 +21778,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -21842,7 +21842,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -21905,7 +21905,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -21968,7 +21968,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
@@ -22032,7 +22032,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -22662,7 +22662,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -22725,7 +22725,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -22788,7 +22788,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -22851,7 +22851,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -22914,7 +22914,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -22977,7 +22977,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -23040,7 +23040,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -23103,7 +23103,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -23166,7 +23166,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -24618,7 +24618,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -24681,7 +24681,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
@@ -24745,7 +24745,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -24808,7 +24808,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -24871,7 +24871,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
@@ -24935,7 +24935,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -24998,7 +24998,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -25061,7 +25061,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
@@ -25125,7 +25125,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -25188,7 +25188,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -25251,7 +25251,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -26007,7 +26007,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -26070,7 +26070,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -26133,7 +26133,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -26196,7 +26196,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -26259,7 +26259,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -26322,7 +26322,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -26385,7 +26385,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -26448,7 +26448,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -26511,7 +26511,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -26574,7 +26574,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -26637,7 +26637,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -2,9 +2,9 @@
 # 437 jobs, total of 1189 runs per week
 periodics:
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k25
-  cron: '36 18 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k25
+  cron: '24 2 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -56,18 +56,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k25
+    testgrid-tab-name: kops-grid-kubenet-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k25-ko27
-  cron: '17 6 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k25-ko27
+  cron: '18 14 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -95,10 +95,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -120,18 +119,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k25-ko27
+    testgrid-tab-name: kops-grid-kubenet-al2023-k25-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k25-ko28
-  cron: '8 23 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k25-ko28
+  cron: '43 15 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -159,7 +158,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -183,18 +182,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-kubenet-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k26
-  cron: '18 16 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k26
+  cron: '26 16 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -222,7 +221,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -246,18 +245,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k26
+    testgrid-tab-name: kops-grid-kubenet-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k26-ko27
-  cron: '11 0 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k26-ko27
+  cron: '52 16 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -285,10 +284,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -310,18 +308,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k26-ko27
+    testgrid-tab-name: kops-grid-kubenet-al2023-k26-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k26-ko28
-  cron: '34 17 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k26-ko28
+  cron: '37 9 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -349,7 +347,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -373,18 +371,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-kubenet-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k27
-  cron: '20 22 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k27
+  cron: '8 22 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -412,7 +410,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -436,18 +434,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k27
+    testgrid-tab-name: kops-grid-kubenet-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k27-ko27
-  cron: '10 5 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k27-ko27
+  cron: '41 21 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -475,10 +473,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -500,18 +497,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k27-ko27
+    testgrid-tab-name: kops-grid-kubenet-al2023-k27-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k27-ko28
-  cron: '3 4 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k27-ko28
+  cron: '32 12 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -539,7 +536,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -563,18 +560,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-kubenet-al2023-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k28
-  cron: '37 15 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k28
+  cron: '49 7 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -602,7 +599,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -626,18 +623,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k28
+    testgrid-tab-name: kops-grid-kubenet-al2023-k28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-amzn2-k28-ko28
-  cron: '50 9 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k28-ko28
+  cron: '25 9 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -665,7 +662,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kubenet" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -689,14 +686,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-amzn2-k28-ko28
+    testgrid-tab-name: kops-grid-kubenet-al2023-k28-ko28
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-deb12-k25
@@ -4177,9 +4174,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k28-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k25
-  cron: '31 5 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k25
+  cron: '57 19 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4207,7 +4204,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -4231,18 +4228,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k25
+    testgrid-tab-name: kops-grid-calico-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k25-ko27
-  cron: '54 21 * * 1'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k25-ko27
+  cron: '0 11 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4270,10 +4267,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -4295,18 +4291,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k25-ko27
+    testgrid-tab-name: kops-grid-calico-al2023-k25-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k25-ko28
-  cron: '55 4 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k25-ko28
+  cron: '13 10 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4334,7 +4330,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -4358,18 +4354,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-calico-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k26
-  cron: '25 15 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k26
+  cron: '7 1 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4397,7 +4393,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -4421,18 +4417,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k26
+    testgrid-tab-name: kops-grid-calico-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k26-ko27
-  cron: '20 11 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k26-ko27
+  cron: '2 21 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4460,10 +4456,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -4485,18 +4480,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k26-ko27
+    testgrid-tab-name: kops-grid-calico-al2023-k26-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k26-ko28
-  cron: '9 18 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k26-ko28
+  cron: '39 4 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4524,7 +4519,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -4548,18 +4543,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-calico-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k27
-  cron: '35 9 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k27
+  cron: '57 7 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4587,7 +4582,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -4611,18 +4606,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k27
+    testgrid-tab-name: kops-grid-calico-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k27-ko27
-  cron: '49 14 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k27-ko27
+  cron: '11 8 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4650,10 +4645,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -4675,18 +4669,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k27-ko27
+    testgrid-tab-name: kops-grid-calico-al2023-k27-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k27-ko28
-  cron: '52 15 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k27-ko28
+  cron: '50 1 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4714,7 +4708,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -4738,18 +4732,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-calico-al2023-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k28
-  cron: '18 0 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k28
+  cron: '28 14 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4777,7 +4771,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -4801,18 +4795,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k28
+    testgrid-tab-name: kops-grid-calico-al2023-k28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k28-ko28
-  cron: '41 18 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k28-ko28
+  cron: '7 12 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4840,7 +4834,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=calico" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -4864,14 +4858,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-amzn2-k28-ko28
+    testgrid-tab-name: kops-grid-calico-al2023-k28-ko28
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb12-k25
@@ -8352,9 +8346,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k28-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k25
-  cron: '41 23 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k25
+  cron: '6 4 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8382,7 +8376,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -8406,18 +8400,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k25
+    testgrid-tab-name: kops-grid-cilium-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k25-ko27
-  cron: '34 1 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k25-ko27
+  cron: '0 15 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8445,10 +8439,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -8470,18 +8463,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k25-ko27
+    testgrid-tab-name: kops-grid-cilium-al2023-k25-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k25-ko28
-  cron: '51 0 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k25-ko28
+  cron: '9 22 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8509,7 +8502,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -8533,18 +8526,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-cilium-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k26
-  cron: '27 5 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k26
+  cron: '16 6 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8572,7 +8565,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -8596,18 +8589,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k26
+    testgrid-tab-name: kops-grid-cilium-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k26-ko27
-  cron: '32 7 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k26-ko27
+  cron: '46 1 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8635,10 +8628,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -8660,18 +8652,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k26-ko27
+    testgrid-tab-name: kops-grid-cilium-al2023-k26-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k26-ko28
-  cron: '33 14 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k26-ko28
+  cron: '47 8 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8699,7 +8691,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -8723,18 +8715,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-cilium-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k27
-  cron: '25 11 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k27
+  cron: '22 8 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8762,7 +8754,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -8786,18 +8778,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k27
+    testgrid-tab-name: kops-grid-cilium-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k27-ko27
-  cron: '45 2 * * 1'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k27-ko27
+  cron: '55 4 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8825,10 +8817,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -8850,18 +8841,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k27-ko27
+    testgrid-tab-name: kops-grid-cilium-al2023-k27-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k27-ko28
-  cron: '28 19 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k27-ko28
+  cron: '34 21 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8889,7 +8880,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -8913,18 +8904,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-cilium-al2023-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k28
-  cron: '16 10 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k28
+  cron: '47 9 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8952,7 +8943,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -8976,18 +8967,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k28
+    testgrid-tab-name: kops-grid-cilium-al2023-k28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k28-ko28
-  cron: '45 6 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k28-ko28
+  cron: '27 8 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9015,7 +9006,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -9039,14 +9030,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-amzn2-k28-ko28
+    testgrid-tab-name: kops-grid-cilium-al2023-k28-ko28
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb12-k25
@@ -12527,9 +12518,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k28-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k25
-  cron: '47 8 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k25
+  cron: '24 3 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12557,7 +12548,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -12581,18 +12572,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k25
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k25-ko27
-  cron: '23 10 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k25-ko27
+  cron: '18 10 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12620,10 +12611,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -12645,18 +12635,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k25-ko27
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k25-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k25-ko28
-  cron: '30 3 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k25-ko28
+  cron: '39 3 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12684,7 +12674,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -12708,18 +12698,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k26
-  cron: '37 2 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k26
+  cron: '22 17 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12747,7 +12737,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -12771,18 +12761,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k26
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k26-ko27
-  cron: '13 12 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k26-ko27
+  cron: '0 12 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12810,10 +12800,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -12835,18 +12824,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k26-ko27
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k26-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k26-ko28
-  cron: '44 5 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k26-ko28
+  cron: '1 13 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12874,7 +12863,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -12898,18 +12887,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k27
-  cron: '39 20 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k27
+  cron: '44 23 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12937,7 +12926,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -12961,18 +12950,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k27
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k27-ko27
-  cron: '12 1 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k27-ko27
+  cron: '13 17 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13000,10 +12989,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -13025,18 +13013,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k27-ko27
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k27-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k27-ko28
-  cron: '17 16 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k27-ko28
+  cron: '36 8 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13064,7 +13052,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -13088,18 +13076,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k28
-  cron: '38 21 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k28
+  cron: '53 14 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13127,7 +13115,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -13151,18 +13139,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k28
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-amzn2-k28-ko28
-  cron: '40 5 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k28-ko28
+  cron: '57 21 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13190,7 +13178,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -13214,14 +13202,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k28-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28-ko28
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb12-k25
@@ -16702,9 +16690,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k25
-  cron: '26 19 * * 3'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k25
+  cron: '16 7 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16732,7 +16720,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -16756,19 +16744,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k25
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k25-ko28
-  cron: '16 6 * * 0'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k25-ko28
+  cron: '46 19 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16796,7 +16784,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -16820,19 +16808,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k26
-  cron: '12 17 * * 4'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k26
+  cron: '58 5 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16860,7 +16848,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -16884,19 +16872,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k26
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k26-ko28
-  cron: '14 8 * * 1'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k26-ko28
+  cron: '24 5 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16924,7 +16912,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -16948,19 +16936,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k27
-  cron: '10 15 * * 5'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k27
+  cron: '56 3 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16988,7 +16976,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -17012,19 +17000,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k27
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k27-ko28
-  cron: '55 13 * * 0'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k27-ko28
+  cron: '13 8 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17052,7 +17040,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -17076,19 +17064,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k28
-  cron: '23 22 * * 1'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k28
+  cron: '13 10 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17116,7 +17104,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -17140,19 +17128,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k28
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k28
 
-# {"cloud": "aws", "distro": "amzn2", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-amzn2-k28-ko28
-  cron: '38 8 * * 0'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k28-ko28
+  cron: '4 21 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17180,7 +17168,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -17204,15 +17192,15 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-amzn2-k28-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k28-ko28
 
 # {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb12-k25
@@ -19782,9 +19770,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k28-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k25
-  cron: '28 2 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k25
+  cron: '13 7 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -19812,7 +19800,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -19836,18 +19824,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k25
+    testgrid-tab-name: kops-grid-flannel-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k25-ko27
-  cron: '14 13 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k25-ko27
+  cron: '58 6 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -19875,10 +19863,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -19900,18 +19887,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k25-ko27
+    testgrid-tab-name: kops-grid-flannel-al2023-k25-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k25-ko28
-  cron: '39 20 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k25-ko28
+  cron: '19 15 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -19939,7 +19926,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -19963,18 +19950,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-flannel-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k26
-  cron: '46 0 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k26
+  cron: '11 13 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20002,7 +19989,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -20026,18 +20013,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k26
+    testgrid-tab-name: kops-grid-flannel-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k26-ko27
-  cron: '0 11 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k26-ko27
+  cron: '48 16 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20065,10 +20052,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -20090,18 +20076,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k26-ko27
+    testgrid-tab-name: kops-grid-flannel-al2023-k26-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k26-ko28
-  cron: '21 2 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k26-ko28
+  cron: '45 17 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20129,7 +20115,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -20153,18 +20139,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-flannel-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k27
-  cron: '4 22 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k27
+  cron: '5 19 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20192,7 +20178,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -20216,18 +20202,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k27
+    testgrid-tab-name: kops-grid-flannel-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k27-ko27
-  cron: '53 6 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k27-ko27
+  cron: '41 5 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20255,10 +20241,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -20280,18 +20265,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k27-ko27
+    testgrid-tab-name: kops-grid-flannel-al2023-k27-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k27-ko28
-  cron: '44 7 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-al2023-k27-ko28
+  cron: '32 20 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20319,7 +20304,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=flannel" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -20343,14 +20328,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-flannel-al2023-k27-ko28
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb12-k25
@@ -23199,9 +23184,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k25
-  cron: '10 12 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k25
+  cron: '12 22 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23229,7 +23214,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -23253,18 +23238,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k25
+    testgrid-tab-name: kops-grid-kopeio-al2023-k25
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k25-ko27
-  cron: '29 18 * * 1'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k25-ko27
+  cron: '54 5 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23292,10 +23277,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -23317,18 +23301,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k25-ko27
+    testgrid-tab-name: kops-grid-kopeio-al2023-k25-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k25-ko28
-  cron: '12 19 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k25-ko28
+  cron: '23 4 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23356,7 +23340,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -23380,18 +23364,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k25-ko28
+    testgrid-tab-name: kops-grid-kopeio-al2023-k25-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k26
-  cron: '12 14 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k26
+  cron: '42 12 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23419,7 +23403,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -23443,18 +23427,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k26
+    testgrid-tab-name: kops-grid-kopeio-al2023-k26
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k26-ko27
-  cron: '27 12 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k26-ko27
+  cron: '40 3 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23482,10 +23466,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -23507,18 +23490,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k26-ko27
+    testgrid-tab-name: kops-grid-kopeio-al2023-k26-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k26-ko28
-  cron: '18 21 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k26-ko28
+  cron: '25 18 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23546,7 +23529,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -23570,18 +23553,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k26-ko28
+    testgrid-tab-name: kops-grid-kopeio-al2023-k26-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k27
-  cron: '50 8 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k27
+  cron: '52 18 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23609,7 +23592,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -23633,18 +23616,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k27
+    testgrid-tab-name: kops-grid-kopeio-al2023-k27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k27-ko27
-  cron: '14 9 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k27-ko27
+  cron: '37 14 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23672,10 +23655,9 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
-          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
@@ -23697,18 +23679,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k27-ko27
+    testgrid-tab-name: kops-grid-kopeio-al2023-k27-ko27
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k27-ko28
-  cron: '59 8 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k27-ko28
+  cron: '36 23 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23736,7 +23718,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -23760,18 +23742,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k27-ko28
+    testgrid-tab-name: kops-grid-kopeio-al2023-k27-ko28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k28
-  cron: '51 1 * * 3'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k28
+  cron: '13 3 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23799,7 +23781,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -23823,18 +23805,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k28
+    testgrid-tab-name: kops-grid-kopeio-al2023-k28
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k28-ko28
-  cron: '10 5 * * 0'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k28-ko28
+  cron: '49 18 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23862,7 +23844,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240131.0-x86_64-gp2' --channel=alpha --networking=kopeio" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -23886,14 +23868,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-amzn2, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k28-ko28
+    testgrid-tab-name: kops-grid-kopeio-al2023-k28-ko28
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb12-k25

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -698,9 +698,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-amzn2-k28-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k25
-  cron: '5 3 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k25
+  cron: '9 11 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -728,7 +728,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -752,18 +752,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k25
+    testgrid-tab-name: kops-grid-kubenet-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k25-ko27
-  cron: '24 11 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k25-ko27
+  cron: '21 6 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -791,7 +791,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -815,18 +815,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k25-ko27
+    testgrid-tab-name: kops-grid-kubenet-deb12-k25-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k25-ko28
-  cron: '45 10 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k25-ko28
+  cron: '12 15 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -854,7 +854,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -878,18 +878,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-kubenet-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k26
-  cron: '39 17 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k26
+  cron: '39 9 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -917,7 +917,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -941,18 +941,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k26
+    testgrid-tab-name: kops-grid-kubenet-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k26-ko27
-  cron: '14 13 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k26-ko27
+  cron: '47 0 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -980,7 +980,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -1004,18 +1004,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k26-ko27
+    testgrid-tab-name: kops-grid-kubenet-deb12-k26-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k26-ko28
-  cron: '59 4 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k26-ko28
+  cron: '14 17 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1043,7 +1043,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -1067,18 +1067,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-kubenet-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k27
-  cron: '21 23 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k27
+  cron: '37 23 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1106,7 +1106,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -1130,18 +1130,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k27
+    testgrid-tab-name: kops-grid-kubenet-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k27-ko27
-  cron: '59 8 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k27-ko27
+  cron: '42 21 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1169,7 +1169,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -1193,18 +1193,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k27-ko27
+    testgrid-tab-name: kops-grid-kubenet-deb12-k27-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k27-ko28
-  cron: '22 9 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k27-ko28
+  cron: '7 12 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1232,7 +1232,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -1256,18 +1256,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-kubenet-deb12-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k28
-  cron: '48 6 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k28
+  cron: '20 22 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1295,7 +1295,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -1319,18 +1319,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k28
+    testgrid-tab-name: kops-grid-kubenet-deb12-k28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb10-k28-ko28
-  cron: '59 20 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k28-ko28
+  cron: '30 1 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1358,7 +1358,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kubenet" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kubenet" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -1382,14 +1382,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb10-k28-ko28
+    testgrid-tab-name: kops-grid-kubenet-deb12-k28-ko28
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-flatcar-k25
@@ -4873,9 +4873,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k28-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k25
-  cron: '30 20 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k25
+  cron: '30 4 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4903,7 +4903,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -4927,18 +4927,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k25
+    testgrid-tab-name: kops-grid-calico-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k25-ko27
-  cron: '39 0 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k25-ko27
+  cron: '2 21 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4966,7 +4966,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -4990,18 +4990,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k25-ko27
+    testgrid-tab-name: kops-grid-calico-deb12-k25-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k25-ko28
-  cron: '50 1 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k25-ko28
+  cron: '31 12 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5029,7 +5029,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -5053,18 +5053,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-calico-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k26
-  cron: '16 14 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k26
+  cron: '36 22 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5092,7 +5092,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -5116,18 +5116,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k26
+    testgrid-tab-name: kops-grid-calico-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k26-ko27
-  cron: '41 22 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k26-ko27
+  cron: '0 19 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5155,7 +5155,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -5179,18 +5179,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k26-ko27
+    testgrid-tab-name: kops-grid-calico-deb12-k26-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k26-ko28
-  cron: '0 7 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k26-ko28
+  cron: '21 2 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5218,7 +5218,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -5242,18 +5242,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-calico-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k27
-  cron: '50 16 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k27
+  cron: '58 0 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5281,7 +5281,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -5305,18 +5305,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k27
+    testgrid-tab-name: kops-grid-calico-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k27-ko27
-  cron: '20 11 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k27-ko27
+  cron: '1 22 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5344,7 +5344,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -5368,18 +5368,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k27-ko27
+    testgrid-tab-name: kops-grid-calico-deb12-k27-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k27-ko28
-  cron: '33 10 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k27-ko28
+  cron: '56 7 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5407,7 +5407,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -5431,18 +5431,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-calico-deb12-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k28
-  cron: '19 17 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k28
+  cron: '47 9 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5470,7 +5470,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -5494,18 +5494,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k28
+    testgrid-tab-name: kops-grid-calico-deb12-k28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k28-ko28
-  cron: '36 15 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k28-ko28
+  cron: '37 18 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5533,7 +5533,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=calico" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=calico" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -5557,14 +5557,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb10-k28-ko28
+    testgrid-tab-name: kops-grid-calico-deb12-k28-ko28
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k25
@@ -9048,9 +9048,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k28-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k25
-  cron: '8 14 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k25
+  cron: '20 14 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9078,7 +9078,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -9102,18 +9102,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k25
+    testgrid-tab-name: kops-grid-cilium-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k25-ko27
-  cron: '35 20 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k25-ko27
+  cron: '2 9 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9141,7 +9141,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -9165,18 +9165,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k25-ko27
+    testgrid-tab-name: kops-grid-cilium-deb12-k25-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k25-ko28
-  cron: '26 13 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k25-ko28
+  cron: '27 8 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9204,7 +9204,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -9228,18 +9228,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-cilium-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k26
-  cron: '46 4 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k26
+  cron: '14 12 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9267,7 +9267,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -9291,18 +9291,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k26
+    testgrid-tab-name: kops-grid-cilium-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k26-ko27
-  cron: '21 18 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k26-ko27
+  cron: '8 15 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9330,7 +9330,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -9354,18 +9354,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k26-ko27
+    testgrid-tab-name: kops-grid-cilium-deb12-k26-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k26-ko28
-  cron: '36 11 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k26-ko28
+  cron: '9 14 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9393,7 +9393,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -9417,18 +9417,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-cilium-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k27
-  cron: '40 2 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k27
+  cron: '12 18 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9456,7 +9456,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -9480,18 +9480,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k27
+    testgrid-tab-name: kops-grid-cilium-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k27-ko27
-  cron: '32 7 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k27-ko27
+  cron: '45 18 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9519,7 +9519,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -9543,18 +9543,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k27-ko27
+    testgrid-tab-name: kops-grid-cilium-deb12-k27-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k27-ko28
-  cron: '57 6 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k27-ko28
+  cron: '8 19 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9582,7 +9582,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -9606,18 +9606,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-cilium-deb12-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k28
-  cron: '9 11 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k28
+  cron: '21 19 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9645,7 +9645,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -9669,18 +9669,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k28
+    testgrid-tab-name: kops-grid-cilium-deb12-k28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k28-ko28
-  cron: '8 3 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k28-ko28
+  cron: '57 14 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9708,7 +9708,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -9732,14 +9732,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb10-k28-ko28
+    testgrid-tab-name: kops-grid-cilium-deb12-k28-ko28
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k25
@@ -13223,9 +13223,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k28-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k25
-  cron: '42 9 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k25
+  cron: '46 1 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13253,7 +13253,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -13277,18 +13277,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k25
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k25-ko27
-  cron: '38 23 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k25-ko27
+  cron: '23 18 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13316,7 +13316,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -13340,18 +13340,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k25-ko27
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k25-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k25-ko28
-  cron: '11 22 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k25-ko28
+  cron: '34 19 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13379,7 +13379,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -13403,18 +13403,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k26
-  cron: '28 11 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k26
+  cron: '4 19 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13442,7 +13442,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -13466,18 +13466,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k26
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k26-ko27
-  cron: '4 17 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k26-ko27
+  cron: '57 4 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13505,7 +13505,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -13529,18 +13529,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k26-ko27
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k26-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k26-ko28
-  cron: '17 0 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k26-ko28
+  cron: '28 13 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13568,7 +13568,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -13592,18 +13592,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k27
-  cron: '22 13 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k27
+  cron: '54 13 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13631,7 +13631,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -13655,18 +13655,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k27
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k27-ko27
-  cron: '13 20 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k27-ko27
+  cron: '28 9 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13694,7 +13694,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -13718,18 +13718,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k27-ko27
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k27-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k27-ko28
-  cron: '44 5 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k27-ko28
+  cron: '13 0 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13757,7 +13757,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -13781,18 +13781,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k28
-  cron: '11 4 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k28
+  cron: '31 4 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13820,7 +13820,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -13844,18 +13844,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k28
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb10-k28-ko28
-  cron: '5 8 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k28-ko28
+  cron: '36 21 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13883,7 +13883,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-etcd" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-etcd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -13907,14 +13907,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb10-k28-ko28
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28-ko28
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-flatcar-k25
@@ -17214,9 +17214,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-amzn2-k28-ko28
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k25
-  cron: '59 10 * * 2'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k25
+  cron: '15 2 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17244,7 +17244,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -17268,19 +17268,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k25
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k25-ko28
-  cron: '25 11 * * 5'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k25-ko28
+  cron: '20 22 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17308,7 +17308,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -17332,19 +17332,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k26
-  cron: '49 0 * * 1'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k26
+  cron: '53 16 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17372,7 +17372,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -17396,19 +17396,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k26
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k26-ko28
-  cron: '7 5 * * 0'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k26-ko28
+  cron: '26 8 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17436,7 +17436,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -17460,19 +17460,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k27
-  cron: '7 14 * * 3'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k27
+  cron: '51 6 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17500,7 +17500,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -17524,19 +17524,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k27
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k27-ko28
-  cron: '18 8 * * 4'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k27-ko28
+  cron: '15 13 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17564,7 +17564,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -17588,19 +17588,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k28
-  cron: '42 15 * * 6'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k28
+  cron: '42 7 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17628,7 +17628,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -17652,19 +17652,19 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k28
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k28
 
-# {"cloud": "aws", "distro": "deb10", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb10-k28-ko28
-  cron: '59 13 * * 0'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k28-ko28
+  cron: '54 8 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17692,7 +17692,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -17716,15 +17716,15 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb10-k28-ko28
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k28-ko28
 
 # {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k25
@@ -20352,9 +20352,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k25
-  cron: '25 3 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k25
+  cron: '9 11 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20382,7 +20382,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -20406,18 +20406,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k25
+    testgrid-tab-name: kops-grid-flannel-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k25-ko27
-  cron: '19 0 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k25-ko27
+  cron: '42 13 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20445,7 +20445,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -20469,18 +20469,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k25-ko27
+    testgrid-tab-name: kops-grid-flannel-deb12-k25-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k25-ko28
-  cron: '14 17 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k25-ko28
+  cron: '39 12 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20508,7 +20508,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -20532,18 +20532,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-flannel-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k26
-  cron: '47 9 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k26
+  cron: '15 9 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20571,7 +20571,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -20595,18 +20595,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k26
+    testgrid-tab-name: kops-grid-flannel-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k26-ko27
-  cron: '37 14 * * 1'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k26-ko27
+  cron: '8 3 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20634,7 +20634,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -20658,18 +20658,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k26-ko27
+    testgrid-tab-name: kops-grid-flannel-deb12-k26-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k26-ko28
-  cron: '36 23 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k26-ko28
+  cron: '1 10 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20697,7 +20697,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -20721,18 +20721,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-flannel-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k27
-  cron: '25 7 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k27
+  cron: '37 23 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20760,7 +20760,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -20784,18 +20784,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k27
+    testgrid-tab-name: kops-grid-flannel-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k27-ko27
-  cron: '40 3 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k27-ko27
+  cron: '37 14 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20823,7 +20823,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -20847,18 +20847,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k27-ko27
+    testgrid-tab-name: kops-grid-flannel-deb12-k27-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k27-ko28
-  cron: '9 2 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb12-k27-ko28
+  cron: '32 7 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -20886,7 +20886,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=flannel" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=flannel" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -20910,14 +20910,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-flannel-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-flannel-deb12-k27-ko28
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k25
@@ -23895,9 +23895,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k28-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k25
-  cron: '3 5 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k25
+  cron: '3 13 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23925,7 +23925,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -23949,18 +23949,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k25
+    testgrid-tab-name: kops-grid-kopeio-deb12-k25
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k25-ko27
-  cron: '8 23 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k25-ko27
+  cron: '41 10 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -23988,7 +23988,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -24012,18 +24012,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k25-ko27
+    testgrid-tab-name: kops-grid-kopeio-deb12-k25-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k25-ko28
-  cron: '1 6 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k25-ko28
+  cron: '8 19 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24051,7 +24051,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
@@ -24075,18 +24075,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.25'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k25-ko28
+    testgrid-tab-name: kops-grid-kopeio-deb12-k25-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k26
-  cron: '37 7 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k26
+  cron: '49 15 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24114,7 +24114,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -24138,18 +24138,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k26
+    testgrid-tab-name: kops-grid-kopeio-deb12-k26
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k26-ko27
-  cron: '2 1 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k26-ko27
+  cron: '31 4 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24177,7 +24177,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -24201,18 +24201,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k26-ko27
+    testgrid-tab-name: kops-grid-kopeio-deb12-k26-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k26-ko28
-  cron: '55 8 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.26", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k26-ko28
+  cron: '2 5 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24240,7 +24240,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -24264,18 +24264,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.26'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k26-ko28
+    testgrid-tab-name: kops-grid-kopeio-deb12-k26-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k27
-  cron: '15 17 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k27
+  cron: '19 17 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24303,7 +24303,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -24327,18 +24327,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k27
+    testgrid-tab-name: kops-grid-kopeio-deb12-k27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k27-ko27
-  cron: '35 4 * * 3'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.27", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k27-ko27
+  cron: '38 1 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24366,7 +24366,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -24390,18 +24390,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.27, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k27-ko27
+    testgrid-tab-name: kops-grid-kopeio-deb12-k27-ko27
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k27-ko28
-  cron: '30 5 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.27", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k27-ko28
+  cron: '39 16 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24429,7 +24429,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -24453,18 +24453,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.27'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k27-ko28
+    testgrid-tab-name: kops-grid-kopeio-deb12-k27-ko28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k28
-  cron: '42 8 * * 4'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k28
+  cron: '30 16 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24492,7 +24492,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -24516,18 +24516,18 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k28
+    testgrid-tab-name: kops-grid-kopeio-deb12-k28
 
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k28-ko28
-  cron: '19 16 * * 2'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.28", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k28-ko28
+  cron: '42 21 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -24555,7 +24555,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20240204-1647' --channel=alpha --networking=kopeio" \
+          --create-args="--image='136693071363/debian-12-amd64-20240211-1654' --channel=alpha --networking=kopeio" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -24579,14 +24579,14 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/k8s_version: '1.28'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb10, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb10-k28-ko28
+    testgrid-tab-name: kops-grid-kopeio-deb12-k28-ko28
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.25", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k25

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -168,7 +168,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -429,7 +429,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -493,7 +493,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -687,7 +687,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --api-loadbalancer-type=public" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --api-loadbalancer-type=public" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -751,7 +751,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --api-loadbalancer-type=public --set=cluster.spec.cloudProvider.aws.warmPool.minSize=1 --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --api-loadbalancer-type=public --set=cluster.spec.cloudProvider.aws.warmPool.minSize=1 --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -815,7 +815,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --topology=private --bastion --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --topology=private --bastion --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -879,7 +879,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --zones=us-west-1a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --zones=us-west-1a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --terraform-version=1.5.5 \
@@ -944,7 +944,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --zones=us-west-1a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --zones=us-west-1a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --terraform-version=1.5.5 \
@@ -1009,7 +1009,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1073,7 +1073,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/latest.txt \
           --test=kops \
@@ -1137,7 +1137,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -1203,7 +1203,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -1271,7 +1271,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --node-size=c5.large --master-size=c5.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --node-size=c5.large --master-size=c5.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -1339,7 +1339,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --publish-version-marker=gs://kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -1717,7 +1717,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1781,7 +1781,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --ipv6 --bastion --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --ipv6 --bastion --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1845,7 +1845,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --env=KOPS_FEATURE_FLAGS=APIServerNodes \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -1912,7 +1912,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --instance-manager=karpenter --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --instance-manager=karpenter --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1978,7 +1978,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --instance-manager=karpenter --ipv6 --topology=private --bastion --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --instance-manager=karpenter --ipv6 --topology=private --bastion --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -2044,7 +2044,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium --set=cluster.spec.containerd.selinuxEnabled=true --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=cilium --set=cluster.spec.containerd.selinuxEnabled=true --discovery-store=s3://k8s-kops-prow/discovery" \
           --env=KOPS_FEATURE_FLAGS=SELinuxMount \
           --kubernetes-feature-gates=SELinuxMountReadWriteOncePod,ReadWriteOncePod \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -2182,7 +2182,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2249,7 +2249,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-common --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-common --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2384,7 +2384,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2520,7 +2520,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -2588,7 +2588,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
           --cluster-name="kubernetes-e2e-al2023-aws-conformance-aws-cni.k8s.local" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -2655,7 +2655,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
           --cluster-name="kubernetes-e2e-al2023-aws-conformance-aws-cni-canary.k8s.local" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
@@ -2724,7 +2724,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=cilium --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeProxy.enabled=false --set=spec.networking.cilium.enableNodePort=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeProxy.enabled=false --set=spec.networking.cilium.enableNodePort=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
           --cluster-name="kubernetes-e2e-al2023-aws-conformance-cilium.k8s.local" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
@@ -2929,7 +2929,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -3066,7 +3066,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -3134,7 +3134,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --discovery-store=s3://k8s-kops-prow/discovery" \
           --kubernetes-feature-gates=AllAlpha,-InTreePluginGCEUnregister,DisableCloudProviders,DisableKubeletCloudCredentialProviders \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=amazonvpc --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=amazonvpc --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -96,7 +96,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -160,7 +160,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=canal --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=canal --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -224,7 +224,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -288,7 +288,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-etcd --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-etcd --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -352,7 +352,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -416,7 +416,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=flannel --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=flannel --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -480,7 +480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kopeio --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kopeio --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -544,7 +544,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=kube-router --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=kube-router --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --publish-version-marker=gs://kops-ci/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/latest.txt \
@@ -99,7 +99,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.28/latest-ci.txt \
           --publish-version-marker=gs://kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
@@ -166,7 +166,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.27/latest-ci.txt \
           --publish-version-marker=gs://kops-ci/markers/release-1.27/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --publish-version-marker=gs://kops-ci/bin/latest-ci-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
@@ -99,7 +99,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
@@ -163,7 +163,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
@@ -227,7 +227,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
@@ -291,7 +291,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
@@ -355,7 +355,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -370,7 +370,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -437,7 +437,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -571,7 +571,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -638,7 +638,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -35,7 +35,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -105,7 +105,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --master-count=3 --node-count=6 --zones=eu-central-1a,eu-central-1b,eu-central-1c --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --master-count=3 --node-count=6 --zones=eu-central-1a,eu-central-1b,eu-central-1c --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -242,7 +242,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.3.20240205.2-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='137112412989/al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -709,7 +709,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium --set=cluster.spec.cloudControllerManager.cloudProvider=aws --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium --set=cluster.spec.cloudControllerManager.cloudProvider=aws --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1006,7 +1006,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1073,7 +1073,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=calico --ipv6 --bastion --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=calico --ipv6 --bastion --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1140,7 +1140,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --set=cluster.spec.kubeDNS.nodeLocalDNS.enabled=true --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --set=cluster.spec.kubeDNS.nodeLocalDNS.enabled=true --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1207,7 +1207,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
             --env=KOPS_FEATURE_FLAGS=APIServerNodes \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
@@ -1277,7 +1277,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1344,7 +1344,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --dns=none --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --dns=none --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1477,7 +1477,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --api-loadbalancer-type=public --api-loadbalancer-class=network --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --api-loadbalancer-type=public --api-loadbalancer-class=network --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1544,7 +1544,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --terraform-version=1.5.5 \
@@ -1612,7 +1612,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --ipv6 --bastion --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --ipv6 --bastion --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --terraform-version=1.5.5 \
@@ -1882,7 +1882,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --instance-manager=karpenter --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --instance-manager=karpenter --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1951,7 +1951,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --instance-manager=karpenter --ipv6 --topology=private --bastion --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --instance-manager=karpenter --ipv6 --topology=private --bastion --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -2356,7 +2356,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240207.1' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240220' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
             --boskos-resource-type=aws-account \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -36,7 +36,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=amazonvpc --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=amazonvpc --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -103,7 +103,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=amazonvpc --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=amazonvpc --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -171,7 +171,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -239,7 +239,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=calico --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=calico --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -307,7 +307,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=canal --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=canal --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -375,7 +375,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -443,7 +443,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -511,7 +511,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium-etcd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium-etcd --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -579,7 +579,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=cilium-eni --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=cilium-eni --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -647,7 +647,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=flannel --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=flannel --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -715,7 +715,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240207.1' --channel=alpha --networking=kube-router --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240220' --channel=alpha --networking=kube-router --node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \


### PR DESCRIPTION
Updates our grid jobs from debian 10 to debian 12 and AL2 to AL2023