### PR TITLE
cluster-autoscaler: Azure E2E builds from source

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -35,6 +35,8 @@ presubmits:
             value: \[SIG AUTOSCALING\]
           - name: GINKGO_SKIP
             value: ""
+          - name: TEST_CLUSTER_AUTOSCALER
+            value: "true"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR adds a simple flag which tells the CAPZ E2E framework to build cluster-autoscaler from source before running tests.