### PR TITLE
CAAPH: don't pin kubebuilder envtest version

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
@@ -115,14 +115,6 @@ presubmits:
         args:
         - runner.sh
         - ./scripts/ci-test.sh
-        env:
-        # This value determines the minimum Kubernetes
-        # supported version for Cluster API management cluster.
-        #
-        # To check the available envtest in Kubebuilder, please
-        # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
-        - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-          value: "1.20.2"
         resources:
           limits:
             cpu: 6


### PR DESCRIPTION
Removes the hard-coded version for `KUBEBUILDER_ENVTEST_KUBERNETES_VERSION` since it seems to be causing a failure in CAAPH when updating envtest itself (see kubernetes-sigs/cluster-api-addon-provider-helm#255).

Testing locally without this change:

```shell
% KUBEBUILDER_ENVTEST_KUBERNETES_VERSION=1.20.0 ./scripts/ci-test.sh 
*** Testing Cluster API Add-on Provider for Helm ***
GOBIN=/Users/matt/projects/cluster-api-addon-provider-helm/hack/tools/bin ./scripts/go_install.sh sigs.k8s.io/controller-runtime/tools/setup-envtest setup-envtest v0.0.0-20240522175850-2e9781e9fc60
unable to fetch hash for requested version: unable to find archive for 1.20.0 (darwin,arm64)
KUBEBUILDER_ASSETS="" go test ./... 
?   	sigs.k8s.io/cluster-api-addon-provider-helm	[no test files]
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1	0.447s
?   	sigs.k8s.io/cluster-api-addon-provider-helm/hack/boilerplate/test	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/internal	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/internal/mocks	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/version	[no test files]
Running Suite: Controller Suite - /Users/matt/projects/cluster-api-addon-provider-helm/controllers
==================================================================================================
Random Seed: 1718920653

Will run 1 of 1 specs
E0620 15:57:33.721032   12228 server.go:317] "unable to start the controlplane" err="exec: \"etcd\": executable file not found in $PATH" logger="controller-runtime.test-env" tries=0
E0620 15:57:33.721742   12228 server.go:317] "unable to start the controlplane" err="exec: \"etcd\": executable file not found in $PATH" logger="controller-runtime.test-env" tries=1
...
FAIL! -- A BeforeSuite node failed so all tests were skipped.
--- FAIL: TestControllers (0.04s)
FAIL
FAIL	sigs.k8s.io/cluster-api-addon-provider-helm/controllers	1.432s
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy	0.918s
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmreleaseproxy	0.488s
FAIL
make: *** [test] Error 1
```

Testing locally with no env var set:

```shell
% ./scripts/ci-test.sh 
*** Testing Cluster API Add-on Provider for Helm ***
KUBEBUILDER_ASSETS="/Users/matt/Library/Application Support/io.kubebuilder.envtest/k8s/1.29.0-darwin-arm64" go test ./... 
?   	sigs.k8s.io/cluster-api-addon-provider-helm	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/hack/boilerplate/test	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/internal	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/internal/mocks	[no test files]
?   	sigs.k8s.io/cluster-api-addon-provider-helm/version	[no test files]
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1	(cached)
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/controllers	(cached)
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy	(cached)
ok  	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmreleaseproxy	(cached)
```

cc: @Jont828 