### PR TITLE
Switch to latest golang in 1.22 series for gcb-docker-gcloud

### DIFF
--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.22.0
+  _GO_VERSION: 1.22.3
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest'


### PR DESCRIPTION
Pick the newest image in gcb-docker-gcloud:
https://explore.ggcr.dev/?repo=gcr.io/k8s-staging-test-infra/gcb-docker-gcloud

It still seems to have older golang! :( 
```
❯ docker run -it --entrypoint bash gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240210-bcb4e42f96
go version go1.21.6 linux/amd64
```

So let's try to get 1.22.3 in there.