### PR TITLE
Specify image-family/project for NPD/ubuntu presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -313,6 +313,8 @@ presubmits:
           --gcp-node-image=ubuntu
           --gcp-zone=us-west1-b
           --ginkgo-parallel=30
+          --image-family=pipeline-1-24
+          --mage-project=ubuntu-os-gke-cloud
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
         resources:
@@ -359,6 +361,8 @@ presubmits:
           --gcp-node-image=ubuntu
           --gcp-zone=us-west1-b
           --ginkgo-parallel=30
+          --image-family=pipeline-1-24
+          --mage-project=ubuntu-os-gke-cloud
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
         resources:


### PR DESCRIPTION
The NPD ubuntu presubmit worker nodes should be ubuntu. But the log shows debian: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/node-problem-detector/870/pull-npd-e2e-kubernetes-gce-ubuntu/1763063655793954816/artifacts/e2e-07e889f7a1-80e1a-minion-group-j5mf/serial-1.log

This PR fixes the issue by following the fix for the CI job: https://github.com/kubernetes/test-infra/pull/30637.