### PR TITLE
migrate pull-kubernetes-e2e-autoscaling-vpa-full

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -160,6 +160,7 @@ presubmits:
 
   kubernetes/autoscaler:
   - name: pull-kubernetes-e2e-autoscaling-vpa-full
+    cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-vpa
       testgrid-tab-name: autoscaling-vpa-full-presubmits
@@ -191,3 +192,10 @@ presubmits:
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi


### PR DESCRIPTION
Same as https://github.com/kubernetes/test-infra/pull/33063, we've already migrated similar jobs in this file, it should just work, I think this is just an oversight.