### PR TITLE
Make RequireSelfApproval documentation less ambiguous

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -314,8 +314,8 @@ type Approve struct {
 	// IssueRequired indicates if an associated issue is required for approval in
 	// the specified repos.
 	IssueRequired bool `json:"issue_required,omitempty"`
-	// RequireSelfApproval requires PR authors to explicitly approve their PRs.
-	// Otherwise the plugin assumes the author of the PR approves the changes in the PR.
+	// RequireSelfApproval disables automatic approval from PR authors with approval rights.
+	// Otherwise the plugin assumes the author of the PR with approval rights approves the changes in the PR.
 	RequireSelfApproval *bool `json:"require_self_approval,omitempty"`
 	// LgtmActsAsApprove indicates that the lgtm command should be used to
 	// indicate approval


### PR DESCRIPTION
We have run into the exact same issue as described here:

- https://github.com/kubernetes/test-infra/issues/12693

The reason being ambiguous documentation.

The original documentation states
```
// RequireSelfApproval requires PR authors to explicitly approve their PRs.
// Otherwise the plugin assumes the author of the PR approves the changes in the PR.
```
The first sentence is not true. This config item doesn't require PR authors to explicitly approve their PRs - they may not approve the PR at all, somebody else can do it for them. It will simply disable automatic approval if a PR author has approval rights.
Second sentence is true just for the authors of the PR with approval rights.

The linked issue ended with a comment that the documentation is bad, so this PR is fixing that.