### PR TITLE
feat: migrate pull-kubernetes-node-arm64-ubuntu-serial-gce-1,28 into community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -1160,6 +1160,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.28
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-node-arm64-ubuntu-serial-gce
     decorate: true
     decoration_config:


### PR DESCRIPTION
Migrate pull-kubernetes-node-arm64-ubuntu-serial-gce-1.28 job to community cluster.
(Resources are the same of already running jobs)

This is the last remaining job of the "pull-kubernetes-node-arm64-ubuntu-serial-gce" so after the merge you can mark all the respective jobs as done.

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam