### PR TITLE
capz: require api upgrade test if trigger files are updated

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -569,7 +569,7 @@ presubmits:
       preset-azure-capz-sa-cred: "true"
     decorate: true
     run_if_changed: '^test\/e2e\/(config\/azure-dev\.yaml)|(data\/shared\/v1beta1_provider\/metadata\.yaml)$'
-    optional: true
+    optional: false
     always_run: false
     branches:
       - ^main$


### PR DESCRIPTION
This PR updates the `pull-cluster-api-provider-azure-apiversion-upgrade` job so that its successful result is required whenever it runs.