### PR TITLE
Skip AMI check as we use a fixed AMI in ec2/gpu periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -31,7 +31,6 @@ periodics:
           - bash
           - -c
           - |
-            source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
             AMI_ID=$(aws ssm get-parameters --names \
                      /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \


### PR DESCRIPTION
Skip the unnecessary check for AMI since we use the fixed EKS 1.29 GPU AMI 