### PR TITLE
Set NPD e2e kubernetes presubmit tests on github PR status

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -156,7 +156,6 @@ presubmits:
     branches:
     - master
     always_run: true
-    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:
@@ -202,7 +201,6 @@ presubmits:
     branches:
     - master
     always_run: true
-    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:
@@ -288,7 +286,6 @@ presubmits:
     branches:
     - master
     always_run: true
-    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:
@@ -336,7 +333,6 @@ presubmits:
     branches:
     - master
     always_run: true
-    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:


### PR DESCRIPTION
Those presubmits are passing now. This PR brings them back to the github PR status.
- https://testgrid.k8s.io/presubmits-node-problem-detector#pull-npd-e2e-kubernetes-gce-gci
- https://testgrid.k8s.io/presubmits-node-problem-detector#pull-npd-e2e-kubernetes-gce-gci-custom-flags
- https://testgrid.k8s.io/presubmits-node-problem-detector#pull-npd-e2e-kubernetes-gce-ubuntu
- https://testgrid.k8s.io/presubmits-node-problem-detector#pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags