### PR TITLE
jobs: migrated remaining k/k jobs into community cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -888,6 +888,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.26
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
     labels:
       preset-dind-enabled: "true"
@@ -924,13 +925,16 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.26
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -920,11 +920,12 @@ presubmits:
         - --env=KUBE_NODE_OS_DISTRIBUTION=gci
         - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
         - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
-        - --gcp-nodes=4
+        - --gcp-nodes=2
         - --gcp-project=k8s-jkns-pr-gce-gpus
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
+        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.26

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -917,11 +917,12 @@ presubmits:
         - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
         - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
         - --gcp-node-image=gci
-        - --gcp-nodes=4
+        - --gcp-nodes=2
         - --gcp-project=k8s-jkns-pr-gce-gpus
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
+        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.27

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -884,6 +884,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.27
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
     labels:
       preset-dind-enabled: "true"
@@ -921,13 +922,16 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.27
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -884,6 +884,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.28
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
     labels:
       preset-dind-enabled: "true"
@@ -918,13 +919,16 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.28
         name: ""
         resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
           requests:
+            cpu: "2"
             memory: 6Gi
         securityContext:
           privileged: true
@@ -1160,6 +1164,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.28
+    cluster: k8s-infra-prow-build
     context: pull-kubernetes-node-arm64-ubuntu-serial-gce
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -914,11 +914,12 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=gci
-        - --gcp-nodes=4
+        - --gcp-nodes=2
         - --gcp-project=k8s-jkns-pr-gce-gpus
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
+        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-1.28


### PR DESCRIPTION
Migrate the remaining jobs to community cluster.

- pull-kubernetes-e2e-gce-device-plugin-gpu-1.26
- pull-kubernetes-e2e-gce-device-plugin-gpu-1.27
- pull-kubernetes-e2e-gce-device-plugin-gpu-1.28
- pull-kubernetes-node-arm64-ubuntu-serial-gce-1.28

Part of https://github.com/kubernetes/kubernetes/issues/123079, https://github.com/kubernetes/test-infra/issues/31789

@ameukam 
