### PR TITLE
bump memory limits for crio serial jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -142,10 +142,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 6Gi
+          memory: 12Gi
         requests:
           cpu: 4
-          memory: 6Gi
+          memory: 12Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: node-kubelet-serial-crio

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1332,10 +1332,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 4
-            memory: 6Gi
+            memory: 12Gi
         env:
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"
@@ -1382,10 +1382,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 4
-            memory: 6Gi
+            memory: 12Gi
         env:
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"


### PR DESCRIPTION
Hoping to fix https://github.com/kubernetes/kubernetes/issues/123589

Saw in the logs that we hit a OOM error so want to try bumping the memory of the job.