### PR TITLE
jobs: migrated node-problem-detector jobs into community cluster

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: ci-npd-build
-  # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-  cluster: default
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -96,8 +96,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-node
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -151,8 +150,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -197,8 +195,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -283,8 +280,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -329,8 +325,7 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true


### PR DESCRIPTION
Migrate the node-problem-detector jobs to community cluster.

Jobs:
- pull-npd-e2e-node
- pull-npd-e2e-kubernetes-gce-gci
- pull-npd-e2e-kubernetes-gce-gci-custom-flags
- pull-npd-e2e-kubernetes-gce-ubuntu
- pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
- ci-npd-build

Part of https://github.com/kubernetes/test-infra/issues/31794.
@ameukam