### PR TITLE
remove google-soak dashboard

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -60,7 +60,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '40'
     testgrid-tab-name: kops-gce-stable
 
@@ -127,6 +127,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '40'
     testgrid-tab-name: kops-gce-latest

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -1078,44 +1078,6 @@ periodics:
     description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
 
 - interval: 12h
-  name: ci-kubernetes-soak-gce-gci
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 1420m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: google-soak
-    testgrid-tab-name: gce-gci
-
-- interval: 12h
   name: ci-kubernetes-soak-gci-gce-beta
   cluster: k8s-infra-prow-build
   labels:

--- a/config/testgrids/google/google.yaml
+++ b/config/testgrids/google/google.yaml
@@ -50,7 +50,6 @@ dashboards:
         value: 'osconfig-head-images issue: <test-name>'
       - key: body
         value: <test-url>
-- name: google-soak
 
 #
 # Start dashboard groups
@@ -62,4 +61,3 @@ dashboard_groups:
   - google-gce
   - google-gci
   - google-osconfig
-  - google-soak

--- a/config/testgrids/google/google.yaml
+++ b/config/testgrids/google/google.yaml
@@ -3,7 +3,6 @@
 #
 dashboards:
 - name: google-gce
-- name: google-kops-gce
 - name: google-gci
 - name: google-osconfig
   dashboard_tab:
@@ -62,6 +61,5 @@ dashboard_groups:
   - google-cel
   - google-gce
   - google-gci
-  - google-kops-gce
   - google-osconfig
   - google-soak

--- a/config/testgrids/kubernetes/sig-cli/config.yaml
+++ b/config/testgrids/kubernetes/sig-cli/config.yaml
@@ -7,9 +7,6 @@ dashboard_groups:
 dashboards:
 - name: sig-cli-master
   dashboard_tab:
-    - name: soak-gce-gci
-      test_group_name: ci-kubernetes-soak-gce-gci
-      base_options: include-filter-by-regex=Kubectl%7Ckubectl
     - name: integration-cmd
       test_group_name: ci-kubernetes-integration-master
       base_options: include-filter-by-regex=kubectl%7COverall


### PR DESCRIPTION
The one job in this is not passing, doesn't appear to be used.

If we discover anyone does want this job, we should add it back under a different dashboard.

This branch also contains https://github.com/kubernetes/test-infra/pull/32856, because it's smaller (only the first commit) and these PRs are going to conflict on changes to `config/testgrids/google/google.yaml` if done in parallel.

I'm hoping #32856 merges first and then this will just be the second and third commit, but merging as one PR would also be fine with me anyhow ...