### PR TITLE
image-builder: add optional job to test workload ID auth

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -1,5 +1,27 @@
 presubmits:
   kubernetes-sigs/image-builder:
+  - name: pull-azure-vhds-wi
+    labels:
+      preset-azure-cred-wi: "true"
+    decorate: true
+    always_run: false
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 5
+    path_alias: sigs.k8s.io/image-builder
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
+        args:
+          - runner.sh
+          - "./images/capi/scripts/ci-azure-e2e.sh"
+        resources:
+          requests:
+            cpu: 1000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-image-builder
+      testgrid-tab-name: pr-azure-vhds-wi
   - name: pull-azure-vhds
     labels:
       preset-azure-cred: "true"


### PR DESCRIPTION
Adds a new, optional `pull-azure-vhds-wi` job for the sig-cluster-lifecycle image-builder project. This will enable us to test and iterate on changes necessary to move this job to community testing infrastructure ASAP.

See also kubernetes-sigs/image-builder#1508