### PR TITLE
bump containerd to v1.7.15

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -263,7 +263,7 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -331,7 +331,7 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_PROVIDERLESS=y
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -517,7 +517,7 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -833,7 +833,7 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -884,7 +884,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.14
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.15
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.1.12
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false,ValidatingAdmissionPolicy=true
       - --env=KUBE_PROXY_DAEMONSET=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -38,7 +38,7 @@ presubmits:
         - --build=quick
         - --extract=local
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -170,7 +170,7 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -767,7 +767,7 @@ presubmits:
       - args:
         - --build=quick
         - --cluster=
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -830,7 +830,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --env=KUBE_PROVIDERLESS=y
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -945,7 +945,7 @@ presubmits:
       - args:
         - --build=quick
         - --cluster=
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -247,7 +247,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.15
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.12
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true


### PR DESCRIPTION
```
grep -rli KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.14 | xargs -i@ sed -i 's/v1.7.14/v1.7.15/g' @
```

New release fixing the regression on the exec command that creates flakiness on CI jobs, since exec is commonly used in most of the e2e tests
https://github.com/containerd/containerd/pull/10039