### PR TITLE
[vsphere-csi-driver] Update golangci-lint to v1.55.1

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -62,7 +62,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.49.0
+        - image: golangci/golangci-lint:v1.55.1
           command:
             - make
           args:


### PR DESCRIPTION
Update golangci-lint to v1.55.1 to match the version present in https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/hack/check-golangci-lint.sh#L54-L60