### PR TITLE
Update CRI-O version to latest stable commit

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1.ign
@@ -79,7 +79,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1_eventedpleg.ign
@@ -79,7 +79,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv1_hugepages.ign
@@ -71,7 +71,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv2.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2.ign
@@ -68,7 +68,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv2_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_hugepages.ign
@@ -68,7 +68,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv2_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_imagefs.ign
@@ -106,7 +106,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv2_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_splitfs.ign
@@ -106,7 +106,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv2_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_swap1g.ign
@@ -68,7 +68,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/crio_cgroupsv2_userns.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_userns.ign
@@ -98,7 +98,7 @@
         "name": "selinux-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=v1.30.1\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d\"\nEnvironment=\"CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       },

--- a/jobs/e2e_node/crio/templates/base/root.yaml
+++ b/jobs/e2e_node/crio/templates/base/root.yaml
@@ -91,7 +91,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv1.yaml
@@ -94,7 +94,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv1_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv1_eventedpleg.yaml
@@ -94,7 +94,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv1_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv1_hugepages.yaml
@@ -90,7 +90,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2.yaml
@@ -88,7 +88,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_hugepages.yaml
@@ -88,7 +88,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_imagefs.yaml
@@ -108,7 +108,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_splitfs.yaml
@@ -108,7 +108,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_swap1g.yaml
@@ -88,7 +88,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_userns.yaml
@@ -105,7 +105,7 @@ systemd:
         [Service]
         Type=oneshot
         Environment="SCRIPT_COMMIT=3e02ed6de9f516af9d8884c06ee3d709b2fa413d"
-        Environment="CRIO_COMMIT=v1.30.1"
+        Environment="CRIO_COMMIT=fd87228975e28a2d53aa2960cb14520cf51f0245"
 
         ExecStartPre=mount /tmp /tmp -o remount,exec,suid
         ExecStartPre=mount -o remount,rw /dev/sda4 /usr


### PR DESCRIPTION
Update CRI-O to the latest stable commit:

- https://github.com/cri-o/cri-o/commit/fd87228975e28a2d53aa2960cb14520cf51f0245

Which corresponds to the following Pull Request:

- https://github.com/cri-o/cri-o/pull/8194

This update brings the CRI-O version closer to the upcoming release **1.31** and introduces several new features, plus various bugs and security fixes.

A full list of changes can be seen [here](https://github.com/cri-o/cri-o/compare/v1.30.1...fd87228975e28a2d53aa2960cb14520cf51f0245).

Related:

- https://github.com/kubernetes/enhancements/issues/4191
- https://github.com/kubernetes/enhancements/pull/4684