### PR TITLE
skip nftables jobs on COS

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -214,7 +214,8 @@ presubmits:
     - master
     - main
     always_run: false
-    run_if_changed: '^(test/e2e/network/|pkg/apis/networking|pkg/proxy/nftables/)'
+    # skip until COS support all the necessary kernel modules
+    # run_if_changed: '^(test/e2e/network/|pkg/apis/networking|pkg/proxy/nftables/)'
     optional: true
     decorate: true
     decoration_config:
@@ -745,47 +746,48 @@ periodics:
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
-- interval: 6h
-  name: ci-kubernetes-e2e-gci-gce-nftables
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 170m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --env=KUBE_PROXY_MODE=nftables
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      # skip ESIPP should work from pods #97081
-      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|ESIPP|LoadBalancers --minStartupPods=8
-      - --timeout=150m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-master
-      resources:
-        limits:
-          cpu: 2
-          memory: "6Gi"
-        requests:
-          cpu: 2
-          memory: "6Gi"
-  annotations:
-    testgrid-dashboards: sig-network-gce
-    testgrid-tab-name: periodic-network-nftables, google-gce
-    testgrid-num-failures-to-alert: '6'
-    testgrid-alert-stale-results-hours: '24'
-    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
-    description: Uses kubetest to run e2e Conformance, SIG-Network tests against a cluster using nftables created with cluster/kube-up.sh
+# skip until COS support all the necessary kernel modules
+#- interval: 6h
+#  name: ci-kubernetes-e2e-gci-gce-nftables
+#  cluster: k8s-infra-prow-build
+#  labels:
+#    preset-service-account: "true"
+#    preset-k8s-ssh: "true"
+#  decorate: true
+#  decoration_config:
+#    timeout: 170m
+#  spec:
+#    containers:
+#    - command:
+#      - runner.sh
+#      - /workspace/scenarios/kubernetes_e2e.py
+#     args:
+#      - --check-leaked-resources
+#      - --env=KUBE_PROXY_MODE=nftables
+#      - --extract=ci/latest
+#      - --gcp-master-image=gci
+#      - --gcp-node-image=gci
+#      - --gcp-zone=us-west1-b
+#      - --ginkgo-parallel=30
+#      - --provider=gce
+#      # skip ESIPP should work from pods #97081
+#      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|ESIPP|LoadBalancers --minStartupPods=8
+#      - --timeout=150m
+#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-master
+#      resources:
+#        limits:
+#          cpu: 2
+#          memory: "6Gi"
+#        requests:
+#          cpu: 2
+#          memory: "6Gi"
+#  annotations:
+#    testgrid-dashboards: sig-network-gce
+#    testgrid-tab-name: periodic-network-nftables, google-gce
+#    testgrid-num-failures-to-alert: '6'
+#    testgrid-alert-stale-results-hours: '24'
+#    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
+#    description: Uses kubetest to run e2e Conformance, SIG-Network tests against a cluster using nftables created with cluster/kube-up.sh
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-kube-dns


### PR DESCRIPTION

Discussed in https://kubernetes.slack.com/archives/C09QYUH5W/p1713628805680269

The COS images does not have the necessary kernel modules so it fails and causes other test to fail ... I need to change the OS image or see how long the COS team can release a new image with the necessary kernel modules

Fixes: https://github.com/kubernetes/kubernetes/issues/124437