### PR TITLE
[sig-windows] Remove service account from job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -101,7 +101,6 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:
-    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240705-131cd74733-master
         command:


### PR DESCRIPTION
This was missed when moving to the knew job and resulted in jobs not running:

https://prow.k8s.io/prowjob?prowjob=9aa346c3-2a43-4e4f-9b3a-987d0954342b

```
build_id: "1816480902931288064"
  completionTime: "2024-07-25T14:29:31Z"
  description: 'Pod can not be created: create pod test-pods/9aa346c3-2a43-4e4f-9b3a-987d0954342b
    in cluster eks-prow-build-cluster: pods "9aa346c3-2a43-4e4f-9b3a-987d0954342b"
    is forbidden: error looking up service account test-pods/prowjob-default-sa: serviceaccount
    "prowjob-default-sa" not found'
  prev_report_states:
    gcsreporter: error
    slackreporter: error
  startTime: "2024-07-25T14:29:30Z"
  state: error
```

/sig windows