### PR TITLE
config/secret: deflake TestAddWithParser

### DIFF
--- a/prow/config/secret/agent_test.go
+++ b/prow/config/secret/agent_test.go
@@ -160,17 +160,27 @@ func testAddWithParser(t *testing.T) {
 			t.Errorf("expected value %d from generator, got %d", expected, actual)
 		}
 	}
+
+	// The secret is reloaded every second by the agent, so give it
+	// enough time to be reloaded (1.5s). If not done we run into
+	// flakes where we get the previous value of the secret for its
+	// current comparison.
+	time.Sleep(1500 * time.Millisecond)
 	checkValueAndErr(1, nil)
 
 	if err := os.WriteFile(secretPath, []byte("2"), 0644); err != nil {
 		t.Fatalf("failed to update secret on disk: %v", err)
 	}
+
+	time.Sleep(1500 * time.Millisecond)
 	// expect secret to get updated
 	checkValueAndErr(2, nil)
 
 	if err := os.WriteFile(secretPath, []byte("not-a-number"), 0644); err != nil {
 		t.Fatalf("failed to update secret on disk: %v", err)
 	}
+
+	time.Sleep(1500 * time.Millisecond)
 	// expect secret to remain unchanged and an error in the parsing func
 	checkValueAndErr(2, errors.New(`strconv.Atoi: parsing "not-a-number": invalid syntax`))
 }


### PR DESCRIPTION
This commit does 2 main things to deflake TestAddWithParser:
1. Ensure that we wait a sufficient amount for the secret to be reoloaded.
2. Try using the last modification time of the initial secret parse. Without this, the parsing function used in the test ends up with duplicates in the channel and we get flakes.

```
❯ stress ./secret.test -test.run=^TestAddWithParser$
5s: 16 runs so far, 0 failures
10s: 32 runs so far, 0 failures
15s: 48 runs so far, 0 failures
20s: 64 runs so far, 0 failures
25s: 80 runs so far, 0 failures
30s: 96 runs so far, 0 failures
35s: 112 runs so far, 0 failures
40s: 128 runs so far, 0 failures
45s: 144 runs so far, 0 failures
50s: 160 runs so far, 0 failures
55s: 180 runs so far, 0 failures
1m0s: 208 runs so far, 0 failures
1m5s: 224 runs so far, 0 failures
1m10s: 240 runs so far, 0 failures
1m15s: 256 runs so far, 0 failures
1m20s: 272 runs so far, 0 failures
1m25s: 288 runs so far, 0 failures
1m30s: 304 runs so far, 0 failures
1m35s: 320 runs so far, 0 failures
1m40s: 336 runs so far, 0 failures
1m45s: 356 runs so far, 0 failures
1m50s: 384 runs so far, 0 failures
1m55s: 400 runs so far, 0 failures
2m0s: 416 runs so far, 0 failures
2m5s: 432 runs so far, 0 failures
2m10s: 448 runs so far, 0 failures
2m15s: 464 runs so far, 0 failures
2m20s: 480 runs so far, 0 failures
2m25s: 496 runs so far, 0 failures
2m30s: 512 runs so far, 0 failures
2m35s: 532 runs so far, 0 failures
2m40s: 560 runs so far, 0 failures
2m45s: 576 runs so far, 0 failures
2m50s: 592 runs so far, 0 failures
2m55s: 608 runs so far, 0 failures
3m0s: 624 runs so far, 0 failures
```

Fixes https://github.com/kubernetes/test-infra/issues/31313

/assign @alvaroaleman 
as the original author of this part of the codebase 