### PR TITLE
replace k80 with t4

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -3,7 +3,7 @@ presets:
     preset-pull-gce-device-plugin-gpu: "true"
   env:
   - name: NODE_ACCELERATORS
-    value: type=nvidia-tesla-k80,count=2
+    value: type=nvidia-tesla-t4,count=2
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
   - name: NODE_SIZE

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -2,9 +2,8 @@ presets:
 - labels:
     preset-ci-gce-device-plugin-gpu: "true"
   env:
-  # K80s will be uncreatable after 1st of May 2024
   - name: NODE_ACCELERATORS
-    value: type=nvidia-tesla-k80,count=2
+    value: type=nvidia-tesla-t4,count=2
   - name: NODE_SIZE
     value: n1-standard-2
 - labels:

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -14,7 +14,7 @@ images:
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
     resources:
       accelerators:
-        - type: nvidia-tesla-k80
+        - type: nvidia-tesla-t4
           count: 2
   cos-stable1:
     image_family: cos-stable


### PR DESCRIPTION
this might not work, but then again, k80s are completely EOL and impossible to use now, so we might as well get a more useful error message to follow up on

xref: #32242 