### PR TITLE
Add size plugin for etcd-io projects

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1596,6 +1596,7 @@ plugins:
     - label
     - pony
     - retitle
+    - size
     - skip
     - wip
     - yuks


### PR DESCRIPTION
This PR will add `size` plugin for etcd-io projects which can label a PR with change length: https://github.com/kubernetes/test-infra/blob/master/config/prow/plugins.yaml#L145-L151

Issue link: https://github.com/etcd-io/etcd/issues/18110