### PR TITLE
scheduler: add `failover` strategy

### DIFF
--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -1076,6 +1076,13 @@ push_gateway:
 # It has to be explicitly enabled.
 scheduler:
     enabled: true
+    # Scheduling strategies
+    failover:
+        # ClusterMappings maps a cluster to another one. It is used when we
+        # want to schedule a ProJob to a cluster other than the one it was
+        # configured to in the first place.
+        mappings:
+            "": ""
 sinker:
     # ExcludeClusters are build clusters that don't want to be managed by sinker.
     exclude_clusters:

--- a/prow/config/scheduler.go
+++ b/prow/config/scheduler.go
@@ -18,4 +18,15 @@ package config
 
 type Scheduler struct {
 	Enabled bool `json:"enabled,omitempty"`
+
+	// Scheduling strategies
+	Failover *FailoverScheduling `json:"failover,omitempty"`
+}
+
+// FailoverScheduling is a configuration for the Failover scheduling strategy
+type FailoverScheduling struct {
+	// ClusterMappings maps a cluster to another one. It is used when we
+	// want to schedule a ProJob to a cluster other than the one it was
+	// configured to in the first place.
+	ClusterMappings map[string]string `json:"mappings,omitempty"`
 }

--- a/prow/scheduler/strategy/default.go
+++ b/prow/scheduler/strategy/default.go
@@ -34,8 +34,12 @@ type Interface interface {
 	Schedule(context.Context, *prowv1.ProwJob) (Result, error)
 }
 
-func Get(*config.Config) Interface {
-	// TODO: Add more strategies and then get one according to the config
+// Get gets a scheduling strategy in accordance to configuration. It defaults
+// to Passthrough stategy if none has been configured.
+func Get(cfg *config.Config) Interface {
+	if cfg.Scheduler.Failover != nil {
+		return NewFailover(*cfg.Scheduler.Failover)
+	}
 	return &Passthrough{}
 }
 

--- a/prow/scheduler/strategy/failover.go
+++ b/prow/scheduler/strategy/failover.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"context"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+// Failover is a scheduling strategy that handles clusters known to be
+// in a faulty state. It holds a list of mapping from a broken cluster to an
+// healthy one. This strategy get the cluster from a ProwJob and replaces it
+// with another one if it was found on the mapping list.
+type Failover struct {
+	cfg config.FailoverScheduling
+}
+
+var _ Interface = &Failover{}
+
+func (f *Failover) Schedule(_ context.Context, pj *prowv1.ProwJob) (Result, error) {
+	if cluster, exists := f.cfg.ClusterMappings[pj.Spec.Cluster]; exists {
+		return Result{Cluster: cluster}, nil
+	}
+	return Result{Cluster: pj.Spec.Cluster}, nil
+}
+
+func NewFailover(cfg config.FailoverScheduling) *Failover {
+	return &Failover{cfg: cfg}
+}

--- a/prow/scheduler/strategy/failover_test.go
+++ b/prow/scheduler/strategy/failover_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/scheduler/strategy"
+)
+
+func TestFailover(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		mappings     map[string]string
+		pj           *prowv1.ProwJob
+		wantDecision strategy.Result
+	}{
+		{
+			name:         "Replace broken cluster",
+			mappings:     map[string]string{"broken": "running"},
+			pj:           &prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Cluster: "broken"}},
+			wantDecision: strategy.Result{Cluster: "running"},
+		},
+		{
+			name:         "Do not replace",
+			mappings:     map[string]string{"broken": "running"},
+			pj:           &prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Cluster: "a-cluster"}},
+			wantDecision: strategy.Result{Cluster: "a-cluster"},
+		},
+		{
+			name:         "No mappings, do not replace",
+			pj:           &prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Cluster: "a-cluster"}},
+			wantDecision: strategy.Result{Cluster: "a-cluster"},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			failover := strategy.NewFailover(config.FailoverScheduling{ClusterMappings: tc.mappings})
+
+			d, err := failover.Schedule(context.TODO(), tc.pj)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.wantDecision, d); diff != "" {
+				t.Errorf("Unexpected decisions: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add the first two scheduling strategies other than the trivial, default `Passthrough`.

#### Round Robin
The classic scheduling algorithm that iterates over a list of fixed clusters. It's stateless as the scheduler stores the index of the next cluster in-memory. If it crashes for whatever reason, it start over again from the first one in the list.
#### Failover
Map one cluster with another. It is meant to handle a scenario in which one cluster is not working and needs to be skipped.
  The configuration looks like so:
```yaml
failover:
  from:
    cluster-foo: cluster-bar
```
This strategy assumes each ProwJob is given a cluster at configuration time, prior the scheduler kicks in.
With respect to the configuration above, the following ProwJob:
```yaml
apiVersion: prow.k8s.io/v1
kind: ProwJob
spec:
  cluster: cluster-foo
status:
  state: scheduling
```
results in:
```yaml
apiVersion: prow.k8s.io/v1
kind: ProwJob
spec:
  cluster: cluster-bar
status:
  state: triggered
```
When a match in `from:` isn't found, this strategy acts like `Passthrough` (see [here](https://github.com/kubernetes/test-infra/blob/a9874786b1d96011fb18f0493bdd38a069738f2a/prow/scheduler/strategy/default.go#L50-L52)).

---

The configuration has been updated to accommodate those new strategies:
```yaml
scheduler:
  round-robin: {}
  failover: {}
```
`round-robin` and `failover` are mutually exclusive and, when none is set, the scheduler assumes `Passthrough` as default.