### PR TITLE
update bom jobs to use go1.22

### DIFF
--- a/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -61,7 +61,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
need for https://github.com/kubernetes-sigs/bom/pull/410


/assign @saschagrunert @Verolop @xmudrii @puerco 
cc @kubernetes-sigs/release-engineering 