### PR TITLE
Revert "Increase resources for Prom to avoid OOM'ng"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -122,8 +122,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --cluster=gce-scale-cluster
-      # TODO: revert this after we get a green run with the pull-through-cache
-      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-96
+      - --env=HEAPSTER_MACHINE_TYPE=e2-standard-32
       # TODO(mborsz): Adjust or remove this change once we understand coredns
       # memory usage regression.
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi


### PR DESCRIPTION
This reverts commit 03bedf97ddecb383a93a9e9b2f79a59e68848fa3.

follow up re: https://github.com/kubernetes/kubernetes/issues/126366

where we determined the root issue to be registry rate limits, and mitigated that