### PR TITLE
[sig-windows] Use main branch from cloudprovider

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure
       workdir: false
-    - base_ref: release-1.28
+    - base_ref: master
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cloud-provider-azure
       repo: cloud-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.28-windows.yaml
@@ -32,7 +32,7 @@ periodics:
     path_alias: sigs.k8s.io/windows-testing
     repo: windows-testing
     workdir: true
-  - base_ref: release-1.28
+  - base_ref: master
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cloud-provider-azure
     repo: cloud-provider-azure
@@ -91,7 +91,7 @@ periodics:
     workdir: true
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.28
+    base_ref: master
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure
       workdir: false
-    - base_ref: release-1.29
+    - base_ref: master
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cloud-provider-azure
       repo: cloud-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows.yaml
@@ -32,7 +32,7 @@ periodics:
     path_alias: sigs.k8s.io/windows-testing
     repo: windows-testing
     workdir: true
-  - base_ref: release-1.29
+  - base_ref: master
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cloud-provider-azure
     repo: cloud-provider-azure
@@ -87,7 +87,7 @@ periodics:
     workdir: true
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.29
+    base_ref: master
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure
       workdir: false
-    - base_ref: release-1.30
+    - base_ref: master
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cloud-provider-azure
       repo: cloud-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
@@ -87,7 +87,7 @@ periodics:
     workdir: true
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: release-1.30
+    base_ref: master
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   spec:


### PR DESCRIPTION
Cloud provider main branch and cluster api 1.16 know how to build the HPC version of the cloudprovider image. Since we don't use cloud provider for much in upstream e2e we should be ok to use the mis matched versions here.  If it become an issue we can backport the cloud provider changes to older versions

Release branches were updated to CAPZ 1.16 which has the fix for building HPC cloud provider images (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4890) this requires the change in https://github.com/kubernetes-sigs/cloud-provider-azure/pull/6318/commits/05f374fd2de6654bce620609bc4c96604bfae43a

Seeing failures like https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-windows-1-29/1816838763871997952

```

 2 warnings found (use --debug to expand):
              
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 23)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 23)
cloud-node-manager-windows.Dockerfile:25
--------------------
  23 |     FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-$OSVERSION as servercore-helper
  24 |     
  25 | >>> FROM mcr.microsoft.com/windows/nanoserver:$OSVERSION
  26 |     
  27 |     ARG OSVERSION
--------------------
ERROR: failed to solve: mcr.microsoft.com/windows/nanoserver:hpc: mcr.microsoft.com/windows/nanoserver:hpc: not found
make[1]: *** [Makefile:162: build-node-image-windows] Error 1
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/cloud-provider-azure'
make: *** [Makefile:266: push-node-image-windows-hpc-amd64] Error 2
```

/sig windows
/assign @aravindhp @ritikaguptams 