### PR TITLE
increase resource request for periodic coverage test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -198,11 +198,11 @@ periodics:
           exit $result
       resources:
         limits:
-          cpu: 2
-          memory: "9Gi"
+          cpu: 10
+          memory: "16Gi"
         requests:
-          cpu: 2
-          memory: "9Gi"
+          cpu: 10
+          memory: "16Gi"
       securityContext:
         privileged: true
 - name: periodic-cluster-api-provider-azure-e2e-main


### PR DESCRIPTION
- This PR increases resource limits and resource requests for `periodic-cluster-api-provider-azure-coverage`.
- `periodic-cluster-api-provider-azure-coverage` has been failing with `level=error msg="Running error: context loading failed: failed to load packages: failed to load with go/packages: couldn't run 'go': context deadline exceeded"` error. Comparing it with its counter part: PR coverage test https://github.com/kubernetes/test-infra/blob/36e8ae3b40a69b8beb293c7c5e8d7112ba87fe49/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml#L36-L42, we see that the resource limits are higher.
- Updating the `resource.limits.cpu` & `resource.requests.cpu` to `10` since default `concurrency` (NumCPU) for golangci-lint is set to `10`.