### PR TITLE
image-builder-presubmits: update resources

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -192,11 +192,11 @@ presubmits:
             - "./images/capi/scripts/ci-container-image.sh"
           resources:
             requests:
-              cpu: 4
-              memory: 6Gi
+              cpu: 2
+              memory: 1Gi
             limits:
-              cpu: 4
-              memory: 6Gi
+              cpu: 2
+              memory: 1Gi
           securityContext:
             privileged: true
             capabilities:


### PR DESCRIPTION
Done as part of the [Contributor Summit workshop](https://sched.co/1aOqL) and efforts to reduce requests for jobs that are not using requested resources.

Relevant dashboards:
- https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=image-builder&var-job=pull-container-image-build&viewPanel=180&from=1710783628992&to=1710788707065
- https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=image-builder&var-job=pull-container-image-build&viewPanel=128&from=1710356324932&to=1710447673164