### PR TITLE
add an option to compress files prior to uploading to storage

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -182,6 +182,16 @@ spec:
                           discouraged to use Bucket without prefix please add the
                           gs:// prefix)'
                         type: string
+                      compress_file_types:
+                        description: 'CompressFileTypes specify file types that should
+                          be gzipped prior to upload. Matching files will be compressed
+                          prior to upload, and the content-encoding on these files
+                          will be set to gzip. GCS will transcode these gzipped files
+                          transparently when viewing. See: https://cloud.google.com/storage/docs/transcoding
+                          Example: "txt", "json" Use "*" for all'
+                        items:
+                          type: string
+                        type: array
                       default_org:
                         description: DefaultOrg is omitted from GCS paths when using
                           the legacy or simple strategy

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -350,7 +350,7 @@ func (rac *RerunAuthConfig) IsAllowAnyone() bool {
 }
 
 type ReporterConfig struct {
-	Slack       *SlackReporterConfig `json:"slack,omitempty"`
+	Slack *SlackReporterConfig `json:"slack,omitempty"`
 }
 
 type SlackReporterConfig struct {
@@ -441,7 +441,7 @@ func (d *Duration) MarshalJSON() ([]byte, error) {
 // in Prow config
 type ProwJobDefault struct {
 	ResultStoreConfig *ResultStoreConfig `json:"resultstore_config,omitempty"`
-	TenantID string `json:"tenant_id,omitempty"`
+	TenantID          string             `json:"tenant_id,omitempty"`
 }
 
 // ResultStoreConfig specifies parameters for uploading results to
@@ -684,7 +684,7 @@ func (d *ProwJobDefault) ApplyDefault(def *ProwJobDefault) *ProwJobDefault {
 		return &merged
 	}
 	if merged.ResultStoreConfig == nil {
-		merged.ResultStoreConfig = def.ResultStoreConfig 
+		merged.ResultStoreConfig = def.ResultStoreConfig
 	}
 	if merged.TenantID == "" {
 		merged.TenantID = def.TenantID
@@ -920,6 +920,12 @@ type GCSConfiguration struct {
 	// LocalOutputDir specifies a directory where files should be copied INSTEAD of uploading to blob storage.
 	// This option is useful for testing jobs that use the pod-utilities without actually uploading.
 	LocalOutputDir string `json:"local_output_dir,omitempty"`
+	// CompressFileTypes specify file types that should be gzipped prior to upload.
+	// Matching files will be compressed prior to upload, and the content-encoding on these files will be set to gzip.
+	// GCS will transcode these gzipped files transparently when viewing. See: https://cloud.google.com/storage/docs/transcoding
+	// Example: "txt", "json"
+	// Use "*" for all
+	CompressFileTypes []string `json:"compress_file_types,omitempty"`
 }
 
 // ApplyDefault applies the defaults for GCSConfiguration decorations. If a field has a zero value,
@@ -968,6 +974,9 @@ func (g *GCSConfiguration) ApplyDefault(def *GCSConfiguration) *GCSConfiguration
 
 	if merged.LocalOutputDir == "" {
 		merged.LocalOutputDir = def.LocalOutputDir
+	}
+	if len(merged.CompressFileTypes) == 0 {
+		merged.CompressFileTypes = def.CompressFileTypes
 	}
 	return &merged
 }

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -975,7 +975,7 @@ func (g *GCSConfiguration) ApplyDefault(def *GCSConfiguration) *GCSConfiguration
 	if merged.LocalOutputDir == "" {
 		merged.LocalOutputDir = def.LocalOutputDir
 	}
-	if len(merged.CompressFileTypes) == 0 {
+	if merged.CompressFileTypes == nil {
 		merged.CompressFileTypes = def.CompressFileTypes
 	}
 	return &merged

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -75,7 +75,6 @@ func TestProwJobDefaulting(t *testing.T) {
 					ProjectID: "default-project",
 				},
 				TenantID: "default-tenant",
-
 			},
 			expected: &ProwJobDefault{
 				ResultStoreConfig: &ResultStoreConfig{
@@ -85,20 +84,19 @@ func TestProwJobDefaulting(t *testing.T) {
 			},
 		},
 		{
-			name: "Empty provided, no default",
+			name:     "Empty provided, no default",
 			provided: &ProwJobDefault{},
-			def: &ProwJobDefault{},
+			def:      &ProwJobDefault{},
 			expected: &ProwJobDefault{},
 		},
 		{
-			name: "Empty provided, use default",
+			name:     "Empty provided, use default",
 			provided: &ProwJobDefault{},
 			def: &ProwJobDefault{
 				ResultStoreConfig: &ResultStoreConfig{
 					ProjectID: "default-project",
 				},
 				TenantID: "default-tenant",
-
 			},
 			expected: &ProwJobDefault{
 				ResultStoreConfig: &ResultStoreConfig{
@@ -108,20 +106,19 @@ func TestProwJobDefaulting(t *testing.T) {
 			},
 		},
 		{
-			name: "Nil provided, empty default",
+			name:     "Nil provided, empty default",
 			provided: nil,
-			def: &ProwJobDefault{},
+			def:      &ProwJobDefault{},
 			expected: &ProwJobDefault{},
 		},
 		{
-			name: "Nil provided, use default",
+			name:     "Nil provided, use default",
 			provided: nil,
 			def: &ProwJobDefault{
 				ResultStoreConfig: &ResultStoreConfig{
 					ProjectID: "default-project",
 				},
 				TenantID: "default-tenant",
-
 			},
 			expected: &ProwJobDefault{
 				ResultStoreConfig: &ResultStoreConfig{
@@ -131,9 +128,9 @@ func TestProwJobDefaulting(t *testing.T) {
 			},
 		},
 		{
-			name: "Nil provided, nil default",
+			name:     "Nil provided, nil default",
 			provided: nil,
-			def: nil,
+			def:      nil,
 			expected: nil,
 		},
 		{
@@ -222,11 +219,12 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 			name: "gcs configuration provided",
 			provided: &DecorationConfig{
 				GCSConfiguration: &GCSConfiguration{
-					Bucket:       "bucket-1",
-					PathPrefix:   "prefix-2",
-					PathStrategy: PathStrategyExplicit,
-					DefaultOrg:   "org2",
-					DefaultRepo:  "repo2",
+					Bucket:            "bucket-1",
+					PathPrefix:        "prefix-2",
+					PathStrategy:      PathStrategyExplicit,
+					DefaultOrg:        "org2",
+					DefaultRepo:       "repo2",
+					CompressFileTypes: []string{"txt", "json"},
 				},
 			},
 			expected: func(orig, def *DecorationConfig) *DecorationConfig {

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -243,6 +243,11 @@ func (in *GCSConfiguration) DeepCopyInto(out *GCSConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	if in.CompressFileTypes != nil {
+		in, out := &in.CompressFileTypes, &out.CompressFileTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -646,6 +646,13 @@ plank:
                 # * a S3 bucket: with s3:// prefix
                 # * a GCS bucket: without a prefix (deprecated, it's discouraged to use Bucket without prefix please add the gs:// prefix)
                 bucket: ' '
+                # CompressFileTypes specify file types that should be gzipped prior to upload.
+                # Matching files will be compressed prior to upload, and the content-encoding on these files will be set to gzip.
+                # GCS will transcode these gzipped files transparently when viewing. See: https://cloud.google.com/storage/docs/transcoding
+                # Example: "txt", "json"
+                # Use "*" for all
+                compress_file_types:
+                    - ""
                 # DefaultOrg is omitted from GCS paths when using the
                 # legacy or simple strategy
                 default_org: ' '
@@ -840,6 +847,13 @@ plank:
                 # * a S3 bucket: with s3:// prefix
                 # * a GCS bucket: without a prefix (deprecated, it's discouraged to use Bucket without prefix please add the gs:// prefix)
                 bucket: ' '
+                # CompressFileTypes specify file types that should be gzipped prior to upload.
+                # Matching files will be compressed prior to upload, and the content-encoding on these files will be set to gzip.
+                # GCS will transcode these gzipped files transparently when viewing. See: https://cloud.google.com/storage/docs/transcoding
+                # Example: "txt", "json"
+                # Use "*" for all
+                compress_file_types:
+                    - ""
                 # DefaultOrg is omitted from GCS paths when using the
                 # legacy or simple strategy
                 default_org: ' '

--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -73,7 +73,7 @@ func completeUpload(ctx context.Context, o Options, uploadTargets map[string]gcs
 	}
 
 	if o.LocalOutputDir == "" {
-		if err := gcs.Upload(ctx, o.Bucket, o.StorageClientOptions.GCSCredentialsFile, o.StorageClientOptions.S3CredentialsFile, uploadTargets); err != nil {
+		if err := gcs.Upload(ctx, o.Bucket, o.StorageClientOptions.GCSCredentialsFile, o.StorageClientOptions.S3CredentialsFile, o.CompressFileTypes, uploadTargets); err != nil {
 			return fmt.Errorf("failed to upload to blob storage: %w", err)
 		}
 		logrus.Info("Finished upload to blob storage")

--- a/prow/io/opener.go
+++ b/prow/io/opener.go
@@ -56,6 +56,8 @@ type storageClient interface {
 type (
 	ReadCloser  = io.ReadCloser
 	WriteCloser = io.WriteCloser
+	Writer      = io.Writer
+	Closer      = io.Closer
 )
 
 type Attributes struct {

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -198,17 +198,6 @@ func DataUploadWithOptions(newReader ReaderFunc, attrs pkgio.WriterOptions) Uplo
 			e = utilerrors.NewAggregate(errors)
 		}()
 
-		if writer.compressData() {
-			path := writer.fullUploadPath()
-			ext := filepath.Ext(path)
-			mediaType := mime.TypeByExtension(ext)
-			if mediaType == "" {
-				mediaType = "text/plain; charset=utf-8"
-			}
-			attrs.ContentType = &mediaType
-			ce := "gzip"
-			attrs.ContentEncoding = &ce
-		}
 		writer.ApplyWriterOptions(attrs)
 
 		reader, err := newReader()
@@ -290,6 +279,17 @@ func (w *openerObjectWriter) Close() error {
 }
 
 func (w *openerObjectWriter) ApplyWriterOptions(opts pkgio.WriterOptions) {
+	if w.compressData() {
+		path := w.fullUploadPath()
+		ext := filepath.Ext(path)
+		mediaType := mime.TypeByExtension(ext)
+		if mediaType == "" {
+			mediaType = "text/plain; charset=utf-8"
+		}
+		opts.ContentType = &mediaType
+		ce := "gzip"
+		opts.ContentEncoding = &ce
+	}
 	w.opts = append(w.opts, opts)
 }
 

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -200,7 +200,7 @@ func DataUploadWithOptions(newReader ReaderFunc, attrs pkgio.WriterOptions) Uplo
 
 		if writer.compressData() {
 			path := writer.fullUploadPath()
-			ext := strings.TrimPrefix(filepath.Ext(path), ".")
+			ext := filepath.Ext(path)
 			mediaType := mime.TypeByExtension(ext)
 			if mediaType == "" {
 				mediaType = "text/plain; charset=utf-8"


### PR DESCRIPTION
GCS allows [transcoding](https://cloud.google.com/storage/docs/transcoding) to occur when downloading files when the content-encoding is set to `gzip`. We can take advantage of this to save cloud storage space and cost. This adds a new option to the `DecorationConfig` called `compress_file_types`. When this option is set, we will compress files of the configured types and add the content-encoding prior to upload. I have tested this out and have seen file sizes as much as 7 times smaller than without compression. I have also confirmed that `gcsweb` maintains current functionality.