### PR TITLE
Switch off NodeSwap for AWS CI jobs that use AL2 based images (Take 2)

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -99,7 +99,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=false"'
           resources:
             limits:
               cpu: 8
@@ -155,7 +155,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=false"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -472,7 +472,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=false"'
           resources:
             limits:
               cpu: 8
@@ -527,7 +527,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance-eks.yaml
             - name: TEST_ARGS
-              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=true"'
+              value: '--kubelet-flags="--cgroup-driver=systemd" --feature-gates="NodeSwap=false"'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Duh! `NodeSwap` should be `false`