### PR TITLE
CAPI: mount k/k on all e2e tests to allow building kindest/node images

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -141,6 +141,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
@@ -182,6 +187,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     branches:
     # The script this job runs is not in all branches.
@@ -215,6 +225,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -252,6 +267,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -334,6 +354,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -367,17 +392,17 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
     - ^main$
     path_alias: sigs.k8s.io/cluster-api
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.30

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
@@ -141,6 +141,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
@@ -182,6 +187,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     branches:
     # The script this job runs is not in all branches.
@@ -215,6 +225,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     optional: true
     branches:
@@ -249,6 +264,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -286,6 +306,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
@@ -141,6 +141,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
@@ -182,6 +187,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     branches:
     # The script this job runs is not in all branches.
@@ -215,6 +225,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -252,6 +267,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
@@ -141,6 +141,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
@@ -182,6 +187,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     branches:
     # The script this job runs is not in all branches.
@@ -215,6 +225,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -252,6 +267,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -334,6 +354,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -367,17 +392,17 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.7$
     path_alias: sigs.k8s.io/cluster-api
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240329-fc17bdd16b-1.29

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -141,6 +141,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
@@ -183,6 +188,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     branches:
     # The script this job runs is not in all branches.
@@ -217,6 +227,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     optional: true
     branches:
@@ -257,6 +272,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -294,6 +314,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     optional: true
     branches:
@@ -334,6 +359,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -416,6 +446,11 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
@@ -449,17 +484,17 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     decorate: true
     always_run: false
     branches:
     # The script this job runs is not in all branches.
     - ^{{ $.branch }}$
     path_alias: sigs.k8s.io/cluster-api
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: {{ $.config.TestImage }}


### PR DESCRIPTION
Mounts the k/k repo on all e2e tests so we can also test pre-releases of kubernetes (e.g. v1.30.0-rc.1) where we have to build the kindest/node image because there is none published by kind.