### PR TITLE
Allow exceptions to consistent images in autobumper.

### DIFF
--- a/prow/cmd/generic-autobumper/helper.go
+++ b/prow/cmd/generic-autobumper/helper.go
@@ -23,6 +23,15 @@ import (
 	"k8s.io/test-infra/prow/cmd/generic-autobumper/imagebumper"
 )
 
+// Extract image from image name
+func imageFromName(name string) string {
+	parts := strings.Split(name, ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0]
+}
+
 // Extract image tag from image name
 func tagFromName(name string) string {
 	parts := strings.Split(name, ":")

--- a/prow/cmd/generic-autobumper/helper_test.go
+++ b/prow/cmd/generic-autobumper/helper_test.go
@@ -20,6 +20,46 @@ import (
 	"testing"
 )
 
+// TestImageAndTagFromName tests ImageFromName() and TagFromName().
+func TestImageAndTagFromName(t *testing.T) {
+	cases := []struct {
+		name          string
+		imageName     string
+		expectedImage string
+		expectedTag   string
+	}{
+		{
+			name:          "empty",
+			imageName:     "",
+			expectedImage: "",
+			expectedTag:   "",
+		},
+		{
+			name:          "basically works",
+			imageName:     "gcr.io/k8s-prow/test:tag1",
+			expectedImage: "gcr.io/k8s-prow/test",
+			expectedTag:   "tag1",
+		},
+		{
+			name:          "just an image",
+			imageName:     "gcr.io/k8s-prow/test",
+			expectedImage: "",
+			expectedTag:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := imageFromName(tc.imageName); actual != tc.expectedImage {
+				t.Errorf("imageFromName(%q) got %q, want %q", tc.imageName, actual, tc.expectedImage)
+			}
+			if actual := tagFromName(tc.imageName); actual != tc.expectedTag {
+				t.Errorf("tagFromName(%q) got %q, want %q", tc.imageName, actual, tc.expectedTag)
+			}
+		})
+	}
+}
+
 func TestCommitToRef(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Images may be built by different jobs, but pushed to the same registeries (see the split of building Prow and non-Prow images in test-infra as an example,  #32249). Allow exceptions to image consistency in the autobumper checks, while still enforcing consistency for other images within a prefix.