### PR TITLE
[sig-windows] Add docker in docker preset back to the windows job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -433,6 +433,7 @@ presubmits:
     branches:
       - master
     labels:
+      preset-dind-enabled: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-2022: "true"


### PR DESCRIPTION
This is required for building cloud node manager images

part of https://github.com/kubernetes-sigs/windows-testing/pull/444

/sig windows
/assign @marosset @ritikaguptams 