### PR TITLE
Update gcp-pd-csi pull-gcp-compute-persistent-disk-csi-driver-e2e to use prow-build ServiceAccount

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -17,6 +17,7 @@ presubmits:
         - runner.sh
         args:
         - "test/run-e2e.sh"
+        - "--service-account=prow-build@k8s-infra-prow-build.iam.gserviceaccount.com"
         env:
         - name: ZONE
           value: us-central1-c


### PR DESCRIPTION
Note: Requires the `test-e2e.sh` script to pass through arguments to ginko (as updated in https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1764) for the argument to have any effect.