### PR TITLE
update container registry for cluster-autoscaler azure e2e presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
           - bash
           - -c
           - |
-            export REGISTRY=capzci.azurecr.io
+            export REGISTRY=capzcicommunity.azurecr.io
             hack/ensure-acr-login.sh
             cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
             make test-e2e TAG=$(git rev-parse --short HEAD)


### PR DESCRIPTION
The new Azure sub uses a different container registry name.

/assign @willie-yao