### PR TITLE
Enable `preset-dind-enabled` to `true`

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -221,6 +221,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-kueue-verify-main
       description: "Run kueue verify checks"
+    labels:
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master


### PR DESCRIPTION
To use docker in test suite, We also have to enable 
```
    labels:
      preset-dind-enabled: "true"
 ```
 
 See https://github.com/kubernetes-sigs/kueue/pull/1552#issuecomment-1984418796 for more information.