### PR TITLE
Switch to the fast builds given we use linux/amd64 only in this CI job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -35,11 +35,11 @@ periodics:
             AMI_ID=$(aws ssm get-parameters --names \
                      /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
-            VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+            VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
             export TEST_MAX_GPU_COUNT=1
             export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
             kubetest2 ec2 \
-             --stage https://dl.k8s.io/ci/ \
+             --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
              --instance-type=g4dn.xlarge \
              --worker-image="$AMI_ID" \


### PR DESCRIPTION
`ci-kubernetes-build` takes longer to build than `ci-kubernetes-build-fast` 