### PR TITLE
bump pull-kubernetes-e2e-gce-device resources to match pull-kubernetes-e2e-gce

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -59,10 +59,10 @@ presubmits:
         - --timeout=60m
         resources:
           limits:
-            cpu: 2
-            memory: "6Gi"
+            cpu: 4
+            memory: "14Gi"
           requests:
-            cpu: 2
-            memory: "6Gi"
+            cpu: 4
+            memory: "14Gi"
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -927,11 +927,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "2"
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
           requests:
-            cpu: "2"
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1087,11 +1087,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "2"
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
           requests:
-            cpu: "2"
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -1194,11 +1194,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "2"
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
           requests:
-            cpu: "2"
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
         securityContext:
           privileged: true
   - always_run: false


### PR DESCRIPTION
Currently it is WAY too slow waiting on the builds to debug this job iteratively.

xref https://github.com/kubernetes/kubernetes/issues/124950
