### PR TITLE
Update manual kubernetes-csi jobs to 1.28

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -54,13 +54,13 @@ presubmits:
 
 periodics:
 - interval: 6h
-  # 1.26 is used because it is the (currently) latest stable
+  # 1.28 is used because it is the (currently) latest stable
   # release.
   #
   # This job is meant to detect regressions in upcoming releases
   # that slipped through pre-merge testing, so we have to use canary
   # images.
-  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-26
+  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-28
   cluster: eks-prow-build-cluster
   decorate: true
   extra_refs:
@@ -76,7 +76,7 @@ periodics:
     testgrid-dashboards: sig-storage-csi-ci
     testgrid-tab-name: distributed-on-1-26
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes 1.26, with CSIStorageCapacity
+    description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes 1.28, with CSIStorageCapacity
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -87,7 +87,7 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.26.0"
+        value: "1.28.0"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_SNAPSHOTTER_VERSION

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -27,7 +27,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.26.0"
+          value: "1.28.0"
         - name: CSI_PROW_USE_BAZEL
           value: "true"
         - name: CSI_PROW_DRIVER_VERSION


### PR DESCRIPTION
Use Kubernetes 1.28 as the latest stable Kubernetes release for manually configured CSI jobs.

This is continuation of https://github.com/kubernetes/test-infra/pull/32052
cc @xing-yang 