### PR TITLE
Reduce nodes used for GPU tests

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
         # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
         - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
         - --gcp-node-image=gci
-        - --gcp-nodes=4
+        - --gcp-nodes=2
         - --gcp-project-type=gpu-project
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -42,6 +42,7 @@ periodics:
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
       - --gcp-node-image=gci
+      - --gcp-nodes=2
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -83,6 +84,7 @@ periodics:
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
       - --gcp-node-image=gci
+      - --gcp-nodes=2
       - --gcp-project=k8s-infra-e2e-gpu-project
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
Reduce the number of nodes used for the tests as discussed in https://kubernetes.slack.com/archives/CCK68P2Q2/p1708914356010229.

This also match the default quota for the GPU used for the tests. By default is 4 GPUs per region per project (instead of 16 as I thought).