### PR TITLE
sig-autoscaling: add azure presubmit e2e

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/OWNERS
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- jackfrancis
+- gandhipr
+- tallaxes
+approvers:
+- jackfrancis
+- gandhipr
+- tallaxes

--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -1,0 +1,40 @@
+presubmits:
+  kubernetes/autoscaler:
+  - name: pull-cluster-autoscaler-e2e-azure
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cloudprovider-azure
+    always_run: false
+    optional: true
+    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: k8s.io/autoscaler
+    extra_refs:
+    - org: jackfrancis # change to kubernetes-sigs when fully baked
+      repo: cluster-api-provider-azure
+      base_ref: cluster-autoscaler-e2e # change to latest release branch when fully baked
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.27
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-e2e.sh
+        env:
+          - name: GINKGO_FOCUS
+            value: \[SIG AUTOSCALING\]
+          - name: GINKGO_SKIP
+            value: ""
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -481,6 +481,7 @@ func TestTrustedJobSecretsRestricted(t *testing.T) {
 		"kubernetes/sig-network":                               {secrets: getSecretsFromPreset(labels{"preset-azure-cred": "true"}), allowedInPresubmit: true},
 		"kubernetes/sig-release":                               {secrets: getSecretsFromPreset(labels{"preset-azure-cred": "true"}), allowedInPresubmit: true},
 		"kubernetes-sigs/cluster-api-provider-azure":           {secrets: getSecretsFromPreset(labels{"preset-azure-cred-only": "true"}), allowedInPresubmit: true},
+		"kubernetes/sig-autoscaling":                           {secrets: getSecretsFromPreset(labels{"preset-azure-cred-only": "true"}), allowedInPresubmit: true},
 	}
 	allSecrets := sets.Set[string]{}
 	for _, s := range secretsRestricted {


### PR DESCRIPTION
This PR adds a new Azure E2E test using a CAPZ branch currently under development to cover cluster-autoscaler Azure scenarios on Azure infra.

Inherited cluster-autoscaler/cloudprovider/azure OWNERS for maintaining these tests.