### PR TITLE
capz: final periodic job migrations to community infra

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -97,13 +97,13 @@ periodics:
     testgrid-tab-name: capi-periodic-upgrade-main-1-27-1-28
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-28-1-29-main
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-community: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -83,6 +83,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests on latest kubernetes master with cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-capi-e2e-main
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -90,8 +91,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-cred-wi: "true"
+    preset-azure-community: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -113,11 +113,19 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-capi-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-apiversion-upgrade-main
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -125,8 +133,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-cred-wi: "true"
+    preset-azure-community: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -150,7 +157,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 7300m
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-apiversion-upgrade-main
@@ -197,6 +208,7 @@ periodics:
       securityContext:
         privileged: true
 - name: periodic-cluster-api-provider-azure-e2e-main
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -204,8 +216,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-cred-wi: "true"
+    preset-azure-community: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -227,6 +238,13 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+          requests:
+            cpu: 6
+            memory: "9Gi"
+          limits:
+            cpu: 6
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-main


### PR DESCRIPTION
This PR moves the final remaining periodic CAPZ jobs that haven't been migrated to k8s community infra.