### PR TITLE
Revert "Move NPD presubmit jobs to k8s-infra-prow-build"

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -96,7 +96,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-node
-    cluster: k8s-infra-prow-build
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -150,7 +151,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci
-    cluster: k8s-infra-prow-build
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -194,7 +196,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
-    cluster: k8s-infra-prow-build
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -278,7 +281,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
-    cluster: k8s-infra-prow-build
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true
@@ -324,7 +328,8 @@ presubmits:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    cluster: k8s-infra-prow-build
+    # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
+    cluster: default
     branches:
     - master
     always_run: true


### PR DESCRIPTION
Reverts kubernetes/test-infra#32228

I still see 403 Forbidden issue: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/node-problem-detector/884/pull-npd-e2e-kubernetes-gce-gci/1767203131650740224
```
ERROR: failed to solve: failed to push gcr.io/node-problem-detector-staging/pr/pr1767203131650740224-20240311.145728.360842797/node-problem-detector:v0.8.16-16-g94ac0bd: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://gcr.io/v2/token?scope=repository%3Anode-problem-detector-staging%2Fpr%2Fpr1767203131650740224-20240311.145728.360842797%2Fnode-problem-detector%3Apull%2Cpush&service=gcr.io: 403 Forbidden
make: *** [Makefile:264: push-container] Error 1
```

Issue ref: https://github.com/kubernetes/kubernetes/issues/119211