### PR TITLE
Revert "disable sctp on network policy tests"

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -115,7 +115,7 @@ presubmits:
         - --provider=gce
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
-        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|SCTP|PerformanceDNS|KubeProxyDaemonSetMigration|ServiceCIDRs|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
+        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|ServiceCIDRs|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-policies
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-master


### PR DESCRIPTION
This reverts commit 57cff76fddb24d62d44efcf7e2e2a89d95e9121f.

After a long week of troubleshooting the current job everything has been sorted out so we should back to the previous state

Network policy test heavily use exec and Containerd v1.7.14 bug on exec was blocking the job https://github.com/kubernetes/test-infra/pull/32394

SCTP seems to have some bug on the kernel when using nfqueue that can be solved by setting a specific flag on the nfqueue config https://github.com/aojea/kube-netpol/pull/7