### PR TITLE
etcd-manager: Migrate to AR 2

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-etcd-manager.yaml
+++ b/config/jobs/image-pushing/k8s-staging-etcd-manager.yaml
@@ -22,8 +22,8 @@ postsubmits:
               - /run.sh
             args:
               # this is the project GCB will run in, which is the same as the GCR images are pushed to.
-              - --project=k8s-staging-images
-              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --project=k8s-staging-images/etcd-manager
+              - --scratch-bucket=gs://k8s-staging-images-gcb/etcd-manager
               - --env-passthrough=PULL_BASE_REF
               - --with-git-dir
               - .


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/etcd-manager-postsubmit-push-to-staging/1803168184132440064
> 2024/06/18 20:49:47 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes-sigs/etcd-manager/cloudbuild.yaml --substitutions _PULL_BASE_REF=main,_GIT_TAG=v20240618-fd2a728 --project k8s-staging-images --gcs-log-dir gs://k8s-staging-images-gcb/logs --gcs-source-staging-dir gs://k8s-staging-images-gcb/source gs://k8s-staging-images-gcb/source/574a894f-72ef-40dd-81f9-825ad9a7a71a.tgz]: exit status 1]

/cc @upodroid 