### PR TITLE
Update presubmit v1beta1 release tests to use WI credentials

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -49,6 +49,7 @@ presubmits:
       testgrid-tab-name: capz-pr-build-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -57,9 +58,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     spec:
@@ -74,6 +73,13 @@ presubmits:
             value: \[REQUIRED\]
           - name: GINKGO_SKIP
             value: ""
+        resources:
+          limits:
+            cpu: 6
+            memory: 8Gi
+          requests:
+            cpu: 6
+            memory: 8Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -82,6 +88,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-apiversion-upgrade-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -90,9 +97,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
       - ^release-1.*
     spec:
@@ -107,6 +112,13 @@ presubmits:
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
               value: "v1.26.15"
+          resources:
+            limits:
+              cpu: 6
+              memory: 8Gi
+            requests:
+              cpu: 6
+              memory: 8Gi
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -116,6 +128,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
       description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
   - name: pull-cluster-api-provider-azure-e2e-optional-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -126,9 +139,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     spec:
@@ -143,6 +154,13 @@ presubmits:
             value: \[OPTIONAL\]
           - name: GINKGO_SKIP
             value: ""
+        resources:
+          limits:
+            cpu: 6
+            memory: 8Gi
+          requests:
+            cpu: 6
+            memory: 8Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -151,6 +169,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-optional-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-aks-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -161,9 +180,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     spec:
@@ -178,6 +195,13 @@ presubmits:
             value: \[Managed Kubernetes\]
           - name: GINKGO_SKIP
             value: ""
+        resources:
+          limits:
+            cpu: 6
+            memory: 8Gi
+          requests:
+            cpu: 6
+            memory: 8Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -186,6 +210,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-aks-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     run_if_changed: 'test\/e2e\/capi_test.go|scripts\/ci-e2e.sh|^go.mod'
@@ -197,9 +222,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     spec:
@@ -214,6 +237,13 @@ presubmits:
             value: "Cluster API E2E tests"
           - name: GINKGO_SKIP
             value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+        resources:
+          limits:
+            cpu: 6
+            memory: 8Gi
+          requests:
+            cpu: 6
+            memory: 8Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -253,6 +283,7 @@ presubmits:
       testgrid-tab-name: capz-pr-verify-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-conformance-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -263,8 +294,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     spec:
@@ -278,6 +308,9 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 2
+            memory: "9Gi"
           requests:
             cpu: 2
             memory: "9Gi"
@@ -313,6 +346,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-v1beta1
   - name: pull-cluster-api-provider-azure-ci-entrypoint-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -321,9 +355,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     spec:
@@ -341,12 +373,20 @@ presubmits:
             value: "true"
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
+        resources:
+          limits:
+            cpu: 6
+            memory: 8Gi
+          requests:
+            cpu: 6
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-ci-entrypoint-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
       description: Creates a CAPZ cluster and exports KUBECONFIG. This job validates ci-entrypoint.sh used by other repositories for running tests on CAPZ clusters.
   - name: pull-cluster-api-provider-azure-conformance-with-ci-artifacts-v1beta1
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -357,9 +397,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     branches:
     - ^release-1.*
     extra_refs:
@@ -380,6 +418,9 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: "9Gi"
             requests:
               cpu: 2
               memory: "9Gi"
@@ -387,12 +428,11 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-k8s-ci-v1beta1
   - name: pull-cluster-api-provider-azure-e2e-workload-upgrade-v1beta1
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-community: "true"
     always_run: false
     optional: false
     decorate: true
@@ -419,8 +459,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 2
+            memory: "9Gi"
           requests:
-            cpu: 7300m
+            cpu: 2
+            memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-upgrade-v1beta1


### PR DESCRIPTION
This PR updates presubmit v1beta1 release jobs to use wi credentials. This PR should be merged once the CAPZ main has been ported to use WI workflow.