### PR TITLE
Move to newer google cloud sdk

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:343.0.0-alpine
+FROM google/cloud-sdk:485.0.0-alpine
 COPY builder run.sh /
 CMD ["/run.sh"]

--- a/images/git-custom-k8s-auth/Dockerfile
+++ b/images/git-custom-k8s-auth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:483.0.0 as builder
+FROM google/cloud-sdk:485.0.0 as builder
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/Dockerfile
 
 ARG AWS_IAM_AUTHENTICATOR_VERSION


### PR DESCRIPTION
the builder one was last updated in 2021!! https://github.com/dims/test-infra/pull/new/move-to-newer-google-cloud-sdk

picking latest one from https://explore.ggcr.dev/?repo=google/cloud-sdk