### PR TITLE
feat: migrate pull-cluster-api-provider-openstack-e2e-full-test jo into community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -131,6 +131,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-conformance-test
   - name: pull-cluster-api-provider-openstack-e2e-full-test
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -173,6 +174,9 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9000Mi"
               # during the tests more like 3-20m is used
+              cpu: 2000m
+            limits:
+              memory: "9000Mi"
               cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack


### PR DESCRIPTION
Migratepull-cluster-api-provider-openstack-e2e-full-test  job to community cluster.

Part of https://github.com/kubernetes/test-infra/issues/31791

@ameukam