### PR TITLE
Change CI Image for Kueue

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -223,7 +223,7 @@ presubmits:
       description: "Run kueue verify checks"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
         - make
         args:


### PR DESCRIPTION
In https://github.com/kubernetes-sigs/kueue/pull/1552, We're using docker container to run shell check and verify all shell scripts in the [repository](https://github.com/kubernetes-sigs/kueue/), The test suite doesn't have docker and causing a [test](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/1552/pull-kueue-verify-main/1764644857353080832) to fail. That's why we're changing the CI image.

I updated the image for pull-kueue-verify-main with kubekins-e2e for the very same reason.