### PR TITLE
switch ci-kubernetes-e2e-gci-gce-scalability-networkpolicies to kube-network-policies

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -82,7 +82,7 @@ periodics:
     path_alias: k8s.io/perf-tests
   annotations:
     testgrid-dashboards: sig-scalability-experiments
-    testgrid-tab-name: calico
+    testgrid-tab-name: kube-network-policies
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-master
@@ -91,7 +91,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       env:
       - name: NETWORK_POLICY_PROVIDER
-        value: "calico"
+        value: "kube-network-policies"
       - name: ADDITIONAL_MACHINE_TYPE
         value: "e2-standard-2"
       - name: NUM_ADDITIONAL_NODES


### PR DESCRIPTION
The CI jobs already migrated to https://github.com/kubernetes-sigs/kube-network-policies
https://testgrid.k8s.io/sig-network-gce#network-policies,%20google-gce&width=20

This jobs is permanent failing https://testgrid.k8s.io/sig-scalability-experiments#calico