### PR TITLE
plank: Do not handle ProwJobs in scheduling

### DIFF
--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -964,7 +964,7 @@ func predicates(additionalSelector string, callback func(bool)) (predicate.Predi
 				return false
 			}
 
-			return pj.Spec.Agent == prowv1.KubernetesAgent
+			return pj.Spec.Agent == prowv1.KubernetesAgent && pj.Status.State != prowv1.SchedulingState
 		}()
 		if callback != nil {
 			callback(result)


### PR DESCRIPTION
Since the scheduler has been introduced ([issue](https://github.com/kubernetes/test-infra/issues/32039) and [PRs](https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+is%3Aclosed+scheduler+in%3Atitle+author%3Adanilo-gemoli)) a ProwJob may be created in `scheduling` state.
The component that should handle PJs in `scheduling`, and that should make them transitioning to `triggered`, is the `scheduler`, as of today running as a reconciler in `prow-controller-manager`.
In this PR I have extended `plank`'s predicate function not to take into account PJs in `scheduling` anymore, since it would interleave/race with the `scheduler`.