### PR TITLE
--maximum-removal-delta removed

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -568,8 +568,6 @@ periodics:
       - --github-endpoint=http://ghproxy.default.svc.cluster.local
       - --github-endpoint=https://api.github.com
       - --github-token-path=/etc/github-token/oauth
-      # TODO(palnabarun): To be removed as soon as the org audit removal is complete
-      - --maximum-removal-delta=0.4
       - --confirm
       volumeMounts:
       - name: github


### PR DESCRIPTION
`- --maximum-removal-delta=0.4` has been removed as the default of 0.25 threshold is maintained by Peribolos