### PR TITLE
Move pull-kubernetes-e2e-ec2-alpha-features to sig-node-presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -819,6 +819,67 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+  - name: pull-kubernetes-node-e2e-alpha-ec2
+    # duplicate job of ci-kubernetes-e2e-ec2-alpha-features to test changes in provider-aws-test-infra
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-node-e2e-alpha-ec2
+      description: Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with kubetest2-ec2
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+      - org: kubernetes
+        repo: release
+        base_ref: master
+        path_alias: k8s.io/release
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
+              GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+              kubetest2 ec2 \
+               --stage https://dl.k8s.io/ci/fast/ \
+               --version $VERSION \
+               --feature-gates="AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false" \
+               --runtime-config="api/all=true" \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+               --test-package-url=https://dl.k8s.io/ \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
+               --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking" \
+               --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0" \
+               --parallel=25
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
   - name: pull-kubernetes-node-kubelet-serial-cpu-manager
     cluster: k8s-infra-prow-build
     always_run: false
@@ -3613,72 +3674,6 @@ presubmits:
                 value: aws-instance-arm64.yaml
               - name: TEST_ARGS
                 value: '--kubelet-flags="--cgroup-driver=systemd"'
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              limits:
-                cpu: 8
-                memory: 10Gi
-              requests:
-                cpu: 8
-                memory: 10Gi
-    - name: pull-kubernetes-e2e-ec2-alpha-features
-      # duplicate job of ci-kubernetes-e2e-ec2-alpha-features to test changes in provider-aws-test-infra
-      cluster: eks-prow-build-cluster
-      annotations:
-        testgrid-dashboards: presubmits-ec2
-        testgrid-tab-name: pr-e2e-ec2-alpha-features
-        description: Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with kubetest2-ec2
-      labels:
-        preset-e2e-containerd-ec2: "true"
-        preset-dind-enabled: "true"
-      always_run: false
-      optional: true
-      decorate: true
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: master
-          path_alias: k8s.io/kubernetes
-          workdir: true
-        - org: kubernetes
-          repo: test-infra
-          base_ref: master
-          path_alias: k8s.io/test-infra
-      spec:
-        serviceAccountName: node-e2e-tests
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240625-1dde27f6a9-master
-            command:
-              - runner.sh
-            args:
-              - bash
-              - -c
-              - |
-                source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
-
-                GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-                VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
-                kubetest2 ec2 \
-                 --stage https://dl.k8s.io/ci/fast/ \
-                 --version $VERSION \
-                 --feature-gates="AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false" \
-                 --runtime-config="api/all=true" \
-                 --up \
-                 --down \
-                 --test=ginkgo \
-                 -- \
-                 --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-                 --test-package-url=https://dl.k8s.io/ \
-                 --test-package-dir=ci/fast \
-                 --test-package-marker=latest-fast.txt \
-                 --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking" \
-                 --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0" \
-                 --parallel=25
-            env:
-              - name: USE_DOCKERIZED_BUILD
-                value: "true"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
This moves pull-kubernetes-e2e-ec2-alpha-features to sig-node-presubmit as pull-kubernetes-node-e2e-alpha-ec2. to allow troubleshooting issues seen in this pipeline ( i.e.https://github.com/kubernetes/kubernetes/issues/116175)