### PR TITLE
add service account to the preset with workload ID

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
@@ -23,6 +23,8 @@ presets:
     value: "097f89a0-9286-43d2-9a1a-08f1d49b1af8"
   - name: AZURE_FEDERATED_TOKEN_FILE
     value: "/var/run/secrets/azure-token/serviceaccount/token"
+  - name: PROW_SERVICE_ACCOUNT
+    value: "prowjob-default-sa"
   volumes:
   - name: azure-token
     projected:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -117,6 +117,7 @@ presubmits:
     branches:
       - ^main$
     spec:
+      serviceAccountName: $(PROW_SERVICE_ACCOUNT)
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240625-1dde27f6a9-1.29
           command:


### PR DESCRIPTION
add service account to the preset via env var and consume it in the optional azure e2e with workload ID job.