### PR TITLE
[kueue] Decrease resource requests for e2e.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -91,10 +91,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "10"
+            cpu: "7"
             memory: "10Gi"
           limits:
-            cpu: "10"
+            cpu: "7"
             memory: "10Gi"
   - name: pull-kueue-test-e2e-main-1-28
     cluster: eks-prow-build-cluster
@@ -129,10 +129,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - name: pull-kueue-test-e2e-main-1-29
     cluster: eks-prow-build-cluster
@@ -167,10 +167,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - name: pull-kueue-test-e2e-main-1-30
     cluster: eks-prow-build-cluster
@@ -205,10 +205,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - name: pull-kueue-test-multikueue-e2e-main
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-7.yaml
@@ -91,10 +91,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "10"
+            cpu: "7"
             memory: "10Gi"
           limits:
-            cpu: "10"
+            cpu: "7"
             memory: "10Gi"
   - name: pull-kueue-test-e2e-release-0-7-1-28
     cluster: eks-prow-build-cluster
@@ -129,10 +129,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - name: pull-kueue-test-e2e-release-0-7-1-29
     cluster: eks-prow-build-cluster
@@ -167,10 +167,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - name: pull-kueue-test-e2e-release-0-7-1-30
     cluster: eks-prow-build-cluster
@@ -205,10 +205,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - name: pull-kueue-test-multikueue-e2e-release-0-7
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -156,10 +156,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-28
@@ -202,10 +202,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-29
@@ -248,10 +248,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-main-1-30
@@ -294,10 +294,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "10"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-multikueue-e2e-main


### PR DESCRIPTION
Decrease resource requests for e2e due to insufficient computing.

```
There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors (0/31 nodes are available: 28 Insufficient cpu, 3 node(s) had untolerated taint {node-group: stable}. preemption: 0/31 nodes are available: 28 No preemption victims found for incoming pod, 3 Preemption is not helpful for scheduling..)
```