### PR TITLE
remove explicit default from CAPZ cloud provider azure jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -65,13 +65,10 @@ generate_serviceaccount_name() {
   indent=${1}
   capz_ref="${2}"
   if [[ "${capz_ref}" == "main" ]]; then
-    serviceaccount="prowjob-default-sa"
-  else
-    serviceaccount="default"
-  fi
-  cat << EOF | pr -to $indent
-serviceAccountName: ${serviceaccount}
+    cat << EOF | pr -to $indent
+serviceAccountName: prowjob-default-sa
 EOF
+  fi
 }
 
 # we need to define the full image URL so it can be autobumped

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.26.yaml
@@ -30,7 +30,7 @@ presubmits:
         base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -81,7 +81,7 @@ presubmits:
         base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -134,7 +134,7 @@ presubmits:
         base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -186,7 +186,7 @@ presubmits:
         base_ref: release-1.26
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -236,7 +236,7 @@ presubmits:
       base_ref: release-1.26
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -278,7 +278,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -326,7 +326,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -376,7 +376,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -433,7 +433,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -493,7 +493,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -555,7 +555,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -614,7 +614,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.27.yaml
@@ -30,7 +30,7 @@ presubmits:
         base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -81,7 +81,7 @@ presubmits:
         base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -134,7 +134,7 @@ presubmits:
         base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -186,7 +186,7 @@ presubmits:
         base_ref: release-1.27
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -236,7 +236,7 @@ presubmits:
       base_ref: release-1.27
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -278,7 +278,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -326,7 +326,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -376,7 +376,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -433,7 +433,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -493,7 +493,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -555,7 +555,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -614,7 +614,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.28.yaml
@@ -30,7 +30,7 @@ presubmits:
         base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -81,7 +81,7 @@ presubmits:
         base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -134,7 +134,7 @@ presubmits:
         base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -186,7 +186,7 @@ presubmits:
         base_ref: release-1.28
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -236,7 +236,7 @@ presubmits:
       base_ref: release-1.28
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -278,7 +278,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -326,7 +326,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -376,7 +376,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -433,7 +433,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -493,7 +493,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -555,7 +555,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -614,7 +614,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -31,7 +31,7 @@ presubmits:
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -87,7 +87,7 @@ presubmits:
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -145,7 +145,7 @@ presubmits:
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -202,7 +202,7 @@ presubmits:
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -257,7 +257,7 @@ presubmits:
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: default
+
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -686,7 +686,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -741,7 +741,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -801,7 +801,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -863,7 +863,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:
@@ -922,7 +922,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: default
+
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
       command:


### PR DESCRIPTION
Removing the explicit `serviceAccountName: default` should ensure that tests run in a context where the default namespace is `default` instead of `test-pods` which leads to errors like this: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/124439/pull-kubernetes-e2e-capz-azure-disk/1813801405987688448