### PR TITLE
support 20 loadbalancer services in parallel on scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -192,7 +192,7 @@ presubmits:
         args:
         - --build=quick
         - --cluster=gce-cluster
-        - --env=CONCURRENT_SERVICE_SYNCS=5
+        - --env=CONCURRENT_SERVICE_SYNCS=20 # support 20 LoadBalancer Services in parallel to deal with existing CI load #122286
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-2
         - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
         - --extract=local

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -28,7 +28,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --cluster=gce-scale-cluster
-      - --env=CONCURRENT_SERVICE_SYNCS=5
+      - --env=CONCURRENT_SERVICE_SYNCS=20 # support 20 LoadBalancer Services in parallel to deal with existing CI load #122286
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-32
       - --extract=ci/fast/latest-fast
       - --extract-ci-bucket=k8s-release-dev


### PR DESCRIPTION
The operations on the scale tests take too long ~XXmins and, since the service controller only has 5 workers, the job flakes.

Use 20 workers to deal with the number of possible tests in parallel, so each test get one worker and don't block the others

Fixes: https://github.com/kubernetes/kubernetes/issues/122286

/sig scalability