### PR TITLE
Increase timeout of pull-kubernetes-node-swap-fedora-serial

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2157,7 +2157,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     decorate: true
     decoration_config:
-      timeout: 240m
+      timeout: 290m
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
@@ -2177,8 +2177,8 @@ presubmits:
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]"
-        - --timeout=180m
+        - --test_args=--nodes=1 --timeout=4h --focus="\[Serial\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]"
+        - --timeout=270m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
         resources:
           limits:


### PR DESCRIPTION
I want to increase the timeout of `pull-kubernetes-node-swap-fedora-serial` presubmit job so that I can test changes in https://github.com/kubernetes/kubernetes/pull/126058. Currently the job is timing out. This change keeps the timeout same as [CI job](https://github.com/kubernetes/test-infra/blob/44535581ad0da7d3f82a19be477a2eb26ad2687d/config/jobs/kubernetes/sig-node/node-kubelet.yaml#L422).