### PR TITLE
update the images for ci jobs running in 1.30 branch

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -163,7 +163,7 @@ periodics:
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+      image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
       name: ""
       resources:
         limits:
@@ -525,7 +525,7 @@ periodics:
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+      image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
       name: ""
       resources:
         limits:
@@ -574,7 +574,7 @@ periodics:
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+      image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
       name: ""
       resources:
         limits:
@@ -1842,7 +1842,7 @@ presubmits:
           value: ipv6
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+        image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
         name: ""
         resources:
           limits:
@@ -1977,7 +1977,7 @@ presubmits:
           value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+        image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
         name: ""
         resources:
           limits:
@@ -2020,7 +2020,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+        image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
         name: ""
         resources:
           limits:
@@ -2057,7 +2057,7 @@ presubmits:
           value: "true"
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20240308-3b134c2624-1.30
+        image: gcr.io/k8s-staging-test-infra/krte:v20240329-fc17bdd16b-1.30
         name: ""
         resources:
           limits:


### PR DESCRIPTION
The specified images do not exist! 

New images have been created from https://github.com/kubernetes/test-infra/pull/32342