### PR TITLE
Fix misc-image push to have git directory.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -335,6 +335,7 @@ postsubmits:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
           - --build-dir=.
+          - --with-git-dir
           - .
 
     #


### PR DESCRIPTION
See note at the bottom of
https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#prow-config-template. The `post-test-infra-push-misc-images-canary` job is currently failing with:

`time="2024-07-31T18:11:37Z" level=error msg="fatal: not a git repository (or any parent up to mount point /)\nStopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\n" args="[rev-parse --show-toplevel]" cmd=git time="2024-07-31T18:11:37Z" level=error msg="Failed getting git root dir" error="exit status 128"`

I think this is the actual last fix we need for this to work, fingers crossed.