### PR TITLE
Update to newer COS image versions for m109

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -40,7 +40,7 @@ periodics:
       - --extract-ci-bucket=k8s-release-dev
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
+      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-nodes=2
       - --gcp-project-type=gpu-project
@@ -82,7 +82,7 @@ periodics:
       - --extract-ci-bucket=k8s-release-dev
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
+      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-nodes=2
       - --gcp-project=k8s-infra-e2e-gpu-project

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -484,7 +484,7 @@ periodics:
       - --extract=ci/latest
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
-      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
+      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -58,7 +58,7 @@ periodics:
       - --extract=ci/latest-1.29
       - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_NODE_OS_DISTRIBUTION=gci
-      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
+      - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -1069,7 +1069,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --env=KUBE_NODE_OS_DISTRIBUTION=gci
-        - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-0-47
+        - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
         - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
         - --gcp-node-image=gci
         - --gcp-nodes=4


### PR DESCRIPTION
Trying to get to the bottom of GPU related jobs failing. Let's switch to the latest image here:
https://cloud.google.com/container-optimized-os/docs/release-notes/m109

and update the cos-gpu-installer to v2.1.10 as well in a k/k PR:
https://github.com/kubernetes/kubernetes/blame/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml

Notes: the last good run had the following in [serial.log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-device-plugin-gpu/1762440034587250688/artifacts/bootstrap-e2e-minion-group-s8pp/serial-1.log)
```
[  419.323527] NVRM: loading NVIDIA UNIX x86_64 Kernel Module  470.199.02  Thu May 11 11:46:56 UTC 2023
```

and the first bad run had the following in [serial.log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-device-plugin-gpu/1762681629983117312/artifacts/bootstrap-e2e-minion-group-7ssd/serial-1.log)
```
[  154.700833] NVRM: loading NVIDIA UNIX Open Kernel Module for x86_64  535.104.05  Release Build  (builder@44844b2c0d8f)  Sat Sep 30 14:39:35 UTC 2023
```
So clearly underneath things have changed and we should move to newer things instead of trying to keep the older image in these jobs.

