### PR TITLE
copy pasta in ci-kubernetes-e2e-ec2-alpha-enabled-default job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -45,7 +45,6 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-             --focus-regex="\[Slow\]" \
              --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0" \
              --parallel=25
         env:


### PR DESCRIPTION
Needs to exactly match `ci-kubernetes-e2e-gci-gce-alpha-enabled-default` which does not have a `focus`:
https://github.com/kubernetes/test-infra/blob/3e7a7587ef785ae493b3e99bec5329dbf0dc4548/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L885-L897