### PR TITLE
Drop dedicated testing lane as PodDisruptionConditions are going GA

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3041,52 +3041,6 @@ presubmits:
             memory: 6Gi
         securityContext:
           privileged: true
-  - name: pull-kubernetes-node-kubelet-serial-pod-disruption-conditions
-    cluster: k8s-infra-prow-build
-    always_run: false
-    optional: true
-    skip_report: false
-    annotations:
-      testgrid-dashboards: sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-gce-e2e-pod-disruption-conditions
-      description: Executes pod disruption conditions e2e node tests
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    decorate: true
-    decoration_config:
-      timeout: 240m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-     containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
-          resources:
-            limits:
-              cpu: 4
-              memory: 6Gi
-            requests:
-              cpu: 4
-              memory: 6Gi
-          command:
-            - runner.sh
-            - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --deployment=node
-            - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
-            - '--node-test-args=--feature-gates=PodDisruptionConditions=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-            - --node-tests=true
-            - --provider=gce
-            - --test_args=--nodes=1 --timeout=180m --skip="" --focus="\[NodeFeature:PodDisruptionConditions\]"
-            - --timeout=180m
-          env:
-            - name: GOPATH
-              value: /go
 
   - name: pull-kubernetes-node-e2e-containerd-standalone-mode-all-alpha
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
Context: the PodDisruptionConditions are graduating to GA in 1.31 and the test cases will be covered by existing test suites.

Per comment: https://github.com/kubernetes/kubernetes/pull/125461#discussion_r1649408184
