### PR TITLE
Add workload identity token to be used with MI

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -389,6 +389,7 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:
+      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
           command:
@@ -405,6 +406,18 @@ presubmits:
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time
+          volumeMounts:
+          - mountPath: /var/run/secrets/azure-token/serviceaccount
+            name: azure-token
+            readOnly: true
+    volumes:
+        - name: azure-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 86400
+                  path: token
     annotations:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-extension

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -418,6 +418,7 @@ presubmits:
               - serviceAccountToken:
                   expirationSeconds: 86400
                   path: token
+                  audience: api://AzureADTokenExchange
     annotations:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-extension

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -410,7 +410,7 @@ presubmits:
           - mountPath: /var/run/secrets/azure-token/serviceaccount
             name: azure-token
             readOnly: true
-    volumes:
+      volumes:
         - name: azure-token
           projected:
             defaultMode: 420


### PR DESCRIPTION
This is a follow up to https://github.com/kubernetes-sigs/windows-testing/pull/430 to prepare in removal of the Azure SP in prow.  It follows the pattern in https://github.com/kubernetes/test-infra/blob/64080be72c747b5ca555558b05c91d0baeecbbd6/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml#L47.

It will require updates to the scripts in https://github.com/kubernetes-sigs/windows-testing to use this token that is generated and should not affect existing runs on this pr job.

/sig windows
/assign @marosset 