### PR TITLE
eliminate ancient google-aws dashboard

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -215,8 +215,6 @@ def build_test(cloud='aws',
         f"kops-k8s-{k8s_version}",
         f"kops-{kops_version or 'latest'}",
     ]
-    if cloud == 'aws':
-        dashboards.extend(['google-aws'])
     if cloud == 'gce':
         dashboards.extend(['kops-gce'])
 

--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -64,7 +64,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-conformance, kops-distro-u2204, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-conformance, kops-distro-u2204, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-1-29
 
@@ -130,7 +130,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-conformance, kops-distro-u2204, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-conformance, kops-distro-u2204, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-arm64-1-29
 
@@ -196,7 +196,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-conformance, kops-distro-u2204, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-conformance, kops-distro-u2204, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-1-28
 
@@ -262,7 +262,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-conformance, kops-distro-u2204, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-conformance, kops-distro-u2204, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-arm64-1-28
 
@@ -328,7 +328,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-conformance, kops-distro-u2204, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.27, kops-conformance, kops-distro-u2204, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-1-27
 
@@ -394,6 +394,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.27'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.27, kops-conformance, kops-distro-u2204, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.27, kops-conformance, kops-distro-u2204, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-arm64-1-27

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb10, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-debian10
 
@@ -126,7 +126,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb11, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb11, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-debian11
 
@@ -190,7 +190,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-debian12
 
@@ -254,7 +254,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-ubuntu2004
 
@@ -318,7 +318,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-ubuntu2004arm64
 
@@ -382,7 +382,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-ubuntu2204
 
@@ -446,7 +446,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-ubuntu2204arm64
 
@@ -510,7 +510,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2404, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2404, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-ubuntu2404
 
@@ -574,7 +574,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2404, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2404, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-ubuntu2404arm64
 
@@ -638,7 +638,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-amzn2, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-amazonlinux2
 
@@ -702,7 +702,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-al2023
 
@@ -766,7 +766,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rhel8
 
@@ -830,7 +830,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel9, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel9, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rhel9
 
@@ -894,7 +894,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rocky9, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rocky9, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rocky9
 
@@ -959,6 +959,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-flatcar

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -61,7 +61,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k25
 
@@ -124,7 +124,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k25-ko28
 
@@ -187,7 +187,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k25-ko29
 
@@ -250,7 +250,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k26
 
@@ -313,7 +313,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k26-ko28
 
@@ -376,7 +376,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k26-ko29
 
@@ -439,7 +439,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k27
 
@@ -502,7 +502,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k27-ko28
 
@@ -565,7 +565,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k27-ko29
 
@@ -628,7 +628,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k28
 
@@ -691,7 +691,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k28-ko28
 
@@ -754,7 +754,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k28-ko29
 
@@ -817,7 +817,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k29
 
@@ -880,7 +880,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k29-ko29
 
@@ -943,7 +943,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k25
 
@@ -1006,7 +1006,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k25-ko28
 
@@ -1069,7 +1069,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k25-ko29
 
@@ -1132,7 +1132,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k26
 
@@ -1195,7 +1195,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k26-ko28
 
@@ -1258,7 +1258,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k26-ko29
 
@@ -1321,7 +1321,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k27
 
@@ -1384,7 +1384,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k27-ko28
 
@@ -1447,7 +1447,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k27-ko29
 
@@ -1510,7 +1510,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k28
 
@@ -1573,7 +1573,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k28-ko28
 
@@ -1636,7 +1636,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k28-ko29
 
@@ -1699,7 +1699,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k29
 
@@ -1762,7 +1762,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k29-ko29
 
@@ -1826,7 +1826,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k25
 
@@ -1890,7 +1890,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k25-ko28
 
@@ -1954,7 +1954,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k25-ko29
 
@@ -2018,7 +2018,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k26
 
@@ -2082,7 +2082,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k26-ko28
 
@@ -2146,7 +2146,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k26-ko29
 
@@ -2210,7 +2210,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k27
 
@@ -2274,7 +2274,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k27-ko28
 
@@ -2338,7 +2338,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k27-ko29
 
@@ -2402,7 +2402,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k28
 
@@ -2466,7 +2466,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k28-ko28
 
@@ -2530,7 +2530,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k28-ko29
 
@@ -2594,7 +2594,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k29
 
@@ -2658,7 +2658,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k29-ko29
 
@@ -2721,7 +2721,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k25
 
@@ -2784,7 +2784,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k25-ko28
 
@@ -2847,7 +2847,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k25-ko29
 
@@ -2910,7 +2910,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k26
 
@@ -2973,7 +2973,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k26-ko28
 
@@ -3036,7 +3036,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k26-ko29
 
@@ -3099,7 +3099,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k27
 
@@ -3162,7 +3162,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k27-ko28
 
@@ -3225,7 +3225,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k27-ko29
 
@@ -3288,7 +3288,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k28
 
@@ -3351,7 +3351,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k28-ko28
 
@@ -3414,7 +3414,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k28-ko29
 
@@ -3477,7 +3477,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k29
 
@@ -3540,7 +3540,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k29-ko29
 
