### PR TITLE
Tune etcd integration 1 cpu presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -144,3 +144,63 @@ presubmits:
           limits:
             cpu: "2"
             memory: "3Gi"
+
+  - name: pull-etcd-integration-2-cpu-amd64
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-integration-2-cpu-amd64
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          make gofail-enable
+          GOOS=linux GOARCH=amd64 CPU=2 make test-integration
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi"
+
+  - name: pull-etcd-integration-4-cpu-amd64
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-integration-4-cpu-amd64
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          make gofail-enable
+          GOOS=linux GOARCH=amd64 CPU=4 make test-integration
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -140,8 +140,8 @@ presubmits:
           GOOS=linux GOARCH=amd64 CPU=1 make test-integration
         resources:
           requests:
-            cpu: "1"
-            memory: "8Gi"
+            cpu: "2"
+            memory: "3Gi"
           limits:
-            cpu: "1"
-            memory: "8Gi"
+            cpu: "2"
+            memory: "3Gi"

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -118,7 +118,6 @@ presubmits:
 
   - name: pull-etcd-integration-1-cpu-amd64
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main


### PR DESCRIPTION
Now that `pull-etcd-integration-1-cpu-amd64` has been running for one week, and after gathering stats from [Spyglass](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-etcd-integration-1-cpu-amd64?buildId=) and [Grafana](https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=etcd-io&var-repo=etcd&var-job=pull-etcd-integration-1-cpu-amd64&orgId=1&refresh=30s&from=now-7d&to=now&var-build=All). I tuned the configuration, and made the job mandatory (removed `optional: true`), as it has been running as expected.

Part of etcd-io/etcd#18065.