### PR TITLE
Bump pull-boskos-build-test-verify to use golang 1.22.5

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.22.3
+          - image: public.ecr.aws/docker/library/golang:1.22.5
             imagePullPolicy: Always
             command:
               - make


### PR DESCRIPTION
Needed for bumping versions in https://github.com/kubernetes-sigs/boskos/pull/199