### PR TITLE
Publish prow images to a new location

### DIFF
--- a/config/jobs/image-pushing/k8s-infra-prow.yaml
+++ b/config/jobs/image-pushing/k8s-infra-prow.yaml
@@ -1,0 +1,22 @@
+postsubmits:
+  kubernetes-sigs/prow:
+    - name: post-k8s-infra-prow-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-k8s-infra-gcb,sig-testing-prow-repo
+        testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-prow-oncall@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: Builds and pushes all prow container images on each commit by running make push-images
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20230711-e33377c2b4
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-infra-prow
+              - --scratch-bucket=gs://k8s-infra-prow-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
+              - .

--- a/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
@@ -71,7 +71,7 @@ postsubmits:
         highcpu: "true"
     annotations:
       testgrid-dashboards: sig-testing-prow-repo
-      testgrid-tab-name: push-images
+      testgrid-tab-name: push-images-legacy
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: Builds and pushes all prow container images on each commit by running make push-images


### PR DESCRIPTION
`gcr.io/k8s-prow` will no longer be available after March 2025, so the images must be published to new location sooner.

Ideally, I would like prow to be versioned and released at `registry.k8s.io/prow` on a rolling basis but they haven't done that yet so we'll continue the old approach of using images from AR at `us-docker.pkg.dev/k8s-infra-prow/images`

Requires: https://github.com/kubernetes-sigs/prow/pull/123