### PR TITLE
fix pull-kubernetes-e2e-gce-storage-slow job failures

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -46,6 +46,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-slow
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=120m
         securityContext:


### PR DESCRIPTION
the pull-kubernetes-e2e-gce-storage-slow job is failing since https://github.com/kubernetes/test-infra/pull/31977 is merged.

success: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/122489/pull-kubernetes-e2e-gce-storage-slow/1752157392843313152/build-log.txt

```
+ /workspace/scenarios/kubernetes_e2e.py --build=quick --cluster= --extract=local --gcp-node-image=gci --gcp-zone=us-west1-b --ginkgo-parallel=30 --provider=gce --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-slow '--test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8' --timeout=120m
starts with local mode
```

failure: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/122489/pull-kubernetes-e2e-gce-storage-slow/1764838050136854528/build-log.txt

```
+ /workspace/scenarios/kubernetes_e2e.py --build=quick --cluster= --extract=local --gcp-node-image=gci --gcp-zone=us-west1-b --ginkgo-parallel=30 --provider=gce '--test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8' --timeout=120m
starts with local mode

2024/03/05 02:35:34 main.go:324: Something went wrong: failed to acquire k8s binaries: open /home/prow/go/src/k8s.io/kubernetes/_output/gcs-stage: no such file or directory
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_e2e.py", line 391, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_e2e.py", line 307, in main
    mode.start(runner_args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 136, in start
    check_env(env, self.command, *args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 57, in check_env
    subprocess.check_call(cmd, env=env)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('kubetest', '--dump=/logs/artifacts', '--gcp-service-account=/etc/service-account/service-account.json', '--build=quick', '--up', '--down', '--test', '--provider=gce', '--cluster=e2e-55e9d145be-390e9', '--gcp-network=e2e-55e9d145be-390e9', '--extract=local', '--gcp-node-image=gci', '--gcp-zone=us-west1-b', '--ginkgo-parallel=30', '--test_args=--ginkgo.focus=\\[sig-storage\\].*\\[Slow\\] --ginkgo.skip=\\[Driver:.gcepd\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8', '--timeout=120m')' returned non-zero exit status 1.
```
/cc @alessandrocapanna @ameukam @pohly @xing-yang @jsafrane 