### PR TITLE
Bump golang from 1.22.3 to 1.22.5 on apiserver-network-proxy test runner

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.3
+      - image: public.ecr.aws/docker/library/golang:1.22.5
         command:
         - make
         args:


### PR DESCRIPTION
Needed to bump apiserver-network-proxy to golang 1.22.5, which has a patch for [CVE-2024-24790](https://security-tracker.debian.org/tracker/CVE-2024-24790).

@cheftako for visibility.