### PR TITLE
Fix prow job ci-kubernetes-gce-conformance-latest

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -20,7 +20,7 @@ periodics:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --extract=ci/latest-fast
+      - --extract=ci/fast/latest-fast
       - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci


### PR DESCRIPTION
Prow job `ci-kubernetes-gce-conformance-latest` has been failing with 

```
{  Failed to set release from https://storage.googleapis.com/k8s-release-dev/ci/latest-fast.txt (Unexpected HTTP status code: 404)}
```

Add missing `fast/` so we have the correct config: `--extract=ci/fast/latest-fast`. 