### PR TITLE
Fix gcp-guest dashboard URLs

### DIFF
--- a/config/testgrids/gcp-guest/gcp-guest.yaml
+++ b/config/testgrids/gcp-guest/gcp-guest.yaml
@@ -27,12 +27,42 @@ dashboards:
     test_group_name: gcp-guest-osconfig-presubmit-gocheck
   - name: CIT periodics
     test_group_name: cit-periodics
+    open_test_template:
+      url: https://oss.gprow.dev/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://oss.gprow.dev/job_history/<gcs_prefix>
+    file_bug_template:
+      url: "https://issuetracker.google.com/issues/new"
+      options:
+        - key: "title"
+          value: "CIT failure: <test-name>"
+        - key: "component"
+          value: "117405"
     alert_options:
+      num_failures_to_alert: 4
+      alert_stale_results_hours: 24
+      num_passes_to_disable_alert: 1
+      broken_column_threshold: 0.02
       alert_mail_to_addresses: 'buganizer-system+117405@google.com'
       debug_url: 'http://go/cit-alert-runbook'
   - name: OSLogin periodics
     test_group_name: oslogin-periodics
+    open_test_template:
+      url: https://oss.gprow.dev/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://oss.gprow.dev/job_history/<gcs_prefix>
+    file_bug_template:
+      url: "https://issuetracker.google.com/issues/new"
+      options:
+        - key: "title"
+          value: "CIT failure: <test-name>"
+        - key: "component"
+          value: "117405"
     alert_options:
+      num_failures_to_alert: 2
+      alert_stale_results_hours: 24
+      num_passes_to_disable_alert: 1
+      broken_column_threshold: 0.01
       alert_mail_to_addresses: 'buganizer-system+117405@google.com'
       debug_url: 'http://go/cit-alert-runbook'
 


### PR DESCRIPTION
If there's some onboarding process I missed for OWNERS addition let me know, I'd just like to make it easier for our team to tweak our dashboard config without bothering repo owners.