### PR TITLE
Add pipefail for etcd verify presubmit

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -67,8 +67,9 @@ presubmits:
         args:
         - -c
         - |
-          make verify
-          make fix
+          set -euo pipefail
+          export PATH=$GOPATH/bin:$PATH && make verify
+          export PATH=$GOPATH/bin:$PATH && make fix
           DIFF=$(git status --porcelain)
           if [ -n "$DIFF" ]; then
             echo "These files were modified:"


### PR DESCRIPTION
As part of the etcd `make verify`, `golangci-lint` installs successfully:

```bash
golangci/golangci-lint info checking GitHub for tag 'v1.57.2'
golangci/golangci-lint info found version: 1.57.2 for v1.57.2/linux/amd64
golangci/golangci-lint info installed /home/prow/go/bin/golangci-lint 
```

Yet then goes on to error saying golangci-lint not found:

```bash
 PASSES="lint" ./scripts/test.sh
Running with --race
Starting at: Sat May  4 05:21:19 UTC 2024
              
'lint' started at Sat May  4 05:21:19 UTC 2024
% (cd api && 'golangci-lint' 'run' '--config' '/home/prow/go/src/github.com/etcd-io/etcd/tools/.golangci.yaml' './...')
stderr: ./scripts/test_lib.sh: line 148: golangci-lint: command not found
[0;31mFAIL: (code:127):
  % (cd api && 'golangci-lint' 'run' '--config' '/home/prow/go/src/github.com/etcd-io/etcd/tools/.golangci.yaml' './...') 
```

Interestingly the job passes despite this failure. I think we should align with github actions where this does fail, the only difference I can see is that in github actions we set pipefail before calling `make verify`.