### PR TITLE
Add kubernetes-sigs/karpenter support for require-matching-label plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1521,6 +1521,10 @@ plugins:
     - override
     - release-note
 
+  kubernetes-sigs/karpenter:
+    plugins:
+    - require-matching-label
+
   kubernetes-sigs/kubebuilder:
     plugins:
     - override


### PR DESCRIPTION
Adds support for the `require-matching-label` plugin