### PR TITLE
Enable alpha feature flag for 'Service.spec.trafficDistribution' field in multizone kind cluster

### DIFF
--- a/experiment/kind-multizone-e2e.sh
+++ b/experiment/kind-multizone-e2e.sh
@@ -149,6 +149,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   TopologyAwareHints: true
+  ServiceTrafficDistribution: true
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
This will help enable e2e tests coverage for this new field, added in https://github.com/kubernetes/kubernetes/pull/123487

/sig network
/cc @aojea @robscott 