### PR TITLE
Add ProwJobs for the kubernetes-sigs/prow repo

### DIFF
--- a/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
@@ -1,0 +1,36 @@
+periodics:
+- name: ci-test-infra-continuous-test
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  interval: 1h
+  labels:
+    # Enable dind for linters that required docker to run, for example typescript.
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+      command:
+      - runner.sh
+      args:
+      - make
+      - test
+      - verify
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
+  annotations:
+    testgrid-dashboards: sig-testing-misc
+    testgrid-tab-name: continuous
+    testgrid-broken-column-threshold: '0.5'
+    description: Runs `make test verify` on the test-infra repo every hour

--- a/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
@@ -1,11 +1,11 @@
 periodics:
-- name: ci-test-infra-continuous-test
+- name: ci-prow-continuous-test-verify
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
+  - org: kubernetes-sigs
+    repo: prow
+    base_ref: main
   interval: 1h
   labels:
     # Enable dind for linters that required docker to run, for example typescript.
@@ -30,7 +30,7 @@ periodics:
           cpu: 2
           memory: 4Gi
   annotations:
-    testgrid-dashboards: sig-testing-misc
-    testgrid-tab-name: continuous
+    testgrid-dashboards: sig-testing-prow-repo
+    testgrid-tab-name: continuous-test-verify
     testgrid-broken-column-threshold: '0.5'
-    description: Runs `make test verify` on the test-infra repo every hour
+    description: Runs `make test verify` on the prow repo every hour

--- a/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
@@ -1,0 +1,88 @@
+postsubmits:
+  kubernetes/test-infra:
+  - name: post-test-infra-test-all
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - test
+        - verify
+        env:
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # This job is very CPU intensive as building prow images in
+            # parallel
+            cpu: "14"
+            memory: "16Gi"
+          limits:
+            cpu: "14"
+            memory: "16Gi"
+    annotations:
+      testgrid-dashboards: sig-testing-misc
+      testgrid-tab-name: post-test-all
+      description: Runs 'make test verify' on the test-infra repo on each commit
+
+### Trusted Jobs ###
+
+# - name: post-test-infra-push-prow
+#   cluster: test-infra-trusted
+#   # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
+#   run_if_changed: '^(\.ko\.yaml|hack/(make-rules|prowimagebuilder)|gencred|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+#   decorate: true
+#   labels:
+#     # Building deck requires docker for typescript compilation.
+#     preset-dind-enabled: "true"
+#   branches:
+#   - ^master$
+#   max_concurrency: 1
+#   spec:
+#     serviceAccountName: pusher
+#     containers:
+#     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+#       command:
+#       - runner.sh
+#       args:
+#       - make
+#       - -C
+#       - prow
+#       - push-images
+#       env:
+#       # TODO(chaodaiG): remove once this becomes the default in `prow/Makefile`
+#       - name: REGISTRY
+#         value: gcr.io/k8s-prow
+#       # docker-in-docker needs privileged mode
+#       securityContext:
+#         privileged: true
+#       resources:
+#         requests:
+#           cpu: "15"
+#     tolerations:
+#     - key: "highcpu"
+#       operator: "Equal"
+#       value: "true"
+#       effect: "NoSchedule"
+#     nodeSelector:
+#       highcpu: "true"
+#   annotations:
+#     testgrid-dashboards: sig-testing-prow
+#     testgrid-tab-name: push-prow
+#     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+#     testgrid-num-failures-to-alert: '1'
+#     description: builds and pushes all prow on each commit by running make -C prow push-images
+#   rerun_auth_config:
+#     github_users:
+#     - alvaroaleman

--- a/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
@@ -1,12 +1,9 @@
 postsubmits:
-  kubernetes/test-infra:
-  - name: post-test-infra-test-all
+  kubernetes-sigs/prow:
+  - name: post-prow-test-verify
     cluster: eks-prow-build-cluster
-    branches:
-    - master
     decorate: true
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     spec:
@@ -32,22 +29,22 @@ postsubmits:
             cpu: "14"
             memory: "16Gi"
     annotations:
-      testgrid-dashboards: sig-testing-misc
-      testgrid-tab-name: post-test-all
-      description: Runs 'make test verify' on the test-infra repo on each commit
+      testgrid-dashboards: sig-testing-prow-repo
+      testgrid-tab-name: post-test-verify
+      description: Runs 'make test verify' on the prow repo on each commit
 
 ### Trusted Jobs ###
 
-# - name: post-test-infra-push-prow
+# - name: post-push-prow
 #   cluster: test-infra-trusted
 #   # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-#   run_if_changed: '^(\.ko\.yaml|hack/(make-rules|prowimagebuilder)|gencred|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+#   skip_if_only_changed: '^site/'
 #   decorate: true
 #   labels:
 #     # Building deck requires docker for typescript compilation.
 #     preset-dind-enabled: "true"
 #   branches:
-#   - ^master$
+#   - ^main$
 #   max_concurrency: 1
 #   spec:
 #     serviceAccountName: pusher
@@ -61,9 +58,6 @@ postsubmits:
 #       - prow
 #       - push-images
 #       env:
-#       # TODO(chaodaiG): remove once this becomes the default in `prow/Makefile`
-#       - name: REGISTRY
-#         value: gcr.io/k8s-prow
 #       # docker-in-docker needs privileged mode
 #       securityContext:
 #         privileged: true
@@ -78,11 +72,11 @@ postsubmits:
 #     nodeSelector:
 #       highcpu: "true"
 #   annotations:
-#     testgrid-dashboards: sig-testing-prow
-#     testgrid-tab-name: push-prow
+#     testgrid-dashboards: sig-testing-prow-repo
+#     testgrid-tab-name: push-images
 #     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
 #     testgrid-num-failures-to-alert: '1'
