### PR TITLE
remove the dedicated job which is used to test storage alpha feature

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -54,52 +54,6 @@ presubmits:
             cpu: "2"
             memory: "6Gi"
 
-  # This jobs runs e2e.test with a focus on tests for all alpha storage features on a kind cluster
-  - name: pull-kubernetes-e2e-storage-kind-alpha-features
-    always_run: false
-    optional: true
-    decorate: true
-    path_alias: k8s.io/kubernetes
-    cluster: eks-prow-build-cluster
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-storage-kind-alpha-features
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-      description: Run storage tests for alpha features in a KIND cluster.
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240515-17c6d50e24-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-        env:
-        - name: FEATURE_GATES
-          value: '{"VolumeAttributesClass":true, "HonorPVReclaimPolicy": true, "CSIVolumeHealth": true}'
-        - name: RUNTIME_CONFIG
-          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true"}'
-        - name: FOCUS
-          value: \[Feature:VolumeAttributesClass\]|\[Feature:HonorPVReclaimPolicy\]|\[Feature:CSIVolumeHealth\]
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-          limits:
-            cpu: "2"
-            memory: "6Gi"
-
 periodics:
   # This jobs runs storage tests that need Kubernetes In Docker (kind).
   - name: ci-kubernetes-e2e-storage-kind-disruptive
@@ -137,53 +91,6 @@ periodics:
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=1 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.focus="\[sig-storage\].*\[Feature:Kind\].*\[Disruptive\]"
 
         # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-          limits:
-            cpu: "2"
-            memory: "6Gi"
-
-  # This jobs runs e2e.test with a focus on tests for all alpha storage features on a kind cluster
-  - name: ci-kubernetes-e2e-storage-kind-alpha-features
-    interval: 12h
-    annotations:
-      testgrid-dashboards: sig-storage-kubernetes
-      testgrid-tab-name: kind-alpha-features
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-      description: Run storage tests for alpha features in a KIND cluster.
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240515-17c6d50e24-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-        env:
-        - name: FEATURE_GATES
-          value: '{"VolumeAttributesClass":true, "HonorPVReclaimPolicy": true, "CSIVolumeHealth": true}'
-        - name: RUNTIME_CONFIG
-          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true"}'
-        - name: FOCUS
-          value: \[Feature:VolumeAttributesClass\]|\[Feature:HonorPVReclaimPolicy\]|\[Feature:CSIVolumeHealth\]
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
the job pull-kubernetes-e2e-storage-kind-alpha-features and ci-kubernetes-e2e-storage-kind-alpha-features can be removed once https://github.com/kubernetes/test-infra/pull/32648 is merged. The existing jobs pull/ci-kubernetes-e2e-alpha-features and pull/ci-kubernetes-e2e-kind-beta-features will cover these tests.

/hold