### PR TITLE
etcd: move ci-etcd-robustness-amd64 from eks to gke cluster.

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -60,7 +60,7 @@ periodics:
           memory: "4Gi"
 - name: ci-etcd-robustness-amd64
   interval: 24h
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 210m


### PR DESCRIPTION
Related to issue https://github.com/etcd-io/etcd/issues/17717

the [`ci-etcd-robustness-release35-amd64`](https://testgrid.k8s.io/sig-etcd-periodics#ci-etcd-robustness-release35-amd64) and `ci-etcd-robustness-release34-amd64` seem to run fine on gke cluster. 