### PR TITLE
config/prow: adjust milestone_applier config for capv v1.11

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -528,7 +528,8 @@ milestone_applier:
     release-0.4: v0.4
     release-0.3: v0.3
   kubernetes-sigs/cluster-api-provider-vsphere:
-    main: v1.10
+    main: v1.11
+    release-1.10: v1.10
     release-1.9: v1.9
     release-1.8: v1.8
     release-1.7: v1.7


### PR DESCRIPTION
We did just cut the release branch for the upcoming v1.10 release.

xref: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/docs/release/release-tasks.md#create-a-release-branch

/assign @sbueringer 
/assign @fabriziopandini 