### PR TITLE
sig-scalability: add scheduler_perf presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -727,6 +727,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-scalability-benchmarks
     testgrid-tab-name: scheduler-perf
+    testgrid-alert-email: sig-scheduling-alerts@kubernetes.io
   decorate: true
   extra_refs:
   - org: kubernetes

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -916,3 +916,46 @@ presubmits:
           limits:
             cpu: 2
             memory: "2Gi"
+
+  # This corresponds to ci-benchmark-scheduler-perf-master, without the reporting
+  # to the performance dashboard. It can be started manually to verify changes
+  # to test/integration/scheduler_perf.
+  - name: pull-scheduler-perf
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: scheduler-perf
+      testgrid-alert-email: sig-scheduling-alerts@kubernetes.io
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    decoration_config:
+      timeout: 2h25m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
+        command:
+        - ./hack/jenkins/benchmark-dockerized.sh
+        args:
+        - ./test/integration/scheduler_perf
+        env:
+        - name: KUBE_TIMEOUT
+          value: --timeout=2h25m
+        - name: TEST_PREFIX
+          value: BenchmarkPerfScheduling
+        # Set the benchtime to a very low value so every test is ran at most once
+        # even on very powerful machines
+        - name: BENCHTIME
+          value: 1ns
+        # We need to constraint compute resources so all the tests
+        # finish approximately at the same time. More compute power
+        # can increase scheduling throughput and make consequent results
+        # incomparable.
+        resources:
+          requests:
+            cpu: 6
+            memory: "24Gi"
+          limits:
+            cpu: 6
+            memory: "24Gi"


### PR DESCRIPTION
The periodic job has been failing for a while, which only got noticed when the release team started to check for the 1.31.0 alpha. I am volunteering to check dashboard notification emails for this because most of the recent changes in scheduler_perf and its configuration have been made by me.

To help with future changes, let's add an optional, non-blocking presubmit job that can be run manually to verify such changes before merging them.

/cc @Huang-Wei @alculquicondor @kerthcet @wojtek-t 