### PR TITLE
Add lgtm, approve plugins for etcd-io projects

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1591,9 +1591,11 @@ plugins:
 
   etcd-io:
     plugins:
+    - approve
     - assign
     - trigger
     - label
+    - lgtm
     - pony
     - retitle
     - skip


### PR DESCRIPTION
This PR will add `lgtm`, `approve` plugins for etcd-io projects which will allow the reviewers to interact with the PRs via chatops to add `lgtm`, `approve` labels.

Issue link: https://github.com/etcd-io/etcd/issues/18110