### PR TITLE
secrets-store: add test jobs to validate migration to community cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -658,6 +658,92 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows
       description: "Run E2E tests on a AKS Windows cluster for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
+  # TODO(aramase): remove this job once the migration is complete
+  - name: pull-secrets-store-csi-driver-e2e-windows-prow-migration-test
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    always_run: false
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    optional: true
+    branches:
+    - ^main$
+    - ^release-*
+    labels:
+      preset-azure-community: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            ./test/scripts/run-e2e-windows.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "6Gi"
+        env:
+          - name: TEST_WINDOWS
+            value: "true"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows-prow-migration-test
+      description: "Run E2E tests on a AKS Windows cluster for Secrets Store CSI driver. This job is used for testing the migration to eks-prow-build-cluster."
+      testgrid-num-columns-recent: '30'
+  # TODO(aramase): remove this job once the migration is complete
+  - name: pull-secrets-store-csi-driver-e2e-azure-prow-migration-test
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: false
+    optional: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    - ^release-*
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # sets up the azure community parameters used for testing
+      preset-azure-community: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            ./test/scripts/run-e2e-windows.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-azure-prow-migration-test
+      description: "Run e2e test with azure provider for Secrets Store CSI driver. This job is used for testing the migration to eks-prow-build-cluster."
+      testgrid-num-columns-recent: '30'
 
   # release jobs
   - name: release-secrets-store-csi-driver-e2e-aws


### PR DESCRIPTION
Adding test jobs `pull-secrets-store-csi-driver-e2e-windows-prow-migration-test` and `pull-secrets-store-csi-driver-e2e-azure-prow-migration-test` to validate move to community prow cluster + change in azure tenant.