### PR TITLE
rename network policies job to reflect current state

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -76,7 +76,7 @@ presubmits:
       testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
       description: Uses kubetest to run e2e Conformance, SIG-Network or Network Ingress tests against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
 
-  - name: pull-kubernetes-e2e-ubuntu-gce-network-policies
+  - name: pull-kubernetes-e2e-gce-network-policies
     cluster: k8s-infra-prow-build
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
@@ -116,7 +116,7 @@ presubmits:
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
         - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|SCTP|PerformanceDNS|KubeProxyDaemonSetMigration|ServiceCIDRs|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-ubuntu-gce-network-policies
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-policies
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-master
         resources:
@@ -825,7 +825,7 @@ periodics:
           memory: "6Gi"
 
 - interval: 6h
-  name: ci-kubernetes-e2e-ubuntu-gce-network-policies
+  name: ci-kubernetes-e2e-gce-network-policies
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/32387 we removed the custom ubuntu images so we should reflect this in the name of the job to avoid confusion