### PR TITLE
Fix missing secuityContext for etcd robustness presubmit

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -280,3 +280,6 @@ presubmits:
             limits:
               cpu: "7"
               memory: "14Gi"
+          # fuse needs privileged mode
+          securityContext:
+            privileged: true


### PR DESCRIPTION
Fuse device requires privileged container.