### PR TITLE
etcd: add file_bug_template to etcd robustness dashboard

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -69,8 +69,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-robustness
-    testgrid-tab-name: ci-etcd-robustness-amd64
+    testgrid-create-test-group: 'true'
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
@@ -114,8 +113,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-robustness
-    testgrid-tab-name: ci-etcd-robustness-main-amd64
+    testgrid-create-test-group: 'true'
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
@@ -157,8 +155,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-robustness
-    testgrid-tab-name: ci-etcd-robustness-release35-amd64
+    testgrid-create-test-group: 'true'
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
@@ -200,8 +197,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-robustness
-    testgrid-tab-name: ci-etcd-robustness-release34-amd64
+    testgrid-create-test-group: 'true'
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -11,3 +11,40 @@ dashboards:
   - name: sig-etcd-periodics
   - name: sig-etcd-postsubmits
   - name: sig-etcd-robustness
+    dashboard_tab:
+    - name: ci-etcd-robustness-amd64
+      test_group_name: ci-etcd-robustness-amd64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: title
+          value: '[robustness tests] main-amd64: <test-name>'
+        - key: body
+          value: <test-url>
+    - name: ci-etcd-robustness-main-amd64
+      test_group_name: ci-etcd-robustness-main-amd64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: title
+          value: '[robustness tests] main-amd64: <test-name>'
+        - key: body
+          value: <test-url>
+    - name: ci-etcd-robustness-release35-amd64
+      test_group_name: ci-etcd-robustness-release35-amd64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: title
+          value: '[robustness tests] 3.5-amd64: <test-name>'
+        - key: body
+          value: <test-url>
+    - name: ci-etcd-robustness-release34-amd64
+      test_group_name: ci-etcd-robustness-release34-amd64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: title
+          value: '[robustness tests] 3.4-amd64: <test-name>'
+        - key: body
+          value: <test-url>


### PR DESCRIPTION
so that etcd issues can be created by one click from the dashboard.