### PR TITLE
releng: Allow specifying custom testSuite for generated jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -25,9 +25,6 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      # TODO: Fix generate_tests.py to set DisableCloudProviders,DisableKubeletCloudCredentialProviders to true when --cloud-proider=external
-      # And also add --env=ENABLE_AUTH_PROVIDER_GCP=true
-      # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
       - --env=ENABLE_AUTH_PROVIDER_GCP=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -496,7 +493,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -723,7 +720,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -993,7 +990,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -320,7 +320,7 @@ class E2ETest:
         cloud_provider = self.cloud_providers[fields[3]]
         image = self.images[fields[4]]
         k8s_version = self.k8s_versions[fields[5][3:]]
-        test_suite = self.test_suites[fields[6]]
+        test_suite = self.test_suites[self.job.get("testSuite")]
 
         # Generates args.
         args = []

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -195,6 +195,8 @@ class E2ENodeTest:
         image = self.images[fields[3]]
         k8s_version = self.k8s_versions[fields[4][3:]]
         test_suite = self.test_suites[fields[5]]
+        if self.job.get("testSuite"):
+            test_suite = self.test_suites[self.job.get("testSuite")]
 
         # envs are disallowed in node e2e tests.
         if 'envs' in self.common or 'envs' in image or 'envs' in test_suite:
@@ -320,7 +322,9 @@ class E2ETest:
         cloud_provider = self.cloud_providers[fields[3]]
         image = self.images[fields[4]]
         k8s_version = self.k8s_versions[fields[5][3:]]
-        test_suite = self.test_suites[self.job.get("testSuite")]
+        test_suite = self.test_suites[fields[6]]
+        if self.job.get("testSuite"):
+            test_suite = self.test_suites[self.job.get("testSuite")]
 
         # Generates args.
         args = []

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -41,31 +41,26 @@ jobs:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sbeta-ingress:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sbeta-default:
     args:
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sbeta-serial:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sbeta-slow:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
@@ -77,12 +72,10 @@ jobs:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable1-ingress:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable1-default:
     args:
     - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -90,54 +83,45 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
-    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable1-serial:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable1-slow:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable1-alphafeatures:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: alphafeatures
 
   # stable2
   ci-kubernetes-e2e-gce-cos-k8sstable2-reboot:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable2-ingress:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable2-default:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
-    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable2-serial:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable2-slow:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable2-alphafeatures:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
@@ -149,30 +133,25 @@ jobs:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable3-reboot:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable3-default:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
-    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable3-serial:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable3-slow:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable3-alphafeatures:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
@@ -188,7 +167,6 @@ jobs:
     - --runtime-config=api/beta=true
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: betaapis
 
   # TODO(1.26): Comment this when removing jobs for release-1.26 branch.
   # TODO(1.31): Uncomment this when adding jobs for release-1.31 branch.
@@ -197,30 +175,25 @@ jobs:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable4-default:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
-    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
-    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
@@ -236,7 +209,6 @@ jobs:
     - --runtime-config=api/beta=true
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: betaapis
 
 # The following settings are used by cluster e2e tests.
 

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -41,40 +41,48 @@ jobs:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sbeta-ingress:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sbeta-default:
     args:
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sbeta-serial:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sbeta-slow:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-ccm-eventedpleg
 
   # stable1
   ci-kubernetes-e2e-gce-cos-k8sstable1-reboot:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable1-ingress:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable1-default:
     args:
     - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -82,78 +90,94 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
+    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable1-serial:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable1-slow:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable1-alphafeatures:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures
 
   # stable2
   ci-kubernetes-e2e-gce-cos-k8sstable2-reboot:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable2-ingress:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable2-default:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
+    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable2-serial:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable2-slow:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable2-alphafeatures:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-no-ccm
 
   # stable3
   ci-kubernetes-e2e-gce-cos-k8sstable3-ingress:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable3-reboot:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable3-default:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
+    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable3-serial:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable3-slow:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable3-alphafeatures:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-no-ccm
   ci-kubernetes-e2e-gce-cos-k8sstable3-betaapis:
     interval: 24h
     args:
@@ -164,6 +188,7 @@ jobs:
     - --runtime-config=api/beta=true
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: betaapis
 
   # TODO(1.26): Comment this when removing jobs for release-1.26 branch.
   # TODO(1.31): Uncomment this when adding jobs for release-1.31 branch.
@@ -172,29 +197,35 @@ jobs:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: ingress
   ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: reboot
   ci-kubernetes-e2e-gce-cos-k8sstable4-default:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
+    testSuite: default
   ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: serial
   ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
+    testSuite: slow
   ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-no-ccm
   ci-kubernetes-e2e-gce-cos-k8sstable4-betaapis:
     interval: 24h
     args:
@@ -205,6 +236,7 @@ jobs:
     - --runtime-config=api/beta=true
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: betaapis
 
 # The following settings are used by cluster e2e tests.
 
@@ -291,6 +323,33 @@ testSuites:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+    - --runtime-config=api/all=true
+    - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
+      --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0
+      --minStartupPods=8
+    cluster: k8s-infra-prow-build
+  alphafeatures-ccm-eventedpleg:
+    args:
+    - --timeout=180m
+    - --env=KUBE_PROXY_DAEMONSET=true
+    - --env=ENABLE_POD_PRIORITY=true
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
+    - --env=ENABLE_AUTH_PROVIDER_GCP=true
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+    - --runtime-config=api/all=true
+    - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
+      --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0
+      --minStartupPods=8
+    cluster: k8s-infra-prow-build
+  alphafeatures-no-ccm:
+    args:
+    - --timeout=180m
+    - --env=KUBE_PROXY_DAEMONSET=true
+    - --env=ENABLE_POD_PRIORITY=true
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true


### PR DESCRIPTION
This PR implements a solution to allow specifying a custom testSuite for jobs defined in `releng/test_config.yaml`.

Before this change, the testSuite name has been determined based on the job name. This however doesn't work well in cases when different Kubernetes versions are requiring different flags.

To mitigate this, this PR ensures that you can create a dedicated testSuite for the given test/Kubernetes version combination, and that you can use that dedicated testSuite only for the given Kubernetes version.

Jobs have been regenerated with the following command:

```shell
./hack/run-in-python-container.sh ./releng/generate_tests.py --yaml-config-path ./releng/test_config.yaml
```

xref https://github.com/kubernetes/kubernetes/issues/124331

/assign @saschagrunert @dims @aojea 
cc @kubernetes/release-engineering 