### PR TITLE
use boskos for containerd presubmit jobs

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -76,7 +76,6 @@ presubmits:
           &&
           /workspace/scenarios/kubernetes_e2e.py
           --deployment=node
-          --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
           '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           --node-tests=true
@@ -135,7 +134,6 @@ presubmits:
           &&
           /workspace/scenarios/kubernetes_e2e.py
           --deployment=node
-          --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
           '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           --node-tests=true
@@ -196,7 +194,6 @@ presubmits:
           &&
           /workspace/scenarios/kubernetes_e2e.py
           --deployment=node
-          --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
           '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           --node-tests=true
@@ -255,7 +252,6 @@ presubmits:
           &&
           /workspace/scenarios/kubernetes_e2e.py
           --deployment=node
-          --gcp-project=cri-c8d-pr-node-e2e
           --gcp-zone=us-central1-f
           '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           --node-tests=true


### PR DESCRIPTION
As part of moving to community infra for presubmit jobs, we dont want to pin to `cri-c8d-pr-node-e2e` project for containerd presubmit jobs. 

 The following error occurs when `cri-c8d-pr-node-e2e`  is used. 
```
Activated service account credentials for: [prow-build@k8s-infra-prow-build.iam.gserviceaccount.com]
2024/06/25 16:15:25 process.go:155: Step 'gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json' finished in 1.229127739s
2024/06/25 16:15:25 process.go:153: Running: gcloud config set project cri-c8d-pr-node-e2e
WARNING: You do not appear to have access to project [cri-c8d-pr-node-e2e] or it does not exist.
Updated property [core/project].
2024/06/25 16:15:26 process.go:155: Step 'gcloud config set project cri-c8d-pr-node-e2e' finished in 1.473634501s
2024/06/25 16:15:26 main.go:795: Checking existing of GCP ssh keys...
2024/06/25 16:15:26 main.go:805: Checking presence of public key in cri-c8d-pr-node-e2e
2024/06/25 16:15:26 process.go:153: Running: gcloud compute --project=cri-c8d-pr-node-e2e project-info describe
ERROR: (gcloud.compute.project-info.describe) Could not fetch resource:
 - Required 'compute.projects.get' permission for 'projects/cri-c8d-pr-node-e2e'
2024/06/25 16:15:28 process.go:155: Step 'gcloud compute --project=cri-c8d-pr-node-e2e project-info describe' finished in 1.837849597s
2024/06/25 16:15:28 process.go:96: Saved XML output to /logs/artifacts/junit_runner.xml.
```