### PR TITLE
Update kubekins to Go 1.22.4 and 1.21.11

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,63 +1,63 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.22.3
+    GO_VERSION: 1.22.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.22.3
+    GO_VERSION: 1.22.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.21.10
+    GO_VERSION: 1.21.11
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
     KIND_VERSION: 0.17.0
   master:
     CONFIG: master
-    GO_VERSION: 1.22.3
+    GO_VERSION: 1.22.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.22.3
+    GO_VERSION: 1.22.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: 1.22.3
+    GO_VERSION: 1.22.4
     K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.30':
     CONFIG: '1.30'
-    GO_VERSION: 1.22.3
+    GO_VERSION: 1.22.4
     K8S_RELEASE: latest-1.30
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.29':
     CONFIG: '1.29'
-    GO_VERSION: 1.21.10
+    GO_VERSION: 1.21.11
     K8S_RELEASE: latest-1.29
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.28':
     CONFIG: '1.28'
-    GO_VERSION: 1.21.10
+    GO_VERSION: 1.21.11
     K8S_RELEASE: latest-1.28
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.27':
     CONFIG: '1.27'
-    GO_VERSION: 1.21.10
+    GO_VERSION: 1.21.11
     K8S_RELEASE: stable-1.27
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Update kubekins to Go 1.22.4 and 1.21.11

xref https://github.com/kubernetes/release/issues/3628

/assign @saschagrunert @Verolop 
cc @kubernetes/release-engineering 