### PR TITLE
capi: fix kubebuilder v1.27.1 reference to not include the v prefix

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -59,7 +59,7 @@ periodics:
       # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
       # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
       - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-        value: "v1.27.1"
+        value: "1.27.1"
       resources:
         requests:
           cpu: 7300m

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -125,7 +125,7 @@ presubmits:
         # To check the latest available envtest in Kubebuilder for the minor version we determined above, please
         # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
         - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-          value: "v1.27.1"
+          value: "1.27.1"
         resources:
           requests:
             cpu: 7300m

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
@@ -36,7 +36,7 @@ prow_ignored:
       interval: "2h"
       upgradesInterval: "24h"
       kubernetesVersionManagement: "v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843"
-      kubebuilderEnvtestKubernetesVersion: "v1.27.1"
+      kubebuilderEnvtestKubernetesVersion: "1.27.1"
       upgrades:
       - from: "1.25"
         to: "1.26"


### PR DESCRIPTION
Fixes broken mink8s jobs: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-test-mink8s-main/1781086477027905536