### PR TITLE
Update apisnoop audit-logger image

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -12,7 +12,7 @@ periodics:
   spec:
     containers:
     - name: apisnoop-gate
-      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20240121-auditlogger-1.2.11-4-gb17b29c
+      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20240310-auditlogger-1.2.11-30-g3c40359
       env:
         - name: LOAD_K8S_DATA
           value: "true"


### PR DESCRIPTION
Apparently https://github.com/kubernetes/test-infra/pull/31749 was not enough to enable autobumps. Will leave it for [BobyMCbobs](https://github.com/BobyMCbobs) to dig into that one.

Here in this PR, just updating by hand to the latest image https://explore.ggcr.dev/?repo=gcr.io/k8s-staging-apisnoop/snoopdb

/assign @upodroid @ameukam 