### PR TITLE
etcd: use issue template in file_bug_template

### DIFF
--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -18,35 +18,51 @@ dashboards:
       file_bug_template:
         url: https://github.com/etcd-io/etcd/issues/new
         options:
+        - key: template
+          value: bug-report.yml
         - key: title
           value: '[robustness tests] main-amd64: <test-name>'
-        - key: body
+        - key: problem
           value: <test-url>
+        - key: etcdVersion
+          value: v3.6
     - name: ci-etcd-robustness-main-amd64
       test_group_name: ci-etcd-robustness-main-amd64
       file_bug_template:
         url: https://github.com/etcd-io/etcd/issues/new
         options:
+        - key: template
+          value: bug-report.yml
         - key: title
           value: '[robustness tests] main-amd64: <test-name>'
-        - key: body
+        - key: problem
           value: <test-url>
+        - key: etcdVersion
+          value: v3.6
     - name: ci-etcd-robustness-release35-amd64
       test_group_name: ci-etcd-robustness-release35-amd64
       file_bug_template:
         url: https://github.com/etcd-io/etcd/issues/new
         options:
+        - key: template
+          value: bug-report.yml
         - key: title
           value: '[robustness tests] 3.5-amd64: <test-name>'
-        - key: body
+        - key: problem
           value: <test-url>
+        - key: etcdVersion
+          value: v3.5
     - name: ci-etcd-robustness-release34-amd64
       test_group_name: ci-etcd-robustness-release34-amd64
       file_bug_template:
         url: https://github.com/etcd-io/etcd/issues/new
         options:
+        - key: template
+          value: bug-report.yml
         - key: title
           value: '[robustness tests] 3.4-amd64: <test-name>'
-        - key: body
+        - key: problem
           value: <test-url>
+        - key: etcdVersion
+          value: v3.4
   - name: sig-etcd-etcd-manager


### PR DESCRIPTION
Use bug-report to file robustness test bugs instead of having to pick a template and lose all the pre-populated fields. 