### PR TITLE
add sig network job to test alpha and beta features

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -1061,3 +1061,54 @@ periodics:
     description: Runs loadbalancer tests in kind with cloud-provider-kind
     testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
     testgrid-num-columns-recent: '3'
+- interval: 6h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-network-kind-alpha-beta-features
+  annotations:
+    testgrid-dashboards: sig-network-kind
+    testgrid-tab-name: sig-network-kind, alpha, beta
+    description: Uses kind to run e2e sig-network tests against a latest kubernetes master and all features enabled cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20240515-17c6d50e24-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: FEATURE_GATES
+        value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG": false}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/all":"true"}'
+      - name: FOCUS
+        value: \[sig-network\]
+      - name: SKIP
+        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|LB.health.check|LoadBalancer|NetworkPolicy|DualStack
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7


### PR DESCRIPTION
Instead of depending on other jobs run the e2e tests for sig network features in its own job