### PR TITLE
CAPZ: sync maintainers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -2,14 +2,14 @@
 
 approvers:
 - jackfrancis
+- Jont828
 - mboersma
 - nojnhuh
+- willie-yao
 reviewers:
-- Jont828
 - jsturtevant
 - marosset
 - nawazkh
-- willie-yao
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, moves @Jont828 and @willie-yao to approvers.

/cc @jackfrancis @Jont828 @nojnhuh