### PR TITLE
descheduler: bump golang version

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -14,7 +14,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.5
+      - image: public.ecr.aws/docker/library/golang:1.21.9
         command:
         - make
         args:
@@ -39,7 +39,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.5
+      - image: public.ecr.aws/docker/library/golang:1.21.9
         command:
         - make
         args:
@@ -65,7 +65,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.5
+      - image: public.ecr.aws/docker/library/golang:1.21.9
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
@@ -14,7 +14,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.5
+      - image: public.ecr.aws/docker/library/golang:1.21.9
         command:
         - make
         args:
@@ -39,7 +39,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.5
+      - image: public.ecr.aws/docker/library/golang:1.21.9
         command:
         - make
         args:
@@ -65,7 +65,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.5
+      - image: public.ecr.aws/docker/library/golang:1.21.9
         command:
         - make
         args:


### PR DESCRIPTION
For https://pkg.go.dev/vuln/GO-2024-2687. Even though http/2 is disabled by default, let's be proactive here just in case.

Alongside https://github.com/kubernetes-sigs/descheduler/pull/1373.