### PR TITLE
CAPI: Merge dualstack and default e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -99,51 +99,7 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 3000m
-            memory: 8Gi
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-e2e-dualstack-and-ipv6-main
-  cluster: eks-prow-build-cluster
-  interval: 2h
-  decorate: true
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes-sigs
-        slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api
-      base_ref: main
-      path_alias: sigs.k8s.io/cluster-api
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.30
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
+            # enable IPV6 in bootstrap image
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
@@ -160,7 +116,7 @@ periodics:
             memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-main
+    testgrid-tab-name: capi-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-main
@@ -190,8 +146,11 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+        # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -159,8 +159,11 @@ presubmits:
         - runner.sh
         - ./scripts/ci-e2e.sh
         env:
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\]|\\[IPv6\\]"
+          value: "\\[Conformance\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -220,48 +223,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-blocking-main
-  - name: pull-cluster-api-e2e-dualstack-and-ipv6-main
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    always_run: false
-    branches:
-      # The script this job runs is not in all branches.
-      - ^main$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.30
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          env:
-            # enable IPV6 in bootstrap image
-            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-              value: "true"
-            - name: GINKGO_SKIP
-              value: "\\[Conformance\\]"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3000m
-              memory: 8Gi
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-main
-
   - name: pull-cluster-api-e2e-main
     cluster: eks-prow-build-cluster
     labels:
@@ -285,8 +246,11 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
+            value: "\\[Conformance\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics.yaml
@@ -99,51 +99,7 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 3000m
-            memory: 8Gi
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
-    testgrid-tab-name: capi-e2e-release-1-5
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-e2e-dualstack-and-ipv6-release-1-5
-  cluster: eks-prow-build-cluster
-  interval: 4h
-  decorate: true
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes-sigs
-        slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api
-      base_ref: release-1.5
-      path_alias: sigs.k8s.io/cluster-api
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.27
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
+            # enable IPV6 in bootstrap image
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
@@ -160,7 +116,7 @@ periodics:
             memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
-    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-5
+    testgrid-tab-name: capi-e2e-release-1-5
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-5
@@ -190,8 +146,11 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+        # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
@@ -159,8 +159,11 @@ presubmits:
         - runner.sh
         - ./scripts/ci-e2e.sh
         env:
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\]|\\[IPv6\\]"
+          value: "\\[Conformance\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -259,48 +262,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
       testgrid-tab-name: capi-pr-e2e-informing-release-1-5
-  - name: pull-cluster-api-e2e-dualstack-and-ipv6-release-1-5
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    always_run: false
-    branches:
-      # The script this job runs is not in all branches.
-      - ^release-1.5$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.27
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          env:
-            # enable IPV6 in bootstrap image
-            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-              value: "true"
-            - name: GINKGO_SKIP
-              value: "\\[Conformance\\]"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3000m
-              memory: 8Gi
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.5
-      testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-release-1-5
-
   - name: pull-cluster-api-e2e-release-1-5
     cluster: eks-prow-build-cluster
     labels:
@@ -324,8 +285,11 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
+            value: "\\[Conformance\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics.yaml
@@ -99,51 +99,7 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 3000m
-            memory: 8Gi
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
-    testgrid-tab-name: capi-e2e-release-1-6
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-e2e-dualstack-and-ipv6-release-1-6
-  cluster: eks-prow-build-cluster
-  interval: 4h
-  decorate: true
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes-sigs
-        slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api
-      base_ref: release-1.6
-      path_alias: sigs.k8s.io/cluster-api
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.28
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
+            # enable IPV6 in bootstrap image
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
@@ -160,7 +116,7 @@ periodics:
             memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
-    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-6
+    testgrid-tab-name: capi-e2e-release-1-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-6
@@ -190,8 +146,11 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+        # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
@@ -159,8 +159,11 @@ presubmits:
         - runner.sh
         - ./scripts/ci-e2e.sh
         env:
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\]|\\[IPv6\\]"
+          value: "\\[Conformance\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -220,48 +223,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
       testgrid-tab-name: capi-pr-e2e-blocking-release-1-6
-  - name: pull-cluster-api-e2e-dualstack-and-ipv6-release-1-6
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    always_run: false
-    branches:
-      # The script this job runs is not in all branches.
-      - ^release-1.6$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.28
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          env:
-            # enable IPV6 in bootstrap image
-            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-              value: "true"
-            - name: GINKGO_SKIP
-              value: "\\[Conformance\\]"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3000m
-              memory: 8Gi
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.6
-      testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-release-1-6
-
   - name: pull-cluster-api-e2e-release-1-6
     cluster: eks-prow-build-cluster
     labels:
