### PR TITLE
set up node 1.30 and drop 1.26

### DIFF
--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -1,53 +1,4 @@
 periodics:
-- name: ci-kubernetes-node-release-branch-1-26
-  cluster: k8s-infra-prow-build
-  interval: 24h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.26
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --gcp-zone=us-central1-a
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          - --timeout=180m
-        env:
-          - name: GOPATH
-            value: /go
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-node-release-blocking
-    testgrid-tab-name: node-conformance-release-1.26
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: Node conformance tests in release branch 1.26
 - name: ci-kubernetes-node-release-branch-1-27
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -195,3 +146,53 @@ periodics:
     testgrid-tab-name: node-conformance-release-1.29
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.29
+- name: ci-kubernetes-node-release-branch-1-30
+  cluster: k8s-infra-prow-build
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 240m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.30
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --deployment=node
+          - --gcp-zone=us-central1-a
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.30.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-release-blocking
+    testgrid-tab-name: node-conformance-release-1.30
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: Node conformance tests in release branch 1.30
+

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.26.yaml
@@ -1,5 +1,0 @@
-images:
-  cos-101:
-    image_family: cos-109-lts
-    project: cos-cloud
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.30.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.30.yaml
@@ -1,5 +1,5 @@
 images:
-  cos-101:
+  cos-dev:
     image_family: cos-109-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
K8s release 1.30 is out! 

We should have e2e test on that branch.

1.26 is out of support so I dropped that one also.