### PR TITLE
[pull-containerd-k8s-e2e-ec2] Fix typo - missing $ sign in variable

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -222,7 +222,8 @@ presubmits:
             - |
               ./test/build.sh
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-              export CONTAINERD_PULL_REFS=PULL_REFS
+              export CONTAINERD_PULL_REFS=$PULL_REFS
+              echo "CONTAINERD_PULL_REFS: $CONTAINERD_PULL_REFS"
               kubetest2 ec2 \
                --build \
                --region us-east-1 \


### PR DESCRIPTION
Typo! forgot to add `$` before `PULL_REFS`