### PR TITLE
use go 1.21 in scheduler-plugins CI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - make
         args:
@@ -31,7 +31,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - make
         args:
@@ -73,7 +73,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.21
         command:
         - make
         args:


### PR DESCRIPTION
Latest code of scheduler-plugins vendors k8s 1.29, which adopts Go 1.21. So changing the CI job to use go 1.21 image.