### PR TITLE
migrate presubmit e2e test to use WI

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -77,12 +77,12 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-cred-wi: "true"
     branches:
     - ^main$
     spec:
+      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -100,41 +100,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-main
-      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-e2e-with-wi-optional # created for WI POC
-    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 4h
-    always_run: false
-    max_concurrency: 5
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
-    branches:
-      - ^main$
-    spec:
-      serviceAccountName: prowjob-default-sa
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
-          command:
-            - runner.sh
-          args:
-            - ./scripts/ci-e2e.sh
-          env:
-            - name: GINKGO_FOCUS
-              value: \[REQUIRED\]
-            - name: GINKGO_SKIP
-              value: ""
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: capz-pr-e2e-main-with-wi-optional
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-optional
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"


### PR DESCRIPTION
As part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4976, This PR migrates `pull-cluster-api-provider-azure-e2e` to WI test path.