### PR TITLE
eliminate google-gci testgrid dashboard

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -880,7 +880,7 @@ periodics:
           cpu: 2
           memory: 6Gi
   annotations:
-    testgrid-dashboards: google-gce, google-gci
+    testgrid-dashboards: sig-testing-misc
     testgrid-tab-name: gce-cos-master-flaky-repro
     description: Same config as ci-kubernetes-e2e-gci-gce but with Flaky tests included, intended to reproduce conditions that cause flakes to appear
 

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -706,7 +706,7 @@ periodics:
           cpu: 2
           memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: gce-cos-master-default
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-email: release-team@kubernetes.io
@@ -757,7 +757,7 @@ periodics:
             cpu: 2
             memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: gce-ubuntu-master-containerd
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, release-team@kubernetes.io
@@ -983,7 +983,7 @@ periodics:
           cpu: 1
           memory: 3Gi
   annotations:
-    testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: gce-cos-master-serial
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-email: release-team@kubernetes.io
@@ -1022,7 +1022,7 @@ periodics:
           cpu: 1
           memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: gce-cos-master-slow
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-email: release-team@kubernetes.io

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -707,7 +707,7 @@ periodics:
           cpu: 2
           memory: "6Gi"
   annotations:
-    testgrid-dashboards: google-gce, google-gci
+    testgrid-dashboards: sig-network-gce
     testgrid-tab-name: ip-alias
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-ipvs

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -709,6 +709,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: ip-alias
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-ipvs
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.26.yaml
@@ -174,7 +174,7 @@ periodics:
 - annotations:
     fork-per-release-cron: ""
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.26-blocking, sig-scalability-gce, google-gce, google-gci
+    testgrid-dashboards: sig-release-1.26-blocking, sig-scalability-gce
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.26-scalability-100
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -256,7 +256,7 @@ periodics:
 - annotations:
     fork-per-release-cron: 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.27-blocking, sig-scalability-gce, google-gce, google-gci
+    testgrid-dashboards: sig-release-1.27-blocking, sig-scalability-gce
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.27-scalability-100
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -256,7 +256,7 @@ periodics:
 - annotations:
     fork-per-release-cron: 0 8-20/12 * * *, 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.28-blocking, sig-scalability-gce, google-gce, google-gci
+    testgrid-dashboards: sig-release-1.28-blocking, sig-scalability-gce
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.28-scalability-100
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -256,7 +256,7 @@ periodics:
 - annotations:
     fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.29-blocking, sig-scalability-gce, google-gce, google-gci
+    testgrid-dashboards: sig-release-1.29-blocking, sig-scalability-gce
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.29-scalability-100
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -296,7 +296,7 @@ periodics:
 - annotations:
     fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.30-blocking, sig-scalability-gce, google-gce, google-gci
+    testgrid-dashboards: sig-release-1.30-blocking, sig-scalability-gce
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.30-scalability-100
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -182,7 +182,7 @@ periodics:
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *
     fork-per-release-deletions: "preset-e2e-scalability-periodics-master"
     fork-per-release-replacements: "--extract=ci/fast/latest-fast -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}"
-    testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with cluster/kube-up.sh"

--- a/config/testgrids/google/google.yaml
+++ b/config/testgrids/google/google.yaml
@@ -3,7 +3,6 @@
 #
 dashboards:
 - name: google-gce
-- name: google-gci
 - name: google-osconfig
   dashboard_tab:
   - name: osconfig-unstable
@@ -59,5 +58,4 @@ dashboard_groups:
   dashboard_names:
   - google-cel
   - google-gce
-  - google-gci
   - google-osconfig

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -35,10 +35,6 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-    - name: gci-gce-ip-alias
-      test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
-      alert_options:
-        alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-ipvs
       test_group_name: ci-kubernetes-e2e-gci-gce-ipvs
       description: network gci-gce e2e tests in ipvs proxier mode


### PR DESCRIPTION
ensure jobs are in a relevant dashboard where they'll be tracked properly instead

this is a very old legacy testgrid dashboard nobody should be using

TODO: google-gce (opportunistically done here when it was the same job, but more to do)

/cc @aojea @dims @michelle192837 