### PR TITLE
capi: use new prowjob resource configurations on all jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-test-main
@@ -129,10 +129,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-test-mink8s-main
@@ -174,11 +174,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-mink8s-main
@@ -212,11 +212,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-blocking-main
@@ -253,11 +253,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
             limits:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-main
@@ -292,11 +292,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main
@@ -340,11 +340,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main-1-29-1-30
@@ -379,11 +379,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-conformance-main
@@ -417,11 +417,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics-upgrades.yaml
@@ -44,11 +44,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5-1-22-1-23
@@ -99,11 +99,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5-1-23-1-24
@@ -154,11 +154,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5-1-24-1-25
@@ -209,11 +209,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5-1-25-1-26
@@ -264,11 +264,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5-1-26-1-27
@@ -319,11 +319,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5-1-27-1-28

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics.yaml
@@ -22,10 +22,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-test-release-1-5
@@ -63,10 +63,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-test-mink8s-release-1-5
@@ -106,11 +106,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-release-1-5
@@ -153,11 +153,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-5
@@ -205,11 +205,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
     testgrid-tab-name: capi-e2e-mink8s-release-1-5

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
@@ -17,11 +17,11 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-build-release-1-5
@@ -42,11 +42,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-1.27
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-apidiff-release-1-5
@@ -68,11 +68,11 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
         securityContext:
           privileged: true
     annotations:
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-test-release-1-5
@@ -129,10 +129,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-test-mink8s-release-1-5
@@ -174,11 +174,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-5
@@ -212,11 +212,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-blocking-release-1-5
@@ -251,11 +251,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-informing-release-1-5
@@ -292,11 +292,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
             limits:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-release-1-5
@@ -331,11 +331,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-release-1-5
@@ -379,11 +379,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-release-1-5-1-27-1-28

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics-upgrades.yaml
@@ -44,11 +44,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-23-1-24
@@ -99,11 +99,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-24-1-25
@@ -154,11 +154,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-25-1-26
@@ -209,11 +209,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-26-1-27
@@ -264,11 +264,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-27-1-28
@@ -319,11 +319,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6-1-28-1-29

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics.yaml
@@ -22,10 +22,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-test-release-1-6
@@ -63,10 +63,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-test-mink8s-release-1-6
@@ -106,11 +106,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-release-1-6
@@ -153,11 +153,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-6
@@ -205,11 +205,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
     testgrid-tab-name: capi-e2e-mink8s-release-1-6

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
@@ -17,11 +17,11 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-build-release-1-6
@@ -42,11 +42,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-1.28
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-apidiff-release-1-6
@@ -68,11 +68,11 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
         securityContext:
           privileged: true
     annotations:
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-test-release-1-6
@@ -129,10 +129,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-test-mink8s-release-1-6
@@ -174,11 +174,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-6
@@ -212,11 +212,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-blocking-release-1-6
@@ -253,11 +253,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
             limits:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-release-1-6
@@ -292,11 +292,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-release-1-6
@@ -340,11 +340,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-release-1-6-1-28-1-29

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics-upgrades.yaml
@@ -44,11 +44,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7-1-24-1-25
@@ -99,11 +99,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7-1-25-1-26
@@ -154,11 +154,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7-1-26-1-27
@@ -209,11 +209,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7-1-27-1-28
@@ -264,11 +264,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7-1-28-1-29
@@ -319,11 +319,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7-1-29-1-30

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
@@ -22,10 +22,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-test-release-1-7
@@ -63,10 +63,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: 9Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-test-mink8s-release-1-7
@@ -106,11 +106,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-release-1-7
@@ -153,11 +153,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-7
@@ -205,11 +205,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 3000m
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-mink8s-release-1-7
@@ -250,11 +250,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-conformance-release-1-7
@@ -294,11 +294,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
         limits:
-          cpu: 7300m
-          memory: 32Gi
+          cpu: 4000m
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
     testgrid-tab-name: capi-e2e-conformance-ci-latest-release-1-7

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
@@ -17,11 +17,11 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-build-release-1-7
@@ -42,11 +42,11 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-1.29
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 6000m
+            memory: 2Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-apidiff-release-1-7
@@ -68,11 +68,11 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
           limits:
-            cpu: 7300m
-            memory: 9Gi
+            cpu: 5000m
+            memory: 3Gi
         securityContext:
           privileged: true
     annotations:
@@ -95,10 +95,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-test-release-1-7
@@ -129,10 +129,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-test-mink8s-release-1-7
@@ -174,11 +174,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-7
@@ -212,11 +212,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-blocking-release-1-7
@@ -253,11 +253,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
             limits:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-release-1-7
