### PR TITLE
Update cluster autoscaler Azure test to use WI credentials

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -10,9 +10,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+      preset-azure-cred-wi: "true"
     decorate: true
     decoration_config:
       timeout: 5h
@@ -24,6 +23,7 @@ presubmits:
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
+      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:


### PR DESCRIPTION
This PR migrates the cluster autoscaler Azure job to use WI.