### PR TITLE
Update kubekins to Go 1.21.9 and drop config for 1.26 branch

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -14,7 +14,7 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.21.8
+    GO_VERSION: 1.21.9
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
@@ -39,25 +39,19 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   '1.29':
     CONFIG: '1.29'
-    GO_VERSION: 1.21.8
+    GO_VERSION: 1.21.9
     K8S_RELEASE: latest-1.29
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.28':
     CONFIG: '1.28'
-    GO_VERSION: 1.21.8
+    GO_VERSION: 1.21.9
     K8S_RELEASE: latest-1.28
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: 1.21.8
+    GO_VERSION: 1.21.9
     K8S_RELEASE: stable-1.27
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
-  '1.26':
-    CONFIG: '1.26'
-    GO_VERSION: 1.21.8
-    K8S_RELEASE: stable-1.26
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
- Update kubekins to Go 1.21.9 and drop config for 1.26 branch

xref https://github.com/kubernetes/release/issues/3529

/assign @puerco   @Verolop @dims 
cc @kubernetes/release-engineering