### PR TITLE
image-builder: make pull-ova-all job optional

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -5,6 +5,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
         preset-image-builder-vsphere-e2e-config: "true"
+      optional: true
       decorate: true
       decoration_config:
         timeout: 1h


### PR DESCRIPTION
This makes the `pull-ova-all` job optional because it's not expected to be migrated to community infrastructure by the August 1st deadline.