### PR TITLE
Switch to ci/fast for ec2 CI jobs

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -226,9 +226,9 @@ presubmits:
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
               export CONTAINERD_PULL_REFS=$PULL_REFS
               echo "CONTAINERD_PULL_REFS: $CONTAINERD_PULL_REFS"
-              VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/ \
+               --stage https://dl.k8s.io/ci/fast/ \
                --version $VERSION \
                --up \
                --down \

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -225,16 +225,19 @@ periodics:
           docker push "${IMAGE_NAME}:${IMAGE_TAG}"
 
           GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-          VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+          VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
           kubetest2 ec2 \
-           --stage https://dl.k8s.io/ci/ \
+           --stage https://dl.k8s.io/ci/fast/ \
            --version $VERSION \
            --up \
            --down \
            --test=ginkgo \
            -- \
            --parallel=30 \
-          --focus-regex='Pods should be submitted and removed'
+           --test-package-url=https://dl.k8s.io/ \
+           --test-package-dir=ci/fast \
+           --test-package-marker=latest-fast.txt \
+           --focus-regex='Pods should be submitted and removed'
       env:
         - name: USE_DOCKERIZED_BUILD
           value: "true"

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -165,9 +165,9 @@ presubmits:
               docker tag "${BUILD_IMAGE}" "${IMAGE_NAME}:${IMAGE_TAG}"
               docker push "${IMAGE_NAME}:${IMAGE_TAG}"
 
-              VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/ \
+               --stage https://dl.k8s.io/ci/fast/ \
                --external-cloud-provider true \
                --external-cloud-provider-image="${IMAGE_NAME}:${IMAGE_TAG}" \
                --version $VERSION \
@@ -176,7 +176,10 @@ presubmits:
                --test=ginkgo \
                -- \
                --parallel=30 \
-              --focus-regex='Pods should be submitted and removed'
+               --test-package-url=https://dl.k8s.io/ \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
+               --focus-regex='Pods should be submitted and removed'
           env:
             - name: USE_DOCKERIZED_BUILD
               value: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -341,16 +341,19 @@ presubmits:
             - -c
             - |
               cd kubetest2-ec2 && GOPROXY=direct go install .
-              VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/ \
+               --stage https://dl.k8s.io/ci/fast/ \
                --version $VERSION \
                --up \
                --down \
                --test=ginkgo \
                -- \
                --parallel=30 \
-              --focus-regex='Pods should be submitted and removed'
+               --test-package-url=https://dl.k8s.io/ \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
+               --focus-regex='Pods should be submitted and removed'
           env:
             - name: USE_DOCKERIZED_BUILD
               value: "true"
@@ -393,9 +396,9 @@ presubmits:
             - -c
             - |
               cd kubetest2-ec2 && GOPROXY=direct go install .
-              VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/ \
+               --stage https://dl.k8s.io/ci/fast/ \
                --external-cloud-provider true \
                --version $VERSION \
                --up \
@@ -403,7 +406,10 @@ presubmits:
                --test=ginkgo \
                -- \
                --parallel=30 \
-              --focus-regex='Pods should be submitted and removed'
+               --test-package-url=https://dl.k8s.io/ \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
+               --focus-regex='Pods should be submitted and removed'
           env:
             - name: USE_DOCKERIZED_BUILD
               value: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -49,6 +49,9 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+             --test-package-url=https://dl.k8s.io/ \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --focus-regex="\[Feature:GPUDevicePlugin\]" \
              --test-package-url=https://dl.k8s.io/ \
              --test-package-dir=ci/fast \
@@ -102,9 +105,9 @@ periodics:
             source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
 
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-            VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+            VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://dl.k8s.io/ci/ \
+             --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
              --feature-gates="AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false,ValidatingAdmissionPolicy=true" \
              --runtime-config="api/all=true" \
@@ -114,6 +117,9 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+             --test-package-url=https://dl.k8s.io/ \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0" \
              --parallel=25
         env:
@@ -165,9 +171,9 @@ periodics:
             source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
 
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-            VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+            VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://dl.k8s.io/ci/ \
+             --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
              --feature-gates="AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
@@ -176,6 +182,9 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+             --test-package-url=https://dl.k8s.io/ \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection|ValidatingAdmissionPolicy)\]|Networking" \
              --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0" \
              --parallel=25


### PR DESCRIPTION
- the ci/ folder takes longer to populate ci/fast is quicker
- test-package-* are needed to be set to pick up e2e.test from the right spot.