### PR TITLE
Skip NodeSwap related tests for AWS/AL2 CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -91,7 +91,7 @@ periodics:
             - name: FOCUS
               value: \[NodeConformance\]
             - name: SKIP
-              value: "Summary API"
+              value: Summary API|\[NodeFeature:NodeSwap\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: IMAGE_CONFIG_DIR
@@ -141,7 +141,7 @@ periodics:
             - name: FOCUS
               value: \[NodeConformance\]
             - name: SKIP
-              value: "Summary API"
+              value: Summary API|\[NodeFeature:NodeSwap\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: BUILD_EKS_AMI_ARCH
@@ -464,7 +464,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
+              value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:NodeSwap\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: IMAGE_CONFIG_DIR
@@ -513,7 +513,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]
+              value: \[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:NodeSwap\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: BUILD_EKS_AMI_ARCH


### PR DESCRIPTION
AL2 images do not have cgroupsv2, so we should skip nodeswap tests that fail without cgroupsv2.

<img width="1391" alt="image" src="https://github.com/kubernetes/test-infra/assets/23304/a81c6847-fb1f-4f8a-a3e8-872ad7b8d242">
