### PR TITLE
Kops - Migrate upgrade tests of newer k/k versions to new prow cluster

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -144,10 +144,7 @@ def build_test(cloud='aws',
     if scenario is not None:
         tmpl_file = "periodic-scenario.yaml.jinja"
         name_hash = hashlib.md5(job_name.encode()).hexdigest()
-        # https://github.com/kubernetes/kops/issues/16352 older k/k versions dont have a
-        # new enough AWS SDK. TODO: remove guard once we stop testing upgrades to k8s 1.26
-        if scenario != "upgrade-ab":
-            build_cluster = "k8s-infra-kops-prow-build"
+        if build_cluster == "k8s-infra-kops-prow-build":
             env['KOPS_STATE_STORE'] = "s3://k8s-kops-ci-prow-state-store"
             env['KOPS_DNS_DOMAIN'] = "tests-kops-aws.k8s.io"
             env['DISCOVERY_STORE'] = "s3://k8s-kops-ci-prow"
@@ -804,6 +801,7 @@ def generate_misc():
 
         build_test(name_override="kops-aws-addon-resource-tracking",
                    cloud="aws",
+                   build_cluster="k8s-infra-kops-prow-build",
                    networking="cilium",
                    kops_channel="alpha",
                    k8s_version="stable",

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1522,6 +1522,12 @@ def generate_upgrades():
             'KOPS_TEMPLATE': 'tests/e2e/templates/many-addons.yaml.tmpl',
             'KOPS_CONTROL_PLANE_SIZE': '3',
         }
+        build_cluster = 'k8s-infra-kops-prow-build'
+        # Older k/k builds dont have new enough aws-sdk-go versions to support
+        # running their e2e.test binary from community-owned EKS clusters.
+        if re.match(r'v1\.2[4-6]', k8s_a):
+            build_cluster = 'default'
+
         results.append(
             build_test(name_override=job_name,
                        distro='u2204',
@@ -1533,6 +1539,7 @@ def generate_upgrades():
                        test_timeout_minutes=120,
                        scenario='upgrade-ab',
                        env=env,
+                       build_cluster=build_cluster,
                        )
         )
         results.append(
@@ -1546,6 +1553,7 @@ def generate_upgrades():
                        runs_per_day=runs_per_day,
                        scenario='upgrade-ab',
                        env=addonsenv,
+                       build_cluster=build_cluster,
                        )
         )
 

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -480,7 +480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240223.0-x86_64-gp2' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240306.2-x86_64-gp2' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -142,12 +142,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko127-to-k127-ko127
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '40 4-23/24 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -160,6 +159,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -208,12 +208,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko127-to-k127-ko127-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '3 23-23/24 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -226,6 +225,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -418,12 +418,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko127-to-k128-ko128
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '40 4-23/24 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -436,6 +435,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -484,12 +484,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko127-to-k128-ko128-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '24 12-23/24 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -502,6 +501,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -556,12 +556,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k128-ko128-to-k128-ko128
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '23 23-23/24 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -574,6 +573,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -622,12 +622,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k128-ko128-to-k128-ko128-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '48 16-23/24 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -640,6 +639,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -1246,12 +1246,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko127-to-k128-kolatest
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '55 6-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -1264,6 +1263,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -1312,12 +1312,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko127-to-k128-kolatest-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '31 7-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -1330,6 +1329,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -1798,12 +1798,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko128-to-k128-kolatest
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '55 6-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -1816,6 +1815,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -1864,12 +1864,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-ko128-to-k128-kolatest-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '42 6-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -1882,6 +1881,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -1936,12 +1936,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k128-kolatest-to-klatest-kolatest
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '46 4-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -1954,6 +1953,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2002,12 +2002,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k128-kolatest-to-klatest-kolatest-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '0 7-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2020,6 +2019,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2074,12 +2074,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-kolatest-to-k128-kolatest
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '11 5-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2092,6 +2091,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2140,12 +2140,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-k127-kolatest-to-k128-kolatest-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '22 2-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2158,6 +2157,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2626,12 +2626,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-kstable-kolatest-to-klatest-kolatest
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '59 7-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2644,6 +2643,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2692,12 +2692,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-kstable-kolatest-to-klatest-kolatest-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '7 2-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2710,6 +2709,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2764,12 +2764,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '52 5-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2782,6 +2781,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh
@@ -2830,12 +2830,11 @@ periodics:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest-many-addons
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   cron: '20 3-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-aws-credential: "true"
     preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
