### PR TITLE
remove periodic-conformance-main-k8s-main from master informing board

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -230,7 +230,7 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-conformance-main-k8s-main
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: release-team@kubernetes.io, sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io


### PR DESCRIPTION
…artifacts from sig release master informing board


https://testgrid.k8s.io/sig-release-master-informing#periodic-conformance-main-k8s-main keeps failing.


See  https://github.com/kubernetes/kubernetes/issues/123663#issuecomment-1983872053 and slack thread https://kubernetes.slack.com/archives/CD6U2V71N/p1709775913695989 