### PR TITLE
Kops - Migrate kops DO jobs to community-owned prow clusters

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -78,6 +78,7 @@ periodics:
       resources:
         limits:
           memory: "3Gi"
+          cpu: "2"
         requests:
           cpu: "2"
           memory: "3Gi"
@@ -135,6 +136,7 @@ periodics:
       resources:
         limits:
           memory: "3Gi"
+          cpu: "2"
         requests:
           cpu: "2"
           memory: "3Gi"
@@ -193,6 +195,7 @@ periodics:
       resources:
         limits:
           memory: "3Gi"
+          cpu: "2"
         requests:
           cpu: "2"
           memory: "3Gi"

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -41,6 +41,7 @@ periodics:
     preset-do-spaces-credential: "true"
     preset-do-ssh: "true"
     preset-dind-enabled: "true"
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -97,6 +98,7 @@ periodics:
     preset-do-spaces-credential: "true"
     preset-do-ssh: "true"
     preset-dind-enabled: "true"
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -153,6 +155,7 @@ periodics:
     preset-do-spaces-credential: "true"
     preset-do-ssh: "true"
     preset-dind-enabled: "true"
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 90m

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -66,6 +66,7 @@ presubmits:
       preset-do-spaces-credential: "true"
       preset-do-ssh: "true"
       preset-dind-enabled: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 90m
@@ -118,6 +119,7 @@ presubmits:
       preset-do-spaces-credential: "true"
       preset-do-ssh: "true"
       preset-dind-enabled: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 90m
@@ -170,6 +172,7 @@ presubmits:
       preset-do-spaces-credential: "true"
       preset-do-ssh: "true"
       preset-dind-enabled: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 90m


### PR DESCRIPTION
[The issue](https://github.com/kubernetes/k8s.io/issues/5127) says DigitalOcean jobs should be migrated to the trusted cluster. This migrates one of kops' 6 DigitalOcean jobs to the new cluster.

/cc @ameukam
Can you confirm these secrets are present in the new cluster?

https://github.com/kubernetes/test-infra/blob/e69c6b03bd14735150534ad3c8e322b130f8804b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presets.yaml#L8-L10

https://github.com/kubernetes/test-infra/blob/e69c6b03bd14735150534ad3c8e322b130f8804b/config/jobs/kubernetes/kops/kops-presets-do.yaml#L8-L10

https://github.com/kubernetes/test-infra/blob/e69c6b03bd14735150534ad3c8e322b130f8804b/config/jobs/kubernetes/kops/kops-presets-do.yaml#L25-L27
