### PR TITLE
Kueue: set gomaxprocs and resources consistently for integration-based

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -50,7 +50,7 @@ presubmits:
         - test-integration
         env:
         - name: GOMAXPROCS
-          value: "4"
+          value: "6"
         resources:
           requests:
             cpu: "6"
@@ -299,7 +299,7 @@ presubmits:
         - test-performance-scheduler
         env:
         - name: GOMAXPROCS
-          value: "4"
+          value: "6"
         resources:
           requests:
             cpu: "6"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-6.yaml
@@ -50,7 +50,7 @@ presubmits:
         - test-integration
         env:
         - name: GOMAXPROCS
-          value: "4"
+          value: "6"
         resources:
           requests:
             cpu: "6"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -69,14 +69,14 @@ periodics:
             - test-integration
           env:
             - name: GOMAXPROCS
-              value: "4"
+              value: "6"
           resources:
             requests:
-              cpu: "4"
-              memory: "6Gi"
+              cpu: "6"
+              memory: "9Gi"
             limits:
-              cpu: "4"
-              memory: "6Gi"
+              cpu: "6"
+              memory: "9Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-27
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Two changes for `test-integration` and `test-performance-scheduler`, for `main` and `release-0.6` branches:
- set GOMAXPROCS to 6 consistently
- set resource requests for CPU and memory consistently

As proposed in the comment: https://github.com/kubernetes/test-infra/pull/32569#discussion_r1591054657.