### PR TITLE
🌱 Kubebuilder: Upgrade k8s to latest 3 releases versions

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
-  - name: pull-kubebuilder-e2e-k8s-1-28-0
+  - name: pull-kubebuilder-e2e-k8s-1-29-2
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
@@ -41,7 +41,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.28.0"
+              value: "v1.29.2"
           resources:
             limits:
               cpu: 4000m
@@ -53,11 +53,11 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-28-0
+      testgrid-tab-name: kubebuilder-e2e-1-29-2
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-27-3
+  - name: pull-kubebuilder-e2e-k8s-1-28-7
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
@@ -74,7 +74,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.27.3"
+              value: "v1.28.7"
           resources:
             limits:
               cpu: 4000m
@@ -86,11 +86,11 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-27-3
+      testgrid-tab-name: kubebuilder-e2e-1-28-7
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-26-6
+  - name: pull-kubebuilder-e2e-k8s-1-27-11
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
@@ -107,7 +107,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.26.6"
+              value: "v1.27.11"
           resources:
             limits:
               cpu: 4000m
@@ -119,7 +119,7 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-26-6
+      testgrid-tab-name: kubebuilder-e2e-1-27-11
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
#### Description

Bump Kubernetes versions running in Kind for Kubebuilder e2e tests.

Switch to `v1.29.2`, `v1.28.7`, and `v1.27.11`, refer to https://github.com/kubernetes-sigs/kind/releases/tag/v0.22.0