### PR TITLE
capv: use separate preset for janitor

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -443,7 +443,7 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-janitor
   labels:
     preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-janitor-config: "true"
   interval: 12h
   decorate: true
   rerun_auth_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
@@ -539,7 +539,7 @@ presubmits:
   - name: pull-cluster-api-provider-vsphere-janitor-main
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-janitor-config: "true"
     always_run: false
     optional: true
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -179,3 +179,58 @@ presets:
         path: ca.crt
       - key: vmc-vpn-tls.key
         path: tls.key
+- labels:
+    preset-cluster-api-provider-vsphere-janitor-config: "true"
+  env:
+  - name: BOSKOS_HOST
+    value: http://192.168.6.138:32222
+  - name: GOVC_URL
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-url
+  - name: GOVC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        # TODO: replace this with vmc-vcenter-janitor-user as soon as it is available
+        key: vmc-vcenter-cluster-api-provider-vsphere-user
+  - name: GOVC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        # TODO: replace this with vmc-vcenter-janitor-user as soon as it is available
+        key: vmc-vcenter-cluster-api-provider-vsphere-password
+  - name: VSPHERE_TLS_THUMBPRINT
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-vsphere-ci
+        key: vmc-vcenter-thumbprint
+  volumeMounts:
+  - name: vmc-vpn
+    mountPath: /root/.openvpn
+  - name: vmc-capv-services-kubeconfig
+    mountPath: /root/ipam-conf
+  volumes:
+  - name: vmc-vpn
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-vpn-config.ovpn
+        path: prow.ovpn
+      - key: vmc-vpn-client.crt
+        path: client.crt
+      - key: vmc-vpn-client.key
+        path: client.key
+      - key: vmc-vpn-ca.crt
+        path: ca.crt
+      - key: vmc-vpn-tls.key
+        path: tls.key
+  - name: vmc-capv-services-kubeconfig
+    secret:
+      secretName: cluster-api-provider-vsphere-ci
+      defaultMode: 256
+      items:
+      - key: vmc-capv-services.kubeconfig
+        path: capv-services.conf

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -346,7 +346,7 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-janitor
   labels:
     preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-janitor-config: "true"
   interval: 12h
   decorate: true
   rerun_auth_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
@@ -395,7 +395,7 @@ presubmits:
   - name: pull-cluster-api-provider-vsphere-janitor-main
     labels:
       preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-janitor-config: "true"
     always_run: false
     optional: true
     decorate: true


### PR DESCRIPTION
Defines a separate preset for the janitor to later on make it easy to use a different user when migrating to the community environment.