### PR TITLE
add cgroupv2 crio performance test

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -347,6 +347,58 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-eviction
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
+- name: ci-node-kubelet-crio-cgroupv2-performance-test
+  cluster: k8s-infra-prow-build
+  interval: 12h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
+      command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --deployment=node
+      - --env=KUBE_SSH_USER=core
+      - --gcp-zone=us-west1-b
+      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --node-tests=true
+      - --provider=gce
+      - --test_args=--nodes=1 --focus="Node Performance Testing"
+      - --timeout=60m
+      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2-performance.yaml
+      env:
+      - name: GOPATH
+        value: /go
+      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+        value: "1"
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: node-kubelet-crio-cgroupv2-performance-test
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
 - name: ci-crio-cgroupv2-node-e2e-conformance
   cluster: k8s-infra-prow-build
   interval: 1h

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-performance.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-performance.yaml
@@ -1,0 +1,6 @@
+images:
+  fedora:
+    image_family: fedora-coreos-stable
+    project: fedora-coreos-cloud
+    machine: n1-standard-16
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2.ign"


### PR DESCRIPTION
Containerd has a corresponding performance test. 

https://testgrid.k8s.io/sig-node-containerd#node-kubelet-containerd-performance-test

Aiming to have a similar one for CRIO.

Use n1-standard-16 and cgroupv2. Cgroupv2 was chosen because it is our default in the future.