### PR TITLE
Bump kOps version in e2e-kops-grid-gcr-mirror-canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -107,7 +107,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.28/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.29/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
           -- \


### PR DESCRIPTION
kOps version 1.28 does not support kube 1.30, which is now the version
published at https://dl.k8s.io/release/stable.txt