@@ -3603,7 +3603,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k25
 
@@ -3666,7 +3666,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k25-ko28
 
@@ -3729,7 +3729,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k25-ko29
 
@@ -3792,7 +3792,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k26
 
@@ -3855,7 +3855,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k26-ko28
 
@@ -3918,7 +3918,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k26-ko29
 
@@ -3981,7 +3981,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k27
 
@@ -4044,7 +4044,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k27-ko28
 
@@ -4107,7 +4107,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k27-ko29
 
@@ -4170,7 +4170,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k28
 
@@ -4233,7 +4233,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k28-ko28
 
@@ -4296,7 +4296,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k28-ko29
 
@@ -4359,7 +4359,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k29
 
@@ -4422,7 +4422,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k29-ko29
 
@@ -4485,7 +4485,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k25
 
@@ -4548,7 +4548,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k25-ko28
 
@@ -4611,7 +4611,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k25-ko29
 
@@ -4674,7 +4674,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k26
 
@@ -4737,7 +4737,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k26-ko28
 
@@ -4800,7 +4800,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k26-ko29
 
@@ -4863,7 +4863,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k27
 
@@ -4926,7 +4926,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k27-ko28
 
@@ -4989,7 +4989,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k27-ko29
 
@@ -5052,7 +5052,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k28
 
@@ -5115,7 +5115,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k28-ko28
 
@@ -5178,7 +5178,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k28-ko29
 
@@ -5241,7 +5241,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k29
 
@@ -5304,7 +5304,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k29-ko29
 
@@ -5367,7 +5367,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k25
 
@@ -5430,7 +5430,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k25-ko28
 
@@ -5493,7 +5493,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k25-ko29
 
@@ -5556,7 +5556,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k26
 
@@ -5619,7 +5619,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k26-ko28
 
@@ -5682,7 +5682,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k26-ko29
 
@@ -5745,7 +5745,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k27
 
@@ -5808,7 +5808,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k27-ko28
 
@@ -5871,7 +5871,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k27-ko29
 
@@ -5934,7 +5934,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k28
 
@@ -5997,7 +5997,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k28-ko28
 
@@ -6060,7 +6060,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k28-ko29
 
@@ -6123,7 +6123,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k29
 
@@ -6186,7 +6186,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k29-ko29
 
@@ -6249,7 +6249,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k25
 
@@ -6312,7 +6312,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k25-ko28
 
@@ -6375,7 +6375,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k25-ko29
 
@@ -6438,7 +6438,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k26
 
@@ -6501,7 +6501,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k26-ko28
 
@@ -6564,7 +6564,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k26-ko29
 
@@ -6627,7 +6627,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k27
 
@@ -6690,7 +6690,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k27-ko28
 
@@ -6753,7 +6753,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k27-ko29
 
@@ -6816,7 +6816,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k28
 
@@ -6879,7 +6879,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k28-ko28
 
@@ -6942,7 +6942,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k28-ko29
 
@@ -7005,7 +7005,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k29
 
@@ -7068,7 +7068,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k29-ko29
 
@@ -7132,7 +7132,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k25
 
@@ -7196,7 +7196,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k25-ko28
 
@@ -7260,7 +7260,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k25-ko29
 
@@ -7324,7 +7324,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k26
 
@@ -7388,7 +7388,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k26-ko28
 
@@ -7452,7 +7452,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k26-ko29
 
@@ -7516,7 +7516,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k27
 
@@ -7580,7 +7580,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k27-ko28
 
@@ -7644,7 +7644,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k27-ko29
 
@@ -7708,7 +7708,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k28
 
@@ -7772,7 +7772,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k28-ko28
 
@@ -7836,7 +7836,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k28-ko29
 
@@ -7900,7 +7900,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k29
 
@@ -7964,7 +7964,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k29-ko29
 
@@ -8027,7 +8027,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k25
 
@@ -8090,7 +8090,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k25-ko28
 
@@ -8153,7 +8153,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k25-ko29
 
@@ -8216,7 +8216,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k26
 
@@ -8279,7 +8279,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k26-ko28
 
@@ -8342,7 +8342,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k26-ko29
 
@@ -8405,7 +8405,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k27
 
@@ -8468,7 +8468,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k27-ko28
 
@@ -8531,7 +8531,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k27-ko29
 
@@ -8594,7 +8594,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k28
 
@@ -8657,7 +8657,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k28-ko28
 
@@ -8720,7 +8720,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k28-ko29
 
@@ -8783,7 +8783,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k29
 
@@ -8846,7 +8846,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k29-ko29
 
@@ -8909,7 +8909,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k25
 
@@ -8972,7 +8972,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k25-ko28
 
@@ -9035,7 +9035,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k25-ko29
 
@@ -9098,7 +9098,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k26
 
@@ -9161,7 +9161,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k26-ko28
 
@@ -9224,7 +9224,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k26-ko29
 
@@ -9287,7 +9287,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k27
 
@@ -9350,7 +9350,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k27-ko28
 
@@ -9413,7 +9413,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k27-ko29
 
@@ -9476,7 +9476,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k28
 
@@ -9539,7 +9539,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k28-ko28
 
