### PR TITLE
Enabled cherrypicker for the kubernetes-sigs/apiserver-network-proxy.

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1670,6 +1670,12 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  kubernetes-sigs/apiserver-network-proxy:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/cloud-provider-azure:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Enabled cherrypicker for the kubernetes-sigs/apiserver-network-proxy, and then we just comment `/cherry-pick release-0.29` at PR, the bot will cherry pick this PR to `release-0.29` after this PR is merged.

/assign @cheftako 
/cc @jkh52 