### PR TITLE
kOps: use new bucket (k8s-staging-kops) for markers, for 1.30

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -77,6 +77,8 @@ def build_test(cloud='aws',
         kops_version = None
     else:
         kops_deploy_url = f"https://storage.googleapis.com/kops-ci/markers/release-{kops_version}/latest-ci-updown-green.txt" # pylint: disable=line-too-long
+        if kops_version == '1.30':
+            kops_deploy_url = f"https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-{kops_version}/latest-ci-updown-green.txt" # pylint: disable=line-too-long
 
     if should_skip_newer_k8s(k8s_version, kops_version):
         return None

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -222,7 +222,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -474,7 +474,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -726,7 +726,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -978,7 +978,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -1167,7 +1167,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -1418,8 +1418,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -1670,8 +1670,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -1922,8 +1922,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -2174,8 +2174,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -2363,8 +2363,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -2619,7 +2619,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
           --test=kops \
@@ -2875,7 +2875,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
           --test=kops \
@@ -3131,7 +3131,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
           --test=kops \
@@ -3387,7 +3387,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --validation-wait=20m \
           --test=kops \
@@ -3579,7 +3579,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --validation-wait=20m \
           --test=kops \
@@ -3832,7 +3832,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -4084,7 +4084,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -4336,7 +4336,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -4588,7 +4588,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -4777,7 +4777,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -5029,7 +5029,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -5281,7 +5281,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -5533,7 +5533,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -5785,7 +5785,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -5974,7 +5974,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -6226,7 +6226,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -6478,7 +6478,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -6730,7 +6730,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -6982,7 +6982,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -7171,7 +7171,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -7423,7 +7423,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -7675,7 +7675,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -7927,7 +7927,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -8179,7 +8179,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -8368,7 +8368,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -8619,8 +8619,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -8871,8 +8871,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -9123,8 +9123,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -9375,8 +9375,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -9564,8 +9564,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -9820,7 +9820,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
           --test=kops \
@@ -10076,7 +10076,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
           --test=kops \
@@ -10332,7 +10332,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
           --test=kops \
@@ -10588,7 +10588,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --validation-wait=20m \
           --test=kops \
@@ -10780,7 +10780,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --validation-wait=20m \
           --test=kops \
@@ -11033,7 +11033,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -11285,7 +11285,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -11537,7 +11537,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -11789,7 +11789,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -11978,7 +11978,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -12230,7 +12230,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -12482,7 +12482,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -12734,7 +12734,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -12986,7 +12986,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -13175,7 +13175,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -13427,7 +13427,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -13679,7 +13679,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -13931,7 +13931,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -14183,7 +14183,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -14372,7 +14372,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -14624,7 +14624,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -14876,7 +14876,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -15128,7 +15128,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -15380,7 +15380,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -15569,7 +15569,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -15820,8 +15820,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -16072,8 +16072,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -16324,8 +16324,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -16576,8 +16576,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -16765,8 +16765,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -17021,7 +17021,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
           --test=kops \
@@ -17277,7 +17277,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
           --test=kops \
@@ -17533,7 +17533,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
           --test=kops \
@@ -17789,7 +17789,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --validation-wait=20m \
           --test=kops \
@@ -17981,7 +17981,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --validation-wait=20m \
           --test=kops \
@@ -18234,7 +18234,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -18486,7 +18486,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -18738,7 +18738,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -18990,7 +18990,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -19179,7 +19179,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -19431,7 +19431,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -19683,7 +19683,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -19935,7 +19935,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -20187,7 +20187,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -20376,7 +20376,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -20628,7 +20628,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -20880,7 +20880,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -21132,7 +21132,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -21384,7 +21384,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -21573,7 +21573,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -21825,7 +21825,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -22077,7 +22077,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -22329,7 +22329,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -22581,7 +22581,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -22770,7 +22770,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -23021,8 +23021,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -23273,8 +23273,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -23525,8 +23525,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -23777,8 +23777,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -23966,8 +23966,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -24222,7 +24222,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
           --test=kops \
@@ -24478,7 +24478,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
           --test=kops \
@@ -24734,7 +24734,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
           --test=kops \
@@ -24990,7 +24990,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --validation-wait=20m \
           --test=kops \
@@ -25182,7 +25182,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --validation-wait=20m \
           --test=kops \
@@ -25435,7 +25435,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -25687,7 +25687,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -25939,7 +25939,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -26191,7 +26191,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -26380,7 +26380,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -26632,7 +26632,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -26884,7 +26884,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -27136,7 +27136,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -27388,7 +27388,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -27577,7 +27577,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -27829,7 +27829,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -28081,7 +28081,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -28333,7 +28333,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -28585,7 +28585,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -28774,7 +28774,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -29029,7 +29029,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -29285,7 +29285,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -29541,7 +29541,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -29797,7 +29797,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -29989,7 +29989,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -30244,8 +30244,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -30500,8 +30500,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -30756,8 +30756,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -31012,8 +31012,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -31204,8 +31204,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -31464,7 +31464,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
           --test=kops \
@@ -31724,7 +31724,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
           --test=kops \
@@ -31984,7 +31984,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
           --test=kops \
@@ -32244,7 +32244,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --validation-wait=20m \
           --test=kops \
@@ -32439,7 +32439,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --validation-wait=20m \
           --test=kops \
@@ -32696,7 +32696,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -32952,7 +32952,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -33208,7 +33208,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -33464,7 +33464,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -33656,7 +33656,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -33912,7 +33912,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -34168,7 +34168,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -34424,7 +34424,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -34680,7 +34680,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -34872,7 +34872,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -35128,7 +35128,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -35384,7 +35384,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -35640,7 +35640,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -35896,7 +35896,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -36088,7 +36088,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -36341,7 +36341,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -36593,7 +36593,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -36845,7 +36845,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -37096,8 +37096,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=flannel" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -37348,8 +37348,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=flannel" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -37600,8 +37600,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=flannel" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -37856,7 +37856,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --validation-wait=20m \
           --test=kops \
@@ -38112,7 +38112,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --validation-wait=20m \
           --test=kops \
@@ -38368,7 +38368,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='075585003325/Flatcar-beta-3975.1.1-hvm' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --validation-wait=20m \
           --test=kops \
@@ -38621,7 +38621,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -38873,7 +38873,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -39125,7 +39125,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -39377,7 +39377,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -39629,7 +39629,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -39881,7 +39881,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -40133,7 +40133,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -40385,7 +40385,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -40637,7 +40637,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=flannel" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -40889,7 +40889,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -41141,7 +41141,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -41393,7 +41393,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -41645,7 +41645,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -41834,7 +41834,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='137112412989/al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -42085,8 +42085,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -42337,8 +42337,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -42589,8 +42589,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -42841,8 +42841,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -43030,8 +43030,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20240702-1796' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20240717-1811' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -43283,7 +43283,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -43535,7 +43535,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -43787,7 +43787,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -44039,7 +44039,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -44228,7 +44228,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -44480,7 +44480,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -44732,7 +44732,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -44984,7 +44984,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -45236,7 +45236,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -45425,7 +45425,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240704' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \
@@ -45677,7 +45677,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.25.txt \
           --test=kops \
           -- \
@@ -45929,7 +45929,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.26.txt \
           --test=kops \
           -- \
@@ -46181,7 +46181,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
           --test=kops \
           -- \
@@ -46433,7 +46433,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
           --test=kops \
           -- \
@@ -46622,7 +46622,7 @@ periodics:
           --up --down \
           --cloud-provider=aws \
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240701' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.30/latest-ci-updown-green.txt \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
           --test=kops \
           -- \


### PR DESCRIPTION
More releases to follow; the marker is no longer published to the old
location.
