### PR TITLE
CAPI/CAPV: Set prow job timeouts explicitly

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-28-1-29-main
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -49,6 +51,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-29-1-30-main
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -94,6 +98,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-30-1-31-main
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -139,6 +145,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-28-1-29-main
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -184,6 +192,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-29-1-30-main
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -229,6 +239,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-30-1-31-main
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -133,6 +135,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -175,6 +179,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -310,6 +316,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -352,6 +360,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -391,6 +401,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -446,6 +458,8 @@ periodics:
     preset-cluster-api-provider-vsphere-janitor-config: "true"
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-main-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -38,6 +40,8 @@ presubmits:
       preset-dind-enabled: "true"
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -69,6 +73,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -101,6 +107,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -210,6 +218,8 @@ presubmits:
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -251,6 +261,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -286,6 +298,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -323,6 +337,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -434,6 +450,8 @@ presubmits:
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -475,6 +493,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -510,6 +530,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -543,6 +565,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 1
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-28-1-29-release-1-10
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -49,6 +51,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-29-1-30-release-1-10
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -94,6 +98,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-28-1-29-release-1-10
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -139,6 +145,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-supervisor-upgrade-1-29-1-30-release-1-10
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -133,6 +135,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -175,6 +179,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -310,6 +316,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -352,6 +360,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 3 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-10-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -38,6 +40,8 @@ presubmits:
       preset-dind-enabled: "true"
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -69,6 +73,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -101,6 +107,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -210,6 +218,8 @@ presubmits:
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -251,6 +261,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -286,6 +298,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -323,6 +337,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -434,6 +450,8 @@ presubmits:
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -475,6 +493,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -510,6 +530,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -42,6 +44,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -129,6 +133,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-7-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -38,6 +40,8 @@ presubmits:
       preset-dind-enabled: "true"
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -69,6 +73,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -101,6 +107,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -138,6 +146,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -210,6 +220,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -42,6 +44,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -129,6 +133,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-8-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -38,6 +40,8 @@ presubmits:
       preset-dind-enabled: "true"
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -69,6 +73,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -101,6 +107,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -138,6 +146,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -210,6 +220,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-28-1-29-release-1-9
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -49,6 +51,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-govmomi-upgrade-1-29-1-30-release-1-9
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -42,6 +44,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -129,6 +133,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -171,6 +177,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: '0 0 * * *'
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-release-1-9-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -38,6 +40,8 @@ presubmits:
       preset-dind-enabled: "true"
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -69,6 +73,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -101,6 +107,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -138,6 +146,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -207,6 +217,8 @@ presubmits:
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -248,6 +260,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -283,6 +297,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-upgrades.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics-upgrades.yaml.tpl
@@ -17,6 +17,8 @@ periodics:
 - name: periodic-cluster-api-provider-vsphere-e2e-{{ $mode }}-upgrade-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.From "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll (TrimPrefix (TrimPrefix $upgrade.To "stable-") "ci/latest-") "." "-" }}-{{ ReplaceAll $.branch "." "-" }}
   cron: {{ $cron }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-periodics.yaml.tpl
@@ -3,6 +3,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -42,6 +44,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -202,6 +206,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: {{ $cron }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -253,6 +259,8 @@ periodics:
     preset-kind-volume-mounts: "true"
   cron: {{ $cron }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -294,6 +302,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -349,6 +359,8 @@ periodics:
     preset-cluster-api-provider-vsphere-janitor-config: "true"
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/templates/cluster-api-provider-vsphere-presubmits.yaml.tpl
@@ -9,6 +9,8 @@ presubmits:
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -37,6 +39,8 @@ presubmits:
       preset-dind-enabled: "true"
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -68,6 +72,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -101,6 +107,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -146,6 +154,8 @@ presubmits:
     # Run if go files, scripts or configuration changed (we use the same for all jobs for simplicity).
     run_if_changed: '^((apis|config|controllers|feature|hack|packaging|pkg|test|webhooks)/|Dockerfile|go\.mod|go\.sum|main\.go|Makefile)'
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -275,6 +285,8 @@ presubmits:
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -320,6 +332,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -364,6 +378,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
     spec:
@@ -399,6 +415,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 1
     spec:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -59,6 +61,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -114,6 +118,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -169,6 +175,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -224,6 +232,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -279,6 +289,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 2h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -35,6 +37,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 2h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -76,6 +80,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 2h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -123,6 +129,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 2h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -179,6 +187,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 2h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -223,6 +233,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 2h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
   - name: pull-cluster-api-build-main
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -28,6 +30,8 @@ presubmits:
   - name: pull-cluster-api-apidiff-main
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -53,6 +57,8 @@ presubmits:
   - name: pull-cluster-api-verify-main
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -81,6 +87,8 @@ presubmits:
   - name: pull-cluster-api-test-main
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     branches:
     # The script this job runs is not in all branches.
@@ -105,6 +113,8 @@ presubmits:
   - name: pull-cluster-api-test-mink8s-main
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -147,6 +157,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -196,6 +208,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     branches:
     # The script this job runs is not in all branches.
     - ^main$
@@ -234,6 +248,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -270,6 +286,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -324,6 +342,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -362,6 +382,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -59,6 +61,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -114,6 +118,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -169,6 +175,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -224,6 +232,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -279,6 +289,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -35,6 +37,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -76,6 +80,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -123,6 +129,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-5-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
   - name: pull-cluster-api-build-release-1-5
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -28,6 +30,8 @@ presubmits:
   - name: pull-cluster-api-apidiff-release-1-5
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -53,6 +57,8 @@ presubmits:
   - name: pull-cluster-api-verify-release-1-5
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -81,6 +87,8 @@ presubmits:
   - name: pull-cluster-api-test-release-1-5
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     branches:
     # The script this job runs is not in all branches.
@@ -105,6 +113,8 @@ presubmits:
   - name: pull-cluster-api-test-mink8s-release-1-5
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -147,6 +157,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -196,6 +208,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.5$
@@ -234,6 +248,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     optional: true
     branches:
       # The script this job runs is not in all branches.
@@ -273,6 +289,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -309,6 +327,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -59,6 +61,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -114,6 +118,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -169,6 +175,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -224,6 +232,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -279,6 +289,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -35,6 +37,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -76,6 +80,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -123,6 +129,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-6-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
   - name: pull-cluster-api-build-release-1-6
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -28,6 +30,8 @@ presubmits:
   - name: pull-cluster-api-apidiff-release-1-6
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -53,6 +57,8 @@ presubmits:
   - name: pull-cluster-api-verify-release-1-6
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -81,6 +87,8 @@ presubmits:
   - name: pull-cluster-api-test-release-1-6
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     branches:
     # The script this job runs is not in all branches.
@@ -105,6 +113,8 @@ presubmits:
   - name: pull-cluster-api-test-mink8s-release-1-6
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -147,6 +157,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -196,6 +208,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.6$
@@ -234,6 +248,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -270,6 +286,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics-upgrades.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -59,6 +61,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -114,6 +118,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -169,6 +175,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -224,6 +232,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -279,6 +289,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -35,6 +37,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -76,6 +80,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -123,6 +129,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -179,6 +187,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -223,6 +233,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 4h
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
   - name: pull-cluster-api-build-release-1-7
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -28,6 +30,8 @@ presubmits:
   - name: pull-cluster-api-apidiff-release-1-7
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -53,6 +57,8 @@ presubmits:
   - name: pull-cluster-api-verify-release-1-7
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -81,6 +87,8 @@ presubmits:
   - name: pull-cluster-api-test-release-1-7
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     branches:
     # The script this job runs is not in all branches.
@@ -105,6 +113,8 @@ presubmits:
   - name: pull-cluster-api-test-mink8s-release-1-7
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -147,6 +157,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -196,6 +208,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     branches:
     # The script this job runs is not in all branches.
     - ^release-1.7$
@@ -234,6 +248,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -270,6 +286,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -324,6 +342,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -362,6 +382,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl
@@ -4,6 +4,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.UpgradesInterval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -3,6 +3,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -34,6 +36,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -75,6 +79,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -122,6 +128,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -178,6 +186,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs
@@ -222,6 +232,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
   decorate: true
+  decoration_config:
+    timeout: 120m
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -3,6 +3,8 @@ presubmits:
   - name: pull-cluster-api-build-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     branches:
@@ -27,6 +29,8 @@ presubmits:
   - name: pull-cluster-api-apidiff-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     branches:
@@ -52,6 +56,8 @@ presubmits:
   - name: pull-cluster-api-verify-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
@@ -80,6 +86,8 @@ presubmits:
   - name: pull-cluster-api-test-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     branches:
     # The script this job runs is not in all branches.
@@ -104,6 +112,8 @@ presubmits:
   - name: pull-cluster-api-test-mink8s-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -146,6 +156,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     path_alias: sigs.k8s.io/cluster-api
     always_run: false
     branches:
@@ -195,6 +207,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     branches:
     # The script this job runs is not in all branches.
     - ^{{ $.branch }}$
@@ -234,6 +248,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     optional: true
     branches:
       # The script this job runs is not in all branches.
@@ -274,6 +290,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -310,6 +328,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -364,6 +384,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.
@@ -402,6 +424,8 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     decorate: true
+    decoration_config:
+      timeout: 120m
     always_run: false
     branches:
     # The script this job runs is not in all branches.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Just to make it obvious that all of these jobs have timeouts (currently Prow is defaulting them internally)