### PR TITLE
Switch off NodeSwap for AWS CI jobs that use AL2 based images

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -99,7 +99,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
           resources:
             limits:
               cpu: 8
@@ -155,7 +155,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -472,7 +472,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
           resources:
             limits:
               cpu: 8
@@ -527,7 +527,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Related to: https://github.com/kubernetes/kubernetes/issues/125173