### PR TITLE
sig-node: fix "classic DRA" periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -82,7 +82,7 @@ periodics:
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
           kind build node-image --image=dra/node:latest . &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
-          kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest &&
+          kind create cluster --retain --config test/e2e/dra/kind-classic-dra.yaml --image dra/node:latest &&
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=2h30m hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation, DRAControlPlaneController} && !Flaky'
 
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
The copy-and-paste of the ci-kind-dra job didn't update the kind cluster config, so the cluster came up without support for classic DRA.