@@ -9602,7 +9602,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k28-ko29
 
@@ -9665,7 +9665,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k29
 
@@ -9728,7 +9728,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k29-ko29
 
@@ -9791,7 +9791,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k25
 
@@ -9854,7 +9854,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k25-ko28
 
@@ -9917,7 +9917,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k25-ko29
 
@@ -9980,7 +9980,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k26
 
@@ -10043,7 +10043,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k26-ko28
 
@@ -10106,7 +10106,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k26-ko29
 
@@ -10169,7 +10169,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k27
 
@@ -10232,7 +10232,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k27-ko28
 
@@ -10295,7 +10295,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k27-ko29
 
@@ -10358,7 +10358,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k28
 
@@ -10421,7 +10421,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k28-ko28
 
@@ -10484,7 +10484,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k28-ko29
 
@@ -10547,7 +10547,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k29
 
@@ -10610,7 +10610,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k29-ko29
 
@@ -10673,7 +10673,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k25
 
@@ -10736,7 +10736,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k25-ko28
 
@@ -10799,7 +10799,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k25-ko29
 
@@ -10862,7 +10862,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k26
 
@@ -10925,7 +10925,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k26-ko28
 
@@ -10988,7 +10988,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k26-ko29
 
@@ -11051,7 +11051,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k27
 
@@ -11114,7 +11114,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k27-ko28
 
@@ -11177,7 +11177,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k27-ko29
 
@@ -11240,7 +11240,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k28
 
@@ -11303,7 +11303,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k28-ko28
 
@@ -11366,7 +11366,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k28-ko29
 
@@ -11429,7 +11429,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k29
 
@@ -11492,7 +11492,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k29-ko29
 
@@ -11555,7 +11555,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k25
 
@@ -11618,7 +11618,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k25-ko28
 
@@ -11681,7 +11681,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k25-ko29
 
@@ -11744,7 +11744,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k26
 
@@ -11807,7 +11807,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k26-ko28
 
@@ -11870,7 +11870,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k26-ko29
 
@@ -11933,7 +11933,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k27
 
@@ -11996,7 +11996,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k27-ko28
 
@@ -12059,7 +12059,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k27-ko29
 
@@ -12122,7 +12122,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k28
 
@@ -12185,7 +12185,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k28-ko28
 
@@ -12248,7 +12248,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k28-ko29
 
@@ -12311,7 +12311,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k29
 
@@ -12374,7 +12374,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k29-ko29
 
@@ -12438,7 +12438,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k25
 
@@ -12502,7 +12502,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k25-ko28
 
@@ -12566,7 +12566,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k25-ko29
 
@@ -12630,7 +12630,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k26
 
@@ -12694,7 +12694,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k26-ko28
 
@@ -12758,7 +12758,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k26-ko29
 
@@ -12822,7 +12822,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k27
 
@@ -12886,7 +12886,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k27-ko28
 
@@ -12950,7 +12950,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k27-ko29
 
@@ -13014,7 +13014,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k28
 
@@ -13078,7 +13078,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k28-ko28
 
@@ -13142,7 +13142,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k28-ko29
 
@@ -13206,7 +13206,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k29
 
@@ -13270,7 +13270,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k29-ko29
 
@@ -13333,7 +13333,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k25
 
@@ -13396,7 +13396,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k25-ko28
 
@@ -13459,7 +13459,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k25-ko29
 
@@ -13522,7 +13522,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k26
 
@@ -13585,7 +13585,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k26-ko28
 
@@ -13648,7 +13648,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k26-ko29
 
@@ -13711,7 +13711,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k27
 
@@ -13774,7 +13774,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k27-ko28
 
@@ -13837,7 +13837,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k27-ko29
 
@@ -13900,7 +13900,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k28
 
@@ -13963,7 +13963,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k28-ko28
 
@@ -14026,7 +14026,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k28-ko29
 
@@ -14089,7 +14089,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k29
 
@@ -14152,7 +14152,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k29-ko29
 
@@ -14215,7 +14215,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k25
 
@@ -14278,7 +14278,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k25-ko28
 
@@ -14341,7 +14341,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k25-ko29
 
@@ -14404,7 +14404,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k26
 
@@ -14467,7 +14467,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k26-ko28
 
@@ -14530,7 +14530,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k26-ko29
 
@@ -14593,7 +14593,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k27
 
@@ -14656,7 +14656,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k27-ko28
 
@@ -14719,7 +14719,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k27-ko29
 
@@ -14782,7 +14782,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k28
 
@@ -14845,7 +14845,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k28-ko28
 
@@ -14908,7 +14908,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k28-ko29
 
@@ -14971,7 +14971,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k29
 
@@ -15034,7 +15034,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k29-ko29
 
@@ -15097,7 +15097,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k25
 
@@ -15160,7 +15160,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k25-ko28
 
@@ -15223,7 +15223,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k25-ko29
 
@@ -15286,7 +15286,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k26
 
@@ -15349,7 +15349,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k26-ko28
 
@@ -15412,7 +15412,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k26-ko29
 
@@ -15475,7 +15475,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k27
 
