### PR TITLE
update Prow Go dependency to 20240419142743-3cb2506c2ff3

### DIFF
--- a/config/pj-on-kind.sh
+++ b/config/pj-on-kind.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Runs sigs.k8s.io/prow/prow/pj-on-kind.sh with config arguments specific to the prow.k8s.io instance.
+# Runs sigs.k8s.io/prow/pkg/pj-on-kind.sh with config arguments specific to the prow.k8s.io instance.
 
 set -o errexit
 set -o nounset

--- a/config/tests/jobs/from_prow_test.go
+++ b/config/tests/jobs/from_prow_test.go
@@ -22,7 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/pkg/config"
 )
 
 // This file contains tests that previously lived in prow/config/jobs_test.go and prow/config/jobtests/job_config_test.go

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -40,8 +40,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/strings/slices"
 
-	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	cfg "sigs.k8s.io/prow/prow/config"
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	cfg "sigs.k8s.io/prow/pkg/config"
 )
 
 var configPath = flag.String("config", "../../../config/prow/config.yaml", "Path to prow config")

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -32,12 +32,12 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/config"
 	config_pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
-	prow_config "sigs.k8s.io/prow/prow/config"
-	"sigs.k8s.io/prow/prow/flagutil"
 	"k8s.io/test-infra/testgrid/pkg/configurator/configurator"
 	"k8s.io/test-infra/testgrid/pkg/configurator/options"
+	prow_config "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/flagutil"
 
-	configflagutil "sigs.k8s.io/prow/prow/flagutil/config"
+	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 )
 
 type SQConfig struct {

--- a/experiment/bumpmonitoring/main.go
+++ b/experiment/bumpmonitoring/main.go
@@ -29,7 +29,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/prow/prow/cmd/generic-autobumper/bumper"
+	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 	"sigs.k8s.io/yaml"
 )
 

--- a/experiment/ci-janitor/main.go
+++ b/experiment/ci-janitor/main.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/prow/prow/config"
-	configflagutil "sigs.k8s.io/prow/prow/flagutil/config"
+	"sigs.k8s.io/prow/pkg/config"
+	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 )
 
 type options struct {

--- a/experiment/ci-janitor/main_test.go
+++ b/experiment/ci-janitor/main_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
 
-	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/pkg/config"
 )
 
 func TestContainers(t *testing.T) {

--- a/experiment/gerrit-onboarder/onboarder.go
+++ b/experiment/gerrit-onboarder/onboarder.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/prow/prow/cmd/generic-autobumper/bumper"
+	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 )
 
 const (

--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	"sigs.k8s.io/prow/prow/config/secret"
-	"sigs.k8s.io/prow/prow/github"
-	"sigs.k8s.io/prow/prow/jenkins"
-	"sigs.k8s.io/prow/prow/pod-utils/downwardapi"
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/jenkins"
+	"sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
 )
 
 type options struct {

--- a/experiment/prowjob-report/main.go
+++ b/experiment/prowjob-report/main.go
@@ -38,8 +38,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	cfg "sigs.k8s.io/prow/prow/config"
-	configflagutil "sigs.k8s.io/prow/prow/flagutil/config"
+	cfg "sigs.k8s.io/prow/pkg/config"
+	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 )
 
 // TODO: parse testgrid config to catch

--- a/experiment/service-account-creator/main.go
+++ b/experiment/service-account-creator/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/pkg/flagutil"
 )
 
 var re = regexp.MustCompile(`^([^@]+)@(.+)\.iam\.gserviceaccount\.com$`)

