### PR TITLE
Start publishing Prow images from kubernetes-sigs/prow.

### DIFF
--- a/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
@@ -35,48 +35,48 @@ postsubmits:
 
 ### Trusted Jobs ###
 
-# - name: post-push-prow
-#   cluster: test-infra-trusted
-#   # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-#   skip_if_only_changed: '^site/'
-#   decorate: true
-#   labels:
-#     # Building deck requires docker for typescript compilation.
-#     preset-dind-enabled: "true"
-#   branches:
-#   - ^main$
-#   max_concurrency: 1
-#   spec:
-#     serviceAccountName: pusher
-#     containers:
-#     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-test-infra
-#       command:
-#       - runner.sh
-#       args:
-#       - make
-#       - -C
-#       - prow
-#       - push-images
-#       env:
-#       # docker-in-docker needs privileged mode
-#       securityContext:
-#         privileged: true
-#       resources:
-#         requests:
-#           cpu: "15"
-#     tolerations:
-#     - key: "highcpu"
-#       operator: "Equal"
-#       value: "true"
-#       effect: "NoSchedule"
-#     nodeSelector:
-#       highcpu: "true"
-#   annotations:
-#     testgrid-dashboards: sig-testing-prow-repo
-#     testgrid-tab-name: push-images
-#     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-#     testgrid-num-failures-to-alert: '1'
-#     description: Builds and pushes all prow container images on each commit by running make -C prow push-images
-#   rerun_auth_config:
-#     github_users:
-#     - alvaroaleman
+  - name: post-push-prow
+    cluster: test-infra-trusted
+    # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
+    skip_if_only_changed: '^site/'
+    decorate: true
+    labels:
+      # Building deck requires docker for typescript compilation.
+      preset-dind-enabled: "true"
+    branches:
+    - ^main$
+    max_concurrency: 1
+    spec:
+      serviceAccountName: pusher
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - -C
+        - prow
+        - push-images
+        env:
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "15"
+      tolerations:
+      - key: "highcpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        highcpu: "true"
+    annotations:
+      testgrid-dashboards: sig-testing-prow-repo
+      testgrid-tab-name: push-images
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: Builds and pushes all prow container images on each commit by running make -C prow push-images
+    rerun_auth_config:
+      github_users:
+      - alvaroaleman

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -158,54 +158,6 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: reconcile the hmac tokens and webhooks based on the managed_webhooks configuration in prow core config file
-  - name: post-test-infra-push-prow
-    cluster: test-infra-trusted
-    # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-    run_if_changed: '^(\.ko\.yaml|hack/(make-rules|prowimagebuilder)|gencred|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
-    decorate: true
-    labels:
-      # Building deck requires docker for typescript compilation.
-      preset-dind-enabled: "true"
-    branches:
-    - ^master$
-    max_concurrency: 1
-    spec:
-      serviceAccountName: pusher
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-test-infra
-        command:
-        - runner.sh
-        args:
-        - make
-        - -C
-        - prow
-        - push-images
-        env:
-        # TODO(chaodaiG): remove once this becomes the default in `prow/Makefile`
-        - name: REGISTRY
-          value: gcr.io/k8s-prow
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "15"
-      tolerations:
-      - key: "highcpu"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-      nodeSelector:
-        highcpu: "true"
-    annotations:
-      testgrid-dashboards: sig-testing-prow
-      testgrid-tab-name: push-prow
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
-      description: builds and pushes all prow on each commit by running make -C prow push-images
-    rerun_auth_config:
-      github_users:
-      - alvaroaleman
   - name: post-test-infra-push-misc-images
     cluster: test-infra-trusted
     # TODO: clean up this regexp once prow is published from kubernetes-sigs/prow.


### PR DESCRIPTION
This switches the source of truth for Prow development from kubernetes/test-infra to kubernetes-sigs/prow as part of https://github.com/kubernetes/test-infra/issues/31728