@@ -15538,7 +15538,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k27-ko28
 
@@ -15601,7 +15601,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k27-ko29
 
@@ -15664,7 +15664,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k28
 
@@ -15727,7 +15727,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k28-ko28
 
@@ -15790,7 +15790,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k28-ko29
 
@@ -15853,7 +15853,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k29
 
@@ -15916,7 +15916,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k29-ko29
 
@@ -15979,7 +15979,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k25
 
@@ -16042,7 +16042,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k25-ko28
 
@@ -16105,7 +16105,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k25-ko29
 
@@ -16168,7 +16168,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k26
 
@@ -16231,7 +16231,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k26-ko28
 
@@ -16294,7 +16294,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k26-ko29
 
@@ -16357,7 +16357,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k27
 
@@ -16420,7 +16420,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k27-ko28
 
@@ -16483,7 +16483,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k27-ko29
 
@@ -16546,7 +16546,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28
 
@@ -16609,7 +16609,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28-ko28
 
@@ -16672,7 +16672,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28-ko29
 
@@ -16735,7 +16735,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k29
 
@@ -16798,7 +16798,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k29-ko29
 
@@ -16861,7 +16861,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k25
 
@@ -16924,7 +16924,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k25-ko28
 
@@ -16987,7 +16987,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k25-ko29
 
@@ -17050,7 +17050,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k26
 
@@ -17113,7 +17113,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k26-ko28
 
@@ -17176,7 +17176,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k26-ko29
 
@@ -17239,7 +17239,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k27
 
@@ -17302,7 +17302,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k27-ko28
 
@@ -17365,7 +17365,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k27-ko29
 
@@ -17428,7 +17428,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28
 
@@ -17491,7 +17491,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28-ko28
 
@@ -17554,7 +17554,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28-ko29
 
@@ -17617,7 +17617,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k29
 
@@ -17680,7 +17680,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k29-ko29
 
@@ -17744,7 +17744,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k25
 
@@ -17808,7 +17808,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k25-ko28
 
@@ -17872,7 +17872,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k25-ko29
 
@@ -17936,7 +17936,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k26
 
@@ -18000,7 +18000,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k26-ko28
 
@@ -18064,7 +18064,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k26-ko29
 
@@ -18128,7 +18128,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k27
 
@@ -18192,7 +18192,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k27-ko28
 
@@ -18256,7 +18256,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k27-ko29
 
@@ -18320,7 +18320,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k28
 
@@ -18384,7 +18384,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k28-ko28
 
@@ -18448,7 +18448,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k28-ko29
 
@@ -18512,7 +18512,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k29
 
@@ -18576,7 +18576,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k29-ko29
 
@@ -18639,7 +18639,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k25
 
@@ -18702,7 +18702,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k25-ko28
 
@@ -18765,7 +18765,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k25-ko29
 
@@ -18828,7 +18828,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k26
 
@@ -18891,7 +18891,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k26-ko28
 
@@ -18954,7 +18954,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k26-ko29
 
@@ -19017,7 +19017,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k27
 
@@ -19080,7 +19080,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k27-ko28
 
@@ -19143,7 +19143,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k27-ko29
 
@@ -19206,7 +19206,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k28
 
@@ -19269,7 +19269,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k28-ko28
 
@@ -19332,7 +19332,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k28-ko29
 
@@ -19395,7 +19395,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k29
 
@@ -19458,7 +19458,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k29-ko29
 
@@ -19521,7 +19521,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k25
 
@@ -19584,7 +19584,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k25-ko28
 
@@ -19647,7 +19647,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k25-ko29
 
@@ -19710,7 +19710,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k26
 
@@ -19773,7 +19773,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k26-ko28
 
@@ -19836,7 +19836,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k26-ko29
 
@@ -19899,7 +19899,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k27
 
@@ -19962,7 +19962,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k27-ko28
 
@@ -20025,7 +20025,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k27-ko29
 
@@ -20088,7 +20088,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k28
 
@@ -20151,7 +20151,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k28-ko28
 
@@ -20214,7 +20214,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k28-ko29
 
@@ -20277,7 +20277,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k29
 
@@ -20340,7 +20340,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k29-ko29
 
@@ -20403,7 +20403,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k25
 
@@ -20466,7 +20466,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k25-ko28
 
@@ -20529,7 +20529,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k25-ko29
 
@@ -20592,7 +20592,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k26
 
@@ -20655,7 +20655,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k26-ko28
 
@@ -20718,7 +20718,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k26-ko29
 
@@ -20781,7 +20781,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k27
 
@@ -20844,7 +20844,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k27-ko28
 
@@ -20907,7 +20907,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k27-ko29
 
@@ -20970,7 +20970,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28
 
@@ -21033,7 +21033,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28-ko28
 
@@ -21096,7 +21096,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28-ko29
 
@@ -21159,7 +21159,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k29
 
@@ -21222,7 +21222,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k29-ko29
 
@@ -21286,7 +21286,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k25
 
@@ -21350,7 +21350,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k25-ko28
 
@@ -21414,7 +21414,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k25-ko29
 
@@ -21478,7 +21478,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k26
 
