### PR TITLE
Bump Go version for cli-utils build to 1.22

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20
+      - image: public.ecr.aws/docker/library/golang:1.22
         command:
         - make
         args:


### PR DESCRIPTION
Required for https://github.com/kubernetes-sigs/cli-utils/pull/641.