### PR TITLE
Switch source for K8s TestGrid canary config.

### DIFF
--- a/config/mergelists/canary.yaml
+++ b/config/mergelists/canary.yaml
@@ -1,7 +1,7 @@
 target: "gs://k8s-testgrid-canary/config"
 sources:
 - name: "" # Kubernetes configs can't be renamed
-  location: "gs://k8s-testgrid-canary/configs/k8s/config"
+  location: "gs://k8s-testgrid-config/k8s/config"
 - name: "google-oss"
   location: "gs://oss-prow-own-testgrid/config"
 - name: "istio"


### PR DESCRIPTION
Switches the config source for the K8s slice (the main one) to the config generated by the new job and not the old job.

Verified the file exists:

```
gsutil ls -al gs://k8s-testgrid-config/k8s/config
   9224776  2024-07-26T22:42:14Z  gs://k8s-testgrid-config/k8s/config#1722033734092142  metageneration=1
   9224776  2024-07-26T22:43:52Z  gs://k8s-testgrid-config/k8s/config#1722033832242692  metageneration=1
TOTAL: 2 objects, 18449552 bytes (17.59 MiB)
```

/hold
Until https://github.com/kubernetes/k8s.io/pull/7076 is submitted + applied

Ref #32432

ETA: New filename is the one uploaded by `post-test-infra-upload-testgrid-config-canary` in  https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml