### PR TITLE
fix typo in CAPZ workload ID config

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -42,7 +42,7 @@ generate_preset_labels() {
   capz_ref="${2}"
   if [[ "${capz_ref}" == "main" ]]; then
     creds=$(cat <<EOF
-  preset-azure-capz-cred-wi: "true"
+  preset-azure-cred-wi: "true"
 EOF
   )
   else

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -284,7 +284,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -330,7 +330,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -378,7 +378,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -426,7 +426,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -484,7 +484,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -544,7 +544,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -601,7 +601,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-anonymous-pull: "true"
-    preset-azure-capz-cred-wi: "true"
+    preset-azure-cred-wi: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
I made a mistake in #32987 using the wrong string for the workload identity preset name for the cloud-provider jobs. This change uses the correct name as added in #32837.