### PR TITLE
kops: migrate presubmits to community infra

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1414,6 +1414,8 @@ def generate_presubmits_distros():
             ]
         results.append(
             presubmit_test(
+                cloud='aws',
+                build_cluster='k8s-infra-kops-prow-build',
                 distro=distro_short,
                 networking='calico',
                 k8s_version='stable',
@@ -1836,6 +1838,8 @@ def generate_presubmits_network_plugins():
             optional = True
         results.append(
             presubmit_test(
+                cloud='aws',
+                build_cluster='k8s-infra-kops-prow-build',
                 distro='u2204arm64',
                 k8s_version=k8s_version,
                 kops_channel='alpha',
@@ -1854,6 +1858,7 @@ def generate_presubmits_network_plugins():
             results.append(
                 presubmit_test(
                     name=f"pull-kops-e2e-cni-{plugin}-ipv6",
+                    build_cluster='k8s-infra-kops-prow-build',
                     distro='u2204arm64',
                     tab_name=f"e2e-{plugin}-ipv6",
                     networking=networking_arg,
@@ -1876,6 +1881,7 @@ def generate_presubmits_network_plugins():
 def generate_presubmits_e2e():
     jobs = [
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='u2204arm64',
             k8s_version='ci',
             kops_channel='alpha',
@@ -1886,6 +1892,7 @@ def generate_presubmits_e2e():
             focus_regex=r'\[Conformance\]|\[NodeConformance\]',
         ),
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='u2204arm64',
             k8s_version='ci',
             kops_channel='alpha',
@@ -1900,6 +1907,7 @@ def generate_presubmits_e2e():
             focus_regex=r'\[Conformance\]|\[NodeConformance\]',
         ),
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='channels',
             k8s_version='stable',
             kops_channel='alpha',
@@ -1909,6 +1917,7 @@ def generate_presubmits_e2e():
             always_run=True,
         ),
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='al2023',
             k8s_version='stable',
             kops_channel='alpha',
@@ -2000,6 +2009,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-cloud-controller-manager",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204",
             k8s_version="ci",
             extra_flags=['--set=cluster.spec.cloudControllerManager.cloudProvider=aws'],
@@ -2009,6 +2019,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-load-balancer-controller",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2004",
             networking="calico",
             scenario="aws-lb-controller",
@@ -2018,6 +2029,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-addon-resource-tracking",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204",
             networking="calico",
             scenario="addon-resource-tracking",
@@ -2027,6 +2039,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-metrics-server",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204",
             networking="calico",
             scenario="metrics-server",
@@ -2036,6 +2049,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-pod-identity-webhook",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204",
             networking="calico",
             scenario="podidentitywebhook",
@@ -2045,6 +2059,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-external-dns",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             networking="calico",
             extra_flags=[
                 '--set=cluster.spec.externalDNS.provider=external-dns',
@@ -2054,6 +2069,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-ipv6-external-dns",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             networking="calico",
             extra_flags=[
                 '--ipv6',
@@ -2065,6 +2081,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-node-local-dns",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro='u2204arm64',
             extra_flags=[
                 '--set=cluster.spec.kubeDNS.nodeLocalDNS.enabled=true'
@@ -2074,6 +2091,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-apiserver-nodes",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             template_path="/home/prow/go/src/k8s.io/kops/tests/e2e/templates/apiserver.yaml.tmpl",
             feature_flags=['APIServerNodes']
         ),
@@ -2081,6 +2099,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-arm64",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204arm64",
             networking="calico",
             extra_flags=["--zones=eu-central-1a",
@@ -2091,6 +2110,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-dns-none",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204arm64",
             networking="calico",
             extra_flags=["--dns=none"],
@@ -2107,6 +2127,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-nlb",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204arm64",
             networking="calico",
             extra_flags=[
@@ -2118,6 +2139,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-terraform",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204arm64",
             terraform_version="1.5.5",
             extra_flags=[
@@ -2127,6 +2149,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-aws-ipv6-terraform",
             cloud="aws",
+            build_cluster='k8s-infra-kops-prow-build',
             distro="u2204arm64",
             terraform_version="1.5.5",
             extra_flags=[
@@ -2137,6 +2160,7 @@ def generate_presubmits_e2e():
         ),
 
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='channels',
             branch='release-1.28',
             k8s_version='1.28',
@@ -2147,6 +2171,7 @@ def generate_presubmits_e2e():
             always_run=True,
         ),
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='channels',
             branch='release-1.27',
             k8s_version='1.27',
@@ -2157,6 +2182,7 @@ def generate_presubmits_e2e():
             always_run=True,
         ),
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='channels',
             branch='release-1.26',
             k8s_version='1.26',
@@ -2168,6 +2194,7 @@ def generate_presubmits_e2e():
         ),
 
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='u2204arm64',
             name="pull-kops-e2e-aws-karpenter",
             run_if_changed=r'^upup\/models\/cloudup\/resources\/addons\/karpenter\.sh\/',
@@ -2181,6 +2208,7 @@ def generate_presubmits_e2e():
             skip_regex=r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|HostPort|two.untainted.nodes',
         ),
         presubmit_test(
+            build_cluster='k8s-infra-kops-prow-build',
             distro='u2204arm64',
             name="pull-kops-e2e-aws-ipv6-karpenter",
             #run_if_changed=r'^upup\/models\/cloudup\/resources\/addons\/karpenter\.sh\/',

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -480,7 +480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240223.0-x86_64-gp2' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240306.2-x86_64-gp2' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -5,7 +5,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-debian10
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -72,7 +72,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "deb11", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-debian11
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -139,7 +139,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "deb12", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-debian12
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -206,7 +206,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-ubuntu2004
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -273,7 +273,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2004arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-ubuntu2004arm64
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -340,7 +340,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-ubuntu2204
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -407,7 +407,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-ubuntu2204arm64
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -474,7 +474,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-amazonlinux2
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -504,7 +504,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240223.0-x86_64-gp2' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240306.2-x86_64-gp2' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -541,7 +541,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "al2023", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-al2023
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -608,7 +608,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-rhel8
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -675,7 +675,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "rhel9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-rhel9
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -742,7 +742,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "rocky8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-rocky8
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -809,7 +809,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-flatcar
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -5,7 +5,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-ci
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -75,7 +75,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--master-count=3 --node-count=6 --zones=eu-central-1a,eu-central-1b,eu-central-1c --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-ci-ha
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -145,7 +145,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "channels", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-aws-calico
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: true
@@ -212,7 +212,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=r5d.xlarge --master-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: pull-kops-e2e-k8s-aws-amazonvpc
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -679,7 +679,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--set=cluster.spec.cloudControllerManager.cloudProvider=aws --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-cloud-controller-manager
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -748,7 +748,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-aws-load-balancer-controller
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -805,7 +805,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-addon-resource-tracking
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -862,7 +862,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-metrics-server
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -919,7 +919,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-pod-identity-webhook
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -976,7 +976,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-aws-external-dns
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1043,7 +1043,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--ipv6 --bastion --set=cluster.spec.externalDNS.provider=external-dns --dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-aws-ipv6-external-dns
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1110,7 +1110,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--set=cluster.spec.kubeDNS.nodeLocalDNS.enabled=true --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-node-local-dns
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1177,7 +1177,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "feature_flags": "APIServerNodes", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-apiserver-nodes
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1247,7 +1247,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-arm64
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1314,7 +1314,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--dns=none --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-aws-dns-none
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1447,7 +1447,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--api-loadbalancer-type=public --api-loadbalancer-class=network --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-aws-nlb
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1514,7 +1514,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-terraform
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1582,7 +1582,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--ipv6 --bastion --dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-ipv6-terraform
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -1650,7 +1650,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "channels", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.28", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-aws-calico-1-28
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - release-1.28
     always_run: true
@@ -1717,7 +1717,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "channels", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.27", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-aws-calico-1-27
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - release-1.27
     always_run: true
@@ -1784,7 +1784,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "channels", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.26", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-aws-calico-1-26
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - release-1.26
     always_run: true
@@ -1851,7 +1851,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--instance-manager=karpenter --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-karpenter
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^upup\/models\/cloudup\/resources\/addons\/karpenter\.sh\/'
@@ -1921,7 +1921,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--instance-manager=karpenter --ipv6 --topology=private --bastion --master-size=c6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-ipv6-karpenter
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -5,7 +5,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: pull-kops-e2e-cni-amazonvpc
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.amazon-vpc-routed-eni\/|pkg\/model\/(firewall|components\/containerd|components\/kubeproxy|iam\/iam_builder)\.go|nodeup\/pkg\/model\/kubelet\.go)'
@@ -73,7 +73,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: pull-kops-e2e-cni-amazonvpc-ipv6
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     always_run: false
@@ -140,7 +140,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-cni-calico
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.projectcalico\.org\/|pkg\/model\/(components\/containerd|firewall|pki|iam\/iam_builder)\.go|nodeup\/pkg\/model\/networking\/calico\.go)'
@@ -208,7 +208,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-cni-calico-ipv6
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.projectcalico\.org\/|pkg\/model\/(components\/containerd|firewall|pki|iam\/iam_builder)\.go|nodeup\/pkg\/model\/networking\/calico\.go)'
@@ -276,7 +276,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.27", "kops_channel": "alpha", "networking": "canal"}
   - name: pull-kops-e2e-cni-canal
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.projectcalico\.org\.canal\/)'
@@ -344,7 +344,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-cni-cilium
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.cilium\.io\/|pkg\/model\/(components\/containerd|firewall|components\/cilium|iam\/iam_builder)\.go|nodeup\/pkg\/model\/(context|networking\/cilium)\.go)'
@@ -412,7 +412,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-cni-cilium-ipv6
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.cilium\.io\/|pkg\/model\/(components\/containerd|firewall|components\/cilium|iam\/iam_builder)\.go|nodeup\/pkg\/model\/(context|networking\/cilium)\.go)'
@@ -480,7 +480,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-etcd"}
   - name: pull-kops-e2e-cni-cilium-etcd
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.cilium\.io\/|pkg\/model\/(components\/containerd|firewall|components\/cilium|iam\/iam_builder)\.go|nodeup\/pkg\/model\/(context|networking\/cilium)\.go)'
@@ -548,7 +548,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
   - name: pull-kops-e2e-cni-cilium-eni
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.cilium\.io\/|pkg\/model\/(components\/containerd|firewall|components\/cilium|iam\/iam_builder)\.go|nodeup\/pkg\/model\/(context|networking\/cilium)\.go)'
@@ -616,7 +616,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.27", "kops_channel": "alpha", "networking": "flannel"}
   - name: pull-kops-e2e-cni-flannel
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.flannel\/|pkg\/model\/components\/containerd\.go)'
@@ -684,7 +684,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=t4g.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "networking": "kube-router"}
   - name: pull-kops-e2e-cni-kuberouter
-    cluster: default
+    cluster: k8s-infra-kops-prow-build
     branches:
     - master
     run_if_changed: '^(upup\/models\/cloudup\/resources\/addons\/networking\.kuberouter\/|pkg\/model\/components\/containerd\.go)'


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Migrate presubmits to k8s-infra with exclusion of those testing kops upgrades.