### PR TITLE
add pull-hydrophone-namespaced-run job

### DIFF
--- a/config/jobs/kubernetes-sigs/hydrophone/hydrophone-periodic.yaml
+++ b/config/jobs/kubernetes-sigs/hydrophone/hydrophone-periodic.yaml
@@ -20,10 +20,6 @@ periodics:
           command:
             - runner.sh
           env:
-            - name: K8S_VERSION
-              value: "v1.29.1"
-            - name: KIND_VERSION
-              value: "v0.21.0"
             - name: CONFORMANCE
               value: "true"
             - name: EXPECTED_NUM_TESTS
@@ -68,10 +64,6 @@ periodics:
           command:
             - runner.sh
           env:
-            - name: K8S_VERSION
-              value: "v1.29.1"
-            - name: KIND_VERSION
-              value: "v0.21.0"
             - name: EXTRA_ARGS
               value: "--parallel=25"
             - name: SKIP

--- a/config/jobs/kubernetes-sigs/hydrophone/hydrophone-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/hydrophone/hydrophone-presubmit.yaml
@@ -80,10 +80,6 @@ presubmits:
             command:
               - runner.sh
             env:
-              - name: K8S_VERSION
-                value: "v1.29.1"
-              - name: KIND_VERSION
-                value: "v0.21.0"
               - name: FOCUS
                 value: "Simple pod should contain last line of the log"
               - name: DRYRUN
@@ -125,10 +121,6 @@ presubmits:
             command:
               - runner.sh
             env:
-              - name: K8S_VERSION
-                value: "v1.29.1"
-              - name: KIND_VERSION
-                value: "v0.21.0"
               - name: FOCUS
                 value: "Simple pod should contain last line of the log"
               - name: CHECK_DURATION
@@ -154,3 +146,44 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-testing-misc
         testgrid-tab-name: hydrophone-simple-run
+    - name: pull-hydrophone-namespaced-run
+      cluster: eks-prow-build-cluster
+      always_run: true
+      decorate: true
+      path_alias: "sigs.k8s.io/hydrophone"
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-master
+            command:
+              - runner.sh
+            env:
+              - name: FOCUS
+                value: "Simple pod should contain last line of the log"
+              - name: NAMESPACE
+                value: "e2e"
+              - name: CHECK_DURATION
+                value: "true"
+              - name: EXPECTED_NUM_TESTS
+                value: "1" # This is the number of specs expected to run.
+            args:
+              - bash
+              - -c
+              - |
+                make build
+                hack/run-e2e.sh
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+              limits:
+                cpu: 2
+                memory: 4Gi
+      annotations:
+        testgrid-dashboards: sig-testing-misc
+        testgrid-tab-name: hydrophone-namespaced-run


### PR DESCRIPTION
This is the follow-up to https://github.com/kubernetes-sigs/hydrophone/pull/171, creating a new job to test the namespaced execution of hydrophone.

This PR also removes the hardcoded Kube/kind versions, allowing the in-repo script to default the values. This should make it much easier to bump dependencies in hydrophone without having to make dedicated PRs here everytime.