### PR TITLE
Set GOWORK=off when using 'go run' in k/k

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -54,6 +54,9 @@ presubmits:
     spec:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.20
+        env:
+        - name: "GOWORK"
+          value: "off"
         command:
         - go
         args:
@@ -156,6 +159,9 @@ presubmits:
     spec:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.20
+        env:
+        - name: "GOWORK"
+          value: "off"
         command:
         - go
         args:


### PR DESCRIPTION
We need to set `-mod=mod` because k/k does not include things like k8s.io/publishing-bot/cmd/validate-rules, but -mod=mod is incompatible with Go workspaces.  Just disable workspaces for these runs.

This should fix the CI failure in https://github.com/kubernetes/kubernetes/pull/123529

I am not sure how to test this, but a manual run works.

```
$ go run -mod=mod k8s.io/publishing-bot/cmd/validate-rules ~/src/kubernetes/staging/publishing/rules.yaml 
go: -mod may only be set to readonly or vendor when in workspace mode, but it is set to "mod"
	Remove the -mod flag to use the default readonly value, 
	or set GOWORK=off to disable workspace mode.

$ GOWORK=off go run -mod=mod k8s.io/publishing-bot/cmd/validate-rules ~/src/kubernetes/staging/publishing/rules.yaml 
go: finding module for package k8s.io/publishing-bot/cmd/validate-rules
go: downloading k8s.io/publishing-bot v0.0.0-20240212065329-68f0bcac4857
go: downloading github.com/golang/glog v1.2.0
I0226 20:21:22.354417 1670875 rules.go:109] loading rules file : /home/thockin/src/kubernetes/staging/publishing/rules.yaml
I0226 20:21:22.358860 1670875 rules.go:145] validating repository order
I0226 20:21:22.358892 1670875 rules.go:168] validating go versions
I0226 20:21:22.358943 1670875 validate.go:36] validating directories exist in the kubernetes branch
I0226 20:21:23.345551 1670875 main.go:49] validation successful
```