### PR TITLE
reduce cores to scheduleable amount on test job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -381,10 +381,10 @@ presubmits:
           # TODO: increase CPU for the pull-kubernetes-e2e-gce, we spend a LONG time building kubernetes and it slows iteration
           resources:
             limits:
-              cpu: 8
+              cpu: 7
               memory: "14Gi"
             requests:
-              cpu: 8
+              cpu: 7
               memory: "14Gi"
           securityContext:
             privileged: true


### PR DESCRIPTION
follow up to https://github.com/kubernetes/test-infra/pull/33158

this job currently can't schedule, because k8s-infra-prow-builds has ~7.X schedulable cores per node

TODO: add a presubmit aware of cluster shapes?