### PR TITLE
fix: Use apt -o APT::Update::Error-Mode=any for updating package lists

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -81,7 +81,7 @@ periodics:
       - -c
       - |
         result=0
-        apt update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
         sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         make install-lazyfs
         set -euo pipefail


### PR DESCRIPTION
This PR is intend to slove the problem of apt error return code.

See more deatil:  https://github.com/etcd-io/etcd/issues/17870#issuecomment-2106952765