### PR TITLE
Fix the big query data set project/dataset name

### DIFF
--- a/kettle/OVERVIEW.md
+++ b/kettle/OVERVIEW.md
@@ -29,9 +29,9 @@ Flags:
 # Create JSON Results and Upload
 This stage gets run for each [BigQuery] table that Kettle is tasked with uploading data to. Typically looking like either:
 - Fixed Time: `pypy3 make_json.py --days <num> | pv | gzip > build_<table>.json.gz`
-    and `bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS} k8s_infra_kettle:build.<table> build_<table>.json.gz schema.json`
+    and `bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS} kubernetes-public:k8s_infra_kettle.<table> build_<table>.json.gz schema.json`
 - All Results: `pypy3 make_json.py | pv | gzip > build_<table>.json.gz`
-    and `bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS} k8s_infra_kettle:build.<table> build_<table>.json.gz schema.json`
+    and `bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS} kubernetes-public:k8s_infra_kettle.<table> build_<table>.json.gz schema.json`
 
 ### Make Json
 `make_json.py` prepares an incremental table to track builds it has emitted to BQ. This table is named `build_emitted_<days>` (if days flag passed) or `build_emitted` otherwise. *This is important because if you change the days AND NOT the table being uploaded to, you will get duplicate results. If the `--reset_emitted` flag is passed, it will refresh the incremental table for fresh data. It then walks all of the builds to fetch within `<days>` or since epoch if unset, and dumps each as a json object to a build `tar.gz`.

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -4,7 +4,7 @@ This collects test results scattered across a variety of GCS buckets,
 stores them in a local SQLite database, and outputs newline-delimited
 JSON files for import into BigQuery. *See [overview](./OVERVIEW.md) for more details.*
 
-Results are stored in the [k8s_infra_kettle:build BigQuery dataset][Big Query Tables],
+Results are stored in the [kubernetes-public:k8s_infra_kettle BigQuery dataset][Big Query Tables],
 which is publicly accessible.
 
 # Deploying
@@ -79,7 +79,7 @@ It can be deployed with `make -C kettle deploy-staging`. If already deployed, yo
 
 #### Adding Fields
 
-To add fields to the BQ table, Visit the [k8s_infra_kettle:build BigQuery dataset][Big Query Tables] and Select the table (Ex. Build > All). Schema -> Edit Schema -> Add field. As well as update [schema.json](./schema.json)
+To add fields to the BQ table, Visit the [kubernetes-public:k8s_infra_kettle BigQuery dataset][Big Query Tables] and Select the table (Ex. Build > All). Schema -> Edit Schema -> Add field. As well as update [schema.json](./schema.json)
 
 ## Adding Buckets
 

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -320,7 +320,7 @@ def get_options(argv):
     )
     parser.add_argument(
         '--dataset',
-        help='BigQuery dataset (e.g. k8s_infra_kettle:build)'
+        help='BigQuery dataset (e.g. kubernetes-public:k8s_infra_kettle)'
     )
     parser.add_argument(
         '--tables',

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -63,23 +63,23 @@ def main():
 
     if os.getenv('DEPLOYMENT', 'staging') == "prod":
         call(f'{mj_cmd} {mj_ext} --days {DAY} | pv | gzip > build_day.json.gz')
-        call(f'{bq_cmd} {bq_ext} k8s_infra_kettle:build.day build_day.json.gz schema.json')
+        call(f'{bq_cmd} {bq_ext} kubernetes-public:k8s_infra_kettle.day build_day.json.gz schema.json')
 
         call(f'{mj_cmd} {mj_ext} --days {WEEK} | pv | gzip > build_week.json.gz')
-        call(f'{bq_cmd} {bq_ext} k8s_infra_kettle:build.week build_week.json.gz schema.json')
+        call(f'{bq_cmd} {bq_ext} kubernetes-public:k8s_infra_kettle.week build_week.json.gz schema.json')
 
         # TODO: (MushuEE) #20024, remove 30 day limit once issue with all uploads is found
         call(f'{mj_cmd} --days {MONTH} | pv | gzip > build_all.json.gz')
-        call(f'{bq_cmd} k8s_infra_kettle:build.all build_all.json.gz schema.json')
+        call(f'{bq_cmd} kubernetes-public:k8s_infra_kettle.all build_all.json.gz schema.json')
 
         call(f'python3 stream.py --poll {SUB_PATH} ' \
-             f'--dataset k8s_infra_kettle:build ' \
+             f'--dataset kubernetes-public:k8s_infra_kettle ' \
              f'--tables all:{MONTH} day:{DAY} week:{WEEK} --stop_at=1')
     else:
         call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
-        call(f'{bq_cmd} k8s_infra_kettle:build.staging build_staging.json.gz schema.json')
+        call(f'{bq_cmd} kubernetes-public:k8s_infra_kettle.staging build_staging.json.gz schema.json')
         call(f'python3 stream.py --poll {SUB_PATH} ' \
-             f'--dataset k8s_infra_kettle:build --tables staging:0 --stop_at=1')
+             f'--dataset kubernetes-public:k8s_infra_kettle --tables staging:0 --stop_at=1')
 
 if __name__ == '__main__':
     os.chdir(os.path.dirname(__file__))

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -63,10 +63,12 @@ def main():
 
     if os.getenv('DEPLOYMENT', 'staging') == "prod":
         call(f'{mj_cmd} {mj_ext} --days {DAY} | pv | gzip > build_day.json.gz')
