### PR TITLE
add containerd log for alpha features ci

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -460,6 +460,7 @@ presubmits:
         - --env=ENABLE_POD_PRIORITY=true
         - --env=ENABLE_APISERVER_TRACING=true
         - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --extract=local
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b


### PR DESCRIPTION
For instance, https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/123909/pull-kubernetes-e2e-gce-cos-alpha-features/1768053447862521856
![image](https://github.com/kubernetes/test-infra/assets/2010320/07d1139d-b40c-4d20-b3a3-6b0188c899c3)

no containerd log, but only docker log.

/priority important-soon
