### PR TITLE
sig node: support different API versions in DRA presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3180,19 +3180,24 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
+        # This picks the latest available k8s.io/api/resource version that is available.
+        # May be different depending on the PR.
         command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
+        - /bin/sh
         args:
-        - --deployment=node
-        - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
-        - '--node-test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=resource.k8s.io/v1alpha2=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-        - --node-tests=true
-        - --provider=gce
-        - '--test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"'
-        - --timeout=65m
-        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+        - -c
+        - >-
+          runner.sh
+          /workspace/scenarios/kubernetes_e2e.py
+          --deployment=node
+          --env=KUBE_SSH_USER=core
+          --gcp-zone=us-west1-b
+          --node-test-args="--feature-gates=DynamicResourceAllocation=true --service-feature-gates=DynamicResourceAllocation=true --runtime-config=api/alpha=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags=\"--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service\" --extra-log={'name':'crio.log','journalctl':'-u','crio']}"
+          --node-tests=true
+          --provider=gce
+          --test_args=--label-filter="Feature: containsAny DynamicResourceAllocation && !Flaky"
+          --timeout=65m
+          --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
         env:
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"


### PR DESCRIPTION
This is a first attempt to make the presubmits support a PR which bumps the API version (like https://github.com/kubernetes/kubernetes/pull/125488).

If this works, the other jobs also will get converted.