### PR TITLE
Moving some of the sig-windows jobs to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.3
+      - image: public.ecr.aws/docker/library/golang:1.22.5
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -12,6 +12,7 @@ presets:
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-capz-windows-master
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: false
     optional: true
@@ -23,12 +24,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
-      preset-azure-cred-wi: "true"
-      preset-windows-private-registry-cred: "true" # Needed for WS 2022 images
+      preset-azure-community: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -46,7 +45,6 @@ presubmits:
       path_alias: k8s.io/windows-testing
       workdir: true
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -59,7 +57,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
     annotations:
       fork-per-release: "true"
       fork-per-release-replacements: "KUBERNETES_VERSION=latest -> KUBERNETES_VERSION=latest-{{.Version}}"
@@ -67,6 +68,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-serial-slow
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 4h
@@ -79,12 +81,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
-      preset-windows-private-registry-cred: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -102,7 +102,6 @@ presubmits:
       path_alias: k8s.io/windows-testing
       workdir: true
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -115,7 +114,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -126,6 +128,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-serial-slow
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-windows-serial-slow-hpa
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: false
     optional: true
@@ -136,12 +139,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
       preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
-      preset-windows-private-registry-cred: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -159,7 +160,6 @@ presubmits:
       path_alias: k8s.io/windows-testing
       workdir: true
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -172,7 +172,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -300,6 +303,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-windows-alpha-feature-vertical-pod-autoscaler
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-master-windows-nodelogquery
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: false
     optional: true
@@ -310,11 +314,9 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-wi: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+      preset-azure-community: "true"
       preset-capz-windows-common: "true"
       preset-capz-windows-2022: "true"
-      preset-windows-private-registry-cred: "true"
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -332,7 +334,6 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -345,7 +346,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
+            limits:
+              cpu: 2
+              memory: "2Gi"
           env:
             - name: GINKGO_FOCUS
               value: \[Feature:NodeLogQuery\] # run the NodeLogQuery tests
@@ -359,6 +363,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubernetes-sigs/windows-testing:
   - name: pull-e2e-capz-windows-2022-extension
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     optional: true
@@ -371,11 +376,9 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-      preset-windows-private-registry-cred: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-azure-cred-wi: "true"
+      preset-azure-community: "true"
       preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -389,7 +392,6 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -402,7 +404,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
+            limits:
+              cpu: 2
+              memory: "2Gi"
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time
@@ -499,10 +504,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
             limits:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time
@@ -510,6 +515,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-extension-community-eks
   - name: pull-e2e-run-capz-sh-windows-2022-hyperv
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: false
     optional: true
@@ -522,9 +528,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-wi: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-      preset-windows-private-registry-cred: "true"
+      preset-azure-community: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-2022: "true"
@@ -540,7 +544,6 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -553,7 +556,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
+            limits:
+              cpu: 2
+              memory: "2Gi"
           env:
           - name: HYPERV
             value: "true"
@@ -565,6 +571,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-run-capz-sh-windows-2022-hyperv
   - name: pull-e2e-capz-windows-2022-extension-gmsa
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: false
     optional: true
@@ -577,9 +584,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-wi: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-      preset-windows-private-registry-cred: "true"
+      preset-azure-community: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-2022: "true"
@@ -595,7 +600,6 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -608,7 +612,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
+            limits:
+              cpu: 2
+              memory: "2Gi"
           env:
           - name: GINKGO_NODES
             value: "1"
@@ -622,6 +629,7 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-e2e-capz-windows-extension-gmsa
   - name: pull-e2e-capz-validate-pr-templates
+    cluster: eks-prow-build-cluster
     decorate: true
     always_run: false
     optional: true
@@ -634,12 +642,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred-wi: "true"
-      preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+      preset-azure-community: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common: "true"
       preset-capz-windows-2022: "true"
-      preset-windows-private-registry-cred: "true"
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -657,7 +663,6 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-azure
       workdir: false
     spec:
-      serviceAccountName: prowjob-default-sa
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
           command:
