### PR TITLE
Update go version in kubernetes-org-jobs.yaml

### DIFF
--- a/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
+++ b/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.22.4
         command:
         - make
         args:
@@ -32,7 +32,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18
+      - image: public.ecr.aws/docker/library/golang:1.22.4
         command:
         - make
         args:


### PR DESCRIPTION
This PR is following up to https://github.com/kubernetes/org/pull/5029

## Change List

- Update go version from 1.18 to 1.22.4