### PR TITLE
Fix the image bumper regex correctly

### DIFF
--- a/experiment/image-bumper/bumper/bumper.go
+++ b/experiment/image-bumper/bumper/bumper.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	imageRegexp = regexp.MustCompile(`\b((?:[a-z0-9]+\.)?gcr\.io|(?:[a-z0-9]+\-)?docker\.pkg\.dev)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_./-]+):([a-zA-Z0-9_.-]+)\b`)
+	imageRegexp = regexp.MustCompile(`\b((?:[a-z0-9]+\.)?gcr\.io|(?:[a-z0-9-]+)?docker\.pkg\.dev)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_./-]+):([a-zA-Z0-9_.-]+)\b`)
 	tagRegexp   = regexp.MustCompile(`(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?`)
 )
 

--- a/experiment/image-bumper/bumper/bumper_test.go
+++ b/experiment/image-bumper/bumper/bumper_test.go
@@ -330,11 +330,19 @@ func TestUpdateAllTags(t *testing.T) {
 			},
 		},
 		{
-			name:           "AR subdomains are supported",
+			name:           "AR multi-regional subdomains are supported",
 			content:        `{"images": ["us-docker.pkg.dev/k8s-testimages/some-image:v20190404-12345678"]}`,
 			expectedResult: `{"images": ["us-docker.pkg.dev/k8s-testimages/some-image:v20190405-123456789"]}`,
 			newTags: map[string]string{
 				"us-docker.pkg.dev/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+		},
+		{
+			name:           "AR regional subdomains are supported",
+			content:        `{"images": ["us-central1-docker.pkg.dev/k8s-testimages/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["us-central1-docker.pkg.dev/k8s-testimages/some-image:v20190405-123456789"]}`,
+			newTags: map[string]string{
+				"us-central1-docker.pkg.dev/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
 			},
 		},
 		{


### PR DESCRIPTION
When I made the change in https://github.com/kubernetes/test-infra/pull/29709, it only worked for multi-regional AR registries instead of regional registries. 

This now supports any AR region.

/cc @dims