### PR TITLE
kubernetes-sigs/nfd: run presubmit e2e-test in privileged container

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-master.yaml
@@ -88,6 +88,9 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-master
+        # Need privileged mode for dind
+        securityContext:
+          privileged: true
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Needed to use docker (in-docker).