### PR TITLE
etcd: Add golvuncheck for 3.4, 3.5

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -123,6 +123,8 @@ presubmits:
     optional: true # remove this once the job is green
     branches:
     - main
+    - release-3.5
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
This commit will run pull-etcd-govulncheck for release-3.4, release-3.5 branch in addition to main.
Issue link: https://github.com/kubernetes/test-infra/issues/32754

cc @ivanvc 