### PR TITLE
Migrate current NPD CI Build job to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: ci-npd-build
-  # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-  cluster: default
+  cluster: k8s-infra-prow-build
   interval: 2h
   decorate: true
   labels:


### PR DESCRIPTION
This PR seeks to replicate the 403 error first encountered by @wangzhen127, as detailed here: https://github.com/kubernetes/test-infra/pull/32222#issuecomment-1988772136

By reproducing this error, we aim to identify and address any underlying issues as we continue transitioning NPD CI jobs to community clusters. This is related to NPD jobs failing during migration, see: https://github.com/kubernetes/kubernetes/issues/119211