### PR TITLE
stop running WI optional test automatically on every CAPZ PR

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -107,7 +107,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h
-    skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|Makefile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
+    always_run: false
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR will stop running `pull-cluster-api-provider-azure-e2e-with-wi-optional` on all the CAPZ PRs. 
This change is based on the [point 3 of Trigger Types for prow jobs](https://docs.prow.k8s.io/docs/jobs/#trigger-types)