### PR TITLE
move some of the non-e2e kubernetes presubmits to EKS prow build cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1420,7 +1420,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.26
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration
     decorate: true
     labels:
@@ -1450,7 +1450,7 @@ presubmits:
       description: run with GO_VERSION set to the original go version used for this branch
     branches:
     - release-1.26
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration-go-compatibility
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -939,7 +939,7 @@ presubmits:
       testgrid-create-test-group: "true"
     branches:
     - release-1.26
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-verify-govet-levee
     decorate: true
     labels:
@@ -1717,7 +1717,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.26
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-verify
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -1653,7 +1653,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.26
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-typecheck
     decorate: true
     name: pull-kubernetes-typecheck

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -1375,7 +1375,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.27
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration
     decorate: true
     labels:
@@ -1403,7 +1403,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.27
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration-go-compatibility
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -1614,7 +1614,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.27
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-typecheck
     decorate: true
     name: pull-kubernetes-typecheck

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -1678,7 +1678,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.27
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-verify
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1602,7 +1602,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.28
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration
     decorate: true
     labels:
@@ -1630,7 +1630,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.28
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration-go-compatibility
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1841,7 +1841,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.28
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-typecheck
     decorate: true
     name: pull-kubernetes-typecheck

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1905,7 +1905,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.28
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-verify
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -2086,7 +2086,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.29
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-verify
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1783,7 +1783,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.29
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration
     decorate: true
     labels:
@@ -1811,7 +1811,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.29
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-integration-go-compatibility
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -2022,7 +2022,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.29
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     context: pull-kubernetes-typecheck
     decorate: true
     name: pull-kubernetes-typecheck

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-typecheck
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     path_alias: "k8s.io/kubernetes"
     decorate: true
     always_run: true

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-verify
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     skip_branches:
@@ -122,7 +122,7 @@ presubmits:
             cpu: 5
             memory: 12Gi
   - name: pull-kubernetes-verify-go-canary
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     always_run: false
     skip_report: false
     decorate: true


### PR DESCRIPTION
We've been using this cluster for critical jobs for a while now and we're over capacity on the GKE k8s infra cluster.

We probably need to scale up the GKE cluster, but we also should be prioritizing running GCE e2e workloads there as for the immediate future those are still much more challenging to replace in a cost effective way with workloads on other clusters than e.g. unit tests, linters ...

verify in particular is one of the jobs currently frequently failing because the large CPU request cannot be serviced