### PR TITLE
image-pushing: add nightly periodic for cluster-api-gcp

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -503,3 +503,37 @@ periodics:
       testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
       testgrid-tab-name: cluster-api-provider-aws-push-images-nightly
       testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+
+  - name: cluster-api-provider-gcp-push-images-nightly
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    cron: '0 8 * * *' # everyday at 0:00 PT (8:00 UTC)
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-gcp
+        base_ref: main
+        path_alias: sigs.k8s.io/cluster-api-provider-gcp
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20230711-e33377c2b4
+          command:
+            - /run.sh
+          args:
+          # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+            - --project=k8s-staging-cluster-api-gcp
+            - --scratch-bucket=gs://k8s-staging-cluster-api-gcp-gcb
+            - --env-passthrough=PULL_BASE_REF
+            - --gcb-config=cloudbuild-nightly.yaml
+            - --with-git-dir
+            - .
+          env:
+          # We need to emulate a pull job for the cloud build to work the same
+          # way as it usually does.
+            - name: PULL_BASE_REF
+              value: main
+    annotations:
+    # this is the name of some testgrid dashboard to report to.
+      testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
+      testgrid-tab-name: cluster-api-provider-gcp-push-images-nightly
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io


### PR DESCRIPTION
This PR adds a nightly periodic job for building and pushing an image for cluster-api-gcp built from the main branch.

Companion PR: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1215

/hold
/cc @cpanato @richardcase 