### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/gopherage/cmd/merge/merge.go
+++ b/gopherage/cmd/merge/merge.go
@@ -57,7 +57,7 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		os.Exit(2)
 	}
 
-	profiles := make([][]*cover.Profile, len(args))
+	profiles := make([][]*cover.Profile, 0, len(args))
 	for _, path := range args {
 		profile, err := util.LoadProfile(path)
 		if err != nil {


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242652262/job/25425741904

```
====================================================================================================
append to slice `profiles` with non-zero initialized length at https://github.com/kubernetes/test-infra/blob/master/gopherage/cmd/merge/merge.go#L67:14
====================================================================================================
```

