### PR TITLE
scheduler: config hot reload

### DIFF
--- a/prow/scheduler/reconciler.go
+++ b/prow/scheduler/reconciler.go
@@ -24,7 +24,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
-	schedulingstrategy "k8s.io/test-infra/prow/scheduler/strategy"
+	"k8s.io/test-infra/prow/scheduler/strategy"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -40,8 +40,7 @@ func Add(mgr controllerruntime.Manager, cfg config.Getter, numWorkers int) error
 		return isPJ && pj.Status.State == prowv1.SchedulingState
 	})
 
-	strategy := schedulingstrategy.Get(cfg())
-	reconciler := NewReconciler(mgr.GetClient(), strategy)
+	reconciler := NewReconciler(mgr.GetClient(), cfg, strategy.Get)
 	if err := controllerruntime.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&prowv1.ProwJob{}).
@@ -54,11 +53,14 @@ func Add(mgr controllerruntime.Manager, cfg config.Getter, numWorkers int) error
 	return nil
 }
 
+type StrategyGetter func(cfg *config.Config) strategy.Interface
+
 type Reconciler struct {
 	pjClient    client.Client
-	passthrough schedulingstrategy.Interface
-	strategy    schedulingstrategy.Interface
+	passthrough strategy.Interface
 	log         *logrus.Entry
+	cfg         config.Getter
+	strategy    StrategyGetter
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -74,13 +76,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	log = log.WithField("job", pj.Spec.Job)
 
-	var result schedulingstrategy.Result
+	var result strategy.Result
 	var err error
 	// So far only k8s and tekton use the cluster field in a meaninful way. Hence
 	// if we're reconciling a job having a different agent (or no agent at all) applying
 	// the passthrough strategy may be the safest approach.
 	if pj.Spec.Agent == prowv1.KubernetesAgent || pj.Spec.Agent == prowv1.TektonAgent {
-		result, err = r.strategy.Schedule(ctx, pj)
+		result, err = r.strategy(r.cfg()).Schedule(ctx, pj)
 	} else {
 		result, err = r.passthrough.Schedule(ctx, pj)
 	}
@@ -102,11 +104,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{}, nil
 }
 
-func NewReconciler(pjClient client.Client, strategy schedulingstrategy.Interface) *Reconciler {
+func NewReconciler(pjClient client.Client, cfg config.Getter, strtgy StrategyGetter) *Reconciler {
 	return &Reconciler{
 		pjClient:    pjClient,
-		passthrough: &schedulingstrategy.Passthrough{},
-		strategy:    strategy,
+		passthrough: &strategy.Passthrough{},
 		log:         logrus.NewEntry(logrus.StandardLogger()).WithField("controller", ControllerName),
+		cfg:         cfg,
+		strategy:    strtgy,
 	}
 }

--- a/prow/scheduler/reconciler_test.go
+++ b/prow/scheduler/reconciler_test.go
@@ -29,8 +29,10 @@ import (
 	testingclient "k8s.io/client-go/testing"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/client/clientset/versioned/scheme"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/scheduler"
 	"k8s.io/test-infra/prow/scheduler/strategy"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -169,7 +171,11 @@ func TestReconcile(t *testing.T) {
 			}
 			pjClient := builder.Build()
 
-			r := scheduler.NewReconciler(pjClient, &fakeStrategy{cluster: tc.cluster, err: tc.schedulingError})
+			r := scheduler.NewReconciler(pjClient,
+				func() *config.Config { return nil },
+				func(_ *config.Config) strategy.Interface {
+					return &fakeStrategy{cluster: tc.cluster, err: tc.schedulingError}
+				})
 			_, err := r.Reconcile(context.TODO(), tc.request)
 
 			if tc.wantError != nil && err != nil {
@@ -199,6 +205,116 @@ func TestReconcile(t *testing.T) {
 				if diff := cmp.Diff(tc.wantPJ, &pjs.Items[0]); diff != "" {
 					t.Errorf("Unexpected ProwJob: %s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestConfigHotReload(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		configs []config.Config
+		pjs     []client.Object
+		wantPJs []prowv1.ProwJob
+	}{
+		{
+			name: "Switch from Passthrough to Failover",
+			configs: []config.Config{
+				{},
+				{
+					ProwConfig: config.ProwConfig{Scheduler: config.Scheduler{
+						Failover: &config.FailoverScheduling{ClusterMappings: map[string]string{"foo": "bar"}},
+					}},
+				},
+			},
+			pjs: []client.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "job1", Namespace: "", ResourceVersion: "1"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "foo"},
+				},
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "job2", Namespace: "", ResourceVersion: "1"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "foo"},
+				},
+			},
+			wantPJs: []prowv1.ProwJob{
+				{
+					ObjectMeta: v1.ObjectMeta{Name: "job1", Namespace: "", ResourceVersion: "2"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "foo"},
+					Status:     prowv1.ProwJobStatus{State: prowv1.TriggeredState},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{Name: "job2", Namespace: "", ResourceVersion: "2"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "bar"},
+					Status:     prowv1.ProwJobStatus{State: prowv1.TriggeredState},
+				},
+			},
+		},
+		{
+			name: "Modify Failover",
+			configs: []config.Config{
+				{
+					ProwConfig: config.ProwConfig{Scheduler: config.Scheduler{
+						Failover: &config.FailoverScheduling{ClusterMappings: map[string]string{"foo": "bar"}},
+					}},
+				},
+				{
+					ProwConfig: config.ProwConfig{Scheduler: config.Scheduler{
+						Failover: &config.FailoverScheduling{ClusterMappings: map[string]string{
+							"foo":   "bar",
+							"super": "duper",
+						}},
+					}},
+				},
+			},
+			pjs: []client.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "job1", Namespace: "", ResourceVersion: "1"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "foo"},
+				},
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "job2", Namespace: "", ResourceVersion: "1"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "super"},
+				},
+			},
+			wantPJs: []prowv1.ProwJob{
+				{
+					ObjectMeta: v1.ObjectMeta{Name: "job1", Namespace: "", ResourceVersion: "2"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "bar"},
+					Status:     prowv1.ProwJobStatus{State: prowv1.TriggeredState},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{Name: "job2", Namespace: "", ResourceVersion: "2"},
+					Spec:       prowv1.ProwJobSpec{Agent: prowv1.KubernetesAgent, Cluster: "duper"},
+					Status:     prowv1.ProwJobStatus{State: prowv1.TriggeredState},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg *config.Config
+			pjClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.pjs...).Build()
+			reconciler := scheduler.NewReconciler(pjClient, func() *config.Config { return cfg }, strategy.Get)
+
+			for i := range tc.configs {
+				cfg = &tc.configs[i]
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.pjs[i].GetName()}}
+				if _, err := reconciler.Reconcile(context.TODO(), request); err != nil {
+					t.Fatalf("Failed to reconcile %v: %s", request, err)
+				}
+			}
+
+			pjs := prowv1.ProwJobList{}
+			if err := pjClient.List(context.TODO(), &pjs); err != nil {
+				// It's just not supposed to happen
+				t.Fatalf("Couldn't get PJs from the fake client: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.wantPJs, pjs.Items); diff != "" {
+				t.Errorf("Unexpected ProwJob: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Every component in Prow is already able to get the latest available configuration without restarting.
This PR adds the same capability to the scheduler. 