### PR TITLE
[sig-windows] Memory limits were causing OOM, revert back to original

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
@@ -41,10 +41,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: 2Gi
+            memory: 9Gi
           limits:
             cpu: "2"
-            memory: 2Gi
+            memory: 9Gi
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -55,10 +55,10 @@ periodics:
       resources:
         requests:
           cpu: "2"
-          memory: 2Gi
+          memory: 9Gi
         limits:
           cpu: "2"
-          memory: 2Gi
+          memory: 9Gi
       securityContext:
         privileged: true
       env:
@@ -107,10 +107,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows-presubmits.yaml
@@ -41,10 +41,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: 2Gi
+            memory: 9Gi
           limits:
             cpu: "2"
-            memory: 2Gi
+            memory: 9Gi
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows.yaml
@@ -54,10 +54,10 @@ periodics:
       resources:
         requests:
           cpu: "2"
-          memory: 2Gi
+          memory: 9Gi
         limits:
           cpu: "2"
-          memory: 2Gi
+          memory: 9Gi
       securityContext:
         privileged: true
 - name: ci-kubernetes-e2e-capz-1-29-windows-serial-slow
@@ -102,10 +102,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows-presubmits.yaml
@@ -41,10 +41,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: "2"
-            memory: "2Gi"
+            memory: "9Gi"
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
@@ -54,10 +54,10 @@ periodics:
       resources:
         requests:
           cpu: "2"
-          memory: 2Gi
+          memory: 9Gi
         limits:
           cpu: "2"
-          memory: 2Gi
+          memory: 9Gi
       securityContext:
         privileged: true
 - name: ci-kubernetes-e2e-capz-1-30-windows-serial-slow
@@ -102,10 +102,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -57,10 +57,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
     annotations:
       fork-per-release: "true"
       fork-per-release-replacements: "KUBERNETES_VERSION=latest -> KUBERNETES_VERSION=latest-{{.Version}}"
@@ -114,10 +114,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -172,10 +172,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -228,10 +228,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
             - name: NODE_FEATURE_GATES
               value: "PodAndContainerStatsFromCRI=true"
@@ -285,10 +285,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
             - name: API_SERVER_FEATURE_GATES
               value: "InPlacePodVerticalScaling=true"
@@ -346,10 +346,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
             - name: GINKGO_FOCUS
               value: \[Feature:NodeLogQuery\] # run the NodeLogQuery tests
@@ -404,10 +404,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time
@@ -504,10 +504,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time
@@ -556,10 +556,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
           - name: HYPERV
             value: "true"
@@ -612,10 +612,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
           - name: GINKGO_NODES
             value: "1"
@@ -675,10 +675,10 @@ presubmits:
           resources:
             requests:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: 2
-              memory: "2Gi"
+              memory: "9Gi"
           env:
           - name: GINKGO_FOCUS
             value: \[sig-windows\] # run just a subset to speed up testing time

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -114,10 +114,10 @@ periodics:
           # current recommendations are at least 1Gi /core
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: IMAGE_VERSION
             value: "127.1.20230417" # pin the Windows nodes to a specific OS patch version while investigating an issue with container updates
@@ -169,10 +169,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -222,10 +222,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -276,10 +276,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release
@@ -327,10 +327,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
@@ -382,10 +382,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: (\[sig-autoscaling\].\[Feature:HPA\]).*(\[Serial\]|\[Slow\])
@@ -438,10 +438,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
@@ -486,10 +486,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: API_SERVER_FEATURE_GATES
             value: "InPlacePodVerticalScaling=true"
@@ -546,10 +546,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: GINKGO_FOCUS
             value: \[Feature:NodeLogQuery\] # run the NodeLogQuery tests
@@ -603,10 +603,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "9Gi"
         env:
           - name: TEMPLATE
             value: "shared-image-gallery-ci.yaml" #contains latest Annual Channel image

--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -188,10 +188,10 @@ periodics:
           resources:
             requests:
               cpu: "2"
-              memory: "2Gi"
+              memory: "9Gi"
             limits:
               cpu: "2"
-              memory: "2Gi"
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-windows-soak-tests
       testgrid-tab-name: delete-win-soak-test-cluster


### PR DESCRIPTION
I've updated the limits to what we originally had before https://github.com/kubernetes/test-infra/pull/33043.  Once we run for awhile we can revisit via  https://monitoring-eks.prow.k8s.io/ and https://monitoring-gke.prow.k8s.io/ to right size the containers

/sig windows
/assign @nawazkh @ritikaguptams @willie-yao 