### PR TITLE
drop upload-oncall job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -250,32 +250,6 @@ postsubmits:
       testgrid-tab-name: postsubmit-gencred-refresh-kubeconfig
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       description: Runs gencred to refresh generated kubeconfigs.
-  - name: post-test-infra-upload-oncall
-    cluster: test-infra-trusted
-    branches:
-    - ^master$
-    run_if_changed: '^maintenance/oncall.html$'
-    decorate: true
-    spec:
-      serviceAccountName: pusher
-      containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20210913-fc7c4e8
-        command:
-        - gsutil
-        args:
-        - cp
-        - -Z
-        - ./maintenance/oncall.html
-        - gs://test-infra-oncall/
-        resources:
-          requests:
-            memory: "1Gi"
-    annotations:
-      testgrid-dashboards: sig-testing-maintenance
-      testgrid-tab-name: oncall-update
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
-      description: Updates the html contents for go.k8s.io/oncall.
   - name: post-test-infra-upload-testgrid-config
     cluster: test-infra-trusted
     branches:

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -665,7 +665,6 @@ func TestCommunityJobs(t *testing.T) {
 		"post-test-infra-push-misc-images",
 		"post-test-infra-reconcile-hmacs",
 		"post-test-infra-upload-boskos-config",
-		"post-test-infra-upload-oncall",
 		"post-test-infra-upload-testgrid-config",
 	)
 

--- a/docs/job-migration-todo.md
+++ b/docs/job-migration-todo.md
@@ -374,5 +374,4 @@ For more context, see the announcement thread at https://groups.google.com/a/kub
 |config/jobs/kubernetes/test-infra/test-infra-trusted.yaml|post-test-infra-push-misc-images|[Search Results](https://cs.k8s.io/?q=name%3A%20post-test-infra-push-misc-images%24&i=nope&files=&excludeFiles=&repos=)|
 |config/jobs/kubernetes/test-infra/test-infra-trusted.yaml|post-test-infra-reconcile-hmacs|[Search Results](https://cs.k8s.io/?q=name%3A%20post-test-infra-reconcile-hmacs%24&i=nope&files=&excludeFiles=&repos=)|
 |config/jobs/kubernetes/test-infra/test-infra-trusted.yaml|post-test-infra-upload-boskos-config|[Search Results](https://cs.k8s.io/?q=name%3A%20post-test-infra-upload-boskos-config%24&i=nope&files=&excludeFiles=&repos=)|
-|config/jobs/kubernetes/test-infra/test-infra-trusted.yaml|post-test-infra-upload-oncall|[Search Results](https://cs.k8s.io/?q=name%3A%20post-test-infra-upload-oncall%24&i=nope&files=&excludeFiles=&repos=)|
 |config/jobs/kubernetes/test-infra/test-infra-trusted.yaml|post-test-infra-upload-testgrid-config|[Search Results](https://cs.k8s.io/?q=name%3A%20post-test-infra-upload-testgrid-config%24&i=nope&files=&excludeFiles=&repos=)|


### PR DESCRIPTION
we don't need this anymore, the page was deprecated.

I can manually update the bucket later if need be, or we can update the go.k8s.io/oncall alias to point to a new location