### PR TITLE
sig-node: use double-quotes for e2e_node test args

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -82,7 +82,7 @@ periodics:
         - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - "--test_args=--label-filter='Feature: containsAny DynamicResourceAllocation && !Flaky'"
+        - '--test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
         env:
@@ -135,7 +135,7 @@ periodics:
         - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - "--test_args=--label-filter='Feature: containsAny DynamicResourceAllocation && !Flaky'"
+        - '--test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
         env:
@@ -188,7 +188,7 @@ periodics:
         - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true,SchedulerQueueingHints=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - "--test_args=--label-filter='Feature: containsAny DynamicResourceAllocation && !Flaky'"
+        - '--test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
         env:
@@ -240,7 +240,7 @@ periodics:
         - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true,SchedulerQueueingHints=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - "--test_args=--label-filter='Feature: containsAny DynamicResourceAllocation && !Flaky'"
+        - '--test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
         env:
@@ -292,7 +292,7 @@ periodics:
         - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true
         - --provider=gce
-        - "--test_args=--label-filter='Feature: containsAny DynamicResourceAllocation && !Flaky'"
+        - '--test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
         resources:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -655,7 +655,7 @@ presubmits:
           - --provider=gce
           # Feature:DynamicResourceAllocation has it's own test jobs with the proper conditions set
           # DRA tests are covered here https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
-          - "--test_args=--nodes=1 --timeout=4h --label-filter='Serial && !(NodeAlphaFeature: isEmpty) && !Flaky && !Benchmark && NodeSpecialFeature: isEmpty && !(NodeFeature: containsAny Eviction && Feature: containsAny CPUManager) && !(Feature: containsAny { MemoryManager, TopologyManager, DynamicResourceAllocation })'"
+          - '--test_args=--nodes=1 --timeout=4h --label-filter="Serial && !(NodeAlphaFeature: isEmpty) && !Flaky && !Benchmark && NodeSpecialFeature: isEmpty && !(NodeFeature: containsAny Eviction && Feature: containsAny CPUManager) && !(Feature: containsAny { MemoryManager, TopologyManager, DynamicResourceAllocation })"'
           - --timeout=240m
           env:
           - name: GOPATH
@@ -702,7 +702,7 @@ presubmits:
           - '--node-test-args=--feature-gates=SidecarContainers=true --service-feature-gates=SidecarContainers=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - "--test_args=--nodes=1 --timeout=4h --label-filter='Serial && NodeFeature: containsAny SidecarContainers && !Flaky && !Benchmark && NodeSpecialFeature: isEmpty && !(NodeFeature: containsAny Eviction)'"
+          - '--test_args=--nodes=1 --timeout=4h --label-filter="Serial && NodeFeature: containsAny SidecarContainers && !Flaky && !Benchmark && NodeSpecialFeature: isEmpty && !(NodeFeature: containsAny Eviction)"'
           - --timeout=240m
           env:
           - name: GOPATH
@@ -812,7 +812,7 @@ presubmits:
             - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
             - --node-tests=true
             - --provider=gce
-            - "--test_args=--nodes=1 --skip= --label-filter='Feature: containsAny CPUManager'"
+            - '--test_args=--nodes=1 --skip= --label-filter="Feature: containsAny CPUManager"'
             - --timeout=180m
           env:
             - name: GOPATH
@@ -920,7 +920,7 @@ presubmits:
             - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - "--test_args=--nodes=1 --label-filter='Feature: containsAny TopologyManager'"
+            - '--test_args=--nodes=1 --label-filter="Feature: containsAny TopologyManager"'
             - --timeout=180m
           env:
             - name: GOPATH
@@ -1026,7 +1026,7 @@ presubmits:
             - '--node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - "--test_args=--nodes=1 --label-filter='Feature: containsAny HugePages'"
+            - '--test_args=--nodes=1 --label-filter="Feature: containsAny HugePages"'
             - --timeout=180m
           env:
             - name: GOPATH
@@ -1068,7 +1068,7 @@ presubmits:
         - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - "--test_args=--nodes=8 --label-filter='(NodeConformance || !(NodeFeature: isEmpty)) && !Flaky && !Slow && !Serial'"
+        - '--test_args=--nodes=8 --label-filter="(NodeConformance || !(NodeFeature: isEmpty)) && !Flaky && !Slow && !Serial"'
         - --timeout=180m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
         resources:


### PR DESCRIPTION
e2e_node tests are sensitive to how args are quoted because eventually the arguments get embedded in a `bash -c` invocation via ssh. Double quotes inside the argument work, single quotes don't.

/assign @aojea 