### PR TITLE
added containerd refs to ResourceHealthStatus presubmit job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3381,6 +3381,10 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    - org: containerd
+      repo: containerd
+      base_ref: main
+      path_alias: github.com/containerd/containerd
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master


### PR DESCRIPTION
Failure example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/126243/pull-kubernetes-node-e2e-resource-health-status/1815603342231998464

/sig node