### PR TITLE
kubernetes_e2e.py: remove working dir check if `--build` is specified

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -122,10 +122,6 @@ class LocalMode(object):
         """Returns path."""
         return path
 
-    def add_k8s(self, *a, **kw):
-        """Add specified k8s.io repos (noop)."""
-        pass
-
     def start(self, args):
         """Starts kubetest."""
         print('starts with local mode', file=sys.stderr)
@@ -254,10 +250,6 @@ def main(args):
             runner_args.append('--build')
         else:
             runner_args.append('--build=%s' % args.build)
-        k8s = os.getcwd()
-        if not os.path.basename(k8s) == 'kubernetes':
-            raise ValueError(k8s)
-        mode.add_k8s(os.path.dirname(k8s), 'kubernetes', 'release')
 
     if args.stage is not None:
         runner_args.append('--stage=%s' % args.stage)


### PR DESCRIPTION
The job `pull-release-cluster-up` is failing right now with:

```
+ /workspace/scenarios/kubernetes_e2e.py --build=quick --cluster= --down=false --extract=local --gcp-node-image=gci --gcp-nodes=4 --gcp-zone=us-west1-b --provider=gce --test_args=--ginkgo.focus=definitely-not-a-real-focus --timeout=65m
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_e2e.py", line 391, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_e2e.py", line 259, in main
    raise ValueError(k8s)
ValueError: /home/prow/go/src/github.com/kubernetes/release
```

Reason for that is that the current working directory is already `/home/prow/go/src/github.com/kubernetes/release` while the script expects to be in `kubernetes/kubernetes`. It does not seem to matter much for `kubetest` in which working directory we are, means we can remove the check completely. Also the method `add_k8s` does not do anything at all which means we can remove it, too.


cc @kubernetes/release-engineering 

Should fix https://github.com/kubernetes/release/issues/3588