### PR TITLE
descheduler: bump master to go1.22.2

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -14,7 +14,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.9
+      - image: public.ecr.aws/docker/library/golang:1.22.2
         command:
         - make
         args:
@@ -39,7 +39,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.9
+      - image: public.ecr.aws/docker/library/golang:1.22.2
         command:
         - make
         args:
@@ -65,7 +65,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21.9
+      - image: public.ecr.aws/docker/library/golang:1.22.2
         command:
         - make
         args:


### PR DESCRIPTION
To align with k8s 1.30: https://github.com/kubernetes/kubernetes/blob/77aa9c21c295614817d5d49ea81f20783480691b/go.mod#L9