### PR TITLE
Update cloud-provider-azure jobs with CAPZ main branch workload ID

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -989,7 +989,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
+    preset-azure-cred-wi: "true"
     preset-azure-anonymous-pull: "true"
   extra_refs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -37,6 +37,30 @@ generate_presubmit_annotations() {
 EOF
 }
 
+generate_preset_labels() {
+  indent=${1}
+  capz_ref="${2}"
+  if [[ "${capz_ref}" == "main" ]]; then
+    creds=$(cat <<EOF
+  preset-azure-capz-cred-wi: "true"
+EOF
+  )
+  else
+    creds=$(cat <<EOF
+  preset-azure-cred-only: "true"
+  preset-azure-capz-sa-cred: "true"
+EOF
+  )
+  fi
+  cat << EOF | pr -to $indent
+labels:
+  preset-dind-enabled: "true"
+  preset-kind-volume-mounts: "true"
+  preset-azure-anonymous-pull: "true"
+${creds}
+EOF
+}
+
 # we need to define the full image URL so it can be autobumped
 tmp="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master"
 kubekins_e2e_image="${tmp/\-master/}"
@@ -73,12 +97,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     branches:
       - ${branch}
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 4 ${capz_release})
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
@@ -123,12 +142,7 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-d
     path_alias: k8s.io/kubernetes
     branches:
       - ${branch}
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 4 ${capz_release})
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
@@ -175,12 +189,7 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-d
     path_alias: k8s.io/kubernetes
     branches:
       - ${branch}
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 4 ${capz_release})
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
@@ -226,12 +235,7 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-f
     path_alias: k8s.io/kubernetes
     branches:
       - ${branch}
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 4 ${capz_release})
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
@@ -279,12 +283,7 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-f
     path_alias: k8s.io/kubernetes
     branches:
       - ${branch}
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 4 ${capz_release})
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -319,12 +318,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -366,12 +360,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -415,12 +404,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -464,12 +448,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -523,12 +502,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -584,12 +558,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -642,12 +611,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_periodic_branch_name})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -705,12 +669,7 @@ EOF
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_release})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -752,12 +711,7 @@ EOF
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_release})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -811,12 +765,7 @@ EOF
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_release})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -872,12 +821,7 @@ EOF
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_release})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -930,12 +874,7 @@ EOF
   decorate: true
   decoration_config:
     timeout: 3h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+$(generate_preset_labels 2 ${capz_release})
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
@@ -12,8 +12,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -62,8 +62,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -114,8 +114,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -165,8 +165,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -218,8 +218,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -258,8 +258,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -305,8 +305,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -354,8 +354,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -403,8 +403,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -462,8 +462,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -523,8 +523,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -581,8 +581,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
@@ -12,8 +12,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -62,8 +62,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -114,8 +114,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -165,8 +165,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -218,8 +218,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -258,8 +258,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -305,8 +305,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -354,8 +354,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -403,8 +403,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -462,8 +462,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -523,8 +523,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -581,8 +581,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
@@ -12,8 +12,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -62,8 +62,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -114,8 +114,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -165,8 +165,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -218,8 +218,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -258,8 +258,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -305,8 +305,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -354,8 +354,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -403,8 +403,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -462,8 +462,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -523,8 +523,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -581,8 +581,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -13,8 +13,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -68,8 +68,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -125,8 +125,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -181,8 +181,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -239,8 +239,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
+      preset-azure-cred-only: "true"
       preset-azure-capz-sa-cred: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -283,9 +283,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -330,9 +329,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -379,9 +377,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -428,9 +425,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -487,9 +483,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -548,9 +543,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -606,9 +600,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
+    preset-azure-capz-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -666,8 +659,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -713,8 +706,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -772,8 +765,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -833,8 +826,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -891,8 +884,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
     preset-azure-anonymous-pull: "true"
+    preset-azure-cred-only: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
   - org: kubernetes-sigs


### PR DESCRIPTION
As of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4978, Using the main branch of CAPZ now requires the new secret-less `preset-azure-cred-wi` preset.

cc @nawazkh @jackfrancis

/assign @andyzhangx 