### PR TITLE
cluster-autoscaler Azure: fix bash syntax

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
         args:
           - bash
           - -c
-          - >-
+          - |
             export REGISTRY=capzci.azurecr.io
             hack/ensure-acr-login.sh
             cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
@@ -45,8 +45,6 @@ presubmits:
             value: v1.29.4
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
-          - name: CLUSTER_CREATE_ATTEMPTS
-            value: "1"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This updates the command passed to ci-entrypoint to preserve newlines such that bash knows to run these lines as separate commands: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/autoscaler/6975/pull-cluster-autoscaler-e2e-azure/1805724243250384896#1:build-log.txt%3A1134-1136

https://yaml-multiline.info/

/assign @jackfrancis 