--- a/experiment/update-hook/main.go
+++ b/experiment/update-hook/main.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/prow/prow/ghhook"
-	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/pkg/ghhook"
+	"sigs.k8s.io/prow/pkg/logrusutil"
 )
 
 func main() {

--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -38,13 +38,13 @@ import (
 	"google.golang.org/api/option"
 
 	"k8s.io/test-infra/gcsweb/pkg/version"
-	prowv1 "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	"sigs.k8s.io/prow/prow/flagutil"
-	pkgio "sigs.k8s.io/prow/prow/io"
-	"sigs.k8s.io/prow/prow/io/providers"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	pkgio "sigs.k8s.io/prow/pkg/io"
+	"sigs.k8s.io/prow/pkg/io/providers"
 
-	"sigs.k8s.io/prow/prow/logrusutil"
-	"sigs.k8s.io/prow/prow/pjutil"
+	"sigs.k8s.io/prow/pkg/logrusutil"
+	"sigs.k8s.io/prow/pkg/pjutil"
 )
 
 const (

--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	prowv1 "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	pkgio "sigs.k8s.io/prow/prow/io"
-	"sigs.k8s.io/prow/prow/io/fakeopener"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	pkgio "sigs.k8s.io/prow/pkg/io"
+	"sigs.k8s.io/prow/pkg/io/fakeopener"
 )
 
 type fakeOpener struct {

--- a/gcsweb/cmd/gcsweb/templates.go
+++ b/gcsweb/cmd/gcsweb/templates.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"text/template"
 
-	prowv1 "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 )
 
 const tmplPageHeaderText = `

--- a/gencred/cmd/gencred/main.go
+++ b/gencred/cmd/gencred/main.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/test-infra/gencred/pkg/certificate"
 	"k8s.io/test-infra/gencred/pkg/serviceaccount"
 	"k8s.io/test-infra/gencred/pkg/util"
-	"sigs.k8s.io/prow/prow/interrupts"
+	"sigs.k8s.io/prow/pkg/interrupts"
 	"sigs.k8s.io/yaml"
 
 	"google.golang.org/api/container/v1"

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 // indirect
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 // indirect
 	github.com/djherbis/atime v1.0.0
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/felixge/fgprof v0.9.1 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-bindata/go-bindata/v3 v3.1.3
 	github.com/go-openapi/spec v0.20.4
 	github.com/golang/glog v1.1.0
@@ -85,7 +85,7 @@ require (
 	knative.dev/pkg v0.0.0-20230221145627-8efb3485adcf // indirect
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/controller-tools v0.9.2
-	sigs.k8s.io/prow v0.0.0-20240409200154-0bca2f1416a9
+	sigs.k8s.io/prow v0.0.0-20240419142743-3cb2506c2ff3
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -110,16 +110,16 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
-	github.com/go-kit/log v0.2.0 // indirect
+	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
-	github.com/go-openapi/jsonreference v0.20.1 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gobuffalo/flect v0.2.5 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
-github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
+github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -195,8 +195,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
-github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -211,8 +211,8 @@ github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsouza/fake-gcs-server v1.19.4 h1:3bRRh/rQnB2XbrMolHAj9oX/PFiWVQFVVfPR5y2pxb8=
 github.com/fsouza/fake-gcs-server v1.19.4/go.mod h1:I0/88nHCASqJJ5M7zVF0zKODkYTcuXFW5J5yajsNJnE=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
@@ -228,8 +228,9 @@ github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3I
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
+github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
@@ -240,8 +241,8 @@ github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
-github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
+github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=
+github.com/go-logr/zapr v1.2.4/go.mod h1:FyHWQIzQORZ0QVE1BtVHv3cKtNLuXsbNLtpuhNapBOA=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -249,8 +250,8 @@ github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.19.6/go.mod h1:diGHMEHg2IqXZGKxqyvWdfWU/aim5Dprw5bqpKkTvns=
-github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTrLC1F86HID8=
-github.com/go-openapi/jsonreference v0.20.1/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
+github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE=
+github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/spec v0.20.4 h1:O8hJrt0UMnhHcluhIdUgCLRWyM2x7QkBXRvOs7m+O1M=
 github.com/go-openapi/spec v0.20.4/go.mod h1:faYFR1CvsJZ0mNsmsphTMSoRrNV3TEDoAM7FOEWeq8I=
@@ -826,6 +827,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1116,8 +1118,8 @@ sigs.k8s.io/controller-tools v0.9.2 h1:AkTE3QAdz9LS4iD3EJvHyYxBkg/g9fTbgiYsrcsFC
 sigs.k8s.io/controller-tools v0.9.2/go.mod h1:NUkn8FTV3Sad3wWpSK7dt/145qfuQ8CKJV6j4jHC5rM=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/prow v0.0.0-20240409200154-0bca2f1416a9 h1:kOYny8dioxldwX8yAAzf0gbocGvj17hz4j4W3JpGnHc=
-sigs.k8s.io/prow v0.0.0-20240409200154-0bca2f1416a9/go.mod h1:7rsZ1ej4cIWtv+w/+62mLOaGMONtsG663VD9eJ7UKL4=
+sigs.k8s.io/prow v0.0.0-20240419142743-3cb2506c2ff3 h1:/FlK96xaEn237foELGS/ghuVP2dJWQrqgEgKwNs6nyE=
+sigs.k8s.io/prow v0.0.0-20240419142743-3cb2506c2ff3/go.mod h1:1YquMB6duwbpb0jSMkRxjz8goepotJ4iqcbj4Ed7gCY=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -39,7 +39,7 @@ import (
 
 	"k8s.io/test-infra/greenhouse/diskcache"
 	"k8s.io/test-infra/greenhouse/diskutil"
-	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/pkg/logrusutil"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"

--- a/hack/cluster-migration/main.go
+++ b/hack/cluster-migration/main.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	cfg "sigs.k8s.io/prow/prow/config"
 	"k8s.io/utils/strings/slices"
+	cfg "sigs.k8s.io/prow/pkg/config"
 )
 
 type Config struct {

--- a/hack/cluster-migration/main_test.go
+++ b/hack/cluster-migration/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	cfg "sigs.k8s.io/prow/prow/config"
+	cfg "sigs.k8s.io/prow/pkg/config"
 )
 
 func TestConfigValidation_EmptyConfigPath(t *testing.T) {

--- a/hack/gen-prow-documented/main.go
+++ b/hack/gen-prow-documented/main.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/pkg/genyaml"
-	"sigs.k8s.io/prow/prow/config"
-	"sigs.k8s.io/prow/prow/plugins"
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/plugins"
 )
 
 const (

--- a/hack/prowimagebuilder/main.go
+++ b/hack/prowimagebuilder/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/pkg/flagutil"
 	"sigs.k8s.io/yaml"
 )
 

--- a/hack/prowimagebuilder/main_test.go
+++ b/hack/prowimagebuilder/main_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/pkg/flagutil"
 )
 
 func TestImageAllowed(t *testing.T) {

--- a/kubetest/boskos/client/client.go
+++ b/kubetest/boskos/client/client.go
@@ -39,7 +39,7 @@ import (
 
 	"k8s.io/test-infra/kubetest/boskos/common"
 	"k8s.io/test-infra/kubetest/boskos/storage"
-	"sigs.k8s.io/prow/prow/config/secret"
+	"sigs.k8s.io/prow/pkg/config/secret"
 )
 
 var (

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -37,10 +37,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/prow/prow/config/secret"
-	"sigs.k8s.io/prow/prow/flagutil"
-	"sigs.k8s.io/prow/prow/github"
-	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/logrusutil"
 )
 
 const maxConcurrentWorkers = 20

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	v1 "k8s.io/api/core/v1"
-	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	"sigs.k8s.io/prow/prow/config"
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
 )
 
 const (

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -25,8 +25,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	"sigs.k8s.io/prow/prow/config"
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
 )
 
 func TestCleanAnnotations(t *testing.T) {

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -27,7 +27,7 @@ import (
 	gyaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/pkg/config"
 )
 
 type options struct {

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -36,9 +36,9 @@ import (
 	"text/template"
 	"time"
 
-	"sigs.k8s.io/prow/prow/config/secret"
-	"sigs.k8s.io/prow/prow/flagutil"
-	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
 )
 
 const (

--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/pkg/github"
 )
 
 func TestParseHTMLURL(t *testing.T) {

--- a/robots/coverage/downloader/downloader.go
+++ b/robots/coverage/downloader/downloader.go
@@ -31,7 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
-	prowv1 "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 )
 
 // listGcsObjects get the slice of gcs objects under a given path

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/prow/prow/flagutil"
 	"k8s.io/test-infra/robots/pr-creator/updater"
+	"sigs.k8s.io/prow/pkg/flagutil"
 )
 
 type options struct {

--- a/robots/pr-creator/main_test.go
+++ b/robots/pr-creator/main_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"sigs.k8s.io/prow/prow/flagutil"
 	"reflect"
 	"testing"
+
+	"sigs.k8s.io/prow/pkg/flagutil"
 )
 
 func Test_options_getLabels(t *testing.T) {

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/pkg/github"
 )
 
 // Indicates whether maintainers can modify a pull request in fork.

--- a/robots/pr-creator/updater/updater_test.go
+++ b/robots/pr-creator/updater/updater_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/prow/prow/github"
-	"sigs.k8s.io/prow/prow/github/fakegithub"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/github/fakegithub"
 )
 
 func TestEnsurePRWithLabel(t *testing.T) {

--- a/robots/pr-labeler/main.go
+++ b/robots/pr-labeler/main.go
@@ -26,9 +26,9 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/prow/prow/config/secret"
-	"sigs.k8s.io/prow/prow/flagutil"
-	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
 )
 
 const (

--- a/testgrid/pkg/configurator/configurator/client.go
+++ b/testgrid/pkg/configurator/configurator/client.go
@@ -28,9 +28,9 @@ import (
 	tgCfgUtil "github.com/GoogleCloudPlatform/testgrid/config"
 	"github.com/GoogleCloudPlatform/testgrid/config/yamlcfg"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
-	prowConfig "sigs.k8s.io/prow/prow/config"
 	"k8s.io/test-infra/testgrid/pkg/configurator/options"
 	"k8s.io/test-infra/testgrid/pkg/configurator/prow"
+	prowConfig "sigs.k8s.io/prow/pkg/config"
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"

--- a/testgrid/pkg/configurator/options/options.go
+++ b/testgrid/pkg/configurator/options/options.go
@@ -21,8 +21,8 @@ import (
 	"flag"
 	"strings"
 
-	"sigs.k8s.io/prow/prow/flagutil"
-	configflagutil "sigs.k8s.io/prow/prow/flagutil/config"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 
 	"github.com/sirupsen/logrus"
 )

--- a/testgrid/pkg/configurator/options/options_test.go
+++ b/testgrid/pkg/configurator/options/options_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"sigs.k8s.io/prow/prow/flagutil"
-	configflagutil "sigs.k8s.io/prow/prow/flagutil/config"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 )
 
 func Test_Options(t *testing.T) {

--- a/testgrid/pkg/configurator/prow/prow.go
+++ b/testgrid/pkg/configurator/prow/prow.go
@@ -27,11 +27,11 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/config/yamlcfg"
 	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
 
-	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	prowConfig "sigs.k8s.io/prow/prow/config"
-	"sigs.k8s.io/prow/prow/pjutil"
-	"sigs.k8s.io/prow/prow/pod-utils/downwardapi"
-	prowGCS "sigs.k8s.io/prow/prow/pod-utils/gcs"
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	prowConfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/pjutil"
+	"sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
+	prowGCS "sigs.k8s.io/prow/pkg/pod-utils/gcs"
 )
 
 const testgridCreateTestGroupAnnotation = "testgrid-create-test-group"

--- a/testgrid/pkg/configurator/prow/prow_test.go
+++ b/testgrid/pkg/configurator/prow/prow_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/GoogleCloudPlatform/testgrid/config/yamlcfg"
 	"github.com/GoogleCloudPlatform/testgrid/pb/config"
 
-	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
-	prowConfig "sigs.k8s.io/prow/prow/config"
-	"sigs.k8s.io/prow/prow/pjutil"
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	prowConfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/pjutil"
 )
 
 const ProwDefaultGCSPath = "pathPrefix/"


### PR DESCRIPTION
https://github.com/kubernetes-sigs/prow has removed the top-level `prow/` directory, this PR makes the necessary changes here.