@@ -21542,7 +21542,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k26-ko28
 
@@ -21606,7 +21606,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k26-ko29
 
@@ -21670,7 +21670,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k27
 
@@ -21734,7 +21734,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k27-ko28
 
@@ -21798,7 +21798,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k27-ko29
 
@@ -21862,7 +21862,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k28
 
@@ -21926,7 +21926,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k28-ko28
 
@@ -21990,7 +21990,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k28-ko29
 
@@ -22054,7 +22054,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k29
 
@@ -22118,7 +22118,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k29-ko29
 
@@ -22182,7 +22182,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k25
 
@@ -22246,7 +22246,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k25-ko28
 
@@ -22310,7 +22310,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k25-ko29
 
@@ -22374,7 +22374,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k26
 
@@ -22438,7 +22438,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k26-ko28
 
@@ -22502,7 +22502,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k26-ko29
 
@@ -22566,7 +22566,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k27
 
@@ -22630,7 +22630,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k27-ko28
 
@@ -22694,7 +22694,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k27-ko29
 
@@ -22758,7 +22758,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k28
 
@@ -22822,7 +22822,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k28-ko28
 
@@ -22886,7 +22886,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k28-ko29
 
@@ -22950,7 +22950,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k29
 
@@ -23014,7 +23014,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k29-ko29
 
@@ -23079,7 +23079,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k25
 
@@ -23144,7 +23144,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k25-ko28
 
@@ -23209,7 +23209,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k25-ko29
 
@@ -23274,7 +23274,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k26
 
@@ -23339,7 +23339,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k26-ko28
 
@@ -23404,7 +23404,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k26-ko29
 
@@ -23469,7 +23469,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k27
 
@@ -23534,7 +23534,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k27-ko28
 
@@ -23599,7 +23599,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k27-ko29
 
@@ -23664,7 +23664,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k28
 
@@ -23729,7 +23729,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k28-ko28
 
@@ -23794,7 +23794,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k28-ko29
 
@@ -23859,7 +23859,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k29
 
@@ -23924,7 +23924,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k29-ko29
 
@@ -23988,7 +23988,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k25
 
@@ -24052,7 +24052,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k25-ko28
 
@@ -24116,7 +24116,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k25-ko29
 
@@ -24180,7 +24180,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k26
 
@@ -24244,7 +24244,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k26-ko28
 
@@ -24308,7 +24308,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k26-ko29
 
@@ -24372,7 +24372,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k27
 
@@ -24436,7 +24436,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k27-ko28
 
@@ -24500,7 +24500,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k27-ko29
 
@@ -24564,7 +24564,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k28
 
@@ -24628,7 +24628,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k28-ko28
 
@@ -24692,7 +24692,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k28-ko29
 
@@ -24756,7 +24756,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k29
 
@@ -24820,7 +24820,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k29-ko29
 
@@ -24884,7 +24884,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k25
 
@@ -24948,7 +24948,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k25-ko28
 
@@ -25012,7 +25012,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k25-ko29
 
@@ -25076,7 +25076,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k26
 
@@ -25140,7 +25140,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k26-ko28
 
@@ -25204,7 +25204,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k26-ko29
 
@@ -25268,7 +25268,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k27
 
@@ -25332,7 +25332,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k27-ko28
 
@@ -25396,7 +25396,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k27-ko29
 
@@ -25460,7 +25460,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k28
 
@@ -25524,7 +25524,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k28-ko28
 
@@ -25588,7 +25588,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k28-ko29
 
@@ -25652,7 +25652,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k29
 
@@ -25716,7 +25716,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k29-ko29
 
@@ -25780,7 +25780,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k25
 
@@ -25844,7 +25844,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k25-ko28
 
@@ -25908,7 +25908,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k25-ko29
 
@@ -25972,7 +25972,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k26
 
@@ -26036,7 +26036,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k26-ko28
 
@@ -26100,7 +26100,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k26-ko29
 
@@ -26164,7 +26164,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k27
 
@@ -26228,7 +26228,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k27-ko28
 
@@ -26292,7 +26292,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k27-ko29
 
@@ -26356,7 +26356,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k28
 
@@ -26420,7 +26420,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k28-ko28
 
@@ -26484,7 +26484,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k28-ko29
 
@@ -26548,7 +26548,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k29
 
@@ -26612,7 +26612,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k29-ko29
 
@@ -26675,7 +26675,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k25
 
@@ -26738,7 +26738,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k25-ko28
 
@@ -26801,7 +26801,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k25-ko29
 
@@ -26864,7 +26864,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k26
 
@@ -26927,7 +26927,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k26-ko28
 
@@ -26990,7 +26990,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k26-ko29
 
@@ -27053,7 +27053,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k27
 
@@ -27116,7 +27116,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k27-ko28
 
@@ -27179,7 +27179,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-al2023-k27-ko29
 
@@ -27242,7 +27242,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k25
 
@@ -27305,7 +27305,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k25-ko28
 
@@ -27368,7 +27368,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k25-ko29
 
@@ -27431,7 +27431,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k26
 
@@ -27494,7 +27494,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k26-ko28
 
@@ -27557,7 +27557,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k26-ko29
 
