### PR TITLE
Update kubekins to Go 1.23rc2

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -21,19 +21,19 @@ variants:
     KIND_VERSION: 0.17.0
   master:
     CONFIG: master
-    GO_VERSION: 1.22.5
+    GO_VERSION: 1.23rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.22.5
+    GO_VERSION: 1.23rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: 1.22.5
+    GO_VERSION: 1.23rc2
     K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Update kubekins to Go 1.23rc2

xref https://github.com/kubernetes/release/issues/3650

/assign @saschagrunert @puerco @Verolop 
cc @kubernetes/release-engineering 