### PR TITLE
Waiting 30 seconds for pods stopped with terminationGracePeriod:30

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -27,6 +27,8 @@ fi
 # runs custom docker data root cleanup binary and debugs remaining resources
 cleanup_dind() {
     if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+        echo "Waiting 30 seconds for pods stopped with terminationGracePeriod:30"
+        sleep 30
         echo "Cleaning up after docker"
         docker ps -aq | xargs -r docker rm -f || true
         echo "Waiting for docker to stop for 30 seconds"

--- a/images/krte/wrapper.sh
+++ b/images/krte/wrapper.sh
@@ -38,6 +38,8 @@ printf '%0.s=' {1..80} >&2; echo >&2
 
 cleanup(){
   if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+    >&2 echo "wrapper.sh] [CLEANUP] Waiting 30 seconds for pods stopped with terminationGracePeriod:30"
+    sleep 30
     >&2 echo "wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ..."
     docker ps -aq | xargs -r docker rm -f || true
     >&2 echo "wrapper.sh] [CLEANUP] Waiting for docker to stop for 30 seconds"


### PR DESCRIPTION
Attempt to fix https://github.com/kubernetes/kubernetes/issues/123313

Checking the logs of failed jobs, seems that we currently stop docker service to early thus pods stopped with terminationGracePeriod: 30 are never being terminated. 

Currently one container is hit by this, as a result the node is waiting for long time ( almost 2 hours ) doing nothing. 

This commit tries to fix this adding a 30 seconds delay before the attempt to stop the docker in docker service, this allows the docker stop command with a timeout of 30 seconds to be executed.

![32200](https://github.com/kubernetes/test-infra/assets/159060890/906b0833-59a6-426c-b0aa-1d36ab8a40e1)
Source: [docker.log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/123453/pull-kubernetes-local-e2e/1764822106035458048/artifacts/kubetest-local1339971749/docker.log) , [kubelet.log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/123453/pull-kubernetes-local-e2e/1764822106035458048/artifacts/kubetest-local1339971749/kubelet.log) , [build.log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/123453/pull-kubernetes-local-e2e/1764822106035458048/build-log.txt)
