### PR TITLE
cluster-api: drop unused template paths for ipv6 / v1.4

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -173,7 +173,7 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-{{ if eq $.branch "release-1.4" "release-1.5" "release-1.6" | not }}
+{{ if eq $.branch "release-1.5" "release-1.6" | not }}
 - name: periodic-cluster-api-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -135,7 +135,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-test-mink8s-{{ ReplaceAll $.branch "." "-" }}
-{{- if eq $.branch "release-1.4" | not }}
   - name: pull-cluster-api-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:
@@ -185,7 +184,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
-{{- end }}
   - name: pull-cluster-api-e2e-blocking-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:
@@ -224,7 +222,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-blocking-{{ ReplaceAll $.branch "." "-" }}
-{{- if eq $.branch "release-1.4" "release-1.5" }}
+{{- if eq $.branch "release-1.5" }}
   - name: pull-cluster-api-e2e-informing-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:
@@ -251,10 +249,6 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[PR-Informing\\]"
-{{- if eq $.branch "release-1.4" }}
-        - name: GINKGO_SKIP
-          value: "\\[IPv6\\]"
-{{- end }}
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -358,7 +352,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).From "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).To "." "-" }}
-{{ if eq $.branch "release-1.4" "release-1.5" "release-1.6" | not }}
+{{ if eq $.branch "release-1.5" "release-1.6" | not }}
   - name: pull-cluster-api-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:


### PR DESCRIPTION
Follow-up for: https://github.com/kubernetes/test-infra/pull/32545#issuecomment-2101112962