### PR TITLE
change nodefeature label from SplitDisk to KubeletSeparateDiskGC

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2701,7 +2701,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
       testgrid-tab-name: pr-crio-cgroupv2-imagefs-e2e-separatedisktest
-  - name: pull-crio-cgroupv2-splitfs-splitdisk
+  - name: pull-crio-cgroupv2-splitfs-separate-disk
     cluster: k8s-infra-prow-build
     skip_branches:
       - release-\d+\.\d+  # per-release image
@@ -2733,7 +2733,7 @@ presubmits:
         - '--node-test-args=--feature-gates="KubeletSeparateDiskGC=true" --service-feature-gates="KubeletSeparateDiskGC=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="SplitDisk" --timeout=300m
+        - --test_args=--nodes=1 --focus="KubeletSeparateDiskGC" --timeout=300m
         - --timeout=300m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2-splitfs.yaml
         env:
@@ -2750,7 +2750,7 @@ presubmits:
             memory: 6Gi
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-splitfs-splitdisk
+      testgrid-tab-name: pr-crio-cgroupv2-splitfs-separate-disk
   - name: pull-kubernetes-cos-cgroupv1-containerd-node-e2e
     skip_branches:
       - release-\d+\.\d+  # per-release image


### PR DESCRIPTION
This PR changes node feature label from `SplitDisk` to `KubeletSeparateDiskGC` according to the suggestion [here](https://github.com/kubernetes/kubernetes/pull/125417#discussion_r1671765382)