### PR TITLE
kubernetes-sigs/nfd: drop the common build-image job

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -25,34 +25,6 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-  - name: pull-node-feature-discovery-build-image-generic
-    cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    skip_branches:
-    - gh-pages
-    decorate: true
-    annotations:
-      testgrid-dashboards: sig-node-node-feature-discovery
-      testgrid-tab-name: build-image
-      description: "Build container image of node-feature-discovery"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
-        securityContext:
-          privileged: true
-        command:
-        - runner.sh
-        args:
-        - scripts/test-infra/build-image.sh
-        resources:
-          limits:
-            cpu: 2
-            memory: 4Gi
-          requests:
-            cpu: 2
-            memory: 4Gi
   - name: pull-node-feature-discovery-build-image-cross-generic
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-15.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-15.yaml
@@ -66,3 +66,31 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
+  - name: pull-node-feature-discovery-build-image-relese-0-15
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^release-0.15
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: build-image-release-0.15
+      description: "Build container image of node-feature-discovery"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
+        securityContext:
+          privileged: true
+        command:
+        - runner.sh
+        args:
+        - scripts/test-infra/build-image.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-release-0-16.yaml
@@ -72,3 +72,31 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
+  - name: pull-node-feature-discovery-build-image-relese-0-16
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^demo/|^deployment/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    branches:
+    - ^release-0.16
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-node-feature-discovery
+      testgrid-tab-name: build-image-release-0.16
+      description: "Build container image of node-feature-discovery"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
+        securityContext:
+          privileged: true
+        command:
+        - runner.sh
+        args:
+        - scripts/test-infra/build-image.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
In master (and later release branches) this is covered by the e2e-test presubmit job.