### PR TITLE
[sig-windows] The wrong preset was being used on the 1.30 job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
@@ -42,7 +42,7 @@ periodics:
     preset-azure-cred-only: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-windows-2022: "true"
-    preset-capz-windows-130: "true"
+    preset-capz-windows-common-130: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-windows-private-registry-cred: "true"


### PR DESCRIPTION
During triage yesterday we found the wrong preset was being used causing it to run 1.30 version.  This fixes the issue.

/sig windows
/assign @knabben @ritikaguptams 