### PR TITLE
Fix prow pj-on-kind.sh location

### DIFF
--- a/config/pj-on-kind.sh
+++ b/config/pj-on-kind.sh
@@ -23,4 +23,4 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 export CONFIG_PATH="${root}/config/prow/config.yaml"
 export JOB_CONFIG_PATH="${root}/config/jobs"
 
-bash <(curl -s https://raw.githubusercontent.com/kubernetes-sigs/prow/main/prow/pj-on-kind.sh) "$@"
+bash <(curl -s https://raw.githubusercontent.com/kubernetes-sigs/prow/main/pkg/pj-on-kind.sh) "$@"


### PR DESCRIPTION
This Pull Request fixes Prow's `pj-on-kind.sh` location, changing from `prow/pj-on-kind.sh` to `pkg/pj-on-kind.sh`.