### PR TITLE
migrate capz presubmit main jobs to eks community infra

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -69,6 +69,7 @@ presubmits:
       testgrid-tab-name: capz-pr-build-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -77,12 +78,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -94,6 +93,13 @@ presubmits:
             value: \[REQUIRED\]
           - name: GINKGO_SKIP
             value: ""
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -102,6 +108,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-optional
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -112,12 +119,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -129,6 +134,13 @@ presubmits:
             value: \[OPTIONAL\]
           - name: GINKGO_SKIP
             value: ""
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -137,6 +149,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-optional-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-aks
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -147,12 +160,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -164,6 +175,13 @@ presubmits:
             value: \[Managed Kubernetes\]
           - name: GINKGO_SKIP
             value: ""
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -172,6 +190,7 @@ presubmits:
       testgrid-tab-name: capz-pr-e2e-aks-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     run_if_changed: 'test\/e2e\/capi_test.go|scripts\/ci-e2e.sh|^go.mod'
@@ -183,12 +202,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -200,6 +217,13 @@ presubmits:
             value: "Cluster API E2E tests"
           - name: GINKGO_SKIP
             value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -239,6 +263,7 @@ presubmits:
       testgrid-tab-name: capz-pr-verify-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-conformance
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -250,11 +275,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -265,14 +289,18 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            cpu: 2
-            memory: "9Gi"
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-conformance-with-ci-artifacts
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -284,8 +312,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -294,7 +321,6 @@ presubmits:
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -307,13 +333,17 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-k8s-ci-main
   - name: pull-cluster-api-provider-azure-conformance-ipv6-with-ci-artifacts
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -325,8 +355,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -335,7 +364,6 @@ presubmits:
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -350,13 +378,17 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-ipv6-k8s-ci-main
   - name: pull-cluster-api-provider-azure-conformance-dual-stack-with-ci-artifacts
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -368,8 +400,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -378,7 +409,6 @@ presubmits:
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -393,13 +423,17 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-dual-stack-k8s-ci-main
   - name: pull-cluster-api-provider-azure-windows-with-ci-artifacts
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -411,8 +445,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -421,7 +454,6 @@ presubmits:
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -443,13 +475,17 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-upstream-k8s-ci-windows-containerd-main
   - name: pull-cluster-api-provider-azure-windows-containerd-upstream-with-ci-artifacts-serial-slow
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -460,8 +496,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -470,7 +505,6 @@ presubmits:
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -495,9 +529,12 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-upstream-k8s-ci-windows-containerd-serial-slow-main
@@ -527,11 +564,11 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main
   - name: pull-cluster-api-provider-azure-e2e-workload-upgrade
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     decorate: true
     optional: true
     always_run: false
@@ -546,7 +583,6 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         args:
@@ -559,17 +595,21 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
           requests:
-            cpu: 7300m
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-upgrade
   - name: pull-cluster-api-provider-azure-apiversion-upgrade
+    cluster: eks-prow-build-cluster
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     decorate: true
     run_if_changed: '^test\/e2e\/(config\/azure-dev\.yaml)|(data\/shared\/v1beta1_provider\/metadata\.yaml)$'
     optional: false
@@ -583,7 +623,6 @@ presubmits:
         base_ref: master
         path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           args:
@@ -598,13 +637,18 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
             requests:
-              cpu: 7300m
+              cpu: 2
+              memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apiversion-upgrade-main
       description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
   - name: pull-cluster-api-provider-azure-ci-entrypoint
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
@@ -613,12 +657,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
         command:
@@ -633,12 +675,20 @@ presubmits:
             value: "true"
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-ci-entrypoint-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
       description: Creates a CAPZ cluster and exports KUBECONFIG. This job validates ci-entrypoint.sh used by other repositories for running tests on CAPZ clusters.
   - name: pull-cluster-api-provider-azure-conformance-custom-builds
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -650,8 +700,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -664,7 +713,6 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -677,13 +725,17 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-custom-k8s-main
   - name: pull-cluster-api-provider-azure-windows-custom-builds
+    cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -695,8 +747,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     branches:
     - ^main$
     extra_refs:
@@ -709,7 +760,6 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-1.29
           command:
@@ -729,9 +779,12 @@ presubmits:
           securityContext:
             privileged: true
           resources:
+            limits:
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: "9Gi"
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-windows-containerd-upstream-custom-k8s-main


### PR DESCRIPTION
This PR migrates CAPZ's presubmit main jobs to use "eks community infra"