### PR TITLE
feat: adds image push prow config

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-secrets-store-sync.yaml
+++ b/config/jobs/image-pushing/k8s-staging-secrets-store-sync.yaml
@@ -1,0 +1,34 @@
+postsubmits:
+  # This is the github repo we'll build from. This block needs to be repeated
+  # for each repo.
+  kubernetes-sigs/secrets-store-sync-controller:
+    # The name should be changed to match the repo name above
+    - name: secrets-store-sync-controller-push-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # This is the name of some testgrid dashboard to report to.
+        # If this is the first one for your sig, you may need to create one
+        testgrid-dashboards: sig-auth-secrets-store-sync-controller, sig-k8s-infra-gcb
+      decorate: true
+      # we only need to run if necessary (e.g.: the version was bumped)
+      run_if_changed: 'docker/Makefile'
+      # this causes the job to only run on the master branch. Remove it if your
+      # job makes sense on every branch (unless it's setting a `latest` tag it
+      # probably does).
+      branches:
+        - ^release-.*
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240523-29e3962433
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --build-dir=.
+              - docker


### PR DESCRIPTION
Adds the prow config needed for pushing the secrets store sync controller to a staging registry, from where the images will be pushed.

The `secrets-store-sync` project group will be created with: https://github.com/kubernetes/k8s.io/pull/7048

part of - https://github.com/kubernetes-sigs/secrets-store-sync-controller/issues/5

/cc @aramase 