### PR TITLE
Fix repository for VPA presubmit tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -158,6 +158,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
+  kubernetes/autoscaler:
   - name: pull-kubernetes-e2e-autoscaling-vpa-full
     annotations:
       testgrid-dashboards: sig-autoscaling-vpa
@@ -167,13 +168,7 @@ presubmits:
     decoration_config:
       timeout: 120m
     run_if_changed: '^vertical-pod-autoscaler\/'
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: autoscaler
-      base_ref: master
-      path_alias: k8s.io/autoscaler
-      workdir: true
+    path_alias: k8s.io/autoscaler
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"


### PR DESCRIPTION
The VPA presubmit tests for PRs introduced with https://github.com/kubernetes/test-infra/pull/30994 did never run despite multiple PRs being raised in the meantime. This seems to be the case, because the triggering condition is never met, as it is checked against k/k, not against k/autoscaler.