### PR TITLE
capi: reduce prowjob cpu and memory resources

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
@@ -44,11 +44,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-24-1-25
@@ -99,11 +99,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-25-1-26
@@ -154,11 +154,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-26-1-27
@@ -209,11 +209,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-27-1-28
@@ -264,11 +264,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-28-1-29
@@ -319,11 +319,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-29-1-30

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -22,10 +22,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-test-main
@@ -63,10 +63,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-test-mink8s-main
@@ -106,11 +106,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main
@@ -153,11 +153,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-main
@@ -205,11 +205,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-mink8s-main
@@ -250,11 +250,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-conformance-main
@@ -294,11 +294,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-conformance-ci-latest-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -17,11 +17,11 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-build-main
@@ -42,11 +42,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.29
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-apidiff-main
@@ -68,11 +68,11 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl
@@ -44,11 +44,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}6Gi{{ else }}32Gi{{ end }}
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}6Gi{{ else }}32Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.From "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.To "stable-") "ci/latest-") "." "-" }}

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -21,10 +21,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-test-{{ ReplaceAll $.branch "." "-" }}
@@ -62,10 +62,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-test-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -105,11 +105,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}
@@ -153,11 +153,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
@@ -206,11 +206,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -251,11 +251,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
@@ -295,11 +295,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
+          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -16,11 +16,11 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}4Gi{{ else }}9Gi{{ end }}
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}4Gi{{ else }}9Gi{{ end }}
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-build-{{ ReplaceAll $.branch "." "-" }}
@@ -41,11 +41,11 @@ presubmits:
         image: {{ $.config.TestImage }}
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}2Gi{{ else }}9Gi{{ end }}
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}2Gi{{ else }}9Gi{{ end }}
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-apidiff-{{ ReplaceAll $.branch "." "-" }}
@@ -67,11 +67,11 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: {{ if eq $.branch "main" }}5000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}3Gi{{ else }}9Gi{{ end }}
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: {{ if eq $.branch "main" }}5000m{{ else }}7300m{{ end }}
+            memory: {{ if eq $.branch "main" }}3Gi{{ else }}9Gi{{ end }}
         securityContext:
           privileged: true
     annotations:


### PR DESCRIPTION
This PR reduces the requests and limits set for some of cluster-api's prowjobs.

This for now affects the following jobs:

* presubmits:
  * `pull-cluster-api-build-main`
  * `pull-cluster-api-apidiff-main`
  * `pull-cluster-api-verify-main`
* postsubmits:
  * `periodic-cluster-api-e2e-upgrade-1-24-1-25-main`
  * `periodic-cluster-api-e2e-upgrade-1-25-1-26-main`
  * `periodic-cluster-api-e2e-upgrade-1-26-1-27-main`
  * `periodic-cluster-api-e2e-upgrade-1-27-1-28-main`
  * `periodic-cluster-api-e2e-upgrade-1-28-1-29-main`
  * `periodic-cluster-api-e2e-upgrade-1-29-1-30-main`
  * `periodic-cluster-api-test-main`
  * `periodic-cluster-api-test-mink8s-main`
  * `periodic-cluster-api-e2e-main`
  * `periodic-cluster-api-e2e-dualstack-and-ipv6-main`
  * `periodic-cluster-api-e2e-mink8s-main`
  * `periodic-cluster-api-e2e-conformance-main`
  * `periodic-cluster-api-e2e-conformance-ci-latest-main`

The idea is to:
* verify these new values are ok on the main branch (to not affect the test signal for upcoming CAPI release for now)
* adjust leftover presubmits jobs which target main after the above values in periodics are seen as okay, because they are pretty similar to them
* apply the new values also for the release branches after we see it is stable

# How did you roll the dice to get the new values?

Good question 😄 

I did make use of this dashboard provided by test-infra: https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api&from=1712214148796&to=1712225862895

And came up with the following calculation (note: also see the comment section):

![image](https://github.com/kubernetes/test-infra/assets/417870/aa2191e0-025b-40b7-879d-f42aadf2d7e0)

https://docs.google.com/spreadsheets/d/18jQgOlhtMbOICJyMFr_gdI3WlhI0kYmuiEMJuKF61dg/edit?usp=sharing
