### PR TITLE
Drop external cloud provider from ci-kubernetes-e2e-ec2-alpha-enabled-default

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -108,7 +108,6 @@ periodics:
              --version $VERSION \
              --feature-gates="AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
-             --external-cloud-provider true \
              --up \
              --down \
              --test=ginkgo \


### PR DESCRIPTION
One test in there that fails consistently with the AWS VPC CNI, so let's switch to kindnetd ( https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-alpha-enabled-default&width=20 )