### PR TITLE
etcd: increase resources of etcd-robustness test.

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -90,11 +90,11 @@ periodics:
         VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness
       resources:
         requests:
-          cpu: "8"
-          memory: "8Gi"
+          cpu: "10"
+          memory: "10Gi"
         limits:
-          cpu: "8"
-          memory: "8Gi"
+          cpu: "10"
+          memory: "10Gi"
       # fuse needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
Currently the test is failing about <10% of the time with [error](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-etcd-robustness-amd64/1771181741914984448)
```
    traffic.go:105: Requiring minimal 100.000000 qps for test results to be reliable, got 98.580444 qps
```

Trying increasing cpu and memory to see if it helps.