### PR TITLE
Update go version in k/community/community-presubmit.yaml

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -8,7 +8,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18.2
+      - image: public.ecr.aws/docker/library/golang:1.22.4
         command:
         - sh
         - "-c"


### PR DESCRIPTION
This PR is following up to https://github.com/kubernetes/community/pull/7947

## Change List

- Update go version from 1.18.2 to 1.22.4