### PR TITLE
bump resources for loud-provider-gcp-e2e-full

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -214,11 +214,11 @@ presubmits:
           kubetest2 gce -v 2 --repo-root "${REPO_ROOT}" --build --up --down --test=ginkgo --node-size n1-standard-4 --master-size n1-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 14Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 14Gi
   - name: cloud-provider-gcp-verify-up-to-date
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
The jobs timesout https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/cloud-provider-gcp-e2e-full

However, there is connectivity as we can see in the logs and checking in the console of a job running, aslo sshing onto the nodes, the cluster is working fine.

The pod where the test are executed is out of resources

![image](https://github.com/kubernetes/test-infra/assets/6450081/64363aa9-30b1-499b-bf56-9b67774c1ba1)


execing into the pod and trying to do `ps axf` hangs, so let's use the same resources as in the other jobs in the same folder