### PR TITLE
Fix failures in ci-kubernetes-e2e-gci-gce-alpha-enabled-default

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -883,7 +883,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast


### PR DESCRIPTION
this CI job is in a bad shape - https://testgrid.k8s.io/google-gce#gci-gce-alpha-enabled-default&width=20 (compare to https://testgrid.k8s.io/google-gce#gce-cos-master-alpha-features&width=20)

we have disabled `EventedPLEG` in https://github.com/kubernetes/test-infra/pull/31787 and https://github.com/kubernetes/test-infra/pull/31767 so let's do the same for this CI job as well.

/kind failing-test
/priority important-soon
/kind bug
