### PR TITLE
Enable trigger github workflow for apiserver-network-proxy.

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -37,6 +37,11 @@ triggers:
   - kubernetes/utils
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
   trigger_github_workflows: true
+- repos:
+  - kubernetes-sigs/apiserver-network-proxy
+  join_org_url: "https://git.k8s.io/community/community-membership.md#member"
+  only_org_members: true
+  trigger_github_workflows: true
 
 owners:
   mdyamlrepos:


### PR DESCRIPTION
This PR is working for Enable trigger github workflow for apiserver-network-proxy, and ~~then `/ok-to-test` can approve github workflow to run by prow~~ (i think it is still not implement.) and `/retest` to rerun github workflow of failed .



/cc @jkh52 @cheftako @tallclair