### PR TITLE
Add new presubmit prow job for gcp-compute-persistent-disk-csi-driver to run e2e tests on NVMe VM target

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -31,6 +31,47 @@ presubmits:
       testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e
       description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build
+  - name: pull-gcp-compute-persistent-disk-csi-driver-e2e-arm
+    cluster: k8s-infra-prow-build
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    decorate: true
+    decoration_config:
+      timeout: 60m
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          test/run-e2e.sh \
+            --machine-type=t2a-standard-2 \
+            --vm-name-prefix=gce-pd-csi-e2e-arm64 \
+            --zones=us-central1-a,us-central1-f \
+            --arch=arm64 \
+            --min-cpu-platform="" \
+            --image-url=projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2404-lts-arm64
+            --ginkgo.focus="\[NVMe\]"
+        env:
+        - name: ZONE
+          value: us-central1-c
+        resources:
+          limits:
+            cpu: 2
+            memory: "6Gi"
+          requests:
+            cpu: 2
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
+      testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e-arm64
+      description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build on ARM64/NVMe
   - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This adds support to run a subset of e2e tests in a configuration that uses NVMe devices on presubmit for the PDCSI Driver

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
