### PR TITLE
Run `[Feature:LoadBalancer]` on GCE periodics

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -1116,7 +1116,7 @@ periodics:
       - --gcp-zone=europe-west1-c
       - --ginkgo-parallel=25
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --minStartupPods=8
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240506-e1212ac574-master
       resources:
@@ -1156,7 +1156,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240506-e1212ac574-master
@@ -1194,7 +1194,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240506-e1212ac574-master
@@ -1231,7 +1231,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240506-e1212ac574-master
@@ -1268,7 +1268,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240506-e1212ac574-master
@@ -1305,7 +1305,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240506-e1212ac574-master


### PR DESCRIPTION
We were going to try to get the loadbalancer tests passing on cloud-provider-kind first, but that's going to take some work, so let's temporarily disable them there and enable them for GCE instead. (NB: `[Feature:LoadBalancer]` doesn't currently exist but will be added by https://github.com/kubernetes/kubernetes/pull/124660.)

Saying "skip all `[Feature]` tags except `[Feature:LoadBalancer]`" is currently ugly but, the plan is to eventually make it less ugly, somehow. ([Slack discussion](https://kubernetes.slack.com/archives/C09QZ4DQB/p1714668500446099).)

(Since it's not immediately obvious from the diff context, the modified jobs are `ci-kubernetes-e2e-gci-gce-slow`, `ci-kubernetes-soak-gce-gci`, `ci-kubernetes-soak-gci-gce-beta`, `ci-kubernetes-soak-gci-gce-stable1`, `ci-kubernetes-soak-gci-gce-stable2`, and `ci-kubernetes-soak-gci-gce-stable3`, which should be all of the jobs that previously ran the LB tests, which are all marked `[Slow]`.)

/assign @aojea 
/sig network
/sig cloud-provider