### PR TITLE
Increase min_ports_per_vm from 64 (default) to 256 to increase number of IPs used for Cloud NAT to avoid being throttled by registry.k8s.io

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -374,6 +374,8 @@ presets:
     value: gctrace=1
   - name: CL2_ENABLE_QUOTAS_USAGE_MEASUREMENT
     value: "true"
+  - name: KUBE_GCE_PRIVATE_CLUSTER_PORTS_PER_VM
+    value: 256
 
 ###### Scalability Envs
 ### Common env variables for node scalability-related suites.


### PR DESCRIPTION
Four time increase is proposed based on increase of 429 present in k8s scalability logs.

Within last month we went from 100k to 400k containerd logs saying "429 Too Many Requests".

/assign @mborsz

Fixes https://github.com/kubernetes/kubernetes/issues/123672

/cc @wojtek-t 