### PR TITLE
Add canaries for test-infra image push jobs.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -249,6 +249,70 @@ postsubmits:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
           - images/kubekins-e2e-v2/
+
+    # TODO: Remove '-canary' from these and other migrated job names once old jobs are deleted.
+    # These are duplicates of the image-pushing jobs in test-infra-trusted.yaml.
+    - name: post-test-infra-push-alpine-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^images/alpine/'
+      annotations:
+        testgrid-dashboards: sig-testing-image-pushes, sig-k8s-infra-gcb
+        testgrid-tab-name: alpine
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20240523-29e3962433
+          command:
+          - /run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - images/alpine/
+    - name: post-test-infra-push-git-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^images/git/'
+      annotations:
+        testgrid-dashboards: sig-testing-image-pushes, sig-k8s-infra-gcb
+        testgrid-tab-name: git
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20240523-29e3962433
+          command:
+          - /run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - images/git/
+    - name: post-test-infra-push-git-custom-k8s-auth-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^images/git-custom-k8s-auth/'
+      annotations:
+        testgrid-dashboards: sig-testing-image-pushes, sig-k8s-infra-gcb
+        testgrid-tab-name: git-custom-k8s-auth
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20240523-29e3962433
+          command:
+          - /run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - images/git-custom-k8s-auth/
+
     #
     # components, e.g. kettle/, triage/
     #

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -15,6 +15,7 @@ dashboard_groups:
   - sig-testing-canaries
   - sig-testing-e2e-framework
   - sig-testing-images
+  - sig-testing-image-pushes
   - sig-testing-kind
   - sig-testing-kubetest2
   - sig-testing-maintenance
@@ -33,6 +34,7 @@ dashboards:
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: sig-testing-e2e-framework
 - name: sig-testing-images
+- name: sig-testing-image-pushes
 - name: sig-testing-kind
 - name: sig-testing-kubetest2
 - name: sig-testing-maintenance


### PR DESCRIPTION
Didn't realize we already had canaries for some of the images! Adding a few more that are listed in test-infra-trusted.yaml (the remaining image push jobs that aren't covered here and aren't under misc-images).

If these succeed, we can move the relevant jobs to use these images instead.

(There is discussion on the linked issue of using a different base image for these, but I think migrating first, then switching will be easier and less subject to time pressure).

ETA: This also uses a new dashboard `sig-testing-image-pushes`, in line with https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#image-pushing-jobs. I'm happy to stick with the existing sig-testing-images as well, but figure this is as good a time as any to make the naming a bit more consistent; the other jobs can also move to this dashboard with later cleanup.

Ref #32432