### PR TITLE
[sig-windows] Remove pre-sets not needed and don't run on PR's unless needed

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -427,16 +427,12 @@ presubmits:
     decorate: true
     always_run: false
     optional: true
-    run_if_changed: 'capz/.*'
     decoration_config:
       timeout: 3h
     path_alias: k8s.io/windows-testing
     branches:
       - master
     labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-2022: "true"


### PR DESCRIPTION
/sig windows
/assign @marosset @ritikaguptams

We don't use Kind in the sig-windows e2e tests so we can remove those.  The `preset-azure-anonymous-pull` sets some other kind variables and the wrong REGISTRY value (which is a new registry in the new community sub)

Also don't automatically trigger this job since it is still a WIP