### PR TITLE
Use N2 kubemark masters for kubemark-500 release branch jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -216,6 +216,7 @@ periodics:
       - --gcp-zone=us-east1-b
       - --kubemark
       - --kubemark-nodes=500
+      - --kubemark-master-size=n2-standard-16
       - --metadata-sources=cl2-metadata.json
       - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=160 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --provider=gce

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -216,6 +216,7 @@ periodics:
       - --gcp-zone=us-east1-b
       - --kubemark
       - --kubemark-nodes=500
+      - --kubemark-master-size=n2-standard-16
       - --metadata-sources=cl2-metadata.json
       - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=160 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --provider=gce

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -216,6 +216,7 @@ periodics:
       - --gcp-zone=us-east1-b
       - --kubemark
       - --kubemark-nodes=500
+      - --kubemark-master-size=n2-standard-16
       - --metadata-sources=cl2-metadata.json
       - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=160 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --provider=gce


### PR DESCRIPTION
[Sample test](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-kubemark-500-gce-1-29/1783390654294921216) failure from the `ci-kubernetes-kubemark-500-gce-1-29` test job:

```
2024/04/25 07:14:17 process.go:153: Running: test/kubemark/start-kubemark.sh
Using image: cos-109-17800-147-60 from project: cos-cloud as master image
Using image: cos-109-17800-147-60 from project: cos-cloud as node image
(...)
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The selected machine type (n1-standard-16) is not compatible with CPU platform icelake
Failed to create master instance due to non-retryable error
2024/04/25 07:15:59 process.go:155: Step 'test/kubemark/start-kubemark.sh' finished in 1m42.414307338s
```

The change mimics what we already have for `release-1.30` and `master` branches  CI jobs.

/assign @wojtek-t 