### PR TITLE
move npd to k8s-infra-prow-builds

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -97,7 +97,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-node
     # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -152,7 +152,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci
     # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -197,7 +197,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
     # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -282,7 +282,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
     # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -329,7 +329,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
     # TODO(kubernetes/kubernetes#119211): switch to k8s-infra-prow-build once it has been properly configured
-    cluster: default
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true


### PR DESCRIPTION
goes with https://github.com/kubernetes/node-problem-detector/pull/928

needs to go in first, but the other one needs to go in right after.