### PR TITLE
sync label-config to k8s-infra-prow-build-trusted

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -625,6 +625,8 @@ config_updater:
     label_sync/labels.yaml:
       name: label-config
       clusters:
+        k8s-infra-prow-build-trusted:
+          - test-pods
         test-infra-trusted:
           - test-pods
     config/prow/config.yaml:


### PR DESCRIPTION
required for https://github.com/kubernetes/test-infra/pull/32948

for now we'll sync to both clusters, to simplify any rollback of the job

later we'll drop syncing to test-infra-trusted when we see we don't need to rollback