### PR TITLE
Reapply "switch gcp-pd-csi to k8s-infra-prow-build"

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - name: pull-gcp-compute-persistent-disk-csi-driver-e2e
+    cluster: k8s-infra-prow-build
     always_run: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
This reverts commit 937cb53bf804716e477d88d0e553e87d2832d665 / #32841

This rolls forward https://github.com/kubernetes/test-infra/pull/32809 now that https://github.com/kubernetes/k8s.io/pull/6920 is deployed