### PR TITLE
fix? kops staging registry job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -76,7 +76,7 @@ periodics:
         requests:
           cpu: 4
           memory: 8Gi
-- name: e2e-kops-grid-gcr-mirror-canary
+- name: e2e-kops-staging-registry
   cluster: k8s-infra-prow-build
   cron: '11 0-23/1 * * *'
   labels:
@@ -141,4 +141,4 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'
-    testgrid-tab-name: kops-grid-gcr-mirror-canary
+    testgrid-tab-name: e2e-kops-staging-registry

--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -106,7 +106,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --set=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.29/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \


### PR DESCRIPTION
We use this job to vet changes to registry.k8s.io before they go live, currently it's failing because EBS CSI doesn't come up due to the paths being different on ECR and the community registry

(`registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.32.0` vs `public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.32.0`, so when the registry host gets clobbered the image isn't available)

TODO: Ask AWS folks to consider moving these to a unified path (not really important but probably makes more sense for everyone)

cc @dims @hakman 

more context: https://kubernetes.slack.com/archives/CCK68P2Q2/p1721682775275289?thread_ts=1721668405.879859&cid=CCK68P2Q2