### PR TITLE
cleanup merge warning config

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -415,13 +415,6 @@ slack:
     exempt_users:
     - k8s-ci-robot # future home of tide
     - k8s-release-robot # anago
-    exempt_branches:
-        feature-serverside-apply:
-            - lavalamp # feature-serverside-apply "branch manager"
-            - apelisse # feature-serverside-apply "branch manager"
-        feature-rate-limiting:
-            - lavalamp # feature-rate-limiting "branch manager"
-            - deads2k # feature-rate-limiting "branch manager"
   - repos:
     - kubernetes/test-infra
     channels:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -413,8 +413,8 @@ slack:
     channels:
     - github-management
     exempt_users:
-    - k8s-ci-robot # future home of tide
-    - k8s-release-robot # anago
+    - k8s-ci-robot # merge robot ("tide")
+    - k8s-release-robot # release automation ("krel")
   - repos:
     - kubernetes/test-infra
     channels:


### PR DESCRIPTION
- drop inactive exempt feature branches xref https://github.com/kubernetes/org/pull/4956
- update stale robot account references