### PR TITLE
Include _GIT_TAG substitution in misc-images job.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,10 @@ steps:
   args:
   - -c
   - |
+    echo "$_GIT_TAG should match the tag in push-misc-images"
     go install github.com/google/ko@latest
     make push-misc-images REGISTRY=gcr.io/$PROJECT_ID
+substitutions:
+  _GIT_TAG: '12345'
 options:
   machineType: E2_HIGHCPU_32


### PR DESCRIPTION
Another attempt to fix the job, this time because of a missing substitution. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-misc-images-canary/1818067771527794688

`ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: generic::invalid_argument: key "_GIT_TAG" in the substitution data is not matched in the template`

ETA: Locally, this seems to fix the error.