### PR TITLE
Make pull-kubernetes-e2e-storage-kind-alpha-beta-features serial

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -87,8 +87,6 @@ presubmits:
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: FOCUS
           value: \[Feature:VolumeAttributesClass\]|\[Feature:HonorPVReclaimPolicy\]|\[Feature:CSIVolumeHealth\]
-        - name: PARALLEL
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -181,8 +179,6 @@ periodics:
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: FOCUS
           value: \[Feature:VolumeAttributesClass\]|\[Feature:HonorPVReclaimPolicy\]|\[Feature:CSIVolumeHealth\]
-        - name: PARALLEL
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
pull-kubernetes-e2e-storage-kind-alpha-beta-features  runs e2e.test with a focus on tests for all alpha/beta storage features on a kind cluster.

We remove parallelism so that serial Volume Metrics tests can run:

x-ref: kubernetes/kubernetes#126166

x-ref: kubernetes/kubernetes#126345

/cc @carlory 

Is deleting these lines enough? Or must PARALLEL be explicitly set to false. 