### PR TITLE
[JobSet] Change Kind node container image tag

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -130,7 +130,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
         env:
         - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.3
+          value: kindest/node:v1.28.9
         - name: BUILDER_IMAGE
           value: public.ecr.aws/docker/library/golang:1.22
         command:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-4.yaml
@@ -130,7 +130,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
         env:
         - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.3
+          value: kindest/node:v1.28.9
         - name: BUILDER_IMAGE
           value: public.ecr.aws/docker/library/golang:1.22
         command:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-5.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-5.yaml
@@ -130,7 +130,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
         env:
         - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.3
+          value: kindest/node:v1.28.9
         - name: BUILDER_IMAGE
           value: public.ecr.aws/docker/library/golang:1.22
         command:


### PR DESCRIPTION
Changing from v1.28.3 (which does not exist) to [v1.28.9](https://hub.docker.com/layers/kindest/node/v1.28.9/images/sha256-9ba4d311e7861d27b210e5960e5ce921a7c53d3c67e0545fd8a1cb9a76dfa2cb?context=explore)

cc @mimowo 