### PR TITLE
remove google-kops-gce dashboard in favor of kops-gce dashboard

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -60,7 +60,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '40'
     testgrid-tab-name: kops-gce-stable
 
@@ -127,6 +127,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '40'
     testgrid-tab-name: kops-gce-latest

--- a/config/testgrids/google/google.yaml
+++ b/config/testgrids/google/google.yaml
@@ -3,7 +3,6 @@
 #
 dashboards:
 - name: google-gce
-- name: google-kops-gce
 - name: google-gci
 - name: google-osconfig
   dashboard_tab:
@@ -62,6 +61,5 @@ dashboard_groups:
   - google-cel
   - google-gce
   - google-gci
-  - google-kops-gce
   - google-osconfig
   - google-soak


### PR DESCRIPTION
this is redundant, and these jobs are not "google" (others to cleanup remain as well ...)