### PR TITLE
move prow sa to azure optional testconfig from the preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presets.yaml
@@ -23,8 +23,6 @@ presets:
     value: "097f89a0-9286-43d2-9a1a-08f1d49b1af8"
   - name: AZURE_FEDERATED_TOKEN_FILE
     value: "/var/run/secrets/azure-token/serviceaccount/token"
-  - name: PROW_SERVICE_ACCOUNT
-    value: "prowjob-default-sa"
   volumes:
   - name: azure-token
     projected:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -117,7 +117,7 @@ presubmits:
     branches:
       - ^main$
     spec:
-      serviceAccountName: $(PROW_SERVICE_ACCOUNT)
+      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240625-1dde27f6a9-1.29
           command:


### PR DESCRIPTION
This PR will move prow sa variable to azure optional testconfig from the preset since the variable substitution in the pod spec does not work
<img width="812" alt="Screenshot 2024-07-01 at 1 34 20 PM" src="https://github.com/kubernetes/test-infra/assets/25679594/e88c8505-df62-4aa4-97c2-dd7a15abcb8c">
