### PR TITLE
feat: add jobs for the CAPA release-2.4 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.4.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-aws-e2e-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-release-2-4
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -14,11 +14,11 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
-    base_ref: release-1.5
+    base_ref: release-2.4
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -40,11 +40,11 @@ periodics:
           cpu: 2
           memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-e2e-release-1-5
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-e2e-release-2-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-eks-e2e-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-eks-canary-release-2-4
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -59,11 +59,55 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
-    base_ref: release-1.5
+    base_ref: release-2.4
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
+      command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      env:
+      - name: BOSKOS_HOST
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: AWS_REGION
+        value: "us-west-2"
+      # Parallelize tests
+      - name: GINKGO_ARGS
+        value: "-nodes 20 -skip='\\[ClusterClass\\]'"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: "9Gi"
+        requests:
+          cpu: 2
+          memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: periodic-aws-e2e-release-2-4-canary
+    testgrid-num-columns-recent: "6"
+- name: periodic-cluster-api-provider-aws-eks-e2e-release-2-4
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: release-2.4
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
       command:
         - "runner.sh"
         - "./scripts/ci-e2e-eks.sh"
@@ -82,11 +126,11 @@ periodics:
           cpu: 2
           memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-eks-e2e-release-1-5
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-eks-e2e-release-2-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-conformance-release-2-4
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -101,11 +145,11 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: release-1.5
+      base_ref: release-2.4
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -117,8 +161,6 @@ periodics:
           # Parallelize tests
           - name: GINKGO_ARGS
             value: "-nodes 20"
-          - name: GINKGO_FOCUS
-            value: "Cluster API E2E tests"
         securityContext:
           privileged: true
         resources:
@@ -129,11 +171,11 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-conformance-release-1-5
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-conformance-release-2-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts-release-1-5
+- name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts-release-2-4
   cluster: eks-prow-build-cluster
   max_concurrency: 1
   labels:
@@ -149,7 +191,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: release-1.5
+      base_ref: release-2.4
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     - org: kubernetes-sigs
       repo: image-builder
@@ -161,7 +203,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"
@@ -188,7 +230,7 @@ periodics:
             cpu: 2
             memory: "9Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-    testgrid-tab-name: periodic-conformance-release-1-5-k8s-main
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-conformance-release-2-4-k8s-main
     testgrid-num-columns-recent: '20'
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+    testgrid-alert-email: release-team@kubernetes.io, sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.4.yaml
@@ -1,17 +1,17 @@
 presubmits:
   kubernetes-sigs/cluster-api-provider-aws:
-  - name: pull-cluster-api-provider-aws-test-release-1-5
+  - name: pull-cluster-api-provider-aws-test-release-2-4
     cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     always_run: true
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -22,9 +22,9 @@ presubmits:
             cpu: "8"
             memory: "16Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-test-release-1-5
-  - name: pull-cluster-api-provider-aws-apidiff-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-test-release-2-4
+  - name: pull-cluster-api-provider-aws-apidiff-release-2-4
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-aws
@@ -34,59 +34,89 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     spec:
       containers:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
         resources:
           requests:
-            cpu: "8"
-            memory: "16Gi"
+            cpu: 7300m
+            memory: 9Gi
           limits:
-            cpu: "8"
-            memory: "16Gi"
+            cpu: 7300m
+            memory: 9Gi
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-apidiff-release-1-5
-  - name: pull-cluster-api-provider-aws-build-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-apidiff-release-2-4
+  - name: pull-cluster-api-provider-aws-build-release-2-4
     cluster: eks-prow-build-cluster
     always_run: true
     optional: false
     decorate: true
     branches:
-      # The script this job runs is not in all branches.
-      - ^release-1.5$
+    - ^release-2.4$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
         command:
         - "./scripts/ci-build.sh"
         resources:
           requests:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "4"
+            memory: "8Gi"
           limits:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "4"
+            memory: "8Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-build-release-1-5
-  - name: pull-cluster-api-provider-aws-verify-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-build-release-2-4
+  - name: pull-cluster-api-provider-aws-build-docker-release-2-4
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: true
+    optional: false
+    decorate: true
+    branches:
+    - ^release-2.4$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-docker-build.sh
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+        # docker-in-docker needs privileged mode
+        securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-build-docker-release-2-4
+  - name: pull-cluster-api-provider-aws-verify-release-2-4
     cluster: eks-prow-build-cluster
     always_run: true
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
         command:
         - "runner.sh"
         - "make"
@@ -102,16 +132,16 @@ presubmits:
         securityContext:
             privileged: true
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-verify-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-verify-release-2-4
     labels:
       preset-dind-enabled: "true"
   # conformance test
-  - name: pull-cluster-api-provider-aws-e2e-conformance-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-conformance-release-2-4
     cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -136,7 +166,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -158,15 +188,14 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-conformance-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-conformance-release-2-4
       testgrid-num-columns-recent: '20'
-  # conformance test against kubernetes main branch with `kind` + cluster-api-provider-aws
-  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-2-4
     cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true
@@ -182,7 +211,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -203,18 +232,18 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-conformance-release-1-5-k8s-main
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-conformance-k8s-release-2-4
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-blocking-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-blocking-release-2-4
     cluster: eks-prow-build-cluster
     branches:
-      # The script this job runs is not in all branches.
-      - ^release-1.5$
+    # The script this job runs is not in all branches.
+    - ^release-2.4$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     #run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 5h
@@ -227,7 +256,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -251,14 +280,14 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-quick-e2e-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-quick-e2e-release-2-4
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-release-2-4
     cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true
@@ -274,7 +303,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -293,14 +322,14 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-e2e-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-release-2-4
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-eks-release-1-5
+  - name: pull-cluster-api-provider-aws-e2e-eks-release-2-4
     cluster: eks-prow-build-cluster
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.5$
+    - ^release-2.4$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true
@@ -316,7 +345,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"
@@ -335,6 +364,92 @@ presubmits:
               cpu: 2
               memory: "9Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
-      testgrid-tab-name: pr-e2e-eks-release-1-5
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-eks-release-2-4
+      testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-eks-gc-release-2-4
+    cluster: eks-prow-build-cluster
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-2.4$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e-eks-gc.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 2
+              memory: "9Gi"
+            requests:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-eks-gc-release-2-4
+      testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-eks-testing-release-2-4
+    cluster: eks-prow-build-cluster
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-2.4$
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.29
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e-eks.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+            - name: GINKGO_ARGS
+              value: "-nodes 2"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 2
+              memory: "9Gi"
+            limits:
+              cpu: 2
+              memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-eks-testing-release-2-4
       testgrid-num-columns-recent: '20'

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -10,7 +10,6 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-1.7
     - sig-cluster-lifecycle-cluster-api-addon-provider-helm
     - sig-cluster-lifecycle-cluster-api-provider-aws
-    - sig-cluster-lifecycle-cluster-api-provider-aws-1.5
     - sig-cluster-lifecycle-cluster-api-provider-aws-2.0
     - sig-cluster-lifecycle-cluster-api-provider-azure
     - sig-cluster-lifecycle-cluster-api-provider-digitalocean
@@ -39,7 +38,6 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-1.6
 - name: sig-cluster-lifecycle-cluster-api-1.7
 - name: sig-cluster-lifecycle-cluster-api-addon-provider-helm
-- name: sig-cluster-lifecycle-cluster-api-provider-aws-1.5
 - name: sig-cluster-lifecycle-cluster-api-provider-aws-2.0
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
   dashboard_tab:


### PR DESCRIPTION
This change adds pre-submit and periodic jobs for the release-2.4 of Cluster API Provider AWS. It also removes some old jobs.