### PR TITLE
kubernetes/gcp: enable ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR for some CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -54,6 +54,7 @@ presubmits:
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         # Panic if data inconsistency is detected
         - --env=ENABLE_KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
@@ -161,6 +162,7 @@ presubmits:
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         # Panic if data inconsistency is detected
         - --env=ENABLE_KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
@@ -217,6 +219,7 @@ presubmits:
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         # Panic if data inconsistency is detected
         - --env=ENABLE_KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-cos-canary
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
@@ -289,6 +292,7 @@ presubmits:
             - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
             # Panic if data inconsistency is detected
             - --env=ENABLE_KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR=true
+            - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
             - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.


### PR DESCRIPTION
The new env var is set for the same jobs the ENABLE_CACHE_MUTATION_DETECTOR and ENABLE_KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR  are set.

A proof PR in https://github.com/kubernetes/kubernetes/pull/125435