### PR TITLE
Revert "Move NPD CI job to k8s-infra-prow-build"

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,6 +1,7 @@
 periodics:
 - name: ci-npd-build
-  cluster: k8s-infra-prow-build
+  # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+  cluster: default
   interval: 2h
   decorate: true
   labels:


### PR DESCRIPTION
Reverts kubernetes/test-infra#32222

I still see `403 Forbidden` issue: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-npd-build/1767190968601153536
```
ERROR: failed to solve: failed to push gcr.io/node-problem-detector-staging/ci/node-problem-detector:v0.8.16-14-gb48e438-20240311.1409: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://gcr.io/v2/token?scope=repository%3Anode-problem-detector-staging%2Fci%2Fnode-problem-detector%3Apull%2Cpush&service=gcr.io: 403 Forbidden
make: *** [Makefile:264: push-container] Error 1
```

Issue ref: https://github.com/kubernetes/kubernetes/issues/119211