### PR TITLE
kops: Migrate pipeline and misc tests.

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -746,7 +746,7 @@ def generate_misc():
                    extra_dashboards=["kops-misc"]),
 
         build_test(name_override="kops-aws-updown",
-                   build_cluster="default",
+                   build_cluster="k8s-infra-kops-prow-build",
                    k8s_version="stable",
                    distro="u2204arm64",
                    networking="calico",
@@ -982,6 +982,7 @@ def generate_misc():
                    runs_per_day=8),
 
         build_test(name_override="ci-kubernetes-e2e-al2023-aws-canary",
+                   build_cluster="k8s-infra-kops-prow-build",
                    cloud="aws",
                    distro="al2023",
                    networking="kubenet",
@@ -998,6 +999,7 @@ def generate_misc():
                    runs_per_day=8),
 
         build_test(name_override="ci-kubernetes-e2e-ubuntu-aws-canary",
+                   build_cluster="k8s-infra-kops-prow-build",
                    cloud="aws",
                    distro="u2204",
                    networking="kubenet",
@@ -1801,7 +1803,7 @@ def generate_pipeline():
         results.append(
             build_test(
                 cloud="aws",
-                build_cluster="default",
+                build_cluster="k8s-infra-kops-prow-build",
                 k8s_version=version.replace('master', 'latest'),
                 kops_version=kops_version,
                 kops_channel='alpha',

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -1316,7 +1316,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -2294,7 +2294,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -2361,7 +2361,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -76,7 +76,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -143,7 +143,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -210,7 +210,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  cluster: default
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m


### PR DESCRIPTION
Ref:

    https://github.com/kubernetes/kops/issues/16637
    https://github.com/kubernetes/k8s.io/issues/5127

Ensure pipeline tests run on community-owned infra

/hold