### PR TITLE
Bump golang from 1.22.2 to 1.22.3 on apiserver-network-proxy test runner

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.2
+      - image: public.ecr.aws/docker/library/golang:1.22.3
         command:
         - make
         args:


### PR DESCRIPTION
Needed in order to merge https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/639