### PR TITLE
add Workload ID to CAPZ tests as an env variable

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
@@ -12,3 +12,27 @@ presets:
       secretKeyRef:
         name: azure-capz-sa-cred
         key: serviceAccountSigningKey
+- labels:
+    preset-azure-cred-wi: "true"
+  env: # below env values are not secrets
+  - name: AZURE_CLIENT_ID # AZURE_CLIENT_ID is being overloaded with Azure Workload ID
+    value: "cabf5f22-ec7e-4e84-9e35-c02e57ca555d"
+  - name: AZURE_SUBSCRIPTION_ID
+    value: "0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e"
+  - name: AZURE_TENANT_ID
+    value: "097f89a0-9286-43d2-9a1a-08f1d49b1af8"
+  - name: AZURE_FEDERATED_TOKEN_FILE
+    value: "/var/run/secrets/azure-token/serviceaccount/token"
+  volumes:
+  - name: azure-token
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 86400
+          path: token
+          audience: api://AzureADTokenExchange
+  volumeMounts:
+  - mountPath: /var/run/secrets/azure-token/serviceaccount
+    name: azure-token
+    readOnly: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -101,6 +101,40 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+  - name: pull-cluster-api-provider-azure-e2e-with-wi-optional # created for WI POC
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|Makefile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-cred-wi: "true"
+    branches:
+      - ^main$
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-1.29
+          command:
+            - runner.sh
+          args:
+            - ./scripts/ci-e2e.sh
+          env:
+            - name: GINKGO_FOCUS
+              value: \[REQUIRED\]
+            - name: GINKGO_SKIP
+              value: ""
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: capz-pr-e2e-main-with-wi-optional
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-optional
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false


### PR DESCRIPTION
What changed: 
This PR adds 
- Creates a Preset named `preset-azure-cred-wi` 
	- that creates env key-value pair `AZURE_WORKLOAD_ID` set to `cabf5f22-ec7e-4e84-9e35-c02e57ca555d`  
	- creates a volume and volume mount to supply mount path to the pod running the tests. This mount path, `"/var/run/secrets/azure-token/serviceaccount"` is the location of the federated token used to az login when using WI to authenticate.

- Updates CAPZ's `capz-pr-e2e-main` prow job to use preset `preset-azure-cred-wi` as POC.

This PR should be merged after https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4939 merges. 