### PR TITLE
Update image-builder to go 1.23

### DIFF
--- a/images/builder/cloudbuild.yaml
+++ b/images/builder/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
     dir: images/builder
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: '1.18'
+  _GO_VERSION: '1.23'
 images:
   - 'gcr.io/$PROJECT_ID/image-builder:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/image-builder:latest'


### PR DESCRIPTION
1.18 is too old and unsupported. let's please move to newer version.