-        call(f'{bq_cmd} {bq_ext} kubernetes-public:k8s_infra_kettle.day build_day.json.gz schema.json')
+        call(f'{bq_cmd} {bq_ext} ' \
+             f'kubernetes-public:k8s_infra_kettle.day build_day.json.gz schema.json')
 
         call(f'{mj_cmd} {mj_ext} --days {WEEK} | pv | gzip > build_week.json.gz')
-        call(f'{bq_cmd} {bq_ext} kubernetes-public:k8s_infra_kettle.week build_week.json.gz schema.json')
+        call(f'{bq_cmd} {bq_ext} ' \
+             f'kubernetes-public:k8s_infra_kettle.week build_week.json.gz schema.json')
 
         # TODO: (MushuEE) #20024, remove 30 day limit once issue with all uploads is found
         call(f'{mj_cmd} --days {MONTH} | pv | gzip > build_all.json.gz')
@@ -77,7 +79,8 @@ def main():
              f'--tables all:{MONTH} day:{DAY} week:{WEEK} --stop_at=1')
     else:
         call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
-        call(f'{bq_cmd} kubernetes-public:k8s_infra_kettle.staging build_staging.json.gz schema.json')
+        call(f'{bq_cmd} kubernetes-public:k8s_infra_kettle.staging ' \
+             f'build_staging.json.gz schema.json')
         call(f'python3 stream.py --poll {SUB_PATH} ' \
              f'--dataset kubernetes-public:k8s_infra_kettle --tables staging:0 --stop_at=1')
 


### PR DESCRIPTION
Found errors in the running pod. Looks like i had the project:dataset combination wrong earlier.

```
29.04user 4.98system 8:37.04elapsed 6%CPU (0avgtext+0avgdata 368072maxresident)k
8inputs+16528outputs (0major+332365minor)pagefaults 0swaps
incremental progress gen #26
BigQuery error in load operation: Invalid project ID 'k8s_infra_kettle'. Project
IDs must contain 6-63 lowercase letters, digits, or dashes. Some project IDs
also include domain name separated by a colon. IDs must start with a letter and
may not end with a dash.
+ time python3 make_db.py --buckets buckets.yaml --junit --threads 32
+ pypy3 make_json.py --days 1 --assert-oldest 1.9
+ pypy3 make_json.py  --days 1 | pv | gzip > build_day.json.gz
+ bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000  k8s_infra_kettle:build.day build_day.json.gz schema.json
Traceback (most recent call last):
  File "/kettle/update.py", line 87, in <module>
    main()
  File "/kettle/update.py", line 66, in main
    call(f'{bq_cmd} {bq_ext} k8s_infra_kettle:build.day build_day.json.gz schema.json')
  File "/kettle/update.py", line 44, in call
    raise OSError('invocation failed')
OSError: invocation failed
```