### PR TITLE
Suspend Prow auto deployment for March 1

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -578,7 +578,9 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
-- cron: "30 18-23/5 * * 1-5"  # Bump with label `skip-review`. Run at 10:30 and 15:30 PST (18:05 UTC, fall) Mon-Fri
+# Temporarily block auto deployment for Friday, March 1 (on-call unavailable); revert after.
+#- cron: "30 18-23/5 * * 1-5"  # Bump with label `skip-review`. Run at 10:30 and 15:30 PST (18:05 UTC, fall) Mon-Fri
+- cron: "30 18-23/5 * * 1-4"  # Bump with label `skip-review`. Run at 10:30 and 15:30 PST (18:05 UTC, fall) Mon-Thu
   # Save for daylight saving:
   # cron: "30 17-22/5 * * 1-5"  # Bump with label `skip-review`. Run at 10:30 and 15:30 PST (17:05 UTC, spring) Mon-Fri
   name: ci-test-infra-autobump-prow-for-auto-deploy


### PR DESCRIPTION
On-call will be unavailable this day, and should resume Monday, March 4. This should be reverted next week.