### PR TITLE
Introduce T4 to GPU canary test

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -7,6 +7,13 @@ presets:
     value: type=nvidia-tesla-k80,count=2
   - name: NODE_SIZE
     value: n1-standard-2
+- labels:
+    preset-ci-gce-device-plugin-gpu-nvidia-t4: "true"
+  env:
+  - name: NODE_ACCELERATORS
+    value: type=nvidia-tesla-t4,count=2
+  - name: NODE_SIZE
+    value: n1-standard-2
 
 periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu
@@ -62,10 +69,10 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-ci-gce-device-plugin-gpu: "true"
+    preset-ci-gce-device-plugin-gpu-nvidia-t4: "true"
   annotations:
     testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: gce-device-plugin-gpu
+    testgrid-tab-name: gce-device-plugin-gpu-canary
     description: Duplicate of ci-kubernetes-e2e-gce-device-plugin-gpu pinned to a k8s-infra project to verify quota
     testgrid-alert-stale-results-hours: '24'
   decorate: true
@@ -86,7 +93,6 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=2
       - --gcp-project=k8s-infra-e2e-gpu-project
-      - --gcp-zone=us-west1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m


### PR DESCRIPTION
Reuse existing canary test for GPU scheduling to investigate flakiness on Nvidia T4 GPUs.