### PR TITLE
CAPV: drop gcs cred preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-kubetest.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-kubetest.yaml
@@ -7,7 +7,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true
@@ -57,7 +56,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true
@@ -107,7 +105,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true
@@ -157,7 +154,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-upgrades.yaml
@@ -11,7 +11,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -57,7 +56,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -103,7 +101,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -112,7 +109,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.29
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240513-a9bd71bf01-1.29
       command:
       - runner.sh
       args:
@@ -149,7 +146,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -195,7 +191,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -241,7 +236,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -250,7 +244,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240507-6463cd4618-1.29
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240513-a9bd71bf01-1.29
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -39,7 +39,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -131,7 +130,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -174,7 +172,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -217,7 +214,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
@@ -311,7 +307,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
@@ -354,7 +349,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
@@ -96,7 +96,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -134,7 +133,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -210,7 +208,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     always_run: false
@@ -251,7 +248,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -287,7 +283,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -323,7 +318,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -361,7 +355,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -439,7 +432,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     always_run: false
@@ -480,7 +472,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -516,7 +507,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -65,23 +65,6 @@ presets:
       - key: vmc-capv-services.kubeconfig
         path: capv-services.conf
 - labels:
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
-  env:
-  - name: GCR_KEY_FILE
-    value: /root/.capv/keyfile.json
-  volumeMounts:
-  - name: capv-gcs-keyfile
-    mountPath: /root/.capv
-    readOnly: true
-  volumes:
-  - name: capv-gcs-keyfile
-    secret:
-      secretName: cluster-api-provider-vsphere-ci
-      items:
-      - key: capv-gcs-keyfile.json
-        path: keyfile.json
-        mode: 288
-- labels:
     # For kubernetes/cloud-provider-vsphere
     preset-cloud-provider-vsphere-e2e-config-capv: "true"
   env:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics-upgrades.yaml
@@ -11,7 +11,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -57,7 +56,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -103,7 +101,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -149,7 +146,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics.yaml
@@ -39,7 +39,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -131,7 +130,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -174,7 +172,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -217,7 +214,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
@@ -311,7 +307,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
@@ -354,7 +349,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-presubmits.yaml
@@ -96,7 +96,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -134,7 +133,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -210,7 +208,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     always_run: false
@@ -251,7 +248,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -287,7 +283,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -323,7 +318,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -361,7 +355,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -439,7 +432,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     always_run: false
@@ -480,7 +472,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -516,7 +507,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-periodics.yaml
@@ -82,7 +82,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -127,7 +126,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-presubmits.yaml
@@ -133,7 +133,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -171,7 +170,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -209,7 +207,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-periodics.yaml
@@ -82,7 +82,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -127,7 +126,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-presubmits.yaml
@@ -133,7 +133,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -171,7 +170,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -209,7 +207,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics-upgrades.yaml
@@ -11,7 +11,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -57,7 +56,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics.yaml
@@ -82,7 +82,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -127,7 +126,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
@@ -170,7 +168,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-presubmits.yaml
@@ -133,7 +133,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -171,7 +170,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -207,7 +205,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     always_run: false
@@ -248,7 +245,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -284,7 +280,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-kubetest.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-kubetest.yaml.tpl
@@ -6,7 +6,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true
@@ -56,7 +55,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true
@@ -106,7 +104,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true
@@ -156,7 +153,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   interval: 168h # one week
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-upgrades.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-upgrades.yaml.tpl
@@ -24,7 +24,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -93,7 +93,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: {{ $cron }}
   decorate: true
@@ -200,7 +199,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: {{ $cron }}
   decorate: true
@@ -252,7 +250,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-cluster-api-provider-vsphere-gcs-creds: "true"
     preset-kind-volume-mounts: "true"
   cron: {{ $cron }}
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
@@ -141,7 +141,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
@@ -183,7 +182,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -275,7 +273,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     always_run: false
@@ -320,7 +317,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
@@ -365,7 +361,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true


### PR DESCRIPTION
Drops the gcs preset which is not used anymore in CAPV

xref: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2955