-#     description: builds and pushes all prow on each commit by running make -C prow push-images
+#     description: Builds and pushes all prow container images on each commit by running make -C prow push-images
 #   rerun_auth_config:
 #     github_users:
 #     - alvaroaleman

--- a/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
@@ -1,13 +1,10 @@
 presubmits:
-  kubernetes/test-infra:
-  - name: pull-test-infra-integration
+  kubernetes-sigs/prow:
+  - name: pull-prow-integration
     cluster: eks-prow-build-cluster
-    branches:
-    - master
-    skip_if_only_changed: '(^config/jobs/)|(^images/)|(^scenarios/)|(^jenkins/)|(^kubetest/)'
+    skip_if_only_changed: '^site/'
     decorate: true
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     spec:
@@ -31,12 +28,10 @@ presubmits:
             cpu: "14"
             memory: "16Gi"
     annotations:
-      testgrid-dashboards: presubmits-test-infra
+      testgrid-dashboards: sig-testing-prow-repo
       testgrid-tab-name: integration
-  - name: pull-test-infra-unit-test-race-detector-nonblocking
+  - name: pull-prow-unit-test-race-detector-nonblocking
     cluster: eks-prow-build-cluster
-    branches:
-    - master
     always_run: true
     decorate: true
     optional: true
@@ -66,12 +61,10 @@ presubmits:
             cpu: "8"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: presubmits-test-infra
+      testgrid-dashboards: sig-testing-prow-repo
       testgrid-tab-name: unit-test-race-detector-nonblocking
-  - name: pull-test-infra-unit-test
+  - name: pull-prow-unit-test
     cluster: eks-prow-build-cluster
-    branches:
-    - master
     always_run: true
     decorate: true
     labels:
@@ -96,13 +89,11 @@ presubmits:
             cpu: "8"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: presubmits-test-infra
+      testgrid-dashboards: sig-testing-prow-repo
       testgrid-tab-name: unit-test
-  - name: pull-test-infra-prow-image-build-test
+  - name: pull-prow-image-build-test
     cluster: eks-prow-build-cluster
-    branches:
-    - master
-    run_if_changed: '^(\.ko\.yaml|hack/(ts-rollup|make-rules|prowimagebuilder)|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+    skip_if_only_changed: '^site/'
     decorate: true
     labels:
       # Building deck requires docker for typescript compilation.
@@ -130,12 +121,10 @@ presubmits:
             cpu: "14"
             memory: "16Gi"
     annotations:
-      testgrid-dashboards: presubmits-test-infra
-      testgrid-tab-name: prow-image-build-test
-  - name: pull-test-infra-verify-lint
+      testgrid-dashboards: sig-testing-prow-repo
+      testgrid-tab-name: image-build-test
+  - name: pull-prow-verify-lint
     cluster: eks-prow-build-cluster
-    branches:
-    - master
     always_run: true
     decorate: true
     labels:
@@ -160,5 +149,5 @@ presubmits:
             cpu: "8"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: presubmits-test-infra
+      testgrid-dashboards: sig-testing-prow-repo
       testgrid-tab-name: verify-test

--- a/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
@@ -1,0 +1,164 @@
+presubmits:
+  kubernetes/test-infra:
+  - name: pull-test-infra-integration
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    skip_if_only_changed: '(^config/jobs/)|(^images/)|(^scenarios/)|(^jenkins/)|(^kubetest/)'
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+        command:
+        - runner.sh
+        args:
+        - ./prow/test/integration/integration-test.sh
+        env:
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # This job is very CPU intensive as building prow images in
+            # parallel
+            cpu: "14"
+            memory: "16Gi"
+          limits:
+            cpu: "14"
+            memory: "16Gi"
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: integration
+  - name: pull-test-infra-unit-test-race-detector-nonblocking
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    optional: true
+    skip_report: false
+    labels:
+      # Python unit tests run in docker.
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - unit
+        env:
+        - name: PROW_UNIT_TEST_EXTRA_FLAGS
+          value: "-race"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "8"
+            memory: "8Gi"
+          limits:
+            cpu: "8"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: unit-test-race-detector-nonblocking
+  - name: pull-test-infra-unit-test
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      # Python unit tests run in docker.
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - unit
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "8"
+            memory: "8Gi"
+          limits:
+            cpu: "8"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: unit-test
+  - name: pull-test-infra-prow-image-build-test
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    run_if_changed: '^(\.ko\.yaml|hack/(ts-rollup|make-rules|prowimagebuilder)|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+    decorate: true
+    labels:
+      # Building deck requires docker for typescript compilation.
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - -C
+        - prow
+        - build-images
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # This job is very CPU intensive as building prow images in
+            # parallel
+            cpu: "14"
+            memory: "16Gi"
+          limits:
+            cpu: "14"
+            memory: "16Gi"
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: prow-image-build-test
+  - name: pull-test-infra-verify-lint
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      # Enable dind for linters that required docker to run, for example typescript.
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "8"
+            memory: "8Gi"
+          limits:
+            cpu: "8"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: verify-test

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -10,6 +10,7 @@ test_groups:
 dashboard_groups:
 - name: sig-testing
   dashboard_names:
+  - sig-testing-prow-repo
   - sig-testing-boskos
   - sig-testing-canaries
   - sig-testing-e2e-framework
@@ -23,6 +24,7 @@ dashboard_groups:
 # Dashboards
 
 dashboards:
+- name: sig-testing-prow-repo
 - name: sig-testing-boskos
 - name: sig-testing-canaries
   dashboard_tab:


### PR DESCRIPTION
The first commit copies the jobs without edits from kubernetes/test-infra to kubernetes-sigs/prow.
The second commit updates the jobs to be appropriate for the new repo. This is the main commit to review and will have a more useful diff.