### PR TITLE
capz: remove non-working prowjob-default-sa

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -506,7 +506,6 @@ presubmits:
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.27
         command:


### PR DESCRIPTION
We have an equivalent test against our v1beta1 release branch:

- https://github.com/kubernetes/test-infra/blob/ee10f4bf31fbfcc920480279e079299021f48925/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml#L288-L314

The above test configuration does not use the `prowjob-default-sa` serviceAccountName, and digging around it doesn't seem like this prow ServiceAccount is widely adopted (and it is dubious whether it was ever needed for this particular job given that this job simply runs validation code in a container).

Our v1beta1 test is running successfully, as recently as yesterday:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4615