@@ -27620,7 +27620,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k27
 
@@ -27683,7 +27683,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k27-ko28
 
@@ -27746,7 +27746,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb12-k27-ko29
 
@@ -27810,7 +27810,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k25
 
@@ -27874,7 +27874,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k25-ko28
 
@@ -27938,7 +27938,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k25-ko29
 
@@ -28002,7 +28002,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k26
 
@@ -28066,7 +28066,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k26-ko28
 
@@ -28130,7 +28130,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k26-ko29
 
@@ -28194,7 +28194,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k27
 
@@ -28258,7 +28258,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k27-ko28
 
@@ -28322,7 +28322,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k27-ko29
 
@@ -28385,7 +28385,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k25
 
@@ -28448,7 +28448,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k25-ko28
 
@@ -28511,7 +28511,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k25-ko29
 
@@ -28574,7 +28574,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k26
 
@@ -28637,7 +28637,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k26-ko28
 
@@ -28700,7 +28700,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k26-ko29
 
@@ -28763,7 +28763,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k27
 
@@ -28826,7 +28826,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k27-ko28
 
@@ -28889,7 +28889,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k27-ko29
 
@@ -28952,7 +28952,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k25
 
@@ -29015,7 +29015,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k25-ko28
 
@@ -29078,7 +29078,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k25-ko29
 
@@ -29141,7 +29141,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k26
 
@@ -29204,7 +29204,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k26-ko28
 
@@ -29267,7 +29267,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k26-ko29
 
@@ -29330,7 +29330,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k27
 
@@ -29393,7 +29393,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k27-ko28
 
@@ -29456,7 +29456,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k27-ko29
 
@@ -29519,7 +29519,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k25
 
@@ -29582,7 +29582,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k25-ko28
 
@@ -29645,7 +29645,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k25-ko29
 
@@ -29708,7 +29708,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k26
 
@@ -29771,7 +29771,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k26-ko28
 
@@ -29834,7 +29834,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k26-ko29
 
@@ -29897,7 +29897,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k27
 
@@ -29960,7 +29960,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k27-ko28
 
@@ -30023,7 +30023,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2204-k27-ko29
 
@@ -30086,7 +30086,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k25
 
@@ -30149,7 +30149,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k25-ko28
 
@@ -30212,7 +30212,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k25-ko29
 
@@ -30275,7 +30275,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k26
 
@@ -30338,7 +30338,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k26-ko28
 
@@ -30401,7 +30401,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k26-ko29
 
@@ -30464,7 +30464,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k27
 
@@ -30527,7 +30527,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k27-ko28
 
@@ -30590,7 +30590,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k27-ko29
 
@@ -30653,7 +30653,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k28
 
@@ -30716,7 +30716,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k28-ko28
 
@@ -30779,7 +30779,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k28-ko29
 
@@ -30842,7 +30842,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k29
 
@@ -30905,7 +30905,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k29-ko29
 
@@ -30968,7 +30968,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k25
 
@@ -31031,7 +31031,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k25-ko28
 
@@ -31094,7 +31094,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k25-ko29
 
@@ -31157,7 +31157,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k26
 
@@ -31220,7 +31220,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k26-ko28
 
@@ -31283,7 +31283,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k26-ko29
 
@@ -31346,7 +31346,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k27
 
@@ -31409,7 +31409,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k27-ko28
 
@@ -31472,7 +31472,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k27-ko29
 
@@ -31535,7 +31535,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k28
 
@@ -31598,7 +31598,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k28-ko28
 
@@ -31661,7 +31661,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k28-ko29
 
@@ -31724,7 +31724,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k29
 
@@ -31787,7 +31787,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k29-ko29
 
@@ -31850,7 +31850,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k25
 
@@ -31913,7 +31913,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k25-ko28
 
@@ -31976,7 +31976,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k25-ko29
 
@@ -32039,7 +32039,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k26
 
@@ -32102,7 +32102,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k26-ko28
 
@@ -32165,7 +32165,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k26-ko29
 
@@ -32228,7 +32228,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k27
 
@@ -32291,7 +32291,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k27-ko28
 
@@ -32354,7 +32354,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k27-ko29
 
@@ -32417,7 +32417,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k28
 
@@ -32480,7 +32480,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k28-ko28
 
@@ -32543,7 +32543,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k28-ko29
 
@@ -32606,7 +32606,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k29
 
@@ -32669,7 +32669,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k29-ko29
 
@@ -32732,7 +32732,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k25
 
@@ -32795,7 +32795,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k25-ko28
 
@@ -32858,7 +32858,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k25-ko29
 
@@ -32921,7 +32921,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k26
 
@@ -32984,7 +32984,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k26-ko28
 
@@ -33047,7 +33047,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k26-ko29
 
@@ -33110,7 +33110,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k27
 
@@ -33173,7 +33173,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k27-ko28
 
@@ -33236,7 +33236,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k27-ko29
 
@@ -33299,7 +33299,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k28
 
@@ -33362,7 +33362,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k28-ko28
 
@@ -33425,7 +33425,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k28-ko29
 
@@ -33488,7 +33488,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k29
 
