### PR TITLE
Add extra refs for kubernetes-e2e-ec2-alpha-features

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3590,6 +3590,10 @@ presubmits:
           base_ref: master
           path_alias: k8s.io/kubernetes
           workdir: true
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
       spec:
         serviceAccountName: node-e2e-tests
         containers:


### PR DESCRIPTION
This adds repo test-infra in extra references for pull-kubernetes-e2e-ec2-alpha-features to make it possible to trigger it as optional jobs.