### PR TITLE
CAPO: Increase resource limits for -test presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -40,10 +40,10 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
-            cpu: "2"
+            cpu: "4"
           limits:
             memory: "6Gi"
-            cpu: "2"
+            cpu: "4"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-test


### PR DESCRIPTION
Tests are occasionally failing in an unusual manner. Looking at the dashboard we're coming extremely close to our memory limit, making me suspect we're being OOM killed.

https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-openstack&var-job=All&from=now-3h&to=now

We are also maxxing out CPU continuously for the whole test. As it's highly multi-thread/process I've also bumped the CPU request.