@@ -285,8 +246,11 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
+            value: "\\[Conformance\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
@@ -99,51 +99,7 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 3000m
-            memory: 8Gi
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
-    testgrid-tab-name: capi-e2e-release-1-7
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-e2e-dualstack-and-ipv6-release-1-7
-  cluster: eks-prow-build-cluster
-  interval: 4h
-  decorate: true
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes-sigs
-        slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api
-      base_ref: release-1.7
-      path_alias: sigs.k8s.io/cluster-api
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.29
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
+            # enable IPV6 in bootstrap image
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
@@ -160,7 +116,7 @@ periodics:
             memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
-    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-release-1-7
+    testgrid-tab-name: capi-e2e-release-1-7
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-7
@@ -190,8 +146,11 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+        # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
@@ -159,8 +159,11 @@ presubmits:
         - runner.sh
         - ./scripts/ci-e2e.sh
         env:
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\]|\\[IPv6\\]"
+          value: "\\[Conformance\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -220,48 +223,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-blocking-release-1-7
-  - name: pull-cluster-api-e2e-dualstack-and-ipv6-release-1-7
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    always_run: false
-    branches:
-      # The script this job runs is not in all branches.
-      - ^release-1.7$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.29
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          env:
-            # enable IPV6 in bootstrap image
-            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-              value: "true"
-            - name: GINKGO_SKIP
-              value: "\\[Conformance\\]"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3000m
-              memory: 8Gi
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
-      testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-release-1-7
-
   - name: pull-cluster-api-e2e-release-1-7
     cluster: eks-prow-build-cluster
     labels:
@@ -285,8 +246,11 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
+            value: "\\[Conformance\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -98,52 +98,7 @@ periodics:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 3000m
-            memory: 8Gi
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
-    testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "4"
-{{ if eq $.branch "release-1.4" | not -}}
-- name: periodic-cluster-api-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
-  cluster: eks-prow-build-cluster
-  interval: {{ $.config.Interval }}
-  decorate: true
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes-sigs
-        slug: cluster-api-maintainers
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api
-      base_ref: {{ $.branch }}
-      path_alias: sigs.k8s.io/cluster-api
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-      - image: {{ $.config.TestImage }}
-        args:
-          - runner.sh
-          - "./scripts/ci-e2e.sh"
-        env:
-          # enable IPV6 in bootstrap image
+            # enable IPV6 in bootstrap image
           - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
             value: "true"
           - name: GINKGO_SKIP
@@ -160,10 +115,9 @@ periodics:
             memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
-    testgrid-tab-name: capi-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
+    testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-{{ end -}}
 - name: periodic-cluster-api-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
@@ -191,8 +145,11 @@ periodics:
       - runner.sh
       - "./scripts/ci-e2e.sh"
       env:
+        # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -159,8 +159,11 @@ presubmits:
         - runner.sh
         - ./scripts/ci-e2e.sh
         env:
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
         - name: GINKGO_SKIP
-          value: "\\[Conformance\\]|\\[IPv6\\]"
+          value: "\\[Conformance\\]"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -266,94 +269,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-informing-{{ ReplaceAll $.branch "." "-" }}
 {{- end }}
-{{- if eq $.branch "release-1.4" | not }}
-  - name: pull-cluster-api-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    always_run: false
-    branches:
-      # The script this job runs is not in all branches.
-      - ^{{ $.branch }}$
-    path_alias: sigs.k8s.io/cluster-api
-    spec:
-      containers:
-        - image: {{ $.config.TestImage }}
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          env:
-            # enable IPV6 in bootstrap image
-            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-              value: "true"
-            - name: GINKGO_SKIP
-              value: "\\[Conformance\\]"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3000m
-              memory: 8Gi
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
-      testgrid-tab-name: capi-pr-e2e-dualstack-and-ipv6-{{ ReplaceAll $.branch "." "-" }}
-{{ else }}
-  - name: pull-cluster-api-e2e-informing-ipv6-{{ ReplaceAll $.branch "." "-" }}
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    optional: true
-    branches:
-      # The script this job runs is not in all branches.
-      - ^{{ $.branch }}$
-    path_alias: sigs.k8s.io/cluster-api
-    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
-    spec:
-      containers:
-        - image: {{ $.config.TestImage }}
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          env:
-            # enable IPV6 in bootstrap image
-            - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-              value: "true"
-            - name: GINKGO_FOCUS
-              value: "\\[IPv6\\] \\[PR-Informing\\]"
-            - name: IP_FAMILY
-              value: "IPv6"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3000m
-              memory: 8Gi
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
-      testgrid-tab-name: capi-pr-e2e-informing-ipv6-{{ ReplaceAll $.branch "." "-" }}
-{{- end }}
   - name: pull-cluster-api-e2e-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:
@@ -377,8 +292,11 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_SKIP
-            value: "\\[Conformance\\]|\\[IPv6\\]"
+            value: "\\[Conformance\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Remove the specific jobs for dualstack and ipv6 from the Cluster API periodic and presubmit jobs. These jobs should run as part of the default e2e tests.