### PR TITLE
Change codesearch periodic job to run restart.sh

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - name: periodic-k8sio-deploy-app-codesearch
   cluster: k8s-infra-prow-build-trusted
-  interval: 24h
+  cron: "0 10 * * 1,4" # At 10:00 UTC on Monday and Thursday.
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -28,7 +28,7 @@ periodics:
     - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
       imagePullPolicy: Always
       command:
-      - ./apps/codesearch/deploy.sh
+      - ./apps/codesearch/restart.sh
       volumeMounts:
       - name: github
         mountPath: /etc/github-token

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - name: periodic-k8sio-deploy-app-codesearch
   cluster: k8s-infra-prow-build-trusted
-  cron: "0 10 * * 1,4" # At 10:00 UTC on Monday and Thursday.
+  cron: "0 */6 * * *" # Runs every 6 hours, we can further reduce if needed
   decorate: true
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
This PR aims to solve https://github.com/kubernetes/k8s.io/issues/2182

Associated PR: https://github.com/kubernetes/k8s.io/pull/6657

* Right now the codesearch periodic job runs `deploy.sh`. This PR changes that to `restart.sh` so that the job restarts codesearch deployment. The restarts should happen on Monday and Thursday at 10 AM UTC. This will pick up any new reference of git repositories.