### PR TITLE
Migrate containerd jobs to community clusters

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -1,6 +1,7 @@
 presubmits:
   containerd/containerd:
   - name: pull-containerd-build
+    cluster: eks-prow-build-cluster
     always_run: true
     branches:
     - main
@@ -24,8 +25,16 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
 
   - name: pull-containerd-node-e2e
+    cluster: eks-prow-build-cluster
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -75,8 +84,16 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
 
   - name: pull-containerd-node-e2e-1-7
+    cluster: eks-prow-build-cluster
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -126,8 +143,16 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
 
   - name: pull-containerd-node-e2e-1-6
+    cluster: eks-prow-build-cluster
     always_run: true
     max_concurrency: 8
     decorate: true
@@ -177,6 +202,13 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.6-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
 
   - name: pull-containerd-k8s-e2e-ec2
     branches:


### PR DESCRIPTION
Migrate Containerd jobs to EKS community cluster.
Fixes part of https://github.com/kubernetes/test-infra/issues/31794

/cc @rjsadow @ameukam