### PR TITLE
fix resource health status label

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3447,7 +3447,7 @@ presubmits:
         - '--node-test-args=--feature-gates="ResourceHealthStatus=true" --service-feature-gates="ResourceHealthStatus=true" --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true
         - --provider=gce
-        - '--test_args=--timeout=1h --label-filter="FeatureGate: containsAny ResourceHealthStatus && FeatureGate: isSubsetOf ResourceHealthStatus && !Flaky && !Slow"'
+        - '--test_args=--timeout=1h --label-filter="NodeFeature: containsAny ResourceHealthStatus && NodeFeature: isSubsetOf ResourceHealthStatus && !Flaky && !Slow"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
         resources:


### PR DESCRIPTION
Hoping to get https://testgrid.k8s.io/sig-node-presubmits#pr-node-kubelet-resource-health-status working again.

This is not pressing for 1.31 but we should get in soon.