### PR TITLE
use boskos for cadvisor CI jobs

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -52,7 +52,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --deployment=node
-        - --gcp-project=cadvisor-e2e
         - --gcp-zone=us-central1-f
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-cadvisor.yaml --test-suite=cadvisor
         - --node-tests=true
@@ -67,6 +66,7 @@ presubmits:
 periodics:
 - name: ci-cadvisor-e2e
   interval: 8h
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -102,7 +102,6 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --deployment=node
-      - --gcp-project=ci-cadvisor-e2e
       - --gcp-zone=us-central1-f
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-cadvisor.yaml --test-suite=cadvisor
       - --node-tests=true


### PR DESCRIPTION
`cadvisor-e2e` is not under community infra AFAIK, let's use boskos instead. (note we tried to move these jobs from `default` cluster to community cluster and landed with this problem)

```
2024/06/24 10:36:08 process.go:155: Step 'gcloud config set project cadvisor-e2e' finished in 1.153281317s
2024/06/24 10:36:08 main.go:795: Checking existing of GCP ssh keys...
2024/06/24 10:36:08 main.go:805: Checking presence of public key in cadvisor-e2e
2024/06/24 10:36:08 process.go:153: Running: gcloud compute --project=cadvisor-e2e project-info describe
ERROR: (gcloud.compute.project-info.describe) Could not fetch resource:
 - Required 'compute.projects.get' permission for 'projects/cadvisor-e2e'

2024/06/24 10:36:10 process.go:155: Step 'gcloud compute --project=cadvisor-e2e project-info describe' finished in 1.560560106s
```