### PR TITLE
Use CRI-O v1.30.0 for hugepages tests

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign
@@ -71,7 +71,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=85f0d4175e1abce29dc9f6efbd45fb235df86c3d\"\nEnvironment=\"CRIO_COMMIT=efff37a2900e5039e5af554c3196633df25890dc\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.0\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/templates/base/root-v2.yaml
+++ b/jobs/e2e_node/crio/templates/base/root-v2.yaml
@@ -4,8 +4,6 @@ version: 1.4.0
 kernel_arguments:
   should_not_exist:
     - mitigations=auto,nosmt
-  should_exist:
-    - systemd.unified_cgroup_hierarchy=0
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml
@@ -43,6 +41,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: tools-install.service
       enabled: true
       contents: |
@@ -62,6 +61,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: selinux-install.service
       enabled: true
       contents: |
@@ -80,6 +80,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: crio-install.service
       enabled: true
       contents: |
@@ -104,6 +105,7 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+
     - name: authorized-key.service
       enabled: true
       contents: |
@@ -120,20 +122,6 @@ systemd:
             >> /home/core/.ssh/authorized_keys && \
           /usr/bin/chown -R core:core /home/core/.ssh && \
           /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'
-
-        [Install]
-        WantedBy=multi-user.target
-    - name: allocate-1G-hugepages.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Allocate 1G hugepages.
-        After=network-online.target
-
-        [Service]
-        Type=oneshot
-        ExecStart=/bin/sh -c '/usr/bin/echo 1 > \
-          /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages'
 
         [Install]
         WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -27,7 +27,7 @@ fi
 declare -A CONFIGURATIONS=(
     ["crio_cgroupsv1"]="root cgroups-v1 criu-enabled"
     ["crio_cgroupsv1_eventedpleg"]="root cgroups-v1 eventedpleg"
-    ["crio_cgroupsv1_hugepages"]="root cgroups-v1 hugepages"
+    ["crio_cgroupsv1_hugepages"]="root-v2 cgroups-v1 hugepages"
     ["crio_cgroupsv2"]="root"
     ["crio_cgroupsv2_swap1g"]="root swap-1G"
     ["crio_cgroupsv2_imagefs"]="root imagefs"


### PR DESCRIPTION
This affects the following tests:

- [pull-crio-cgroupv1-node-e2e-hugepages](https://testgrid.k8s.io/sig-node-cri-o#pr-kubelet-crio-cgroupv1-node-e2e-hugepages)
- [ci-crio-cgroupv1-node-e2e-hugepages](https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-hugepages)

cc @kubernetes/sig-node-cri-o-test-maintainers 

```bash
diff root.yaml root-v2.yaml
```

```diff
93,94c93,94
<         Environment="SCRIPT_COMMIT=85f0d4175e1abce29dc9f6efbd45fb235df86c3d"
<         Environment="CRIO_COMMIT=efff37a2900e5039e5af554c3196633df25890dc"
---
>         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
>         Environment="CRIO_COMMIT=v1.30.0"
>
```