### PR TITLE
Add etcd robustness presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -236,3 +236,44 @@ presubmits:
           limits:
             cpu: "4"
             memory: "8Gi"
+
+  - name: pull-etcd-robustness-amd64
+    cluster: k8s-infra-prow-build
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+      - main
+    decorate: true
+    decoration_config:
+      timeout: 60m
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits, sig-etcd-robustness
+      testgrid-tab-name: pull-etcd-robustness-amd64
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              return_code=0
+              apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+              sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+              make install-lazyfs
+              set -euo pipefail
+              go clean -testcache
+              GO_TEST_FLAGS="-v --count 12 --timeout '30m' --run TestRobustness"
+              VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness-main || return_code=$?
+              if [ -d /tmp/results ]; then
+                zip -r ${ARTIFACTS}/results.zip /tmp/results
+              fi
+              exit $return_code
+          resources:
+            requests:
+              cpu: "7"
+              memory: "14Gi"
+            limits:
+              cpu: "7"
+              memory: "14Gi"


### PR DESCRIPTION
This commit will migrate etcd robustness [presubmit github action](https://github.com/etcd-io/etcd/blob/main/.github/workflows/robustness.yaml) to presubmit prowjob for `main` branch.

Issue link: https://github.com/etcd-io/etcd/issues/18136