### PR TITLE
config/prow: remove cla/linuxfoundation optional contexts

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -807,28 +807,10 @@ tide:
   context_options:
     orgs:
       kubernetes:
-        optional-contexts:
-        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
-        # to ensure things get merged in.
-        - "cla/linuxfoundation"
         repos:
           dashboard:
             from-branch-protection: true
-      kubernetes-client:
-        optional-contexts:
-        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
-        # to ensure things get merged in.
-        - "cla/linuxfoundation"
-      kubernetes-csi:
-        optional-contexts:
-        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
-        # to ensure things get merged in.
-        - "cla/linuxfoundation"
       kubernetes-sigs:
-        optional-contexts:
-        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
-        # to ensure things get merged in.
-        - "cla/linuxfoundation"
         repos:
           cluster-api:
             from-branch-protection: true


### PR DESCRIPTION
We've fully migrated to EasyCLA and there has been a soak period of greater than 1 release to make sure it works fine, most of the faults have been ironed out and we should be good to remove the optional context as well now.

Follow up from: https://github.com/kubernetes/test-infra/pull/24844 
xref: https://github.com/kubernetes/test-infra/issues/22721 

/assign @Priyankasaggu11929 @cblecker 