### PR TITLE
Exempt non-Prow images from autobump consistency check.

### DIFF
--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -22,6 +22,15 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: true
     consistentImages: true
+    consistentImageExceptions:
+      - "gcr.io/k8s-prow/label_sync"
+      - "gcr.io/k8s-prow/robots/commenter"
+      - "gcr.io/k8s-prow/robots/pr-creator"
+      - "gcr.io/k8s-prow/robots/issue-creator"
+      - "gcr.io/k8s-prow/testgrid/cmd/configurator"
+      - "gcr.io/k8s-prow/gcsweb/cmd/gcsweb"
+      - "gcr.io/k8s-prow/gencred"
+      - "gcr.io/k8s-prow/experiment/ml/analyze"
   - name: "Boskos"
     prefix: "gcr.io/k8s-staging-boskos/"
     refConfigFile: "config/prow/cluster/build/boskos.yaml"


### PR DESCRIPTION
Now that the Prow and non-Prow images are separated out and built separately, they may be bumped to different versions. Allow the autobumper to update the gcr.io/k8s-prow prefix without requiring the non-Prow images to be at the same versions as the Prow images.

/hold

Hold until the next Prow bump goes through and the autobumper image includes the "consistentImageExceptions" option for prefixes.