### PR TITLE
Update periodics v1beta1 release 1.15 jobs to use community infra

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.15.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.15.yaml
@@ -1,5 +1,6 @@
 periodics:
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-14
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-15
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -7,13 +8,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-community: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.14
+      base_ref: release-1.15
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -27,14 +26,22 @@ periodics:
           value: "Cluster API E2E tests"
         - name: GINKGO_SKIP
           value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-14
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-15
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-14
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-15
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -42,13 +49,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-community: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.14
+      base_ref: release-1.15
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -62,14 +67,22 @@ periodics:
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
           value: \[Managed Kubernetes\]
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-14
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-15
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-14
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-15
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -77,13 +90,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-community: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.14
+      base_ref: release-1.15
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
@@ -97,10 +108,17 @@ periodics:
           value: \[Managed Kubernetes\]
         - name: GINKGO_SKIP
           value: ""
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-14
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-15
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
- This PR replaces `cluster-api-provider-azure-periodics-v1beta1-release-1.14.yaml` -> `cluster-api-provider-azure-periodics-v1beta1-release-1.15.yaml`
- All the periodic jobs in newly created `cluster-api-provider-azure-periodics-v1beta1-release-1.15.yaml` will run at `eks-prow-build-cluster`
- default `resource.requests` and `resource.limits` have been added to each of the jobs.