### PR TITLE
cluster-api: update pull-cluster-api-e2e-blocking-main resources

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -203,10 +203,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 32Gi
+            memory: 4Gi
           limits:
             cpu: 7300m
-            memory: 32Gi
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-blocking-main


### PR DESCRIPTION
This PR updates the resources for pull-cluster-api-e2e-blocking-main per the contributor summit workshop.

Memory: https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&refresh=30s&var-org=kubernetes-sigs&var-repo=cluster-api&var-job=pull-cluster-api-e2e-blocking-main&viewPanel=128&from=now-24h&to=now

CPU: https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&refresh=30s&var-org=kubernetes-sigs&var-repo=cluster-api&var-job=pull-cluster-api-e2e-blocking-main&viewPanel=180&from=now-24h&to=now

Health: https://prow.k8s.io/?job=pull-cluster-api-e2e-blocking-main