### PR TITLE
Add voelzmo to VPA test owners

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/OWNERS
+++ b/config/jobs/kubernetes/sig-autoscaling/OWNERS
@@ -5,8 +5,10 @@ reviewers:
 - maciekpytel
 - bskiba
 - kwiesmueller
+- voelzmo
 approvers:
 - mwielgus
 - maciekpytel
 - bskiba
 - kwiesmueller
+- voelzmo


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/autoscaler/pull/6912 to also add @voelzmo to VPA test owners.