### PR TITLE
feat: migrate pull-kubernetes-node-arm64-ubuntu-serial-gce-1.29 into community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1336,6 +1336,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.29
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-node-arm64-ubuntu-serial-gce
     decorate: true
     decoration_config:


### PR DESCRIPTION
Migrate pull-kubernetes-node-arm64-ubuntu-serial-gce-1.29 job to community cluster.
(Resources are the same of already running jobs)

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam