### PR TITLE
Add job for apiserver-network-proxy release-0.1

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-0.1.yaml
@@ -1,0 +1,127 @@
+presubmits:
+  kubernetes-sigs/apiserver-network-proxy:
+  - name: pull-apiserver-network-proxy-test-0-1
+    cluster: eks-prow-build-cluster
+    always_run: true
+    branches:
+    - release-0.1
+    skip_report: false
+    decorate: true
+    path_alias: sigs.k8s.io/apiserver-network-proxy
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/golang:1.20.12
+        command:
+        - make
+        args:
+        - test
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: 2
+          limits:
+            memory: 8Gi
+            cpu: 2
+    annotations:
+      testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
+      testgrid-tab-name: pr-test-0-1
+      description: Tests the apiserver-network-proxy
+  - name: pull-apiserver-network-proxy-docker-build-amd64-0-1
+    cluster: eks-prow-build-cluster
+    always_run: true
+    branches:
+    - release-0.1
+    skip_report: false
+    decorate: true
+    path_alias: sigs.k8s.io/apiserver-network-proxy
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-1.27
+        command:
+        - "runner.sh"
+        args:
+        - make
+        - docker-build/proxy-agent-amd64
+        env:
+        - name: REGISTRY
+          value: testlocal.io
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: 2
+          limits:
+            memory: 8Gi
+            cpu: 2
+    annotations:
+      testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
+      testgrid-tab-name: pr-docker-build-amd64-0-1
+      description: Build amd64 image via Docker for the apiserver-network-proxy
+  - name: pull-apiserver-network-proxy-docker-build-arm64-0-1
+    cluster: eks-prow-build-cluster
+    always_run: true
+    branches:
+    - release-0.1
+    skip_report: false
+    decorate: true
+    path_alias: sigs.k8s.io/apiserver-network-proxy
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-1.27
+        command:
+        - "runner.sh"
+        args:
+        - make
+        - docker-build/proxy-agent-arm64
+        env:
+        - name: REGISTRY
+          value: testlocal.io
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: 2
+          limits:
+            memory: 8Gi
+            cpu: 2
+    annotations:
+      testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
+      testgrid-tab-name: pr-docker-build-arm64-0-1
+      description: Build arm64 image via Docker for the apiserver-network-proxy
+  - name: pull-apiserver-network-proxy-make-lint-0-1
+    cluster: eks-prow-build-cluster
+    always_run: true
+    branches:
+    - release-0.1
+    skip_report: false
+    decorate: true
+    path_alias: sigs.k8s.io/apiserver-network-proxy
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-1.27
+        command:
+        - "runner.sh"
+        args:
+        - make
+        - lint
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: 2
+          limits:
+            memory: 8Gi
+            cpu: 2
+    annotations:
+      testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
+      testgrid-tab-name: pr-make-lint-0-1
+      description: Run lint target for the apiserver-network-proxy


### PR DESCRIPTION
Still need to support release-0.1 https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/622#issuecomment-2086509592, so add  a prow job for release-0.1

Basically, this is copied from the release-0.28 jobs and  update the kubekins-e2e to `gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-1.27`, and update go version to `1.20.12`

/cc @jkh52 
/assign @cheftako 