### PR TITLE
move modules mount to all dind jobs now that we modprobe ipv6

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -999,25 +999,27 @@ presets:
   # krte (normal) path
   - name: docker-root
     emptyDir: {}
+  # we need to modprobe ipv6 iptables
+  # TODO: move this out of being done in the jobs
+  - name: modules
+    hostPath:
+      path: /lib/modules
+      type: Directory
   volumeMounts:
   - name: docker-graph
     mountPath: /docker-graph
   - name: docker-root
     mountPath: /var/lib/docker
+  - mountPath: /lib/modules
+    name: modules
+    readOnly: true
 # volume mounts for kind
 - labels:
     preset-kind-volume-mounts: "true"
   volumeMounts:
-    - mountPath: /lib/modules
-      name: modules
-      readOnly: true
     - mountPath: /sys/fs/cgroup
       name: cgroup
   volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
     - name: cgroup
       hostPath:
         path: /sys/fs/cgroup


### PR DESCRIPTION
rollforward instead of https://github.com/kubernetes/test-infra/pull/32894

currently we hit:
```
wrapper.sh] [SETUP] Docker in Docker enabled, initializing ...
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
modprobe: FATAL: Module ip6table_nat not found in directory /lib/modules/5.15.0-1054-gke
```

in jobs with the dind preset, but not the kind preset, so we lift this to dind everywhere

longer term, will refactor this out entirely