### PR TITLE
jobs/sig-windows: Use UserNamespacesSupport feature to skip ProcMount option

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -60,6 +60,9 @@ presubmits:
           requests:
             cpu: 2
             memory: "9Gi"
+        env:
+          - name: API_SERVER_FEATURE_GATES
+            value: "UserNamespacesSupport=true"
     annotations:
       fork-per-release: "true"
       fork-per-release-replacements: "KUBERNETES_VERSION=latest -> KUBERNETES_VERSION=latest-{{.Version}}"


### PR DESCRIPTION
related to https://github.com/kubernetes/kubernetes/issues/126180

Kubernetes API server strips the `hostUsers` field when the `UsernamespacesSupport` feature-gate isn't enabled. Due to which the `hostUsers` field is not present during validation, causing the test to fail. https://github.com/kubernetes/kubernetes/blob/d0545c8eb4ca5e8bb7704b5f51197b5082964e85/pkg/api/pod/util.go#L650-L655

I think this change + https://github.com/kubernetes/kubernetes/pull/126182 should address https://github.com/kubernetes/kubernetes/issues/126180

/sig-windows