### PR TITLE
run e2e tests as presubmit for cloud-provider-gcp

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -109,6 +109,46 @@ presubmits:
               cpu: 2
               memory: 4Gi
 
+  - name: pull-cloud-provider-gcp-e2e
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 80m
+    path_alias: cloud-provider-gcp
+    annotations:
+      testgrid-dashboards: provider-gcp-presubmits
+      description: Runs the e2e scenario against PRs
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-master
+        resources:
+          limits:
+            cpu: 4
+            memory: 14Gi
+          requests:
+            cpu: 4
+            memory: 14Gi
+        securityContext:
+          privileged: true
+        command:
+        - runner.sh
+        args:
+        - "/bin/bash"
+        - "-c"
+        - set -o errexit;
+          set -o nounset;
+          set -o pipefail;
+          set -o xtrace;
+          cd $GOPATH/src/cloud-provider-gcp;
+          tools/run-e2e-test.sh
+
   - name: pull-cloud-provider-gcp-scenario-kops-simple
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
This will allow us to run https://github.com/kubernetes/cloud-provider-gcp/pull/683 on demand to validte the PR before merge

/assign @seans3 @BenTheElder 