### PR TITLE
[e2e-ci-kubernetes-e2e-al2023-aws-serial-canary] Redo specifying multiple packages

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1259,7 +1259,8 @@ def generate_misc():
                    build_cluster="k8s-infra-prow-build",
                    extra_flags=[
                        "--node-volume-size=100",
-                       "--set=spec.packages=nfs-utils,git",
+                       "--set=spec.packages=nfs-utils",
+                       "--set=spec.packages=git",
                    ],
                    focus_regex=r'\[Serial\]',
                    skip_regex=r'\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]', # pylint: disable=line-too-long

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -3171,7 +3171,7 @@ periodics:
     testgrid-days-of-results: '71'
     testgrid-tab-name: ci-kubernetes-e2e-cos-gce-serial-canary
 
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-volume-size=100 --set=spec.packages=nfs-utils,git --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-volume-size=100 --set=spec.packages=nfs-utils --set=spec.packages=git --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-ci-kubernetes-e2e-al2023-aws-serial-canary
   cron: '6 0-23/6 * * *'
   labels:
@@ -3201,7 +3201,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils,git --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils --set=spec.packages=git --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -3230,7 +3230,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/extra_flags: --node-volume-size=100 --set=spec.packages=nfs-utils,git --discovery-store=s3://k8s-kops-prow/discovery
+    test.kops.k8s.io/extra_flags: --node-volume-size=100 --set=spec.packages=nfs-utils --set=spec.packages=git --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/32900/commits/35cf7c0e44640cb9103c6e807ce0e5e92ff7ce35, tried specifying multiple packages using a comma `"--set=spec.packages=nfs-utils,git"`, that did not work and let to a failure in the logs like the following:

```
W0707 12:11:14.175439   14594 state.go:46] failed to run /home/prow/go/src/k8s.io/kops/_rundir/03b8806d-616b-4169-843b-c884d53a6c73/kops get cluster e2e-e2e-ci-kubernetes-e2e-al2023-aws-serial-canary.test-cncf-aws.k8s.io -ojson; stderr=Error: cluster not found "e2e-e2e-ci-kubernetes-e2e-al2023-aws-serial-canary.test-cncf-aws.k8s.io"
I0707 12:11:14.175495   14594 http.go:37] curl https://ip.jsb.workers.dev
I0707 12:11:14.360162   14594 up.go:219] /home/prow/go/src/k8s.io/kops/_rundir/03b8806d-616b-4169-843b-c884d53a6c73/kops create cluster --name e2e-e2e-ci-kubernetes-e2e-al2023-aws-serial-canary.test-cncf-aws.k8s.io --cloud aws --kubernetes-version https://storage.googleapis.com/k8s-release-dev/ci/v1.31.0-alpha.3.67+07cc20a7509e73 --ssh-public-key /tmp/kops/e2e-e2e-ci-kubernetes-e2e-al2023-aws-serial-canary.test-cncf-aws.k8s.io/id_ed25519.pub --set cluster.spec.nodePortAccess=0.0.0.0/0 --set spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2 --image=137112412989/al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64 --channel=alpha --networking=kubenet --node-volume-size=100 --set=spec.packages=nfs-utils,git --discovery-store=s3://k8s-kops-prow/discovery --admin-access 34.42.199.231/32 --master-count 1 --master-size c5.large --master-volume-size 48 --node-count 4 --zones us-east-2a
Flag --master-count has been deprecated, use --control-plane-count instead
Flag --master-size has been deprecated, use --control-plane-size instead
Flag --master-volume-size has been deprecated, use --control-plane-volume-size instead
I0707 12:11:14.430838   14641 create_cluster.go:880] Using SSH public key: /tmp/kops/e2e-e2e-ci-kubernetes-e2e-al2023-aws-serial-canary.test-cncf-aws.k8s.io/id_ed25519.pub
I0707 12:11:14.762792   14641 new_cluster.go:1454] Cloud Provider ID: "aws"
Error: unhandled field: "git"
```

So trying to explicitly specify multiple times in this PR instead.