### PR TITLE
Enable ValidatingAdmissionPolicy feature for ci-kubernetes-e2e-gci-gce-alpha-enabled-default job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -883,7 +883,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false,ValidatingAdmissionPolicy=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast


### PR DESCRIPTION
Similar to https://github.com/kubernetes/test-infra/pull/32095

we have the tests running in https://testgrid.k8s.io/google-gce#gci-gce-alpha-enabled-default&width=20 but the feature gate defaults to false:
https://cs.k8s.io/?q=ValidatingAdmissionPolicy&i=nope&files=.*feature.*&excludeFiles=&repos=kubernetes/kubernetes