### PR TITLE
Revert "change ci image for kueue"

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -223,7 +223,7 @@ presubmits:
       description: "Run kueue verify checks"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - make
         args:


### PR DESCRIPTION
This reverts commit 59a52e1748fb4363a18ad5b659cb800d999f80ca #32136, because it causes golangci-lint to crash