### PR TITLE
Add docker preset to verify-all PDCSI presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -88,6 +88,7 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
+      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 10m


### PR DESCRIPTION
This change allows https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1762 to run docker in the gcp-compute-persistent-disk-csi-driver `verify` presubmit. The docker-in-docker script is used to validate that there are no missing dependencies in the output container images.