### PR TITLE
etcd: remove --failfast for robustness test.

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -84,7 +84,7 @@ periodics:
         sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         make install-lazyfs
         set -euo pipefail
-        GO_TEST_FLAGS="-v --count 150 --failfast --timeout '200m' --run TestRobustnessExploratory"
+        GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
         make gofail-enable
         make build
         VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness
@@ -124,7 +124,7 @@ periodics:
         sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         make install-lazyfs
         set -euo pipefail
-        GO_TEST_FLAGS="-v --count 150 --failfast --timeout '200m' --run TestRobustnessExploratory"
+        GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
         VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness-release-3.5
       resources:
         requests:
@@ -162,7 +162,7 @@ periodics:
         sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         make install-lazyfs
         set -euo pipefail
-        GO_TEST_FLAGS="-v --count 150 --failfast --timeout '200m' --run TestRobustnessExploratory"
+        GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
         VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness-release-3.4
       resources:
         requests:


### PR DESCRIPTION
Each run in  robustness test is different. Collecting more run data would be beneficial rather than only collecting data of a few runs if it gets unlucky. 