### PR TITLE
increase `pull-hydrophone-verify` to use 2 cpus for golangci-lint

### DIFF
--- a/config/jobs/kubernetes-sigs/hydrophone/hydrophone-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/hydrophone/hydrophone-presubmit.yaml
@@ -58,10 +58,10 @@ presubmits:
               - verify
             resources:
               limits:
-                cpu: 1
+                cpu: 2
                 memory: 4Gi
               requests:
-                cpu: 1
+                cpu: 2
                 memory: 4Gi
       annotations:
         testgrid-dashboards: sig-testing-misc


### PR DESCRIPTION
This is a companion PR to https://github.com/kubernetes-sigs/hydrophone/pull/170 -- `golangci-lint` catches many more things than the normal `golint` linter, but it requires more resources (as can be seen in the PR; running with one CPU takes around 10 minutes).

To improve performance of the `pull-hydrophone-verify` job, this increases the CPU requests/limits to 2, as that was the bottleneck in the successful run: https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-sigs&var-repo=hydrophone&var-job=pull-hydrophone-verify&var-build=All&from=1712229969986&to=1712230612688&viewPanel=248.

/assign @dims @rjsadow 