### PR TITLE
Add a canary TestGrid upload job.

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -26,6 +26,41 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: Updates the html contents for go.k8s.io/triage.
+  # TODO: Remove 'canary-' once `post-test-infra-upload-testgrid-config` job is removed.
+  - name: post-test-infra-upload-testgrid-config-canary
+    cluster: k8s-infra-prow-build-trusted
+    branches:
+    - ^master$
+    max_concurrency: 1
+    run_if_changed: '^config/(jobs|testgrids)/.*$'
+    decorate: true
+    spec:
+      serviceAccountName: k8s-testgrid-config-updater
+      containers:
+      # TODO: Switch this to use the k8s-staging-infra-tools/k8s-infra image instead.
+      - image: gcr.io/k8s-prow/configurator:v20240513-a9bd71bf01
+        command:
+        - configurator
+        args:
+        - --yaml=config/testgrids
+        - --default=config/testgrids/default.yaml
+        - --prow-config=config/prow/config.yaml
+        - --prow-job-config=config/jobs/
+        - --output=gs://k8s-testgrid-config/k8s/config
+        - --prowjob-url-prefix=https://git.k8s.io/test-infra/config/jobs/
+        - --update-description
+        - --oneshot
+        - --world-readable
+        resources:
+          requests:
+            memory: "1Gi"
+    annotations:
+      testgrid-dashboards: sig-testing-maintenance, sig-k8s-infra-prow
+      testgrid-tab-name: testgrid-config-update-canary
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: Compiles and updates testgrid config on test-infra pushes
+
 
 periodics:
 - name: metrics-bigquery


### PR DESCRIPTION
Part of job migration in #32432. Create a duplicate job that uses a new bucket in community-owned infra.

After we verify this successfully uploads, need to switch the TestGrid Config Merger to use the new uploaded config, then turn down the old job.

/hold

Blocked on ensuring the new bucket + service account are added to the relevant projects.