### PR TITLE
Use current dir instead of root for misc image job.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -334,7 +334,8 @@ postsubmits:
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
-          - /
+          - --build-dir=.
+          - .
 
     #
     # components, e.g. kettle/, triage/


### PR DESCRIPTION
Using `.` to specify the root instead of `/`; not actually sure if this'll fix things, but other jobs are also using `.` so it seems more in-line with what others are doing.

Also specifying `--build-dir=.` since a number of other jobs are.

I'm attempting to fix a failure of the `post-test-infra-push-misc-images-canary` job, ex. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-misc-images-canary/1818033933984468992

```
Running...
$ARTIFACTS is set, sending logs to /logs/artifacts
[2](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-misc-images-canary/1818033933984468992#1:build-log.txt%3A2)024/07/29 21:20:58 Build directory: 
2024/07/29 21:20:58 Config directory: /home/prow/go/src/github.com/kubernetes/test-infra
202[4](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-misc-images-canary/1818033933984468992#1:build-log.txt%3A4)/07/29 21:20:58 cd-ing to build directory: 
2024/07/29 21:20:58 Failed to chdir to build directory (): chdir : no such file or directory
```