@@ -33551,7 +33551,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k29-ko29
 
@@ -33614,7 +33614,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.25, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k25
 
@@ -33677,7 +33677,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k25-ko28
 
@@ -33740,7 +33740,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.25, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k25-ko29
 
@@ -33803,7 +33803,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.26, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k26
 
@@ -33866,7 +33866,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k26-ko28
 
@@ -33929,7 +33929,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.26, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k26-ko29
 
@@ -33992,7 +33992,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.27, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k27
 
@@ -34055,7 +34055,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k27-ko28
 
@@ -34118,7 +34118,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.27, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k27-ko29
 
@@ -34181,7 +34181,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k28
 
@@ -34244,7 +34244,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.28'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.28, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k28-ko28
 
@@ -34307,7 +34307,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k28-ko29
 
@@ -34370,7 +34370,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.29, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k29
 
@@ -34433,7 +34433,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.29'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k29-ko29
 

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -86,7 +86,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: 'calico'
-    testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
+    testgrid-dashboards: kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
     testgrid-tab-name: e2e-kops-do-calico-gossip
 - name: e2e-kops-do-calico-dns-none
@@ -142,7 +142,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: 'calico'
-    testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
+    testgrid-dashboards: kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
     testgrid-tab-name: e2e-kops-do-calico-dns-none
 - name: e2e-kops-do-calico-fqdn
@@ -199,6 +199,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: 'calico'
-    testgrid-dashboards: google-aws, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
+    testgrid-dashboards: kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
     testgrid-tab-name: e2e-kops-do-calico-fqdn

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.29, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.29, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-scenario-gcr-mirror
 
@@ -134,7 +134,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-artifacts-sandbox
 
@@ -200,7 +200,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-k8s-ci
 
@@ -330,7 +330,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb11, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb11, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico-deb11
 
@@ -395,7 +395,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico-flatcar
 
@@ -459,7 +459,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico-ipv6
 
@@ -523,7 +523,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-ipv6
 
@@ -588,7 +588,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-ipv6, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-distros, kops-ipv6, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-ipv6-flatcar
 
@@ -653,7 +653,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-ipv6, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-distros, kops-ipv6, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico-ipv6-flatcar
 
@@ -717,7 +717,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-scenario-no-irsa
 
@@ -781,7 +781,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-warm-pool
 
@@ -845,7 +845,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-private
 
@@ -910,7 +910,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-scenario-terraform
 
@@ -975,7 +975,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-scenario-ipv6-terraform
 
@@ -1039,7 +1039,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-ha-euwest1
 
@@ -1103,7 +1103,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-arm64-release
 
@@ -1169,7 +1169,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-arm64-ci
 
@@ -1237,7 +1237,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-arm64-conformance
 
@@ -1305,7 +1305,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-amd64-conformance
 
@@ -1371,7 +1371,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-aws-updown
 
@@ -1433,7 +1433,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-aws-load-balancer-controller
 
@@ -1497,7 +1497,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-keypair-rotation-ha
 
@@ -1559,7 +1559,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-metrics-server
 
@@ -1621,7 +1621,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-pod-identity-webhook
 
@@ -1683,7 +1683,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-addon-resource-tracking
 
@@ -1747,7 +1747,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-external-dns
 
@@ -1811,7 +1811,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-ipv6-external-dns
 
@@ -1878,7 +1878,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-apiserver-nodes
 
@@ -1944,7 +1944,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-karpenter
 
@@ -2010,7 +2010,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-ipv6, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-ipv6-karpenter
 
@@ -2075,7 +2075,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-al2023, kops-k8s-1.28, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-k8s-1.28, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-k28-hostname-bug123255
 
@@ -2145,7 +2145,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-selinux
 
@@ -2216,7 +2216,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-selinux-alpha
 
@@ -2350,7 +2350,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-canary
 
@@ -2417,7 +2417,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: ci-kubernetes-e2e-ubuntu-aws-canary
 
@@ -2553,7 +2553,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-slow-canary
 
@@ -2689,7 +2689,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-conformance-canary
 
@@ -2756,7 +2756,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-conformance-aws-cni
 
@@ -2825,7 +2825,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-conformance-aws-cni-canary
 
@@ -2894,7 +2894,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-conformance-cilium-canary
 
@@ -3098,7 +3098,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-disruptive-canary
 
@@ -3235,7 +3235,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '71'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-serial-canary
 
@@ -3304,7 +3304,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: amazon-ec2-al2023, google-aws, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
+    testgrid-dashboards: amazon-ec2-al2023, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-alpha-features
 

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-amazon-vpc
 
@@ -126,7 +126,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico
 
@@ -190,7 +190,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: canal
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-canal
 
@@ -254,7 +254,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium
 
@@ -318,7 +318,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-etcd
 
@@ -382,7 +382,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-eni
 
@@ -446,7 +446,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-flannel
 
@@ -510,7 +510,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-kopeio
 
@@ -576,6 +576,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kube-router
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-kuberouter

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -65,7 +65,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-latest, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-latest, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kopsmaster
 
@@ -132,7 +132,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.29, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.29, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops129
 
