### PR TITLE
Add flag to skip dumping cluster logs

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -173,7 +173,7 @@ func run(deploy deployer, o options) error {
 		}
 	}
 
-	if dumpPreTestLogs != "" {
+	if !o.skipDumpClusterLogs && dumpPreTestLogs != "" {
 		errs = append(errs, dumpRemoteLogs(deploy, o, dumpPreTestLogs, "pre-test")...)
 	}
 
@@ -263,7 +263,7 @@ func run(deploy deployer, o options) error {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "Helm Charts", chartsTest))
 	}
 
-	if dump != "" {
+	if !o.skipDumpClusterLogs && dump != "" {
 		errs = append(errs, dumpRemoteLogs(deploy, o, dump, "")...)
 	}
 

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -110,6 +110,7 @@ type options struct {
 	runtimeConfig           string
 	save                    string
 	skew                    bool
+	skipDumpClusterLogs     bool
 	skipRegex               string
 	soak                    bool
 	soakDuration            time.Duration
@@ -179,6 +180,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.stage.dockerRegistry, "registry", "", "Push images to the specified docker registry (e.g. gcr.io/a-test-project)")
 	flag.StringVar(&o.save, "save", "", "Save credentials to gs:// path on --up if set (or load from there if not --up)")
 	flag.BoolVar(&o.skew, "skew", false, "If true, run tests in another version at ../kubernetes/kubernetes_skew")
+	flag.BoolVar(&o.skipDumpClusterLogs, "skip-dump-cluster-logs", false, "If true, skip the cluster log dumping")
 	flag.BoolVar(&o.soak, "soak", false, "If true, job runs in soak mode")
 	flag.DurationVar(&o.soakDuration, "soak-duration", 7*24*time.Hour, "Maximum age of a soak cluster before it gets recycled")
 	flag.Var(&o.stage, "stage", "Upload binaries to gs://bucket/devel/job-suffix if set")


### PR DESCRIPTION
Added a new flag to skip dumping cluster logs after tests and before the tear down. Reason for adding the flag is that in large enough clusters this step takes quite a long time causing a timeout.

We cannot rely on setting the `--dump=""` to disable the cluster log dumping, because in [kubernetes_e2e.py](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_e2e.py#L221C2-L221C42), that flag is added/overwritten to be the artifacts directory. So we can't actually disable dumping the cluster logs via `--dump`, hence the introduction of the `--skip-dump-cluster-logs` flag.