### PR TITLE
crio userns: add yaml file so tests run

### DIFF
--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-userns.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-userns.yaml
@@ -1,0 +1,5 @@
+images:
+  fedora:
+    image_family: fedora-coreos-stable
+    project: fedora-coreos-cloud
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2_userns.ign"


### PR DESCRIPTION
or else we fail like this:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/125256/pull-kubernetes-node-crio-cgrpv2-userns-e2e/1796599193641422848/build-log.txt