### PR TITLE
Increase memory request/limit for `pull-aws-ebs-csi-driver-verify`

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -84,10 +84,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: verify-ebs


### PR DESCRIPTION
This PR increases the memory request/limit for `pull-aws-ebs-csi-driver-verify` - `golangci-lint` utilizes more than 4Gi of memory.