### PR TITLE
containerd: add slow_chown to enable userns idmap testing

### DIFF
--- a/jobs/e2e_node/containerd/config-systemd.toml
+++ b/jobs/e2e_node/containerd/config-systemd.toml
@@ -11,6 +11,13 @@ oom_score = -999
 [debug]
   level = "debug"
 
+# Set `slow_chown` so jobs that rely on user namespaces don't fail with
+# 'failed to create containerd container: snapshotter "overlayfs" doesn't support
+# idmap mounts on this host, configure `slow_chown` to allow a slower and expensive fallback'
+# when the kernel is too old to support idmaps.
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+  slow_chown = true
+
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
@@ -36,5 +43,3 @@ oom_score = -999
 # See: https://github.com/kubernetes/k8s.io/issues/3411
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
   endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]
-
-

--- a/jobs/e2e_node/containerd/config-v2.toml
+++ b/jobs/e2e_node/containerd/config-v2.toml
@@ -7,6 +7,13 @@ oom_score = -999
 [debug]
   level = "debug"
 
+# Set `slow_chown` so jobs that rely on user namespaces don't fail with
+# 'failed to create containerd container: snapshotter "overlayfs" doesn't support
+# idmap mounts on this host, configure `slow_chown` to allow a slower and expensive fallback'
+# when the kernel is too old to support idmaps.
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+  slow_chown = true
+
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
@@ -24,4 +31,3 @@ oom_score = -999
 # Runtime handler used for runtime class test.
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
   runtime_type = "io.containerd.runc.v2"
-

--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -7,6 +7,13 @@ oom_score = -999
 [debug]
   level = "debug"
 
+# Set `slow_chown` so jobs that rely on user namespaces don't fail with
+# 'failed to create containerd container: snapshotter "overlayfs" doesn't support
+# idmap mounts on this host, configure `slow_chown` to allow a slower and expensive fallback'
+# when the kernel is too old to support idmaps.
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+  slow_chown = true
+
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144


### PR DESCRIPTION
needed for https://github.com/kubernetes/kubernetes/pull/123303