### PR TITLE
Add missing stage in gce-storage/gce-csi presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -45,6 +45,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-slow
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=120m
         securityContext:
@@ -100,6 +101,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --provider=gce
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-snapshot
         - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=150m
         securityContext:
@@ -159,6 +161,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --provider=gce
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=150m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master


### PR DESCRIPTION
found in https://github.com/kubernetes/kubernetes/pull/123529

see example failed log:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/123529/pull-kubernetes-e2e-gce-csi-serial/1762731324134658048/build-log.txt

```
2024/02/28 07:05:21 process.go:155: Step 'make -C /home/prow/go/src/k8s.io/kubernetes quick-release' finished in 15m29.05255974s
2024/02/28 07:05:21 util.go:263: Flushing memory.
2024/02/28 07:05:27 process.go:96: Saved XML output to /logs/artifacts/junit_runner.xml.
2024/02/28 07:05:27 process.go:153: Running: bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"
2024/02/28 07:05:29 process.go:155: Step 'bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"' finished in 1.471509865s
2024/02/28 07:05:29 main.go:324: Something went wrong: failed to acquire k8s binaries: open /home/prow/go/src/k8s.io/kubernetes/_output/gcs-stage: no such file or directory
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_e2e.py", line 391, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_e2e.py", line 307, in main
    mode.start(runner_args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 136, in start
    check_env(env, self.command, *args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 57, in check_env
    subprocess.check_call(cmd, env=env)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('kubetest', '--dump=/logs/artifacts', '--gcp-service-account=/etc/service-account/service-account.json', '--build=quick', '--up', '--down', '--test', '--provider=gce', '--cluster=e2e-22e9fdf1b3-930d0', '--gcp-network=e2e-22e9fdf1b3-930d0', '--extract=local', '--gcp-node-image=gci', '--gcp-zone=us-west1-b', '--test_args=--ginkgo.focus=CSI.*(\\[Serial\\]|\\[Disruptive\\]) --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|\\[Slow\\] --minStartupPods=8', '--timeout=150m')' returned non-zero exit status 1.
```