### PR TITLE
Update golang image to 1.22 for ibm-powervs-block-csi-driver jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
@@ -78,7 +78,7 @@ presubmits:
       - ^main$
      spec:
        containers:
-       - image: public.ecr.aws/docker/library/golang:1.21
+       - image: public.ecr.aws/docker/library/golang:1.22
          command:
          - make
          args:
@@ -105,7 +105,7 @@ presubmits:
       - ^main$
      spec:
        containers:
-       - image: public.ecr.aws/docker/library/golang:1.21
+       - image: public.ecr.aws/docker/library/golang:1.22
          command:
          - make
          args:


### PR DESCRIPTION
Update golang image to 1.22 for ibm-powervs-block-csi-driver jobs.