### PR TITLE
:bug: ci-kubernetes-e2e-ec2-alpha-enabled-default needs --external-cloud-provider

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -108,6 +108,7 @@ periodics:
              --version $VERSION \
              --feature-gates="AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false,ValidatingAdmissionPolicy=true" \
              --runtime-config="api/all=true" \
+             --external-cloud-provider true \
              --up \
              --down \
              --test=ginkgo \


### PR DESCRIPTION
missing topology labels!

from [logs](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-ec2-alpha-enabled-default/1766937797756719104):
```
{ failed [FAILED] failed to get current driver topologies: node ip-172-31-26-203.ec2.internal missing topology label topology.kubernetes.io/zone
In [It] at: k8s.io/kubernetes/test/e2e/storage/testsuites/topology.go:136 @ 03/10/24 21:45:05.062
}
```