### PR TITLE
feat: fix the kubernetes-sigs/prow presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
         command:
         - runner.sh
         args:
-        - ./test/integration/integration-test.sh
+        - ./prow/test/integration/integration-test.sh
         env:
         # docker-in-docker needs privileged mode
         securityContext:
@@ -105,6 +105,8 @@ presubmits:
         - runner.sh
         args:
         - make
+        - -C
+        - prow
         - build-images
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
fixes the jobs:

```
line 119: ./test/integration/integration-test.sh: No such file or directory
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_prow/112/pull-prow-integration/1780514148061286400

and
```
make: *** No rule to make target 'build-images'.  Stop.

```
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_prow/112/pull-prow-image-build-test/1780514148203892736



Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
