### PR TITLE
Remove extra serviceAccountName from lone job

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-aws-credential-aws-shared-testing: "true"
     spec:
-      serviceAccountName: aws-shared-testing-role
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-master
         command:


### PR DESCRIPTION
Removes lone SA from helm chart job, which we think might be breaking our CI (and this also makes the job consistent with other jobs).

/cc @torredil