### PR TITLE
Tune etcd presubmit jobs

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -168,6 +168,7 @@ presubmits:
         - |
           set -euo pipefail
           make gofail-enable
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
           GOOS=linux GOARCH=amd64 CPU=1 make test-integration
         resources:
           requests:
@@ -198,6 +199,7 @@ presubmits:
         - |
           set -euo pipefail
           make gofail-enable
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
           GOOS=linux GOARCH=amd64 CPU=2 make test-integration
         resources:
           requests:
@@ -228,6 +230,7 @@ presubmits:
         - |
           set -euo pipefail
           make gofail-enable
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
           GOOS=linux GOARCH=amd64 CPU=4 make test-integration
         resources:
           requests:

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -55,7 +55,6 @@ presubmits:
 
   - name: pull-etcd-unit-test-386
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -77,10 +76,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "2Gi"
           limits:
             cpu: "4"
-            memory: "4Gi"
+            memory: "2Gi"
 
   - name: pull-etcd-verify
     cluster: eks-prow-build-cluster

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -180,7 +180,6 @@ presubmits:
 
   - name: pull-etcd-integration-2-cpu-amd64
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -203,15 +202,14 @@ presubmits:
           GOOS=linux GOARCH=amd64 CPU=2 make test-integration
         resources:
           requests:
-            cpu: "2"
-            memory: "8Gi"
+            cpu: "3"
+            memory: "3Gi"
           limits:
-            cpu: "2"
-            memory: "8Gi"
+            cpu: "3"
+            memory: "3Gi"
 
   - name: pull-etcd-integration-4-cpu-amd64
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -234,11 +232,11 @@ presubmits:
           GOOS=linux GOARCH=amd64 CPU=4 make test-integration
         resources:
           requests:
-            cpu: "4"
-            memory: "8Gi"
+            cpu: "6"
+            memory: "3Gi"
           limits:
-            cpu: "4"
-            memory: "8Gi"
+            cpu: "6"
+            memory: "3Gi"
 
   - name: pull-etcd-robustness-amd64
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
Tuning the integration and 386 unit test jobs after reviewing Grafana and Testgrid for the last two weeks.

Part of etcd-io/etcd#18065, kubernetes/k8s.io#6102.