### PR TITLE
Switch some builds to k8s-staging-test-infra images.

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,13 +1,13 @@
 # Distroless images:
 # defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
-  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  k8s.io/test-infra/label_sync: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  k8s.io/test-infra/robots/commenter: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  k8s.io/test-infra/gencred: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
+  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
+  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
+  k8s.io/test-infra/label_sync: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
+  k8s.io/test-infra/robots/commenter: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
+  k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-staging-test-infra/git:v20240716-28236d8b05
+  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
+  k8s.io/test-infra/gencred: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
 
 # https://pkg.go.dev/cmd/link
 # -s: omit symbol/debug info

--- a/config/jobs/image-pushing/README.md
+++ b/config/jobs/image-pushing/README.md
@@ -78,7 +78,7 @@ images:
 ### Makefile build example
 
 If your build process is driven by a Makefile or similar, you can use GCB to
-invoke that. We provide the [`gcr.io/k8s-testimages/gcb-docker-gcloud` image][gcb-docker-gcloud],
+invoke that. We provide the [`gcr.io/k8s-staging-test-infra/gcb-docker-gcloud` image][gcb-docker-gcloud],
 which contains components that are likely to be useful for your builds. A sample
 `cloudbuild.yaml` using `make` to build and push might look like this:
 
@@ -92,7 +92,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20190906-745fed4'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/images/alpine/cloudbuild.yaml
+++ b/images/alpine/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: /buildx-entrypoint
     args:
     - build
@@ -9,7 +9,7 @@ steps:
     - --push
     - .
     dir: .
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: gcloud
     args:
     - container

--- a/images/git-custom-k8s-auth/cloudbuild.yaml
+++ b/images/git-custom-k8s-auth/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: /buildx-entrypoint
     args:
       - build
@@ -11,7 +11,7 @@ steps:
       - --push
       - .
     dir: .
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: gcloud
     args:
       - container

--- a/images/git/README.md
+++ b/images/git/README.md
@@ -5,7 +5,7 @@ Use this image when you want to use `git` and `alpine` as a base in a job.
 ## contents
 
 - base:
-  - `gcr.io/k8s-prow/alpine:v20240108-a28886d2bd`
+  - `alpine`
 - directories:
   - `/github_known_hosts` holds the [`github-known-hosts`](/images/git/github-known-hosts) file copied during image build
   - `/etc/ssh/ssh_config` contains [`ssh-config`](/images/git/ssh-config) file copied during image build

--- a/images/git/cloudbuild.yaml
+++ b/images/git/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: /buildx-entrypoint
     args:
     - build
@@ -9,7 +9,7 @@ steps:
     - --push
     - .
     dir: .
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: gcloud
     args:
     - container

--- a/kettle/Makefile
+++ b/kettle/Makefile
@@ -16,7 +16,7 @@ include ../Makefile.base.mk
 # Makefile.base.mk requires REPO_ROOT to be set
 REPO_ROOT:=${CURDIR}/..
 
-IMG = gcr.io/k8s-testimages/kettle
+IMG = gcr.io/k8s-staging-test-infra/kettle
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # These are the usual GKE variables.


### PR DESCRIPTION
Specifically for alpine, gcb-docker-gcloud, git, and kettle, which all have updated images published to gcr.io/k8s-staging-test-infra instead of gcr.io/k8s-prow or gcr.io/k8s-testimages.

Ref #32432