### PR TITLE
Remove lingering prow config for non-Kubernetes repos

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1596,13 +1596,6 @@ plugins:
     - size    # Mark size of PRs
     - wip     # Mark draft PRs
 
-  GoogleCloudPlatform/k8s-cluster-bundle:
-    plugins:
-    - trigger
-    - lgtm
-    - size
-    - welcome
-
   kubernetes-sigs/secrets-store-csi-driver:
     plugins:
     - milestone

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -31,8 +31,6 @@ triggers:
   join_org_url: "https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md"
   trigger_github_workflows: true
 - repos:
-  - bazelbuild
-- repos:
   - kubernetes/utils
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
   trigger_github_workflows: true
@@ -1111,26 +1109,6 @@ cherry_pick_approved:
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
 plugins:
-  # Enable the following for any bazelbuild repo (rules_k8s, rules_docker) that sends prow webhooks
-  # Repos that do not send prow webhooks will see no effect.
-  bazelbuild:
-    plugins:
-    - approve  # Allow OWNERS to /approve
-    - assign  # Allow /assign and /cc
-    - blunderbuss  # Auto-assign people
-    - cat # /meow replies with cat pictures
-    - dog # /bark replies with dog pictures
-    - help  # Support /help and /good-first-issue
-    - hold  # Support /hold to delay merge
-    - lgtm  # Allow /lgtm
-    - lifecycle  # Allow /lifecycle stale
-    - override
-    - size  # Auto-label size of PR
-    - trigger  # Allow people to configure CI jobs to /test
-    - verify-owners # Validates OWNERS file changes in PRs.
-    - wip  # Auto-hold PRs with WIP in title
-    - yuks # Let prow tell a /joke
-
   google/cadvisor:
     plugins:
     - trigger

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -18,7 +18,6 @@ triggers:
   only_org_members: true
 - repos:
   - google/cadvisor
-  - GoogleCloudPlatform/k8s-multicluster-ingress
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
 - repos:
   - containerd/cri
@@ -1596,10 +1595,6 @@ plugins:
     - mergecommitblocker # Mark PRs with merge commits
     - size    # Mark size of PRs
     - wip     # Mark draft PRs
-
-  GoogleCloudPlatform/k8s-multicluster-ingress:
-    plugins:
-    - trigger
 
   GoogleCloudPlatform/k8s-cluster-bundle:
     plugins:

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -380,7 +380,6 @@ func TestConfig(t *testing.T) {
 // Tracking issue: https://github.com/kubernetes/test-infra/issues/18159
 var noPresubmitsInTestgridPrefixes = []string{
 	"containerd/cri",
-	"GoogleCloudPlatform/k8s-multicluster-ingress",
 	"kubernetes-sigs/cluster-capacity",
 	"kubernetes-sigs/gcp-filestore-csi-driver",
 	"kubernetes-sigs/kind",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/12863, https://github.com/GoogleCloudPlatform/k8s-cluster-bundle/issues/321

These repos are all either archived, not using prow, or in the case of k8s-cluster-bundle just not active but not archived.

There has been a lengthy warning period, and most repos were already done.

This leaves cAdvisor / containerd (which we depend on in K8s) and apisnoop (which is moving into the k8s org)