### PR TITLE
Increase the Resources for `pull-verify-kueue-main`

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -242,7 +242,7 @@ presubmits:
             memory: "8Gi"
           limits:
             cpu: "4"
-            memory: "6Gi"
+            memory: "8Gi"
   - name: pull-kueue-build-image-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -235,13 +235,13 @@ presubmits:
           - verify
         env:
         - name: GOMAXPROCS
-          value: "2"
+          value: "4"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "6Gi"
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "6Gi"
   - name: pull-kueue-build-image-main
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -239,7 +239,7 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "6Gi"
+            memory: "8Gi"
           limits:
             cpu: "4"
             memory: "6Gi"


### PR DESCRIPTION
The verify job takes more than ~15 mins to complete, which adds more time to the release process. This is an attempt to check if increasing the resources for verify job reduces the time.

See for more info: https://github.com/kubernetes-sigs/kueue/issues/1849