### PR TITLE
Update config/OWNERS

### DIFF
--- a/config/OWNERS
+++ b/config/OWNERS
@@ -2,18 +2,21 @@
 
 reviewers:
 - cblecker
-- spiffxp
-- wojtek-t
 - chases2
 - dims
+- MadhavJivrajani
+- Priyankasaggu11929
 - rjsadow
+- wojtek-t
 approvers:
 - cblecker
-- spiffxp
-- wojtek-t
 - chases2
 - dims
+- MadhavJivrajani
+- Priyankasaggu11929
+- wojtek-t
 emeritus_approvers:
 - krzyzacy
+- spiffxp
 labels:
 - area/config

--- a/config/prow/OWNERS
+++ b/config/prow/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-required_reviewers:
-  - cblecker
+filters:
+  "(config|plugins)\\.yaml":
+    required_reviewers:
+      - cblecker
+      - sig-contributor-experience-technical-leads


### PR DESCRIPTION
Making some changes to OWNERS files for the prow configuration:
- Moving @spiffxp to emeritus (thanks so much for your many years of help here!)
- Add @MadhavJivrajani and @Priyankasaggu11929 as approvers. They are contribex TLs, and share responsibility for many of the configurations here. As a follow up, I believe they are working on a more descriptive policy for changes to prow contribution workflows so that there is more clarity in this space.
- Update `required-reviewers` in the prow config to ensure that contribex TLs are tagged for changes in this area.