### PR TITLE
scheduler: handle scheduling everywhere

### DIFF
--- a/prow/cmd/deck/rerun.go
+++ b/prow/cmd/deck/rerun.go
@@ -260,6 +260,7 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 			}
 			return
 		}
+		enableScheduling := cfg().Scheduler.Enabled
 		var newPJ prowapi.ProwJob
 		if mode == LATEST {
 			prowJobSpec, labels, annotations, err := getProwJobSpec(pj.Spec.Type, cfg, pj.Spec.Job, pj.Spec.Refs, pj.Labels)
@@ -289,9 +290,9 @@ func handleRerun(cfg config.Getter, prowJobClient prowv1.ProwJobInterface, creat
 				}
 			}
 
-			newPJ = pjutil.NewProwJob(*prowJobSpec, labels, annotations)
+			newPJ = pjutil.NewProwJob(*prowJobSpec, labels, annotations, pjutil.RequireScheduling(enableScheduling))
 		} else {
-			newPJ = pjutil.NewProwJob(pj.Spec, pj.ObjectMeta.Labels, pj.ObjectMeta.Annotations)
+			newPJ = pjutil.NewProwJob(pj.Spec, pj.ObjectMeta.Labels, pj.ObjectMeta.Annotations, pjutil.RequireScheduling(enableScheduling))
 		}
 		l = l.WithField("job", newPJ.Spec.Job)
 		switch r.Method {

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -202,7 +202,8 @@ func sync(prowJobClient ctrlruntimeclient.Client, cfg *config.Config, cr cronCli
 			}).Debug("Trigger time has not yet been reached.")
 		}
 		if !previousFound || shouldTrigger {
-			prowJob := pjutil.NewProwJob(pjutil.PeriodicSpec(p), p.Labels, p.Annotations)
+			prowJob := pjutil.NewProwJob(pjutil.PeriodicSpec(p), p.Labels, p.Annotations,
+				pjutil.RequireScheduling(cfg.Scheduler.Enabled))
 			prowJob.Namespace = cfg.ProwJobNamespace
 			logger.WithFields(logrus.Fields{
 				"should-trigger": shouldTrigger,

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -257,7 +257,7 @@ func main() {
 			logrus.WithError(err).Fatal("Failed to default base ref")
 		}
 	}
-	pj := pjutil.NewProwJob(pjs, job.Labels, job.Annotations)
+	pj := pjutil.NewProwJob(pjs, job.Labels, job.Annotations, pjutil.RequireScheduling(conf.Scheduler.Enabled))
 	if !o.triggerJob {
 		b, err := yaml.Marshal(&pj)
 		if err != nil {

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -776,10 +776,13 @@ func (c *Controller) triggerJobs(logger logrus.FieldLogger, instance string, cha
 		}
 	}
 
+	schedulerEnabled := c.config().Scheduler.Enabled
+
 	for _, jSpec := range jobSpecs {
 		labels, annotations := LabelsAndAnnotations(instance, jSpec.labels, jSpec.annotations, change)
 
-		pj := pjutil.NewProwJob(jSpec.spec, labels, annotations)
+		pj := pjutil.NewProwJob(jSpec.spec, labels, annotations, pjutil.RequireScheduling(schedulerEnabled))
+
 		logger := logger.WithField("prowjob", pj.Name)
 		timeBeforeCreate := time.Now()
 		if _, err := c.prowJobClient.Create(context.TODO(), &pj, metav1.CreateOptions{}); err != nil {

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -166,7 +166,8 @@ func (s *Subscriber) handleMessage(msg messageInterface, subscription string, al
 	var allowedApiClient *config.AllowedApiClient = nil
 	var requireTenantID bool = false
 
-	if _, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigGetter, allowedApiClient, requireTenantID, allowedClusters); err != nil {
+	cfgAdapter := gangway.ProwCfgAdapter{Config: s.ConfigAgent.Config()}
+	if _, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, &cfgAdapter, s.InRepoConfigGetter, allowedApiClient, requireTenantID, allowedClusters); err != nil {
 		l.WithError(err).Info("failed to create Prow Job")
 		s.Metrics.ErrorCounter.With(prometheus.Labels{
 			subscriptionLabel: subscription,

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -599,7 +599,8 @@ func TestHandlePeriodicJob(t *testing.T) {
 				t1.Error("programmer error: could not convert ProwJobEvent to CreateJobExecutionRequest")
 			}
 
-			_, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, s.ConfigAgent.Config(), s.InRepoConfigGetter, nil, false, tc.allowedClusters)
+			cfgAdapter := gangway.ProwCfgAdapter{Config: s.ConfigAgent.Config()}
+			_, err = gangway.HandleProwJob(l, s.getReporterFunc(l), cjer, s.ProwJobClient, &cfgAdapter, s.InRepoConfigGetter, nil, false, tc.allowedClusters)
 			if err != nil {
 				if err.Error() != tc.err {
 					t1.Errorf("Expected error '%v' got '%v'", tc.err, err.Error())

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1359,6 +1359,7 @@ func (c *syncController) trigger(sp subpool, presubmits []config.Presubmit, prs 
 	// If multiple required jobs have the same context, we assume the
 	// same shard will be run to provide those contexts
 	triggeredContexts := sets.New[string]()
+	enableScheduling := c.config().Scheduler.Enabled
 	for _, ps := range presubmits {
 		if triggeredContexts.Has(string(ps.Context)) {
 			continue
@@ -1374,7 +1375,7 @@ func (c *syncController) trigger(sp subpool, presubmits []config.Presubmit, prs 
 			spec = pjutil.BatchSpec(ps, refs)
 		}
 		labels, annotations := c.provider.labelsAndAnnotations(sp.org, ps.Labels, ps.Annotations, prs...)
-		pj := pjutil.NewProwJob(spec, labels, annotations)
+		pj := pjutil.NewProwJob(spec, labels, annotations, pjutil.RequireScheduling(enableScheduling))
 		pj.Namespace = c.config().ProwJobNamespace
 		log := c.logger.WithFields(pjutil.ProwJobFields(&pj))
 		start := time.Now()


### PR DESCRIPTION
Follow #32085 up. 
Enable scheduling in the following components:
- deck
- horologium
- gangway
- gerrit
- tide
- pubsub
- mkpj

Even if I changed a lot of files the diff is always the same:
```diff
- pjutil.NewProwJob(*prowJobSpec, labels, annotations)
+ pjutil.NewProwJob(*prowJobSpec, labels, annotations, pjutil.RequireScheduling(config.Scheduler.Enabled))
``` 