### PR TITLE
peribolos: update testgrid-alert-email to add new kubernetes.io mailing list

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -4,7 +4,9 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-contribex-org
       testgrid-tab-name: post-peribolos
-      testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      # TODO: remove kubernetes-github-managment-alerts@googlegroups.com,
+      # when new kubernetes.io mailing list is stable.
+      testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com, k8s-infra-oncall@google.com, github-managment-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
     rerun_auth_config:
       github_team_slugs:
@@ -40,7 +42,9 @@ periodics:
   annotations:
     testgrid-dashboards: sig-contribex-org
     testgrid-tab-name: ci-peribolos
-    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    # TODO: remove kubernetes-github-managment-alerts@googlegroups.com,
+    # when new kubernetes.io mailing list is stable.
+    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com, k8s-infra-oncall@google.com, github-managment-alerts@kubernetes.io
     testgrid-num-failures-to-alert: '1'
   rerun_auth_config:
     github_team_slugs:


### PR DESCRIPTION
PR adds the new managed `github-managment-alerts@kubernetes.io` mailing list to peribolos CI job for the respective testgrid alert emails.

/sig contributor-experience

cc: @cblecker @MadhavJivrajani @kubernetes/owners 


