### PR TITLE
etcd: change robustness RESULTS_DIR to /data/results

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -88,9 +88,9 @@ periodics:
         GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
         make gofail-enable
         make build
-        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness || result=$?
-        if [ -d /tmp/results ]; then
-          zip -r ${ARTIFACTS}/results.zip /tmp/results
+        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
         fi
         exit $result
       resources:
@@ -131,9 +131,9 @@ periodics:
         make install-lazyfs
         set -euo pipefail
         GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
-        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness-release-3.5 || result=$?
-        if [ -d /tmp/results ]; then
-          zip -r ${ARTIFACTS}/results.zip /tmp/results
+        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-release-3.5 || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
         fi
         exit $result
       resources:
@@ -174,9 +174,9 @@ periodics:
         make install-lazyfs
         set -euo pipefail
         GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
-        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness-release-3.4 || result=$?
-        if [ -d /tmp/results ]; then
-          zip -r ${ARTIFACTS}/results.zip /tmp/results
+        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-release-3.4 || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
         fi
         exit $result
       resources:


### PR DESCRIPTION
change robustness RESULTS_DIR to /data/results instead of /tmp/results.

Right now reports from robustness tests on prow seem incomplete (missing some clients, [example](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-etcd-robustness-release35-amd64/1783766887738380288)). 
I cannot reproduce the problem locally. One guess is that `/tmp` dir is being deleted while zip is in progress. 
Trying moving RESULTS_DIR to a non-tmp location.