### PR TITLE
gengo: use make directive for verify job

### DIFF
--- a/config/jobs/kubernetes/gengo/gengo-config.yaml
+++ b/config/jobs/kubernetes/gengo/gengo-config.yaml
@@ -40,10 +40,9 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-master
           command:
             - runner.sh
-            - bash
           args:
-           - -c
-           - hack/verify-examples.sh
+          - make
+           - verify
           resources:
             requests:
               memory: 4Gi


### PR DESCRIPTION
To bring this into effect: https://github.com/kubernetes/gengo/pull/267

/assign @dims
/hold 
till https://github.com/kubernetes/gengo/pull/267 is merged.