@@ -199,7 +199,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.28, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.28, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops128
 
@@ -266,6 +266,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops127

--- a/config/jobs/kubernetes/kops/kops-periodics-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-scale.yaml
@@ -63,6 +63,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-scale-amazonvpc

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -64,7 +64,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko126-to-k127-ko127
 
@@ -136,7 +136,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko126-to-k127-ko127-many-addons
 
@@ -206,7 +206,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko127-to-k127-ko127
 
@@ -282,7 +282,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko127-to-k127-ko127-many-addons
 
@@ -348,7 +348,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko126-to-k127-ko128
 
@@ -420,7 +420,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko126-to-k127-ko128-many-addons
 
@@ -490,7 +490,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko127-to-k128-ko128
 
@@ -566,7 +566,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko127-to-k128-ko128-many-addons
 
@@ -636,7 +636,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k128-ko128-to-k128-ko128
 
@@ -712,7 +712,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k128-ko128-to-k128-ko128-many-addons
 
@@ -778,7 +778,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko126-to-k127-kolatest
 
@@ -850,7 +850,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko126-to-k127-kolatest-many-addons
 
@@ -916,7 +916,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k124-ko127-to-k125-kolatest
 
@@ -988,7 +988,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k124-ko127-to-k125-kolatest-many-addons
 
@@ -1054,7 +1054,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k125-ko127-to-k126-kolatest
 
@@ -1126,7 +1126,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k125-ko127-to-k126-kolatest-many-addons
 
@@ -1192,7 +1192,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko127-to-k127-kolatest
 
@@ -1264,7 +1264,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko127-to-k127-kolatest-many-addons
 
@@ -1334,7 +1334,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko127-to-k128-kolatest
 
@@ -1410,7 +1410,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko127-to-k128-kolatest-many-addons
 
@@ -1476,7 +1476,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k124-ko128-to-k125-kolatest
 
@@ -1548,7 +1548,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k124-ko128-to-k125-kolatest-many-addons
 
@@ -1614,7 +1614,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k125-ko128-to-k126-kolatest
 
@@ -1686,7 +1686,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k125-ko128-to-k126-kolatest-many-addons
 
@@ -1752,7 +1752,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko128-to-k127-kolatest
 
@@ -1824,7 +1824,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-ko128-to-k127-kolatest-many-addons
 
@@ -1894,7 +1894,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko128-to-k128-kolatest
 
@@ -1970,7 +1970,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-ko128-to-k128-kolatest-many-addons
 
@@ -2040,7 +2040,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k128-kolatest-to-klatest-kolatest
 
@@ -2116,7 +2116,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k128-kolatest-to-klatest-kolatest-many-addons
 
@@ -2186,7 +2186,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-kolatest-to-k128-kolatest
 
@@ -2262,7 +2262,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k127-kolatest-to-k128-kolatest-many-addons
 
@@ -2328,7 +2328,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-kolatest-to-k127-kolatest
 
@@ -2400,7 +2400,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k126-kolatest-to-k127-kolatest-many-addons
 
@@ -2466,7 +2466,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k125-kolatest-to-k126-kolatest
 
@@ -2538,7 +2538,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k125-kolatest-to-k126-kolatest-many-addons
 
@@ -2604,7 +2604,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k124-kolatest-to-k125-kolatest
 
@@ -2676,7 +2676,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-k124-kolatest-to-k125-kolatest-many-addons
 
@@ -2746,7 +2746,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-kstable-kolatest-to-klatest-kolatest
 
@@ -2822,7 +2822,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-kstable-kolatest-to-klatest-kolatest-many-addons
 
@@ -2892,7 +2892,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-kstable-kolatest-to-kci-kolatest
 
@@ -2968,7 +2968,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades-many-addons, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-kstable-kolatest-to-kci-kolatest-many-addons
 
@@ -3038,7 +3038,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-bug16276-calico
 
@@ -3108,6 +3108,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-upgrades, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-upgrade-bug16276-cilium

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -65,7 +65,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-ci, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-ci, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-latest
 
@@ -129,7 +129,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.29, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.29, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-29
 
@@ -193,7 +193,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.28, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.28, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-28
 
@@ -257,7 +257,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.27, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-27
 
@@ -321,7 +321,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.26, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.26, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-26
 
@@ -385,6 +385,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2204, kops-k8s-1.25, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2204, kops-k8s-1.25, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-25

--- a/config/testgrids/google/google.yaml
+++ b/config/testgrids/google/google.yaml
@@ -2,7 +2,6 @@
 # Start dashboards
 #
 dashboards:
-- name: google-aws
 - name: google-gce
 - name: google-kops-gce
 - name: google-gci
@@ -60,7 +59,6 @@ dashboards:
 dashboard_groups:
 - name: google
   dashboard_names:
-  - google-aws
   - google-cel
   - google-gce
   - google-gci


### PR DESCRIPTION
This maybe made sense when google paid for AWS testing, it does not make sense today.

There are other old dashboards like this that should be cleaned up, I will follow up in other PRs

cc @dims @justinsb @hakman 