### PR TITLE
etcd: tune govulncheck etcd presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -120,7 +120,6 @@ presubmits:
   - name: pull-etcd-govulncheck
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true # remove this once the job is green
     branches:
     - main
     decorate: true
@@ -140,10 +139,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "1Gi"
           limits:
             cpu: "4"
-            memory: "4Gi"
+            memory: "1Gi"
 
   - name: pull-etcd-e2e-amd64
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Remove the optional flag from the `govulncheck` job, and set resources accordingly with resource usage from the last two weeks.

Follow up from https://github.com/kubernetes/test-infra/pull/32801#issuecomment-2182971119.
Part of etcd-io/etcd#18173.