### PR TITLE
Fix the project and dataset for kettle-metrics

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-test-infra.yaml
@@ -15,9 +15,9 @@ periodics:
       - ./kettle/monitor.py
       - --stale=6
       - --table
-      - k8s_infra_kettle:build.all
-      - k8s_infra_kettle:build.week
-      - k8s_infra_kettle:build.day
+      - kubernetes-public:k8s_infra_kettle.all
+      - kubernetes-public:k8s_infra_kettle.week
+      - kubernetes-public:k8s_infra_kettle.day
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '12'


### PR DESCRIPTION
I had the entries wrong here!

```
davanum@cloudshell:~/test-infra/kettle (k8s-staging-publishing-bot)$ bq ls --project_id=kubernetes-public --dataset_id=k8s_infra_kettle
     tableId       Type    Labels   Time Partitioning   Clustered Fields
 ---------------- ------- -------- ------------------- ------------------
  all              TABLE
  all_build_logs   TABLE
  day              TABLE
  staging          TABLE
  week             TABLE
```