### PR TITLE
[sig-windows] July patches are causing networking issues on WS 2022

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -26,6 +26,8 @@ presets:
   env:
   - name: WINDOWS_SERVER_VERSION
     value: "windows-2022"
+  - name: IMAGE_VERSION
+    value: "130.2.20240612" # windows july 2024 patches break networking
 - labels:
     preset-capz-serial-slow: "true"
   env:


### PR DESCRIPTION
We started to rollout July patches to WS2022 and found that networking is failing with errors like:

```
  I0719 19:55:56.268791 3228 rest.go:69] Unexpected error: 
      <*fmt.wrapError | 0xc004a94a80>: 
      client rate limiter Wait returned an error: context deadline exceeded
      {
          msg: "client rate limiter Wait returned an error: context deadline exceeded",
          err: <context.deadlineExceededError>{},
```

and 

```
  I0719 17:34:06.421848 129511 util.go:239] Service reachability failing with error: error running /usr/local/bin/kubectl --kubeconfig=/home/prow/go/src/k8s.io/windows-testing/capz/capz-conf-8tkatc.kubeconfig --namespace=services-3932 exec execpodxslw8 -- /bin/sh -x -c echo hostName | nc -v -t -w 2 10.101.172.74 80:
  Command stdout:
  stderr:
  + echo hostName
  + nc -v -t -w 2 10.101.172.74 80
  10.101.172.74: inverse host lookup failed: h_errno 11004: NO_DATA        
  (UNKNOWN) [10.101.172.74] 80 (http): ACCES         
  command terminated with exit code 1
```