### PR TITLE
caaph: sync maintainers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/OWNERS
@@ -4,8 +4,6 @@ approvers:
 - Jont828
 - fabriziopandini
 - jackfrancis
-
-reviewers:
 - mboersma
 
 emeritus_approvers:


### PR DESCRIPTION
Syncs up maintainers with the [OWNERS_ALIASES](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/OWNERS_ALIASES) in CAAPH. Specifically, @mboersma moves to maintainer from reviewer.

/assign @Jont828