### PR TITLE
Update golangci-lint version for vsphere csi driver jobs config

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -62,7 +62,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.55.1
+        - image: golangci/golangci-lint:v1.58.2
           command:
             - make
           args:


### PR DESCRIPTION
Update golangci-lint version to 1.58 for vsphere csi driver jobs config