### PR TITLE
Add needs-rebase plugin for etcd project

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1925,3 +1925,7 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION
This PR will add `needs-rebase` plugin to the etcd project which will add `needs-rebase` to a PR that requires a rebase and removes it once it's rebased with the concerned branch.

Issue link: https://github.com/etcd-io/etcd/issues/18110