### PR TITLE
capz: trigger CI tests on changes to scripts dir

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -267,7 +267,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decorate: true
     decoration_config:
       timeout: 4h
@@ -305,7 +305,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decoration_config:
       timeout: 4h
     max_concurrency: 5
@@ -348,7 +348,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decoration_config:
       timeout: 4h
     max_concurrency: 5
@@ -393,7 +393,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decoration_config:
       timeout: 4h
     max_concurrency: 5
@@ -437,7 +437,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decorate: true
     decoration_config:
       timeout: 4h
@@ -652,7 +652,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     optional: false
     decorate: true
-    run_if_changed: 'scripts\/ci-entrypoint.sh|scripts\/ci-build-azure-ccm.sh|scripts\/ci-build-kubernetes.sh|^hack/|templates\/test'
+    run_if_changed: '^scripts\/|^hack/|templates\/test'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
@@ -693,7 +693,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decoration_config:
       timeout: 4h
     max_concurrency: 5
@@ -740,7 +740,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|scripts\/ci-conformance.sh|scripts\/ci-build-kubernetes.sh|scripts\/ci-build-azure-ccm.sh|conformance.mk'
+    run_if_changed: 'test\/e2e\/conformance_test.go|templates\/test|^scripts\/|conformance.mk'
     decoration_config:
       timeout: 4h
     max_concurrency: 5


### PR DESCRIPTION
This PR adds more sensitive CAPZ test job triggers so that any changes to any files in the `scripts/` directory will invoke tests that rely upon those scripts.

The interdependencies between these scripts is pretty complex at this point and it's not really practical to identify specific files and correlate them with specific tests.