### PR TITLE
Add more CAPV e2e supervisor tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-upgrades.yaml
@@ -47,6 +47,52 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-28-1-29-main
+  interval: 24h
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.28"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "stable-1.29"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-main-1-28-1-29
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
 - name: periodic-cluster-api-provider-vsphere-e2e-upgrade-1-29-1-30-main
   interval: 24h
   decorate: true
@@ -90,5 +136,51 @@ periodics:
   annotations:
     testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
     testgrid-tab-name: periodic-e2e-main-1-29-1-30
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-29-1-30-main
+  interval: 24h
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.29"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.30"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-main-1-29-1-30
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -152,6 +152,8 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[supervisor\\]"
+      - name: GINKGO_SKIP
+        value: "\\[Conformance\\] \\[specialized-infra\\]"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -167,6 +169,92 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
     description: Runs e2e tests with supervisor mode
+
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-conformance-main
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  interval: 24h
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-conformance-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+    description: Runs conformance tests for CAPV with supervisor mode
+
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-conformance-ci-latest-main
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  interval: 24h
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-conformance-ci-latest-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+    description: Runs conformance tests with K8S ci latest for CAPV with supervisor mode
 
 - name: periodic-cluster-api-provider-vsphere-e2e-vcsim-govmomi-main
   cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
@@ -321,6 +321,117 @@ presubmits:
       testgrid-tab-name: pr-e2e-supervisor-main
       description: Runs e2e tests with supervisor mode
 
+  - name: pull-cluster-api-provider-vsphere-e2e-supervisor-conformance-main
+    branches:
+    - ^main$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-supervisor-conformance-main
+      description: Runs conformance tests for CAPV with suprervisor mode
+
+  - name: pull-cluster-api-provider-vsphere-e2e-supervisor-conformance-ci-latest-main
+    branches:
+    - ^main$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-supervisor-conformance-ci-latest-main
+      description: Runs conformance tests with K8S ci latest for CAPV with suprervisor mode
+
+  - name: pull-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-29-1-30-main
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.28
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.29"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "ci/latest-1.30"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-supervisor-main-1-29-1-30
+
   - name: pull-cluster-api-provider-vsphere-e2e-upgrade-1-29-1-30-main
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-upgrades.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-upgrades.yaml.tpl
@@ -46,5 +46,52 @@ periodics:
     testgrid-tab-name: periodic-e2e-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.From "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.To "stable-") "ci/latest-") "." "-" }}
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
+{{ if eq $.branch "main" }}
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.From "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.To "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll $.branch "." "-" }}
+  interval: {{ $.config.UpgradesInterval }}
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: {{ $.branch }}
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: {{ $.config.TestImage }}
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "{{ index (index $.versions $upgrade.From) "k8sRelease" }}"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "{{ index (index $.versions $upgrade.To) "k8sRelease" }}"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.From "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.To "stable-") "ci/latest-") "." "-" }}
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+{{ end -}}
 {{ end -}}
 {{ end -}}

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -151,6 +151,8 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[supervisor\\]"
+      - name: GINKGO_SKIP
+        value: "\\[Conformance\\] \\[specialized-infra\\]"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -166,6 +168,92 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
     description: Runs e2e tests with supervisor mode
+
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-conformance-{{ ReplaceAll $.branch "." "-" }}
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  interval: {{ $.config.Interval }}
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: {{ $.branch }}
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: {{ $.config.TestImage }}
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-conformance-{{ ReplaceAll $.branch "." "-" }}
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+    description: Runs conformance tests for CAPV with supervisor mode
+
+- name: periodic-cluster-api-provider-vsphere-e2e-supervisor-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  interval: {{ $.config.Interval }}
+  decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-provider-vsphere-maintainers
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: {{ $.branch }}
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: {{ $.config.TestImage }}
+      command:
+      - runner.sh
+      args:
+      - ./hack/e2e.sh
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["NET_ADMIN"]
+      resources:
+        requests:
+          cpu: "4000m"
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-e2e-supervisor-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+    description: Runs conformance tests with K8S ci latest for CAPV with supervisor mode
 
 - name: periodic-cluster-api-provider-vsphere-e2e-vcsim-govmomi-{{ ReplaceAll $.branch "." "-" }}
   cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
@@ -319,6 +319,117 @@ presubmits:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-e2e-supervisor-{{ ReplaceAll $.branch "." "-" }}
       description: Runs e2e tests with supervisor mode
+
+  - name: pull-cluster-api-provider-vsphere-e2e-supervisor-conformance-{{ ReplaceAll $.branch "." "-" }}
+    branches:
+    - ^{{ $.branch }}$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+      - image: {{ $.config.TestImage }}
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-supervisor-conformance-{{ ReplaceAll $.branch "." "-" }}
+      description: Runs conformance tests for CAPV with suprervisor mode
+
+  - name: pull-cluster-api-provider-vsphere-e2e-supervisor-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
+    branches:
+    - ^{{ $.branch }}$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+      - image: {{ $.config.TestImage }}
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-supervisor-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
+      description: Runs conformance tests with K8S ci latest for CAPV with suprervisor mode
+
+  - name: pull-cluster-api-provider-vsphere-e2e-supervisor-upgrade-{{ ReplaceAll (last $.config.Upgrades).From "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).To "." "-" }}-{{ ReplaceAll $.branch "." "-" }}
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^{{ $.branch }}$
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: {{ $.config.TestImage }}
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[supervisor\\] \\[Conformance\\] \\[K8s-Upgrade\\]"
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "{{ index (index $.versions ((last $.config.Upgrades).From)) "k8sRelease" }}"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "{{ index (index $.versions ((last $.config.Upgrades).To)) "k8sRelease" }}"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-supervisor-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).From "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).To "." "-" }}
 {{ end }}{{ if eq $.branch "release-1.5" "release-1.6" "release-1.7" "release-1.8" | not }}
   - name: pull-cluster-api-provider-vsphere-e2e-upgrade-{{ ReplaceAll (last $.config.Upgrades).From "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).To "." "-" }}-{{ ReplaceAll $.branch "." "-" }}
     labels:


### PR DESCRIPTION
Add more CAPV e2e supervisor tests, ensuring ~ the same coverage we have for govmomi mode for Kubernetes conformance and Kubernetes upgrade tests