### PR TITLE
secrets-store: move manifest test job to eks prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -213,7 +213,8 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-azure
       description: "Run e2e test with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-deploy-manifest-azure
+  - name: pull-secrets-store-csi-driver-e2e-deploy-manifest-e2e-provider
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 25m
@@ -227,8 +228,6 @@ presubmits:
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
       preset-kind-volume-mounts: "true"
-      # sets up the azure keyvault parameters used for testing
-      preset-azure-secrets-store-creds: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
@@ -238,17 +237,20 @@ presubmits:
           - bash
           - -c
           - >-
-            IS_YAML_TEST=true make e2e-bootstrap e2e-deploy-manifest e2e-azure
+            IS_YAML_TEST=true ./test/scripts/e2e_provider.sh
         securityContext:
           privileged: true
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-deploy-manifest-azure
-      description: "Run e2e test using deploy manifest with azure provider for Secrets Store CSI driver."
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-deploy-manifest-e2e-provider
+      description: "Run e2e test using deploy manifest with e2e-provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-gcp
     decorate: true


### PR DESCRIPTION
- Move manifest test job to eks prow cluster

The driver changes are here: https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/1573. 