### PR TITLE
apidiff: use eks-prow-build-cluster, fix comparison

### DIFF
--- a/config/jobs/kubernetes/sig-testing/apidiff.yaml
+++ b/config/jobs/kubernetes/sig-testing/apidiff.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-apidiff
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     # A job which automatically runs for changes in staging and then only
     # diffs staging might be useful. For now, this checks everything and
     # has to be started manually with:
@@ -27,7 +27,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - "git checkout ${PULL_PULL_SHA} && ./hack/apidiff.sh -r ${PULL_BASE_SHA}"
+        - "./hack/apidiff.sh -r ${PULL_BASE_SHA} -t ${PULL_PULL_SHA}"
         env:
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes


### PR DESCRIPTION
Should have used eks-prow-build-cluster already before as the script has no special requirements that would make it depend on k8s-infra-prow-build.

The trick with manually checking out the "right" revision had the downside that then some older apidiff.sh gets used. We want to use the latest one, because that is where we roll out fixes and enhancements.

With https://github.com/kubernetes/kubernetes/pull/124552, the script itself can check out the target revision.

/assign @dims

Getting there... I hope.