@@ -2848,6 +2847,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - command:
       - runner.sh

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -174,14 +174,18 @@ periodics:
         value: "1.27"
       - name: K8S_VERSION_B
         value: "v1.27.8"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-5f6a7c34d6-41951.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -246,14 +250,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-ec26b3174a-cd001.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -450,14 +458,18 @@ periodics:
         value: "1.28"
       - name: K8S_VERSION_B
         value: "v1.28.4"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-5cce897dd9-6fae0.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -522,14 +534,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-eb7d632f12-192d9.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -588,14 +604,18 @@ periodics:
         value: "1.28"
       - name: K8S_VERSION_B
         value: "v1.28.4"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-42bfef03b8-389b1.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -660,14 +680,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-cb6ec85b38-a11dd.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -1278,14 +1302,18 @@ periodics:
         value: "latest"
       - name: K8S_VERSION_B
         value: "v1.28.0"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-1731c72aa2-b68de.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -1350,14 +1378,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-3e38f4058a-0e0be.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -1830,14 +1862,18 @@ periodics:
         value: "latest"
       - name: K8S_VERSION_B
         value: "v1.28.0"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-e27d55cd2a-41048.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -1902,14 +1938,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-3788fcc203-58f41.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -1968,14 +2008,18 @@ periodics:
         value: "latest"
       - name: K8S_VERSION_B
         value: "latest"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-e2cdb5dc79-ded41.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2040,14 +2084,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-1fb091dcd3-b22a5.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2106,14 +2154,18 @@ periodics:
         value: "latest"
       - name: K8S_VERSION_B
         value: "v1.28.0"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-91022f0f89-36174.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2178,14 +2230,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-138aaeffda-13c0c.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2658,14 +2714,18 @@ periodics:
         value: "latest"
       - name: K8S_VERSION_B
         value: "latest"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-3a5daf4e9a-96255.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2730,14 +2790,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-734077b544-64c63.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2796,14 +2860,18 @@ periodics:
         value: "latest"
       - name: K8S_VERSION_B
         value: "ci"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-ed4da97961-6b857.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master
@@ -2868,14 +2936,18 @@ periodics:
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
       - name: KOPS_CONTROL_PLANE_SIZE
         value: "3"
+      - name: KOPS_STATE_STORE
+        value: "s3://k8s-kops-ci-prow-state-store"
+      - name: KOPS_DNS_DOMAIN
+        value: "tests-kops-aws.k8s.io"
+      - name: DISCOVERY_STORE
+        value: "s3://k8s-kops-ci-prow"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
         value: "e2e-9b8b75964a-36844.tests-kops-aws.k8s.io"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-prow"
       - name: KOPS_IRSA
         value: "true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240310-bac0a3c105-master

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -504,7 +504,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240223.0-x86_64-gp2' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240306.2-x86_64-gp2' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \


### PR DESCRIPTION
We can't migrate older k/k versions because of failures like this:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k124-ko127-to-k125-kolatest/1755361705824620544

The e2e.test binary uses the AWS SDK to interact with EBS volumes, and older k/k versions have an old enough AWS SDK version that doesn't support authentication methods required in the new prow cluster.

```
     Feb  7 23:47:03.103: INFO: Unexpected error: 
        <*awserr.baseError | 0xc0001fcd00>: {
            code: "NoCredentialProviders",
            message: "no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors",
            errs: nil,
        }
    Feb  7 23:47:03.103: FAIL: NoCredentialProviders: no valid providers in chain. Deprecated.
    	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
    Full Stack Trace
    k8s.io/kubernetes/test/e2e/storage/drivers.(*awsDriver).CreateVolume(0xc000e08840?, 0xc003722d20, {0x736e653, 0xc})
    	test/e2e/storage/drivers/in_tree.go:1798 +0x1bb
    k8s.io/kubernetes/test/e2e/storage/framework.CreateVolume({0x7c46fc8, 0xc0009e69c0}, 0xc003828600?, {0x736e653, 0xc})
    	test/e2e/storage/framework/driver_operations.go:43 +0xd2
    k8s.io/kubernetes/test/e2e/storage/framework.CreateVolumeResource({0x7c46fc8, 0xc0009e69c0}, 0xc003722d20, {{0x73c1c70, 0x1a}, {0x0, 0x0}, {0x736e653, 0xc}, {0x0, ...}, ...}, ...)
    	test/e2e/storage/framework/volume_resource.go:65 +0x225
    k8s.io/kubernetes/test/e2e/storage/testsuites.(*volumesTestSuite).DefineTests.func1()
    	test/e2e/storage/testsuites/volumes.go:142 +0x28e
    k8s.io/kubernetes/test/e2e/storage/testsuites.(*volumesTestSuite).DefineTests.func4()
    	test/e2e/storage/testsuites/volumes.go:200 +0x6f 
```