### PR TITLE
dra: test DRA with SchedulerQueueingHints enabled

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -98,6 +98,59 @@ periodics:
             cpu: 2
             memory: 9Gi
 
+  # This job runs the same tests as ci-node-e2e-crio-dra with some relevant feature gates (currently SchedulerQueueingHints) at non-default values.
+  - name: ci-node-e2e-crio-dra-features
+    cluster: k8s-infra-prow-build
+    interval: 6h
+    annotations:
+      testgrid-dashboards: sig-node-cri-o, sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-node-e2e-crio-dra-features
+      testgrid-alert-email: patrick.ohly@intel.com
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --deployment=node
+        - --env=KUBE_SSH_USER=core
+        - --gcp-zone=us-west1-b
+        - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true,SchedulerQueueingHints=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --node-tests=true
+        - --provider=gce
+        - --test_args=--focus="\[Feature:DynamicResourceAllocation\]" --skip="\[Flaky\]"
+        - --timeout=65m
+        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
+        - name: GOPATH
+          value: /go
+        resources:
+          limits:
+            cpu: 2
+            memory: 9Gi
+          requests:
+            cpu: 2
+            memory: 9Gi
+
   # This job runs the same tests as ci-node-e2e-crio-dra with Containerd 1.7 runtime
   - name: ci-node-e2e-containerd-1-7-dra
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
The scheduler plugin has special code to handle pod requeueing more intelligently. That code only gets exercised when the scheduler is configured to use queueing hints.

/assign @klueska 