### PR TITLE
KMM: changing the merge method to `rebase`.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -786,7 +786,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/ibm-vpc-block-csi-driver: squash
     kubernetes-sigs/karpenter: squash
-    kubernetes-sigs/kernel-module-management: squash
+    kubernetes-sigs/kernel-module-management: rebase
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
     kubernetes-sigs/kubespray: squash


### PR DESCRIPTION
When publishing a new release, multiple commits are going to be cherry-picked from the main branch.

With the previous `squash` merge method, all those commits would squash to a single huge commit message which is difficult to follow, blame and polluted with multiple signatures.

With this change, we should get a much cleaner git history.

In order to mitigate the risk that comes with the `rebase` merge methods, we have a CI job that validates that each PR contain a single commit to ensure we don't merge multiple "garbage" commits for a single change in a PR.

--

/cc @qbarrand 