### PR TITLE
picked wrong instance type for nvidia in ec2/aws

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -284,7 +284,7 @@ presubmits:
               export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
               kubetest2 ec2 \
                --build \
-               --instance-type=g4ad.8xlarge \
+               --instance-type=g4dn.xlarge \
                --worker-image="$AMI_ID" \
                --region us-east-1 \
                --target-build-arch linux/amd64 \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -41,7 +41,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/ \
              --version $VERSION \
-             --instance-type=g4ad.8xlarge \
+             --instance-type=g4dn.xlarge \
              --worker-image="$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
              --up \


### PR DESCRIPTION
g4ad is AMD!  g4dn is nvidia.

- https://instances.vantage.sh/aws/ec2/g4ad.xlarge
- https://instances.vantage.sh/aws/ec2/g4dn.xlarge