### PR TITLE
Update autoscaler OWNERS to include kwiesmueller@

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/OWNERS
+++ b/config/jobs/kubernetes/sig-autoscaling/OWNERS
@@ -4,7 +4,9 @@ reviewers:
 - mwielgus
 - maciekpytel
 - bskiba
+- kwiesmueller
 approvers:
 - mwielgus
 - maciekpytel
 - bskiba
+- kwiesmueller


### PR DESCRIPTION
kwiesmueller is a [reviewer/approver for VPA](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/OWNERS) - should also have the same abilities for test code.

This will also ensure there is a bigger pool of folks who can help review changes here.