### PR TITLE
feat: migrate pull-cluster-api-provider-openstack-conformance-test into community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -88,6 +88,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-e2e-test
   - name: pull-cluster-api-provider-openstack-conformance-test
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -126,6 +127,9 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9000Mi"
               # during the tests more like 3-20m is used
+              cpu: 2000m
+            limits:
+              memory: "9000Mi"
               cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack


### PR DESCRIPTION
Migrate pull-cluster-api-provider-openstack-conformance-test  job to community cluster.

Part of https://github.com/kubernetes/test-infra/issues/31791

@ameukam