### PR TITLE
update pull-cip-verify to use go1.22

### DIFF
--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -152,7 +152,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.21-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
need for https://github.com/kubernetes-sigs/promo-tools/pull/1262

/assign @puerco @saschagrunert @xmudrii 
cc @kubernetes/release-managers 