### PR TITLE
[sig-autoscaling] Reduce frequency of perma-failing job

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -229,7 +229,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
     testgrid-tab-name: autoscaling-vpa-updater
-- interval: 30m
+- interval: 24h
   name: ci-kubernetes-e2e-gci-gce-autoscaling
   cluster: k8s-infra-prow-build
   labels:
@@ -309,7 +309,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gce-autoscaling-hpa-cm
-- interval: 30m
+- interval: 24h
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
   cluster: k8s-infra-prow-build
   labels:


### PR DESCRIPTION
Temporary until https://github.com/kubernetes/kubernetes/issues/124748 gets addressed. No point running job as frequently as 30 mins when we know they will fail. However, we do want to see the failures in https://storage.googleapis.com/k8s-triage/index.html etc so we don't lose sight of it.

/sig autoscaling
/sig cloud-provider