### PR TITLE
Drop typecheck-providerless verification

### DIFF
--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -32,4 +32,4 @@ presubmits:
         env:
         # Space separated list of the checks to run
         - name: WHAT
-          value: typecheck typecheck-providerless
+          value: typecheck


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/124519 removes the `providerless` tags, so we can stop running this verification.