### PR TITLE
Update image-builder jobs to use new Azure creds preset

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -1,10 +1,10 @@
 presubmits:
   kubernetes-sigs/image-builder:
-  - name: pull-azure-vhds-wi
+  - name: pull-azure-vhds
     labels:
       preset-azure-cred-wi: "true"
     decorate: true
-    always_run: false
+    run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/(config|goss|azure)/.*|images/capi/hack/ensure-(ansible|packer|jq|azure-cli|goss).*'
     decoration_config:
       timeout: 1h
     max_concurrency: 5
@@ -21,31 +21,10 @@ presubmits:
             cpu: 1000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
-      testgrid-tab-name: pr-azure-vhds-wi
-  - name: pull-azure-vhds
-    labels:
-      preset-azure-cred: "true"
-    decorate: true
-    run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/(config|goss|azure)/.*|images/capi/hack/ensure-(ansible|packer|jq|azure-cli|goss).*'
-    decoration_config:
-      timeout: 1h
-    max_concurrency: 5
-    path_alias: sigs.k8s.io/image-builder
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
-        args:
-          - runner.sh
-          - "./images/capi/scripts/ci-azure-e2e.sh"
-        resources:
-          requests:
-            cpu: 1000m
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-azure-vhds
   - name: pull-azure-sigs
     labels:
-      preset-azure-cred: "true"
+      preset-azure-cred-wi: "true"
     decorate: true
     run_if_changed: 'images/capi/Makefile|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/azure/.*'
     optional: true
@@ -54,6 +33,7 @@ presubmits:
     max_concurrency: 5
     path_alias: sigs.k8s.io/image-builder
     spec:
+      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         args:


### PR DESCRIPTION
Follows up on successful testing of #32986 by deleting the temporary test job and moving those credentials to the main Azure jobs, in preparation for switching to community infrastructure for image-builder e2e.