### PR TITLE
capv: use janitor user and password in preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presets.yaml
@@ -175,14 +175,12 @@ presets:
     valueFrom:
       secretKeyRef:
         name: cluster-api-provider-vsphere-ci
-        # TODO: replace this with vmc-vcenter-janitor-user as soon as it is available
-        key: vmc-vcenter-cluster-api-provider-vsphere-user
+        key: vmc-vcenter-janitor-user
   - name: GOVC_PASSWORD
     valueFrom:
       secretKeyRef:
         name: cluster-api-provider-vsphere-ci
-        # TODO: replace this with vmc-vcenter-janitor-user as soon as it is available
-        key: vmc-vcenter-cluster-api-provider-vsphere-password
+        key: vmc-vcenter-janitor-password
   - name: VSPHERE_TLS_THUMBPRINT
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
Since

- #32688

is merged and according to secrets manager the new credentials are getting accessed, we can now start using it.