### PR TITLE
Switch source for K8s TestGrid production config.

### DIFF
--- a/config/mergelists/prod.yaml
+++ b/config/mergelists/prod.yaml
@@ -1,7 +1,7 @@
 target: "gs://k8s-testgrid/config"
 sources:
 - name: "" # Kubernetes configs can't be renamed
-  location: "gs://k8s-testgrid/configs/k8s/config"
+  location: "gs://k8s-testgrid-config/k8s/config"
 - name: "google-oss"
   location: "gs://oss-prow-own-testgrid/config"
 - name: "istio"


### PR DESCRIPTION
Switches the config source for the K8s slice (the main one) to the config generated by the new job and not the old job.

/hold

Do not merge until we verify that https://github.com/kubernetes/test-infra/pull/33130 works.

Ref #32432