### PR TITLE
kubespray: enable plugins release-note, cherrypicker, mergecommitblocker, override

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1434,6 +1434,10 @@ plugins:
     plugins:
     - override
 
+  kubernetes-sigs/kubespray:
+    plugins:
+    - release-note
+
   kubernetes-sigs/kwok:
     plugins:
     - milestone

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1436,6 +1436,7 @@ plugins:
 
   kubernetes-sigs/kubespray:
     plugins:
+    - mergecommitblocker
     - release-note
 
   kubernetes-sigs/kwok:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1437,6 +1437,7 @@ plugins:
   kubernetes-sigs/kubespray:
     plugins:
     - mergecommitblocker
+    - override
     - release-note
 
   kubernetes-sigs/kwok:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1904,6 +1904,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/kubespray:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/scheduler-plugins:
   - name: cherrypicker
     events:


### PR DESCRIPTION
This should help us (the kubespray maintainers) automate some of the tedious stuff

wdyt ?
/cc @yankay @mzaian @MRFreezex @floryut
