### PR TITLE
Allow tweaking number of GPU containers using TEST_MAX_GPU_COUNT

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -257,7 +257,6 @@ presubmits:
     path_alias: k8s.io/kubernetes
     always_run: false
     optional: true
-    skip_report: true
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
@@ -281,6 +280,7 @@ presubmits:
               AMI_ID=$(aws ssm get-parameters --names \
                      /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
+              export TEST_MAX_GPU_COUNT=1
               export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
               kubetest2 ec2 \
                --build \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -37,6 +37,7 @@ periodics:
                      /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
             VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+            export TEST_MAX_GPU_COUNT=1
             export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/ \


### PR DESCRIPTION
getting a g4dn instance with 2 nvidia GPU(s) is costly. we'll essentially need `g4dn.12xlarge` ( https://instances.vantage.sh/aws/ec2/g4dn.12xlarge ). To be frugal, let's use `g4dn.xlarge` with 1 nvidia GPU.

`makeCudaAdditionDevicePluginTestPod` usually creates a pod with 2 containers, both needing 1 GPU each. Let's use `TEST_MAX_GPU_COUNT` to be able to reduce this to 1 container needing 1 GPU.

https://github.com/kubernetes/kubernetes/blob/2ec63e0d28951bb525a5bce0d9459afa1c71c0bd/test/e2e/scheduling/nvidia-gpus.go#L63-L94