### PR TITLE
Move containerd and cadvisor jobs out of default cluster

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -20,6 +20,7 @@ presubmits:
   google/cadvisor:
   - name: pull-cadvisor-e2e
     always_run: true
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -63,47 +64,6 @@ presubmits:
       testgrid-dashboards: presubmits-misc
       testgrid-tab-name: cadvisor
 
-  kubernetes/kubernetes: # Temporary test for https://github.com/kubernetes/kubernetes/pull/116517
-  - name: pull-cadvisor-e2e-kubernetes
-    always_run: false
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    decorate: true
-    decoration_config:
-      timeout: 90m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-master
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-        command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
-        - --deployment=node
-        - --gcp-project=cadvisor-e2e
-        - --gcp-zone=us-central1-f
-        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-cadvisor.yaml --test-suite=cadvisor
-        - --node-tests=true
-        - --provider=gce
-        - --test_args=--nodes=1
-        - --timeout=10m
-
-    annotations:
-      testgrid-dashboards: presubmits-misc
-      testgrid-tab-name: cadvisor-temp
 periodics:
 - name: ci-cadvisor-e2e
   interval: 8h

--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -2,6 +2,7 @@ presubmits:
   containerd/containerd:
   - name: pull-containerd-build
     always_run: true
+    cluster: k8s-infra-prow-build
     branches:
     - main
     - release/1.6
@@ -24,9 +25,17 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e
     always_run: true
+    cluster: k8s-infra-prow-build
     max_concurrency: 8
     decorate: true
     branches:
@@ -75,9 +84,17 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e-1-7
     always_run: true
+    cluster: k8s-infra-prow-build
     max_concurrency: 8
     decorate: true
     branches:
@@ -126,9 +143,17 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e-1-7-sandboxed
     always_run: false
+    cluster: k8s-infra-prow-build
     max_concurrency: 8
     decorate: true
     branches:
@@ -179,9 +204,17 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-node-e2e-1-6
     always_run: true
+    cluster: k8s-infra-prow-build
     max_concurrency: 8
     decorate: true
     branches:
@@ -230,6 +263,13 @@ presubmits:
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
           "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.6-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
 
   - name: pull-containerd-k8s-e2e-ec2
     branches:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -574,6 +574,7 @@ presubmits:
               memory: 6Gi
   - name: pull-kubernetes-node-kubelet-containerd-flaky
     always_run: false
+    cluster: k8s-infra-prow-build
     optional: true
     skip_report: false
     skip_branches:


### PR DESCRIPTION
cadvisor and containerd were running in `default` cluster which is being shut down...

xref: https://github.com/kubernetes/test-infra/pull/32808/files