### PR TITLE
Kops - fix digitalocean S3 endpoint for aws-sdk-go-v2

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -65,7 +65,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=digitalocean \
-          --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+          --env S3_ENDPOINT=https://sfo3.digitaloceanspaces.com \
           --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3 --dns=private" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -121,7 +121,7 @@ periodics:
         -v 2 \
         --up --down \
         --cloud-provider=digitalocean \
-        --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+        --env S3_ENDPOINT=https://sfo3.digitaloceanspaces.com \
         --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3 --dns=none" \
         --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
         --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -177,7 +177,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=digitalocean \
-          --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+          --env S3_ENDPOINT=https://sfo3.digitaloceanspaces.com \
           --create-args "--networking=calico --node-count=3 --master-count=3" \
           --cluster-name=e2e-b284d3e83b-4c997.test-cncf-do.k8s.io \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=digitalocean \
             --cluster-name=e2e-test-do.k8s.local \
-            --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+            --env S3_ENDPOINT=https://sfo3.digitaloceanspaces.com \
             --env JOB_NAME=pull-kops-e2e-kubernetes-do-gossip \
             --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3 --dns=private" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -138,7 +138,7 @@ presubmits:
           --up --build --down \
           --cloud-provider=digitalocean \
           --cluster-name=e2e-test-do.k8s.local \
-          --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+          --env S3_ENDPOINT=https://sfo3.digitaloceanspaces.com \
           --env JOB_NAME=pull-kops-e2e-kubernetes-do-gossip \
           --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3 --dns=none" \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -190,7 +190,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=digitalocean \
             --cluster-name=e2e-b284d3e83b-4c77c.test-cncf-do.k8s.io \
-            --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+            --env S3_ENDPOINT=https://sfo3.digitaloceanspaces.com \
             --env JOB_NAME=pull-kops-e2e-kubernetes-do-fqdn \
             --create-args "--networking=calico --node-count=2" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \


### PR DESCRIPTION
The Kops DigitalOcean jobs are currently failing:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-do-calico-gossip/1812591510407876608

`Error: error reading cluster configuration "e2e-e2e-kops-do-calico-gossip.k8s.local": error reading do://e2e-kops-space/e2e-e2e-kops-do-calico-gossip.k8s.local/config: error fetching do://e2e-kops-space/e2e-e2e-kops-do-calico-gossip.k8s.local/config: operation error S3: GetObject, resolve auth scheme: resolve endpoint: endpoint rule error, Custom endpoint `sfo3.digitaloceanspaces.com` was not a valid URI`

The aws-sdk-go-v2 now expects endpoints to include the protocol: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/#with-baseendpoint

This adds the protocol to DigitalOcean's S3-compatible endpoints.