### PR TITLE
Fix pull-kubernetes-local-e2e job

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -176,6 +176,11 @@ func (n localCluster) Down() error {
 		"kubelet",
 	}
 
+	// Waiting 30 seconds for pods stopped with terminationGracePeriod:30
+	// otherwise pods containers will remain and cannot be deleted before
+	// timeout has expired.
+	time.Sleep(30 * time.Second)
+
 	// make sure all containers are removed
 	if err := control.FinishRunning(exec.Command("sh", "-c", `docker ps -aq | xargs -r docker rm -fv`)); err != nil {
 		log.Printf("unable to cleanup containers in docker: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

To fix failing job https://testgrid.k8s.io/sig-testing-misc#pull-kubernetes-local-e2e&width=90, (even if test pass, it fail because a container is still present from DiD and cannot be delete after, resulting to job failure due to timeout.

Checking the logs of failed jobs, and the time when docker is terminated seems that we currently stop docker service still to early thus pods stopped with terminationGracePeriod: 30 are never being terminated still.

This commit attempts to fix this by waiting 30 seconds for pods stopped with terminationGracePeriod:30 before Docker inside docker containers are terminated.


#### Which issue(s) this PR fixes:

Attempt to fix https://github.com/kubernetes/kubernetes/issues/123313


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
NONE
```