### PR TITLE
Enable cherrypicker plugin for etcd-io/etcd

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1920,3 +1920,8 @@ external_plugins:
     events:
     - issue_comment
     - pull_request
+  etcd-io/etcd:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION
This PR will enable cherrypicker external plugin for `etcd-io/etcd` repo as suggested in the issue: https://github.com/etcd-io/etcd/issues/18110