### PR TITLE
Add skip plugin to containerd/containerd

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1614,6 +1614,7 @@ plugins:
     - label   # Allow people to label issues and PRs
     - mergecommitblocker # Mark PRs with merge commits
     - size    # Mark size of PRs
+    - skip    # Skip non-essential prow CI jobs
     - wip     # Mark draft PRs
 
   kubernetes-sigs/secrets-store-csi-driver:


### PR DESCRIPTION
`/skip` allows marking broken/non-required prow CI jobs to be skipped.