### PR TITLE
etcd: add benchmark periodic jobs

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -174,3 +174,168 @@ periodics:
       # fuse needs privileged mode
       securityContext:
         privileged: true
+- name: ci-etcd-performance-ratio-1-128-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-performance-ratio-1-128-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        make build tools
+        RATIO_LIST=1/128 ./tools/rw-heatmaps/rw-benchmark.sh
+        cp result-*.csv "${ARTIFACTS}/result-$(git rev-parse HEAD).csv"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "4Gi"
+        limits:
+          cpu: "7"
+          memory: "4Gi"
+- name: ci-etcd-performance-ratio-1-8-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 10h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-performance-ratio-1-8-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        make build tools
+        RATIO_LIST=1/8 ./tools/rw-heatmaps/rw-benchmark.sh
+        cp result-*.csv "${ARTIFACTS}/result-$(git rev-parse HEAD).csv"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "8Gi"
+        limits:
+          cpu: "7"
+          memory: "8Gi"
+- name: ci-etcd-performance-ratio-1-4-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 14h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-performance-ratio-1-4-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        make build tools
+        RATIO_LIST=1/4 ./tools/rw-heatmaps/rw-benchmark.sh
+        cp result-*.csv "${ARTIFACTS}/result-$(git rev-parse HEAD).csv"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "8Gi"
+        limits:
+          cpu: "7"
+          memory: "8Gi"
+- name: ci-etcd-performance-ratio-1-2-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 16h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-performance-ratio-1-2-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        make build tools
+        RATIO_LIST=1/2 ./tools/rw-heatmaps/rw-benchmark.sh
+        cp result-*.csv "${ARTIFACTS}/result-$(git rev-parse HEAD).csv"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "10Gi"
+        limits:
+          cpu: "7"
+          memory: "10Gi"
+- name: ci-etcd-performance-ratio-2-1-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 16h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-performance-ratio-2-1-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240408-d4d9f8e6b8-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        make build tools
+        RATIO_LIST=2/1 ./tools/rw-heatmaps/rw-benchmark.sh
+        cp result-*.csv "${ARTIFACTS}/result-$(git rev-parse HEAD).csv"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "10Gi"
+        limits:
+          cpu: "7"
+          memory: "10Gi"


### PR DESCRIPTION
Adds performance jobs for ratios:

| Ratio | Observed CPU usage | Observed RAM usage | Completion Time | CPU request | RAM request | Configured Timeout |
|--|-|-|-|-|-|-|
| 1/128 | 1.1 avg / 1.75 max | 1 Gi avg / 3.2 Gi max | 2 hrs | 7 | 4 Gi | 4 hrs | 
| 1/8 | 1.4 avg / 5 max | 1 Gi avg / 4.9 Gi max | 8 hrs | 7 | 8 Gi | 10 hrs |
| 1/4 | 2.3 avg / 7 max | 1.2 Gi avg / 5.4 Gi max | 12 hrs | 7 | 8 Gi | 14 hrs |
| 1/2 | 4.7 avg / 7 max | 1.25 Gi avg / 6.3 Gi max | 13 hrs | 7 | 10 Gi | 16 hrs |
| 2/1 | 6.9 avg / 7 max | 1.4Gi avg / 7.5 Gi max | 14 hrs | 7 | 10 Gi | 16 hrs |


Part of etcd-io/etcd#17754.