### PR TITLE
Add unit file changing imageStore selinux label to splitfs test

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupsv2_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_splitfs.ign
@@ -70,7 +70,7 @@
         "path": "/etc/containers/storage.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/1SNSwqDQBBE932KZjyAJ8jOnCDLkEUbWx0Yp6VsDd4+GPNzVfDgvbpObpBOb0QFV9rKnJwvO+MKcVFQ8xo+cbBFkWQNRJgzzHyD5SIo75ZdYlZM5bsYqODz2OugkPRNSm74gegqdVJOsiq4NfDPpw4y9od4ivXfwRb+5DY1DtLpRPu4QQ/ejsMzAAD//4r2l3roAAAA"
+          "source": "data:;base64,H4sIAAAAAAAC/3TNQQ6CMBCF4f2cYlIO0BO4wxO4NC4GGaBJ6ZBHwXB7g1WMC1eT/Mn75jpng/R6I6q41k6WmPlSGtcIq4La1+ETO1sVUTZHhCXBLO/RY0n+bilLSIrZv0VHFZ+nQUeFxIOU1PIDIas0UTnKpuDOwN899ZBpOPBV4GNo/jz4sDsRRul1pnKyQX/2JTt6BgAA//8FDtV48QAAAA=="
         },
         "mode": 420
       }
@@ -114,6 +114,11 @@
         "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=NetworkManager-wait-online.service\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '\\\n  /usr/bin/mkdir -m 0700 -p /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/cat /etc/ssh-key-secret/ssh-public \\\n    \u003e\u003e /home/core/.ssh/authorized_keys \u0026\u0026 \\\n  /usr/bin/chown -R core:core /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Label ImageStore\nAfter=crio-install.service\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  policycoreutils-python-utils\nExecStart=semanage fcontext -a -e /var/lib/containers/storage /var/lib/images\nExecStart=restorecon -R -v /var/lib/images\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "label-imagestore.service"
       }
     ]
   }

--- a/jobs/e2e_node/crio/templates/base/60-storage-split-disk.conf
+++ b/jobs/e2e_node/crio/templates/base/60-storage-split-disk.conf
@@ -3,8 +3,8 @@
 # Default Storage Driver
 driver = "overlay"
 
-runroot = "/var/containers/storage"
+runroot = "/run/containers/storage"
 # Ephemeral Storage and writeable layer for containers
-graphroot = "/var/lib/containers"
+graphroot = "/var/lib/containers/storage"
 # Storage for images
 imagestore = "/var/lib/images"

--- a/jobs/e2e_node/crio/templates/base/splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/base/splitfs.yaml
@@ -21,3 +21,24 @@ storage:
       device: /dev/disk/by-partlabel/images
       format: ext4
       with_mount_unit: true
+systemd:
+  units:
+    - name: label-imagestore.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Label ImageStore
+        After=crio-install.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=rpm-ostree install \
+          -y \
+          --apply-live \
+          --allow-inactive \
+          policycoreutils-python-utils
+        ExecStart=semanage fcontext -a -e /var/lib/containers/storage /var/lib/images
+        ExecStart=restorecon -R -v /var/lib/images
+
+        [Install]
+        WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_splitfs.yaml
@@ -141,3 +141,22 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+    - name: label-imagestore.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Label ImageStore
+        After=crio-install.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=rpm-ostree install \
+          -y \
+          --apply-live \
+          --allow-inactive \
+          policycoreutils-python-utils
+        ExecStart=semanage fcontext -a -e /var/lib/containers/storage /var/lib/images
+        ExecStart=restorecon -R -v /var/lib/images
+
+        [Install]
+        WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a unit file to change the selinux label of imageStore in order to fix the test failures in
https://github.com/kubernetes/kubernetes/pull/125417
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/125417/pull-crio-cgroupv2-splitfs-splitdisk/1800694672788557824
Also it modifies the graphroot and runroot to the [default](https://github.com/containers/storage/blob/main/docs/containers-storage.conf.5.md#storage-table).

---

In the test, all containers failed with exitCode 127, which normally succeed without any errors.
Having tested on the remote e2e, I found that the containers failed with the error like
```
error while loading shared libraries: /lib64/libc.so.6: cannot apply additional memory protection after relocation: Permission denied
```
It turned out to be caused by selinux label mismatch.
Since we split imageStore and graphRoot path, imageStore also must have the same selinux label as graphRoot.

cf. https://github.com/containers/podman/blob/main/troubleshooting.md#11-changing-the-location-of-the-graphroot-leads-to-permission-denied.

I tested this ignition file by running remote e2e with https://github.com/kubernetes/kubernetes/pull/125417 this change, and it passed the tests.