### PR TITLE
Bump memory requests/limits to 8Gi to avoid being killed by OOM

### DIFF
--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.7.yaml
@@ -113,7 +113,7 @@ presubmits:
             resources:
               limits:
                 cpu: 2
-                memory: 4Gi
+                memory: 8Gi
               requests:
                 cpu: 2
-                memory: 4Gi
+                memory: 8Gi

--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
@@ -113,7 +113,7 @@ presubmits:
          resources:
            limits:
              cpu: 2
-             memory: 4Gi
+             memory: 8Gi
            requests:
              cpu: 2
-             memory: 4Gi
+             memory: 8Gi


### PR DESCRIPTION
Increase memory limits and requests for `pull-ibm-powervs-block-csi-driver-verify` jobs run for 0.7 release and main, as recent runs seem to hit the OOMKilled issue. 


----
Ref: 
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_ibm-powervs-block-csi-driver/711/pull-ibm-powervs-block-csi-driver-verify/1816706299803471872

https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-sigs&var-repo=ibm-powervs-block-csi-driver&var-job=pull-ibm-powervs-block-csi-driver-verify&var-build=All&from=1721969444856&to=1721974262373

https://kubernetes.slack.com/archives/C90BWDWCE/p1721719910208109