### PR TITLE
pull-capi-ibm-make: update resources

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -23,11 +23,11 @@ presubmits:
         imagePullPolicy: Always
         resources:
           limits:
-            cpu: "2"
-            memory: "6Gi"
+            cpu: "1"
+            memory: "1Gi"
           requests:
-            cpu: "2"
-            memory: "6Gi"
+            cpu: "1"
+            memory: "1Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
       testgrid-tab-name: pr-make


### PR DESCRIPTION
Done as part of the [Contributor Summit workshop](https://sched.co/1aOqL) and efforts to reduce requests for jobs that are not using requested resources.

Relevant dashboards:

- https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-ibmcloud&var-job=pull-cluster-api-provider-ibmcloud-make&viewPanel=128&from=1710833729992&to=1710853036718
- https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-ibmcloud&var-job=pull-cluster-api-provider-ibmcloud-make&viewPanel=180&from=1710833250687&to=1710854767381