### PR TITLE
ensure memory requests/limits are reasonable

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-4.yaml
@@ -92,10 +92,10 @@ presubmits:
         resources:
           requests:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
           limits:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
   - name: pull-kueue-test-e2e-release-0-4-1-25
     cluster: eks-prow-build-cluster
     branches:
@@ -130,10 +130,10 @@ presubmits:
         resources:
           requests:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
           limits:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
   - name: pull-kueue-test-e2e-release-0-4-1-26
     cluster: eks-prow-build-cluster
     branches:
@@ -168,10 +168,10 @@ presubmits:
         resources:
           requests:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
           limits:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
   - name: pull-kueue-test-e2e-release-0-4-1-27
     cluster: eks-prow-build-cluster
     branches:
@@ -206,10 +206,10 @@ presubmits:
         resources:
           requests:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
           limits:
             cpu: "10"
-            memory: "40Gi"
+            memory: "24Gi"
   - name: pull-kueue-verify-release-0-4
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -20,10 +20,10 @@ presubmits:
         - "version-dist"
         resources:
           requests:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
           limits:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
@@ -48,10 +48,10 @@ presubmits:
         - "test"
         resources:
           requests:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
           limits:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
@@ -343,10 +343,10 @@ presubmits:
         - "govet"
         resources:
           requests:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
           limits:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
@@ -372,10 +372,10 @@ presubmits:
         - "verify-golangci-lint"
         resources:
           requests:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
           limits:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
@@ -400,10 +400,10 @@ presubmits:
         - "verify-hashes"
         resources:
           requests:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
           limits:
-            memory: "64Gi"
+            memory: "24Gi"
             cpu: 8
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -61,10 +61,10 @@ postsubmits:
           # request most of one node 🚀
           requests:
             cpu: 7
-            memory: "40Gi"
+            memory: 30Gi
           limits:
             cpu: 7
-            memory: "40Gi"
+            memory: 30Gi
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -259,10 +259,10 @@ periodics:
         # request most of one node 🚀
         requests:
           cpu: 7
-          memory: "40Gi"
+          memory: 30Gi
         limits:
           cpu: 7
-          memory: "40Gi"
+          memory: 30Gi
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -109,10 +109,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: 32Gi
+          memory: 24Gi
         limits:
           cpu: 6
-          memory: 32Gi
+          memory: 24Gi
 
 - name: ci-test-infra-autobump-prowjobs
   cron: "06 14-23 * * 1-5"  # Run every hour at 7:06 - 16:06 PDT (in UTC) Mon-Fri

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -24,10 +24,10 @@ presubmits:
         resources:
           limits:
             cpu: 7300m
-            memory: "41Gi"
+            memory: "16Gi"
           requests:
             cpu: 7300m
-            memory: "41Gi"
+            memory: "16Gi"
     annotations:
       testgrid-create-test-group: 'true'
 
@@ -62,10 +62,10 @@ periodics:
       resources:
         limits:
           cpu: "7"
-          memory: "34Gi"
+          memory: "30Gi"
         requests:
           cpu: "7"
-          memory: "34Gi"
+          memory: "30Gi"
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -165,10 +165,10 @@ periodics:
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
       securityContext:
         privileged: true
 - annotations:
@@ -391,11 +391,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
         requests:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
 - annotations:
     fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
@@ -1616,11 +1616,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
   - always_run: true
     annotations:
       description: run with GO_VERSION set to the original go version used for this branch
@@ -1645,11 +1645,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
   - always_run: true
     branches:
     - release-1.26
@@ -1672,10 +1672,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
   - always_run: false
     branches:
     - release-1.26

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -170,10 +170,10 @@ periodics:
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
       securityContext:
         privileged: true
 - annotations:
@@ -397,11 +397,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
         requests:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -1569,11 +1569,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -1601,11 +1601,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -1633,10 +1633,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
   - always_run: false
     branches:
     - release-1.27

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -170,10 +170,10 @@ periodics:
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
       securityContext:
         privileged: true
 - annotations:
@@ -397,11 +397,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
         requests:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -1796,11 +1796,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -1828,11 +1828,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -1860,10 +1860,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
   - always_run: false
     branches:
     - release-1.28

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -170,10 +170,10 @@ periodics:
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 30Gi
       securityContext:
         privileged: true
 - annotations:
@@ -397,11 +397,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
         requests:
-          cpu: "4"
-          memory: 36Gi
+          cpu: "7"
+          memory: 30Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -1977,11 +1977,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -2009,11 +2009,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
           requests:
