### PR TITLE
Test ci-kubernetes-e2e-gci-gce-alpha-enabled-default with newer containerd/runc

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -883,6 +883,8 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.14
+      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.1.12
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false,ValidatingAdmissionPolicy=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true


### PR DESCRIPTION
To fix the one test failure in https://testgrid.k8s.io/google-gce#gci-gce-alpha-enabled-default&width=20 which was fixed in newer containerd/runc. Please see more context in the linked PR.

needs https://github.com/kubernetes/kubernetes/pull/123943 to land first

/hold 