### PR TITLE
peribolos: bump timeout to 210m for CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -13,7 +13,7 @@ postsubmits:
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     decoration_config:
-      timeout: 180m
+      timeout: 210m
     branches:
     - ^main$
     max_concurrency: 1
@@ -49,7 +49,8 @@ periodics:
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   decoration_config:
-    timeout: 180m
+    #TODO: bump timeout duration back to 3hrs, once alternate solution is investigated
+    timeout: 210m
   max_concurrency: 1
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
Peribolos CI jobs [have been failing](https://kubernetes.slack.com/archives/C01672LSZL0/p1712182376329389) for a few months now due to (i) timeout issues and (ii) oauth token scope issues.

PR https://github.com/kubernetes/k8s.io/pull/6667 & https://github.com/kubernetes/test-infra/pull/32410 added a new dedicated github token for Peribolos CI jobs, potentially fixing (ii).

This PR is bumping the timeout duration for the Peribolos CI jobs by 30 min (new timeout - 210m or 3.5 hrs), to try fixing (i).

cc: @cblecker @MadhavJivrajani 