### PR TITLE
Trigger pull-containerd-k8s-e2e-ec2 if files in directory named cri or cri-api are touched

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -192,6 +192,7 @@ presubmits:
       preset-service-account: "true"
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
+    run_if_changed: '(pkg|plugins|internal|integration|vendor|third_party).*\/(cri|cri-api)\/'
     always_run: false
     optional: true
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
In containerd/containerd repository, for both release/1.7 and main branch, if any CRI related files are touched then we should trigger the new CI job. The new CI job runs a sanity check set of tests to make sure the containerd PR works fine with kubernetes master.