### PR TITLE
etcd: add ci-etcd-robustness-release36-amd64

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -69,7 +69,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics
+    testgrid-dashboards: sig-etcd-robustness
     testgrid-tab-name: ci-etcd-robustness-amd64
   spec:
     containers:
@@ -103,6 +103,49 @@ periodics:
       # fuse needs privileged mode
       securityContext:
         privileged: true
+- name: ci-etcd-robustness-main-amd64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-robustness
+    testgrid-tab-name: ci-etcd-robustness-main-amd64
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 150 --timeout '200m' --run TestRobustnessExploratory"
+        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-main || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
 - name: ci-etcd-robustness-release35-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -114,7 +157,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics
+    testgrid-dashboards: sig-etcd-robustness
     testgrid-tab-name: ci-etcd-robustness-release35-amd64
   spec:
     containers:
@@ -157,7 +200,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics
+    testgrid-dashboards: sig-etcd-robustness
     testgrid-tab-name: ci-etcd-robustness-release34-amd64
   spec:
     containers:

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -4,8 +4,10 @@ dashboard_groups:
   - sig-etcd-presubmits
   - sig-etcd-periodics
   - sig-etcd-postsubmits
+  - sig-etcd-robustness
 
 dashboards:
   - name: sig-etcd-presubmits
   - name: sig-etcd-periodics
   - name: sig-etcd-postsubmits
+  - name: sig-etcd-robustness


### PR DESCRIPTION
To include the mix version scenarios from https://github.com/etcd-io/etcd/pull/17923

https://github.com/etcd-io/etcd/issues/17097

also move robustness tests to separate dashboard.