@@ -670,7 +675,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "9Gi"
+              memory: "2Gi"
+            limits:
+              cpu: 2
+              memory: "2Gi"
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -72,6 +72,7 @@ presets:
       value: "true"
 periodics:
 - name: ci-kubernetes-e2e-capz-master-windows
+  cluster: eks-prow-build-cluster
   interval: 3h
   decorate: true
   decoration_config:
@@ -79,12 +80,10 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
     preset-capz-windows-common: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-7-latest: "true"
-    preset-windows-private-registry-cred: "true"
-    preset-azure-cred-wi: "true"
+    preset-azure-community: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -113,9 +112,13 @@ periodics:
         securityContext:
           privileged: true
         resources:
+          # current recommendations are at least 1Gi /core
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: IMAGE_VERSION
             value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
@@ -126,6 +129,7 @@ periodics:
     testgrid-dashboards: sig-release-master-informing, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -133,13 +137,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
-    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -156,7 +158,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -169,7 +170,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -180,6 +184,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow-hpa
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -187,13 +192,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
-    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -210,7 +213,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -221,7 +223,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -272,15 +277,16 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
           limits:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master
 - name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -288,13 +294,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
-    preset-windows-private-registry-cred: "true"
     preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -312,7 +316,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -325,7 +328,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -336,6 +342,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-2022-serial-slow-hpa
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -343,9 +350,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-    preset-windows-private-registry-cred: "true"
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
@@ -366,7 +371,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -379,7 +383,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -390,6 +397,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-2022-master-serial-slow-hpa
 - name: ci-kubernetes-e2e-capz-master-containerd-nightly-windows
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -397,9 +405,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
-    preset-windows-private-registry-cred: "true"
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
   extra_refs:
@@ -418,7 +424,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -434,12 +439,16 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-nightly-master
 - name: ci-kubernetes-e2e-capz-master-windows-alpha
+  cluster: eks-prow-build-cluster
   interval: 3h
   decorate: true
   decoration_config:
@@ -447,11 +456,9 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
-    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -468,7 +475,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -481,7 +487,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: API_SERVER_FEATURE_GATES
             value: "InPlacePodVerticalScaling=true"
@@ -498,6 +507,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-master-alpha-features
 - name: ci-kubernetes-e2e-capz-master-windows-nodelogquery
+  cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
   decoration_config:
@@ -505,11 +515,9 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-windows-2022: "true"
-    preset-windows-private-registry-cred: "true"
     preset-capz-containerd-1-7-latest: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -527,7 +535,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -540,7 +547,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: GINKGO_FOCUS
             value: \[Feature:NodeLogQuery\] # run the NodeLogQuery tests
@@ -553,6 +563,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-master-windows-nodelogquery
 - name: ci-kubernetes-e2e-capz-master-windows-annual-channel
+  cluster: eks-prow-build-cluster
   interval: 12h
   decorate: true
   decoration_config:
@@ -560,11 +571,9 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true" # Sets REGISTRY which is needed when building CCM/CNM images
+    preset-azure-community: "true"
     preset-capz-windows-common: "true"
     preset-capz-containerd-1-7-latest: "true"
-    preset-windows-private-registry-cred: "true"
     preset-capz-windows-2022: "true" # although it is not WS 2022, the tooling and container images treat it like WS2022
   extra_refs:
   - org: kubernetes-sigs
@@ -583,7 +592,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:
@@ -596,7 +604,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "9Gi"
+            memory: "2Gi"
+          limits:
+            cpu: 2
+            memory: "2Gi"
         env:
           - name: TEMPLATE
             value: "shared-image-gallery-ci.yaml" #contains latest Annual Channel image


### PR DESCRIPTION
This move the jobs to the eks cluster for now.  a few things are needed:

- cluster: eks-prow-build-cluster
- no Serviceaccount defined
- resource requests/limits need to be defined 
   - I've dropped memory to 1g for windows since we don't run kind, the 9gig was left over from when we relied on capz and kind clusters

/sig windows
/assign @marosset 