### PR TITLE
Add support for triage bot for `kubernetes-sigs/karpenter`

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -828,6 +828,18 @@ require_matching_label:
     If Ingress contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
 
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-triage
+  org: kubernetes-sigs
+  repo: karpenter
+  issues: true
+  prs: false
+  regexp: ^triage/
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If Karpenter contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 - missing_label: needs-kind
   org: kubernetes
   repo: ingress-nginx


### PR DESCRIPTION
This change adds support for the k8s-bot to allow the Karpenter contributors to triage issues