### PR TITLE
secrets-store: move upgrade jobs to eks prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -1041,7 +1041,8 @@ periodics:
     description: "Run vulnerability scans for Secrets Store CSI driver images."
     testgrid-num-columns-recent: '30'
 - interval: 12h
-  name: periodic-secrets-store-csi-driver-upgrade-test-azure
+  name: periodic-secrets-store-csi-driver-upgrade-test-e2e-provider
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 30m
@@ -1050,8 +1051,6 @@ periodics:
     preset-dind-enabled: "true"
     # this is required to make CNI installation to succeed for kind
     preset-kind-volume-mounts: "true"
-    # sets up the azure keyvault parameters used for testing
-    preset-azure-secrets-store-creds: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
@@ -1066,15 +1065,22 @@ periodics:
           - bash
           - -c
           - >-
-            make e2e-bootstrap e2e-helm-deploy-release e2e-azure && make e2e-helm-upgrade e2e-azure
+            make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy e2e-provider && make e2e-helm-upgrade e2e-provider
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
-    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-e2e-provider
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
-    description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
+    description: "Run driver upgrade test with e2e-provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'
 - interval: 12h
   name: periodic-secrets-store-csi-driver-inplace-upgrade-test-e2e-provider

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.3-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.3-config.yaml
@@ -18,7 +18,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.26
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
           - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.3-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.3-config.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 12h
-  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-3
+  name: periodic-secrets-store-csi-driver-upgrade-test-e2e-provider-release-1-3
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 30m
@@ -9,8 +10,6 @@ periodics:
     preset-dind-enabled: "true"
     # this is required to make CNI installation to succeed for kind
     preset-kind-volume-mounts: "true"
-    # sets up the azure keyvault parameters used for testing
-    preset-azure-secrets-store-creds: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
@@ -25,13 +24,20 @@ periodics:
           - bash
           - -c
           - >-
-            make e2e-bootstrap e2e-helm-deploy-release e2e-azure && make e2e-helm-upgrade e2e-azure
+            make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy e2e-provider && make e2e-helm-upgrade e2e-provider
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
-    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-3
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-e2e-provider-release-1-3
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
-    description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
+    description: "Run driver upgrade test with e2e-provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.4-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.4-config.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 12h
-  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-4
+  name: periodic-secrets-store-csi-driver-upgrade-test-e2e-provider-release-1-4
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 30m
@@ -9,8 +10,6 @@ periodics:
     preset-dind-enabled: "true"
     # this is required to make CNI installation to succeed for kind
     preset-kind-volume-mounts: "true"
-    # sets up the azure keyvault parameters used for testing
-    preset-azure-secrets-store-creds: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
@@ -25,13 +24,20 @@ periodics:
           - bash
           - -c
           - >-
-            make e2e-bootstrap e2e-helm-deploy-release e2e-azure && make e2e-helm-upgrade e2e-azure
+            make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy e2e-provider && make e2e-helm-upgrade e2e-provider
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
-    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-4
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-e2e-provider-release-1-4
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
-    description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
+    description: "Run driver upgrade test with e2e-provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.4-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.4-config.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 12h
-  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-2
+  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-4
   decorate: true
   decoration_config:
     timeout: 30m
@@ -14,11 +14,11 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
-    base_ref: release-1.2
+    base_ref: release-1.4
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
           - runner.sh
         args:
@@ -31,7 +31,7 @@ periodics:
           privileged: true
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
-    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-2
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-4
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
     description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'


### PR DESCRIPTION
- Remove jobs for release 1.2
- Move all the upgrade jobs to use e2e-provider
- Move upgrade jobs to eks prow cluster

part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1273