### PR TITLE
Fix `graphroot` path to be the same as default.

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv2_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_splitfs.ign
@@ -70,7 +70,7 @@
         "path": "/etc/containers/storage.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/1SNSwqDQBBE932KZjyAJ8jOnCDLkEUbWx0Yp6VsDd4+GPNzVfDgvbpObpBOb0QFV9rKnJwvO+MKcVFQ8xo+cbBFkWQNRJgzzHyD5SIo75ZdYlZM5bsYqODz2OugkPRNSm74gegqdVJOsiq4NfDPpw4y9od4ivXfwRb+5DY1DtLpRPu4QQ/ejsMzAAD//4r2l3roAAAA"
+          "source": "data:;base64,H4sIAAAAAAAC/3TNQQ6CMBCF4f2cYlIO0BO4wxO4NC4GGaBJ6ZBHwXB7g1WMC1eT/Mn75jpng/R6I6q41k6WmPlSGtcIq4La1+ETO1sVUTZHhCXBLO/RY0n+bilLSIrZv0VHFZ+nQUeFxIOU1PIDIas0UTnKpuDOwN899ZBpOPBV4GNo/jz4sDsRRul1pnKyQX/2JTt6BgAA//8FDtV48QAAAA=="
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/templates/base/60-storage-split-disk.conf
+++ b/jobs/e2e_node/crio/templates/base/60-storage-split-disk.conf
@@ -3,8 +3,8 @@
 # Default Storage Driver
 driver = "overlay"
 
-runroot = "/var/containers/storage"
+runroot = "/run/containers/storage"
 # Ephemeral Storage and writeable layer for containers
-graphroot = "/var/lib/containers"
+graphroot = "/var/lib/containers/storage"
 # Storage for images
 imagestore = "/var/lib/images"


### PR DESCRIPTION
This PR fixes the test issue observed in https://github.com/kubernetes/kubernetes/pull/123518 .

According to https://github.com/containers/storage/blob/main/docs/containers-storage.conf.5.md ,
> When changing the graphroot location on an SELINUX system, ensure the labeling matches the default locations labels with the following commands:

Since SELinux is enabled on the test environment, `graphroot` should have the same label as the default locations, but this `graphroot` doesn't.

The main aim is not to change the `graphroot` but to split `imagestore`, so I made `graphroot` and `runroot` default as well.