### PR TITLE
[kubetest2-ec2] fix missing and duplicate test-package-* CLI parameters

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -234,6 +234,9 @@ presubmits:
                --down \
                --test=ginkgo \
                -- \
+               --test-package-url=https://dl.k8s.io/ \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
                --parallel=30 \
                --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Services should fallback to local terminating endpoints when there are no ready endpoints with externalTrafficPolicy|Services should preserve source pod IP for traffic thru service cluster IP'
           env:

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -53,9 +53,6 @@ periodics:
              --test-package-dir=ci/fast \
              --test-package-marker=latest-fast.txt \
              --focus-regex="\[Feature:GPUDevicePlugin\]" \
-             --test-package-url=https://dl.k8s.io/ \
-             --test-package-dir=ci/fast \
-             --test-package-marker=latest-fast.txt \
              --parallel=5
         env:
           - name: USE_DOCKERIZED_BUILD


### PR DESCRIPTION
Added some extra params in one and not the other job!

we should be using the e2e.test from the ci/fast bucket as well.