### PR TITLE
Add ssh and dind setup to pull-kubernetes-e2e-aws-storage-selinux

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -245,6 +245,7 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
+      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 150m


### PR DESCRIPTION
Another experiment to make pull-kubernetes-e2e-aws-storage-selinux working (it [fails](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/126131/pull-kubernetes-e2e-aws-storage-selinux/1813495518895017984) currently).

pull-kubernetes-e2e-gce-canary has this setting and it [works](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-canary/1813469086990995456), so try to add it to pull-kubernetes-e2e-aws-storage-selinux.