### PR TITLE
set pull through cache for 5k node scale tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -21,8 +21,21 @@ periodics:
     testgrid-base-options: 'exclude-filter-by-regex=^(kubetest\.Test|ci-kubernetes-e2e-gce-scale-correctness\.Overall)$'
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
+    volumes:
+    - name: cache-secret
+      secret:
+        secretName: scale-pull-cache-token
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      volumeMounts:
+      - name: cache-secret
+        readOnly: true
+        mountPath: /etc/registry-auth
+      env:
+      - name: KUBERNETES_REGISTRY_PULL_THROUGH_HOST
+        value: https://us-central1-docker.pkg.dev/v2/k8s-infra-e2e-scale-5k-project/k8s-5k-scale-cache/
+      - name: KUBERNETES_REGISTRY_PULL_THROUGH_BASIC_AUTH_TOKEN_PATH
+        value: /etc/registry-auth/token
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -89,13 +102,27 @@ periodics:
     testgrid-tab-name: gce-master-scale-performance
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
+    volumes:
+    - name: cache-secret
+      secret:
+        secretName: scale-pull-cache-token
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      volumeMounts:
+      - name: cache-secret
+        readOnly: true
+        mountPath: /etc/registry-auth
+      env:
+      - name: KUBERNETES_REGISTRY_PULL_THROUGH_HOST
+        value: https://us-central1-docker.pkg.dev/v2/k8s-infra-e2e-scale-5k-project/k8s-5k-scale-cache/
+      - name: KUBERNETES_REGISTRY_PULL_THROUGH_BASIC_AUTH_TOKEN_PATH
+        value: /etc/registry-auth/token
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --cluster=gce-scale-cluster
+      # TODO: revert this after we get a green run with the pull-through-cache
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-96
       # TODO(mborsz): Adjust or remove this change once we understand coredns
       # memory usage regression.


### PR DESCRIPTION
this will go with https://github.com/kubernetes/kubernetes/pull/126448

TODO: 
- merge https://github.com/kubernetes/kubernetes/pull/126448 and make sure this works as intended (this can merge first)
- ~document this registry in github.com/kubernetes/k8s.io (it's very easy to setup, I just created a remote source repository with source `https://registry.k8s.io` which is one of the doc sample values, I set it to use-central1 because that's where jobs typically run, and I set a trivial 5d GC policy (to be iterated on))~  https://kubernetes.slack.com/archives/CCK68P2Q2/p1722376465155889 for now, will check into a repo later
- ~figure out locking down access (right now the pull through cache is public read, that won't do ...) https://github.com/kubernetes/kubernetes/blob/b5b21717cac7c02f2f754feb3e07b24a9d85a2fc/cluster/gce/gci/configure.sh#L607-L621 ... not sure how best to configure this yet when using mirrors ...~ done. we pass through auth now and only allow authenticated access