### PR TITLE
Remove branch protection for gh-pages in secrets-store-sync-controller

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -628,6 +628,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        secrets-store-sync-controller:
+          branches:
+            gh-pages:
+              protect: false
         security-profiles-operator:
           enforce_admins: true
           required_linear_history: true


### PR DESCRIPTION
The `gh-pages` branch will be used for hosting helm charts. The github action's user can't sign CLA. So, removing the branch protection for that branch.

The `gh-pages` branch will only be used for hosting helm charts.

fixes https://github.com/kubernetes-sigs/secrets-store-sync-controller/issues/29