### PR TITLE
k8s-infra: Fix kops staging registry

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -106,7 +106,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --set=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --set=cluster.spec.cloudProvider.aws.ebsCSIDriver.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.29/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/test-infra/pull/33061

Use the correct field to disable the AWS EBS CSI driver.