@@ -292,11 +292,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-release-1-7
@@ -340,11 +340,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-release-1-7-1-29-1-30
@@ -379,11 +379,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-conformance-release-1-7
@@ -417,11 +417,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-release-1-7

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl
@@ -44,11 +44,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}6Gi{{ else }}32Gi{{ end }}
+          cpu: 6000m
+          memory: 6Gi
         limits:
-          cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}6Gi{{ else }}32Gi{{ end }}
+          cpu: 6000m
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.From "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.To "stable-") "ci/latest-") "." "-" }}

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -21,10 +21,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-test-{{ ReplaceAll $.branch "." "-" }}
@@ -62,10 +62,10 @@ periodics:
       resources:
         requests:
           cpu: 7300m
-          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
+          memory: 8Gi
         limits:
           cpu: 7300m
-          memory: {{ if eq $.branch "main" }}8Gi{{ else }}9Gi{{ end }}
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-test-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -105,11 +105,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}
@@ -153,11 +153,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
+            cpu: 3000m
+            memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
@@ -206,11 +206,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
+          cpu: 3000m
+          memory: 8Gi
         limits:
-          cpu: {{ if eq $.branch "main" }}3000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}8Gi{{ else }}32Gi{{ end }}
+          cpu: 3000m
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -251,11 +251,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
+          cpu: 4000m
+          memory: 4Gi
         limits:
-          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
+          cpu: 4000m
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
@@ -295,11 +295,11 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
+          cpu: 4000m
+          memory: 4Gi
         limits:
-          cpu: {{ if eq $.branch "main" }}4000m{{ else }}7300m{{ end }}
-          memory: {{ if eq $.branch "main" }}4Gi{{ else }}32Gi{{ end }}
+          cpu: 4000m
+          memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
     testgrid-tab-name: capi-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -16,11 +16,11 @@ presubmits:
         - ./scripts/ci-build.sh
         resources:
           requests:
-            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}4Gi{{ else }}9Gi{{ end }}
+            cpu: 6000m
+            memory: 4Gi
           limits:
-            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}4Gi{{ else }}9Gi{{ end }}
+            cpu: 6000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-build-{{ ReplaceAll $.branch "." "-" }}
@@ -41,11 +41,11 @@ presubmits:
         image: {{ $.config.TestImage }}
         resources:
           requests:
-            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}2Gi{{ else }}9Gi{{ end }}
+            cpu: 6000m
+            memory: 2Gi
           limits:
-            cpu: {{ if eq $.branch "main" }}6000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}2Gi{{ else }}9Gi{{ end }}
+            cpu: 6000m
+            memory: 2Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-apidiff-{{ ReplaceAll $.branch "." "-" }}
@@ -67,11 +67,11 @@ presubmits:
         - ./scripts/ci-verify.sh
         resources:
           requests:
-            cpu: {{ if eq $.branch "main" }}5000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}3Gi{{ else }}9Gi{{ end }}
+            cpu: 5000m
+            memory: 3Gi
           limits:
-            cpu: {{ if eq $.branch "main" }}5000m{{ else }}7300m{{ end }}
-            memory: {{ if eq $.branch "main" }}3Gi{{ else }}9Gi{{ end }}
+            cpu: 5000m
+            memory: 3Gi
         securityContext:
           privileged: true
     annotations:
@@ -94,10 +94,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-test-{{ ReplaceAll $.branch "." "-" }}
@@ -128,10 +128,10 @@ presubmits:
         resources:
           requests:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
           limits:
             cpu: 7300m
-            memory: 9Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-test-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -174,11 +174,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -213,11 +213,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-blocking-{{ ReplaceAll $.branch "." "-" }}
@@ -257,11 +257,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-informing-{{ ReplaceAll $.branch "." "-" }}
@@ -300,11 +300,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
             limits:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
@@ -345,11 +345,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
             limits:
-              cpu: 7300m
-              memory: 32Gi
+              cpu: 3000m
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-informing-ipv6-{{ ReplaceAll $.branch "." "-" }}
@@ -384,11 +384,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 3000m
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-{{ ReplaceAll $.branch "." "-" }}
@@ -432,11 +432,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 6000m
+            memory: 6Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).From "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).To "." "-" }}
@@ -471,11 +471,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
@@ -509,11 +509,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
           limits:
-            cpu: 7300m
-            memory: 32Gi
+            cpu: 4000m
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}


### PR DESCRIPTION
/assign @sbueringer 

AFAIK the usage we defined for the jobs in

- #32376

turned out good.

Let's apply this across the jobs and maybe have another iteration afterwards to decrease further.