### PR TITLE
chore: add optional presubmit for conjur provider with secrets-store-csi

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -577,6 +577,46 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-akeyless
       description: "Run e2e test with akeyless provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-conjur
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 15m
+    always_run: false
+    optional: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    - ^release-*
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240409-13cd3acf7e-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            make e2e-bootstrap e2e-helm-deploy e2e-conjur
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-conjur
+      description: "Run e2e test with conjur provider for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-windows
     decorate: true
     decoration_config:


### PR DESCRIPTION
Adds an optional presubmit job to validate conjur provider with secrets-store-csi-driver.

After this PR is merged, tests can be manually triggered in PRs with /test pull-secrets-store-csi-driver-e2e-conjur