### PR TITLE
Remove world-readable (legacy ACL) flag.

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -50,7 +50,6 @@ postsubmits:
         - --prowjob-url-prefix=https://git.k8s.io/test-infra/config/jobs/
         - --update-description
         - --oneshot
-        - --world-readable
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
--world-readable tries to make the uploaded config file public, but only that particular file. This isn't compatible with uniform buckets in GCS, since permissions need to apply to the entire bucket and not specific objects.

Ref #32432