### PR TITLE
scheduler: opt-in scheduling on PR merge

### DIFF
--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -85,7 +85,7 @@ func handlePE(c Client, pe github.PushEvent) error {
 			labels[k] = v
 		}
 		labels[github.EventGUID] = pe.GUID
-		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, refs), labels, j.Annotations)
+		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, refs), labels, j.Annotations, pjutil.RequireScheduling(c.Config.Scheduler.Enabled))
 		c.Logger.WithFields(pjutil.ProwJobFields(&pj)).Info("Creating a new prowjob.")
 		if err := createWithRetry(context.TODO(), c.ProwJobClient, &pj); err != nil {
 			return err


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/32173 Follow up.
Opt-in scheduling in `trigger` when a PR merges.