### PR TITLE
Update periodic main test jobs to use WI credentials

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -7,14 +7,14 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: main
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -41,9 +41,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -56,6 +55,7 @@ periodics:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -85,15 +85,15 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: main
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
       command:
@@ -120,15 +120,15 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: main
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -199,15 +199,15 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: main
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
       command:
@@ -234,15 +234,15 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: main
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
       command:


### PR DESCRIPTION
With the success of presubmit main e2e tests, this PR migrates the periodic main jobs to use WI. 
Since these are periodic jobs and do not immediately hinder dev flow, we can tolerate breakage of these tests(if any). 

Therefore a direct conversion, i.e. `test with azure secrets -> migrate to tests with WI` is proposed here instead of `test with azure secrets -> create a copy with WI -> wait for copied tests to be green -> migrate to tests with WI`