### PR TITLE
add presubmit CI job for ec2+GPU scenario

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -242,6 +242,75 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-device-plugin-gpu
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
+      description: Runs presubmit tests using kubetest2-ec2 against kubernetes master on EC2 (equivalent of pull-kubernetes-e2e-gce)
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: k8s.io/kubernetes
+    always_run: false
+    optional: true
+    skip_report: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: sigs.k8s.io/provider-aws-test-infra
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+              AMI_ID=$(aws ssm get-parameters --names \
+                     /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
+                     --query 'Parameters[0].[Value]' --output text)
+              export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
+              kubetest2 ec2 \
+               --build \
+               --instance-type=g4ad.8xlarge \
+               --worker-image="$AMI_ID" \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --stage provider-aws-test-infra \
+               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+               --focus-regex="\[Feature:GPUDevicePlugin\]" \
+               --use-built-binaries true \
+               --parallel=5
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
   kubernetes-sigs/provider-aws-test-infra:
   - name: pull-kubernetes-e2e-ec2-quick
     skip_branches:

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -37,12 +37,12 @@ periodics:
                      /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
             VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+            export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/ \
              --version $VERSION \
-             --instance-type=g4dn.xlarge \
+             --instance-type=g4ad.8xlarge \
              --worker-image="$AMI_ID" \
-             --device-plugin-nvidia true \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
              --up \
              --down \
@@ -50,7 +50,7 @@ periodics:
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
              --focus-regex="\[Feature:GPUDevicePlugin\]" \
-             --parallel=25
+             --parallel=5
         env:
           - name: USE_DOCKERIZED_BUILD
             value: "true"


### PR DESCRIPTION
Add a presubmit so it's easier to test the ec2/AWS GPU scenarios.