### PR TITLE
Kops - Fix test-package flag in GCE job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -100,7 +100,7 @@ periodics:
           -- \
           --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
-          --test-package-bucket=k8s-release-dev \
+          --test-package-url=https://storage.googleapis.com/k8s-release-dev \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25


### PR DESCRIPTION
This was updated in jobs generated by build_jobs.py but missed in this manually-maintained file

Example https://github.com/kubernetes/test-infra/blob/1cff27cb5e1f0f7205b96a504a6e44aa50889819/config/jobs/kubernetes/kops/kops-periodics-versions.yaml#L42

/cc @hakman