### PR TITLE
Enforce 1.31 code freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -697,6 +697,32 @@ tide:
     - do-not-merge/work-in-progress
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+      - master
+      - release-1.31
+    labels:
+      - lgtm
+      - approved
+      - "cncf-cla: yes"
+    missingLabels:
+      - do-not-merge
+      - do-not-merge/blocked-paths
+      - do-not-merge/cherry-pick-not-approved
+      - do-not-merge/contains-merge-commits
+      - do-not-merge/hold
+      - do-not-merge/invalid-commit-message
+      - do-not-merge/invalid-owners-file
+      - do-not-merge/needs-kind
+      - do-not-merge/needs-sig
+      - do-not-merge/release-note-label-needed
+      - do-not-merge/work-in-progress
+      - needs-rebase
+  - repos:
+      - kubernetes/kubernetes
+    milestone: v1.31
+    includedBranches:
+      - master
+      - release-1.31
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes 1.31 Code Freeze is scheduled to start at 02:00 UTC Wednesday 24th July 2024 / 19:00 PDT Tuesday 23rd July 2024.

/hold
The hold should ONLY be cancelled by the Release Team Leads when the 1.31 Release Team is ready around the Code Freeze deadline.

/priority critical-urgent
/cc https://github.com/orgs/kubernetes/teams/release-team-leads https://github.com/orgs/kubernetes/teams/release-engineering