### PR TITLE
CAPV: fix janitor prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -442,6 +442,7 @@ periodics:
 
 - name: periodic-cluster-api-provider-vsphere-janitor
   labels:
+    preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
   interval: 12h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
@@ -538,6 +538,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-janitor-main
     labels:
+      preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -345,6 +345,7 @@ periodics:
 
 - name: periodic-cluster-api-provider-vsphere-janitor
   labels:
+    preset-dind-enabled: "true"
     preset-cluster-api-provider-vsphere-e2e-config: "true"
   interval: 12h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
@@ -394,6 +394,7 @@ presubmits:
 {{- if eq $.branch "main" }}
   - name: pull-cluster-api-provider-vsphere-janitor-main
     labels:
+      preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
     always_run: false
     optional: true


### PR DESCRIPTION
Janitor needs Docker to start VPN, missed this before

Signed-off-by: Stefan Büringer buringerst@vmware.com