### PR TITLE
[ec2][gpu] Switch to using e2e.test from ci/fast/latest-fast.txt

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -50,6 +50,9 @@ periodics:
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
              --focus-regex="\[Feature:GPUDevicePlugin\]" \
+             --test-package-url=https://dl.k8s.io/ \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --parallel=5
         env:
           - name: USE_DOCKERIZED_BUILD


### PR DESCRIPTION
If we don't do this, we are picking up the kubernetes-test tgz from here:

https://github.com/kubernetes-sigs/kubetest2/blob/bcfe5d638d28a621254e53d159c04874694cbc0b/pkg/testers/ginkgo/ginkgo.go#L244-L246