### PR TITLE
Add multiarch build support for etcd

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - build
+        - build-all
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
This PR will add support for building multiarch etcd as a part of `pull-etcd-build` presubmit job.

Fixes: https://github.com/etcd-io/etcd/issues/18064