### PR TITLE
Fix typo in e2e-kops-aws-selinux skips

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -881,7 +881,7 @@ def generate_misc():
                    #   that multiply nr. of tests.
                    # - FeatureGate:SELinuxMount: the feature gate is alpha / disabled by default
                    #   in v1.30.
-                   skip_regex=r"\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.local\]|\FeatureGate:SELinuxMount\]", # pylint: disable=line-too-long
+                   skip_regex=r"\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.local\]|\[FeatureGate:SELinuxMount\]", # pylint: disable=line-too-long
                    # [Serial] and [Disruptive] are intentionally not skipped, therefore run
                    # everything as serial.
                    test_parallelism=1,

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2120,7 +2120,7 @@ periodics:
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --focus-regex="\[Feature:SELinux\]" \
-          --skip-regex="\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.local\]|\FeatureGate:SELinuxMount\]" \
+          --skip-regex="\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.local\]|\[FeatureGate:SELinuxMount\]" \
           --parallel=1
       env:
       - name: KUBE_SSH_KEY_PATH


### PR DESCRIPTION
Add missing `[` to skip_regex. The job fails with `\F`: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-selinux/1764223757959827456