### PR TITLE
enable ipv6 in all dind jobs due to docker v27 upgrade

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -992,6 +992,9 @@ presets:
   env:
   - name: DOCKER_IN_DOCKER_ENABLED
     value: "true"
+  # TODO: handle minimial ipv6 enablement by default in image instead of fully configuring ipv6 always?
+  - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+    value: "true"
   volumes:
   # kubekins-e2e legacy path
   - name: docker-graph


### PR DESCRIPTION
FYI @aojea when you're back tomorrow

/cc @dims 

xref: https://github.com/kubernetes/test-infra/pull/32863#issuecomment-2202678906 https://github.com/kubernetes-sigs/kind/issues/3677