### PR TITLE
kOps: migrate specific scenarios to community infra

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -494,6 +494,7 @@ def generate_misc():
         build_test(name_override="kops-scenario-gcr-mirror",
                    runs_per_day=24,
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    # Latest runs with a staging AWS CCM, not available in registry.k8s.io
                    k8s_version='1.28',
                    extra_dashboards=['kops-misc']),
@@ -502,6 +503,7 @@ def generate_misc():
         build_test(name_override="kops-artifacts-sandbox",
                    runs_per_day=3,
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version='stable',
                    extra_dashboards=['kops-misc'],
                    scenario='smoketest',
@@ -516,6 +518,7 @@ def generate_misc():
         # Test Cilium against ci k8s test suite
         build_test(name_override="kops-aws-cni-cilium-k8s-ci",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="ci",
                    networking="cilium",
@@ -545,6 +548,7 @@ def generate_misc():
         # A special test for Calico CNI on Flatcar
         build_test(name_override="kops-aws-cni-calico-flatcar",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="flatcararm64",
                    k8s_version="stable",
                    networking="calico",
@@ -554,6 +558,7 @@ def generate_misc():
         # A special test for IPv6 using Calico CNI
         build_test(name_override="kops-aws-cni-calico-ipv6",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="calico",
@@ -568,6 +573,7 @@ def generate_misc():
         # A special test for IPv6 using Cilium CNI
         build_test(name_override="kops-aws-cni-cilium-ipv6",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="cilium",
@@ -582,6 +588,7 @@ def generate_misc():
         # A special test for IPv6 on Flatcar
         build_test(name_override="kops-aws-ipv6-flatcar",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="flatcararm64",
                    k8s_version="stable",
                    runs_per_day=3,
@@ -594,6 +601,7 @@ def generate_misc():
         # A special test for IPv6 using Calico on Flatcar
         build_test(name_override="kops-aws-cni-calico-ipv6-flatcar",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="flatcararm64",
                    k8s_version="stable",
                    networking="calico",
@@ -608,6 +616,7 @@ def generate_misc():
         # A special test for disabling IRSA
         build_test(name_override="kops-scenario-no-irsa",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    runs_per_day=3,
@@ -618,6 +627,8 @@ def generate_misc():
 
         # A special test for warm pool
         build_test(name_override="kops-warm-pool",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    runs_per_day=3,
@@ -630,6 +641,7 @@ def generate_misc():
         # A special test for private topology
         build_test(name_override="kops-aws-private",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    runs_per_day=3,
@@ -640,6 +652,8 @@ def generate_misc():
                    extra_dashboards=['kops-misc']),
 
         build_test(name_override="kops-scenario-terraform",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    runs_per_day=1,
@@ -650,6 +664,8 @@ def generate_misc():
                    ],
                    extra_dashboards=['kops-misc']),
         build_test(name_override="kops-scenario-ipv6-terraform",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    runs_per_day=1,
@@ -664,6 +680,8 @@ def generate_misc():
                    extra_dashboards=['kops-misc', 'kops-ipv6']),
 
         build_test(name_override="kops-aws-ha-euwest1",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="calico",
@@ -676,6 +694,8 @@ def generate_misc():
                    extra_dashboards=["kops-misc"]),
 
         build_test(name_override="kops-aws-arm64-release",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version="latest",
                    distro="u2204arm64",
                    networking="calico",
@@ -687,6 +707,8 @@ def generate_misc():
                    extra_dashboards=["kops-misc"]),
 
         build_test(name_override="kops-aws-arm64-ci",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version="ci",
                    distro="u2204arm64",
                    networking="calico",
@@ -698,6 +720,8 @@ def generate_misc():
                    extra_dashboards=["kops-misc"]),
 
         build_test(name_override="kops-aws-arm64-conformance",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version="ci",
                    distro="u2204arm64",
                    networking="calico",
@@ -711,6 +735,8 @@ def generate_misc():
                    extra_dashboards=["kops-misc"]),
 
         build_test(name_override="kops-aws-amd64-conformance",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version="ci",
                    distro='u2204',
                    networking="calico",
@@ -723,6 +749,7 @@ def generate_misc():
                    extra_dashboards=["kops-misc"]),
 
         build_test(name_override="kops-aws-updown",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version="stable",
                    distro="u2204arm64",
                    networking="calico",
@@ -735,6 +762,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-aws-load-balancer-controller",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    networking="cilium",
                    kops_channel="alpha",
                    k8s_version="stable",
@@ -744,6 +772,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-keypair-rotation-ha",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    kops_channel="alpha",
                    k8s_version="stable",
                    runs_per_day=1,
@@ -754,6 +783,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-metrics-server",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    networking="cilium",
                    kops_channel="alpha",
                    k8s_version="stable",
@@ -763,6 +793,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-pod-identity-webhook",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    networking="cilium",
                    kops_channel="alpha",
                    k8s_version="stable",
@@ -781,6 +812,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-external-dns",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="cilium",
@@ -794,6 +826,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-ipv6-external-dns",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="cilium",
@@ -809,6 +842,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-apiserver-nodes",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    runs_per_day=3,
@@ -817,6 +851,8 @@ def generate_misc():
                    feature_flags=['APIServerNodes']),
 
         build_test(name_override="kops-aws-karpenter",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="cilium",
@@ -831,6 +867,8 @@ def generate_misc():
                    skip_regex=r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|HostPort|two.untainted.nodes'), # pylint: disable=line-too-long
 
         build_test(name_override="kops-aws-ipv6-karpenter",
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="u2204arm64",
                    k8s_version="stable",
                    networking="cilium",
@@ -851,6 +889,7 @@ def generate_misc():
         # https://github.com/kubernetes/kubernetes/issues/123255
         build_test(name_override="kops-aws-k28-hostname-bug123255",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="al2023",
                    k8s_version="1.28",
                    networking="cilium",
@@ -863,6 +902,8 @@ def generate_misc():
         # Test the latest kops and CI build of Kubernetes (=almost master).
         build_test(name_override="kops-aws-selinux",
                    # RHEL8 VM image is enforcing SELinux by default.
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="rhel8",
                    networking="cilium",
                    k8s_version="ci",
@@ -893,6 +934,8 @@ def generate_misc():
         # This will need to merge with kops-aws-selinux when SELinuxMount gets enabled by default.
         build_test(name_override="kops-aws-selinux-alpha",
                    # RHEL8 VM image is enforcing SELinux by default.
+                   cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    distro="rhel8",
                    networking="cilium",
                    k8s_version="ci",

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -145,7 +145,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -341,7 +341,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -406,7 +406,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -470,7 +470,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -534,7 +534,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -599,7 +599,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -664,7 +664,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -728,7 +728,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -792,7 +792,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -856,7 +856,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -921,7 +921,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -986,7 +986,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1050,7 +1050,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1114,7 +1114,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1180,7 +1180,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1248,7 +1248,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1316,7 +1316,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1694,7 +1694,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1758,7 +1758,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1822,7 +1822,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1889,7 +1889,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -1955,7 +1955,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -2021,7 +2021,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -2086,7 +2086,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 150m
@@ -2156,7 +2156,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 150m


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Moving specific scenarios to k8s-infra-kops-prow-build