### PR TITLE
scheduler: update ProwJob CRD

### DIFF
--- a/config/prow/cluster/prowjob-crd/legacy/prowjob-schemaless_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/legacy/prowjob-schemaless_customresourcedefinition.yaml
@@ -40,6 +40,7 @@ spec:
               state:
                 type: string
                 enum:
+                - "scheduling"
                 - "triggered"
                 - "pending"
                 - "success"

--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -52763,6 +52763,7 @@ spec:
               state:
                 description: ProwJobState specifies whether the job is running
                 enum:
+                - scheduling
                 - triggered
                 - pending
                 - success

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -1048,7 +1048,7 @@ type ProwJobStatus struct {
 	PendingTime *metav1.Time `json:"pendingTime,omitempty"`
 	// CompletionTime is the timestamp for when the job goes to a final state
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
-	// +kubebuilder:validation:Enum=triggered;pending;success;failure;aborted;error
+	// +kubebuilder:validation:Enum=scheduling;triggered;pending;success;failure;aborted;error
 	// +kubebuilder:validation:Required
 	State       ProwJobState `json:"state,omitempty"`
 	Description string       `json:"description,omitempty"`


### PR DESCRIPTION
Update ProwJob CRD using the latest `controller-gen` as the last one used `v0.6.x` is 3 years old now.
Add `scheduling` in the allowed values for `.status.state` field.

The command I've used to regenerate the CRD:
```bash
$ go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest

$ controller-gen --version
Version: v0.14.0

$ controller-gen crd \
  paths=./prow/apis/prowjobs/v1/... \
  output:stdout >config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
```

`config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml` diff is huge but the only remarkable difference I was able to spot, other than `scheduling`, is `x-kubernetes-map-type: atomic`.