### PR TITLE
Bump go version to 1.22 for controller-runtime

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-periodics-main.yaml
@@ -9,7 +9,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.21
+    - image: public.ecr.aws/docker/library/golang:1.22
       command:
       - ./hack/ci-check-everything.sh
       resources:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-main.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21
+      - image: public.ecr.aws/docker/library/golang:1.22
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -33,7 +33,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21
+      - image: public.ecr.aws/docker/library/golang:1.22
         command:
         - ./hack/apidiff.sh
         resources:


### PR DESCRIPTION
So that controller-runtime can bump  Kubernetes to v1.30:
* kubernetes-sigs/controller-runtime#2693