### PR TITLE
fix vsphere cpi post merge job fail because of docker unavailable

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -446,9 +446,10 @@ postsubmits:
           requests:
             cpu: "1000m"
         command:
-        - "make"
+        - runner.sh
         args:
-        - "release-push"
+        - make
+        - release-push
         securityContext:
           privileged: true
     annotations:
@@ -477,9 +478,10 @@ postsubmits:
           requests:
             cpu: "1000m"
         command:
-        - "make"
+        - runner.sh
         args:
-        - "release-push"
+        - make
+        - release-push
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -41,8 +41,9 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - fmt
         resources:
           limits:
@@ -71,8 +72,9 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - lint
         resources:
           limits:
@@ -101,8 +103,9 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - vet
         resources:
           limits:
@@ -186,8 +189,9 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - staticcheck
         resources:
           limits:
@@ -219,9 +223,10 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - "make"
+        - runner.sh
         args:
-        - "build"
+        - make
+        - build
         resources:
           limits:
             cpu: 2
@@ -250,9 +255,10 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - "make"
+        - runner.sh
         args:
-        - "unit-test"
+        - make
+        - unit-test
         resources:
           limits:
             cpu: 2
@@ -284,9 +290,10 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240223-1ded72f317-master
         command:
-        - "make"
+        - runner.sh
         args:
-        - "integration-test"
+        - make
+        - integration-test
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
fix vsphere cpi post-merge job fail because of docker unavailable: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cloud-provider-vsphere-deploy/1765975262702342144

also remove starting docker in make file as suggest here: https://github.com/kubernetes/cloud-provider-vsphere/pull/903