-            cpu: "4"
-            memory: 36Gi
+            cpu: "7"
+            memory: 30Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -2041,10 +2041,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 16Gi
   - always_run: false
     branches:
     - release-1.29

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -125,7 +125,7 @@ periodics:
       resources:
         requests:
           cpu: "10"
-          memory: "48Gi"
+          memory: 30Gi
         limits:
           cpu: "10"
-          memory: "48Gi"
+          memory: 30Gi

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -1,7 +1,7 @@
 periodics:
 # This is a sig-release-master-blocking job.
 # The frequency was cut to reduce infrastructure costs.
-- cron: '1 17 2-31/2 * *' # Run on even days at 9:01PST (17:01 UTC)
+- cron: '1 05 2-31/2 * *' # Run on odd days at 21:01PST (05:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-correctness
   cluster: k8s-infra-prow-build
   labels:
@@ -22,7 +22,7 @@ periodics:
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -51,14 +51,14 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "39Gi"
+          memory: "16Gi"
         limits:
           cpu: 6
-          memory: "39Gi"
+          memory: "16Gi"
 
 # This is a sig-release-master-blocking job.
 # The frequency was cut to reduce infrastructure costs.
-- cron: '1 17 1-31/2 * *' # Run on odd days at 9:01PST (17:01 UTC)
+- cron: '1 05 1-31/2 * *' # Run on even days at 21:01PST (05:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
@@ -90,7 +90,7 @@ periodics:
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -189,7 +189,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -31,10 +31,10 @@ presubmits:
           resources:
             limits:
               cpu: 4
-              memory: "36Gi"
+              memory: "16Gi"
             requests:
               cpu: 4
-              memory: "36Gi"
+              memory: "16Gi"
   - name: pull-kubernetes-unit-go-compatibility
     annotations:
       fork-per-release: "true"
@@ -69,11 +69,11 @@ presubmits:
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
             requests:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
   - name: pull-kubernetes-unit-experimental
     # try clonerefs with preclone
     decoration_config:
@@ -106,11 +106,11 @@ presubmits:
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
             requests:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
   - name: pull-kubernetes-unit-go-canary
     annotations:
       testgrid-num-failures-to-alert: '10'
@@ -141,11 +141,11 @@ presubmits:
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
             requests:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
 periodics:
   - interval: 1h
     name: ci-kubernetes-unit
@@ -181,8 +181,8 @@ periodics:
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"
             requests:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7
+              memory: "16Gi"

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -23,10 +23,10 @@ presubmits:
         resources:
           limits:
             cpu: 5
-            memory: 32Gi
+            memory: 16Gi
           requests:
             cpu: 5
-            memory: 32Gi
+            memory: 16Gi
         args:
         - verify
         env:


### PR DESCRIPTION
Required for https://github.com/kubernetes/k8s.io/pull/6525

/cc @BenTheElder @dims @ameukam 

Some jobs had an outrageous amount of memory configured on them. I tweaked those down to sane values.

We want to make sure that jobs don't request more than 30Gi of memory so they can fit on the modern 8core 32gb VMs.

Before:
```
 mahamed  MAHAALI-M-2PY9  ~  Desktop  Git  k8s-test-infra   master  346⬆  6⚑  $  grep -rh memory: config/ | sed -e 's/^[ \t]*//' |tr -d "'\"" | sort | uniq -c
   1 #             memory: 1Gi
   4 memory: 1.2Gi
   1 memory: 100Mi
 154 memory: 10Gi
   8 memory: 1288490188800m
  42 memory: 12Gi
 118 memory: 14Gi
  20 memory: 15Gi
 113 memory: 16Gi
  28 memory: 1Gi
   6 memory: 2000Mi
  12 memory: 20Gi
  14 memory: 24Gi
   2 memory: 2500Mi
   6 memory: 256Mi
 124 memory: 2Gi
 164 memory: 32Gi
  10 memory: 34Gi
  34 memory: 36Gi
   2 memory: 39Gi
  70 memory: 3Gi
  12 memory: 40Gi
   2 memory: 41Gi
   2 memory: 48Gi
1055 memory: 4Gi
   1 memory: 50Mi
  20 memory: 512Mi
  10 memory: 64Gi
2136 memory: 6Gi
   6 memory: 8000Mi
 160 memory: 8Gi
 201 memory: 9000Mi
 631 memory: 9Gi
```