### PR TITLE
sig-k8s-infra: bump go version for peribolos jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -21,7 +21,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.22
         command:
         - ./admin/update.sh
         args:
@@ -61,7 +61,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.20
+    - image: public.ecr.aws/docker/library/golang:1.22
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
For latest failing run of peribolos: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1784974488945823744

This happened after the version of go was bumped to go1.22 here: https://github.com/kubernetes/org/pull/4925 

/assign @cblecker 