### PR TITLE
install git for ci-kubernetes-e2e-al2023-aws-serial-canary ci job

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1259,7 +1259,7 @@ def generate_misc():
                    build_cluster="k8s-infra-prow-build",
                    extra_flags=[
                        "--node-volume-size=100",
-                       "--set=spec.packages=nfs-utils",
+                       "--set=spec.packages=nfs-utils,git",
                    ],
                    focus_regex=r'\[Serial\]',
                    skip_regex=r'\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]', # pylint: disable=line-too-long

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2317,7 +2317,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-utils --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --set=spec.nodeProblemDetector.enabled=true --set=spec.packages=nfs-utils,git --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \


### PR DESCRIPTION
Trying to fix the following test in the above mentioned CI job:
https://github.com/dims/test-infra/pull/new/install-git-for-ci-kubernetes-e2e-al2023-aws-serial-canary

as the test is failing with the following error message:
```
I0703 06:30:54.773691 14739 dump.go:53] At 2024-07-03 06:25:52 +0000 UTC - event for wrapped-volume-race-49710477-c8bb-4c3e-b3ec-239ef1ac3a92-fv9mq: {kubelet i-077c4d1d7583c335b} FailedMount: MountVolume.SetUp failed for volume "racey-git-repo-32" : failed to exec 'git clone -- http://100.70.95.86:2345/ test': : executable file not found in $PATH
```