### PR TITLE
chore: pin go versions in k/sig-k8s-infra

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -34,7 +34,7 @@ periodics:
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
   spec:
     containers:
-    - image: golang
+    - image: golang:1.22.4
       command:
       - make
       - e2e-test

--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
       containers:
-      - image: golang
+      - image: golang:1.22.4
         command:
         - make
         - verify
@@ -35,7 +35,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
       containers:
-      - image: golang
+      - image: golang:1.22.4
         command:
         - make
         - shellcheck
@@ -57,7 +57,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
       containers:
-      - image: golang
+      - image: golang:1.22.4
         command:
         - make
         - test
@@ -79,7 +79,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
       containers:
-      - image: golang
+      - image: golang:1.22.4
         command:
         - make
         - e2e-test-local
@@ -101,7 +101,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
       containers:
-      - image: golang
+      - image: golang:1.22.4
         command:
         - make
         - images


### PR DESCRIPTION
## Change List

- pin go versions in `config/jobs/k/sig-k8s-infra`

ref. https://github.com/kubernetes/registry.k8s.io/pull/283#issuecomment-2179062933

> I don’t know where the golang image in [`config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml` in k/test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/sig-k8s-infra-registry-presubmits.yaml) is referenced to. (Docker Hub?)
> 
> It seems to be running with Go 1.21.3, so I want to update/pin this (and this is causing the error).

