### PR TITLE
Add CAPZ v1.17 milestone to plugins

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -507,9 +507,9 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.15
-    release-1.14: v1.14
-    release-1.13: v1.13
+    main: v1.17
+    release-1.16: v1.16
+    release-1.15: v1.15
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0


### PR DESCRIPTION
Updates the current milestone and supported branches for CAPZ.

I think we forgot to do this with the last release, hence bumping two revisions. Please let me know if I'm mistaken.