### PR TITLE
[releng] Add 1.30 and remove 1.26 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -459,10 +459,10 @@ milestone_applier:
     master: v1.30
   kubernetes/kubernetes:
     master: v1.30
+    release-1.30: v1.30
     release-1.29: v1.29
     release-1.28: v1.28
     release-1.27: v1.27
-    release-1.26: v1.26
   kubernetes/org:
     main: v1.30
   kubernetes/release:


### PR DESCRIPTION
- releng: Add 1.30 and remove 1.26 milestone_applier rules

Pending branch cut:
/hold

/sig release
/area release-eng
/assign @saschagrunert @cpanato @xmudrii @dims 
cc: @kubernetes/release-engineering