### PR TITLE
Increasing memory for GCE PD driver E2E tests

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -23,10 +23,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: "6Gi"
+            memory: "8Gi"
           requests:
             cpu: 2
-            memory: "6Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e


### PR DESCRIPTION
GCE PD driver [PR#1771](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1771) adds some additional dependencies to the docker file which is causing E2E tests to fail due to OOM. The current Memory limit is 6Gi, this PR updates the limit to 8Gi.

Memory limit reached for E2E test: 
![image](https://github.com/user-attachments/assets/c33c84a2-a6f3-4c69-a17a-1c91a9b7323c)

Failed test run : [link](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_gcp-compute-persistent-disk-csi-driver/1771/pull-gcp-compute-persistent-disk-csi-driver-e2e/1812987095782789120)
