### PR TITLE
kOps: Switch `kops-pipeline-updown` jobs to the default build cluster

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1803,7 +1803,7 @@ def generate_pipeline():
         results.append(
             build_test(
                 cloud="aws",
-                build_cluster="k8s-infra-kops-prow-build",
+                build_cluster="default",
                 k8s_version=version.replace('master', 'latest'),
                 kops_version=kops_version,
                 kops_channel='alpha',

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 90m
@@ -76,7 +76,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 90m
@@ -143,7 +143,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 90m
@@ -210,7 +210,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
+  cluster: default
   decorate: true
   decoration_config:
     timeout: 90m


### PR DESCRIPTION
/cc @dims @rifelpet @ameukam 

Ref: #16447