### PR TITLE
k-s/prow: restrict postsubmits to main branch

### DIFF
--- a/config/jobs/image-pushing/k8s-infra-prow.yaml
+++ b/config/jobs/image-pushing/k8s-infra-prow.yaml
@@ -1,6 +1,8 @@
 postsubmits:
   kubernetes-sigs/prow:
     - name: post-k8s-infra-prow-images
+      branches:
+        - ^main$
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-k8s-infra-gcb,sig-testing-prow-repo

--- a/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
@@ -1,6 +1,8 @@
 postsubmits:
   kubernetes-sigs/prow:
   - name: post-prow-test-verify
+    branches:
+      - ^main$
     cluster: eks-prow-build-cluster
     decorate: true
     labels:


### PR DESCRIPTION
Happened to me in https://github.com/kubernetes-sigs/prow/pull/156: 

Using GitHub revert button creates local branches (instead of forks) when folks with write permissions use them, and these trigger postsubmits unless we restrict them. 