### PR TITLE
Add kubekins-e2e / kubekins-e2e-v2 / krte variants for v1.30

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -31,6 +31,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.30':
+    CONFIG: '1.30'
+    GO_VERSION: 1.22.1
+    K8S_RELEASE: latest-1.30
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.29':
     CONFIG: '1.29'
     GO_VERSION: 1.21.8


### PR DESCRIPTION
We are missing 1.30 for these images. context : https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-1-30/1773737123896102912

single file is symlinked to all the images
```
lrwxr-xr-x 1 davanum staff   32 Feb  9 15:50 ./images/krte/variants.yaml -> ../kubekins-e2e-v2/variants.yaml
lrwxr-xr-x 1 davanum staff   32 Feb  9 15:50 ./images/kubekins-e2e/variants.yaml -> ../kubekins-e2e-v2/variants.yaml
-rw-r--r-- 1 davanum staff 1412 Mar 29 14:51 ./images/kubekins-e2e-v2/variants.yaml
```