### PR TITLE
update mdtoc jobs to use go1.22

### DIFF
--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
need for https://github.com/kubernetes-sigs/mdtoc/pull/21


/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes/release-engineering 