### PR TITLE
Add preset-service-account to pull-containerd-k8s-e2e-ec2

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -188,6 +188,7 @@ presubmits:
       testgrid-dashboards: presubmits-ec2
       description: Runs presubmit tests using kubetest2-ec2 against kubernetes master on EC2 using containerd master
     labels:
+      preset-service-account: "true"
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
     always_run: false


### PR DESCRIPTION
Add missing creds!

```
+ /home/prow/go/src/github.com/containerd/containerd/test/../test/push.sh
Copying file:///tmp/tmp.FWYL3vXEM6/containerd-cni-2.0.0-beta.2-222-g6d01762c2.linux-amd64.tar.gz [Content-Type=application/x-tar]...
/ [0 files][    0.0 B/148.1 MiB]                                                
ResumableUploadAbortException: 401 Anonymous caller does not have storage.objects.create access to the Google Cloud Storage object. Permission 'storage.objects.create' denied on resource (or it may not exist).
+ cleanup
```