### PR TITLE
Fix kubemark release jobs - second attempt

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -208,7 +208,7 @@ periodics:
     - args:
       - --cluster=kubemark-500
       - --extract=ci/latest-1.27
-      - --gcp-master-size=n1-standard-4
+      - --gcp-master-size=n2-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
@@ -1186,7 +1186,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
-        - --gcp-master-size=n1-standard-4
+        - --gcp-master-size=n2-standard-4
         - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
@@ -1816,7 +1816,7 @@ presubmits:
       - args:
         - --cluster=
         - --extract=ci/latest
-        - --gcp-master-size=n1-standard-2
+        - --gcp-master-size=n2-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
         - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -208,7 +208,7 @@ periodics:
     - args:
       - --cluster=kubemark-500
       - --extract=ci/latest-1.28
-      - --gcp-master-size=n1-standard-4
+      - --gcp-master-size=n2-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
@@ -1414,7 +1414,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
-        - --gcp-master-size=n1-standard-4
+        - --gcp-master-size=n2-standard-4
         - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
@@ -2044,7 +2044,7 @@ presubmits:
       - args:
         - --cluster=
         - --extract=ci/latest
-        - --gcp-master-size=n1-standard-2
+        - --gcp-master-size=n2-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
         - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -208,7 +208,7 @@ periodics:
     - args:
       - --cluster=kubemark-500
       - --extract=ci/latest-1.29
-      - --gcp-master-size=n1-standard-4
+      - --gcp-master-size=n2-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
@@ -1590,7 +1590,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
-        - --gcp-master-size=n1-standard-4
+        - --gcp-master-size=n2-standard-4
         - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
@@ -2270,7 +2270,7 @@ presubmits:
       - args:
         - --cluster=
         - --extract=ci/latest
-        - --gcp-master-size=n1-standard-2
+        - --gcp-master-size=n2-standard-2
         - --gcp-node-size=e2-standard-4
         - --gcp-nodes=4
         - --gcp-project-type=scalability-project


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/3250 - `--kubemark-master-size` change was not enough and we also have to change the `--gcp-master-size` flag to make sure we use N2 family machines for both kubemark as well as the "real" K8s cluster.