### PR TITLE
Update Boskos Golang image

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.21.4
+          - image: public.ecr.aws/docker/library/golang:1.22.3
             imagePullPolicy: Always
             command:
               - make


### PR DESCRIPTION
Update Boskos Presubmit to target Golang `v1.22.3`.
Required for https://github.com/kubernetes-sigs/boskos/pull/192.