### PR TITLE
apidiff: current work tree must be head of PR branch

### DIFF
--- a/config/jobs/kubernetes/sig-testing/apidiff.yaml
+++ b/config/jobs/kubernetes/sig-testing/apidiff.yaml
@@ -27,7 +27,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - "./hack/apidiff.sh -r ${PULL_BASE_SHA}"
+        - "git checkout ${PULL_PULL_SHA} && ./hack/apidiff.sh -r ${PULL_BASE_SHA}"
         env:
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes


### PR DESCRIPTION
apidiff.sh supports -r for the base revision and compares against the current work tree. This means that the Prow job must undo the merging against the target branch before invoking the script.

/assign @dims 

Follow-up to https://github.com/kubernetes/test-infra/pull/32504