### PR TITLE
Update kubekins to Go 1.22.3 and add 1.31 config

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,34 +1,40 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.22.2
+    GO_VERSION: 1.22.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.22.2
+    GO_VERSION: 1.22.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.21.9
+    GO_VERSION: 1.21.10
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
     KIND_VERSION: 0.17.0
   master:
     CONFIG: master
-    GO_VERSION: 1.22.2
+    GO_VERSION: 1.22.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.22.2
+    GO_VERSION: 1.22.3
     K8S_RELEASE: stable
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
+  '1.31':
+    CONFIG: '1.31'
+    GO_VERSION: 1.22.3
+    K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.30':


### PR DESCRIPTION
- Update kubekins to Go 1.22.3 and add 1.31 config

xref https://github.com/kubernetes/release/issues/3597

/assign @saschagrunert  @Verolop @dims 
cc @kubernetes/release-engineering