### PR TITLE
Revert "Bumping Prow and Boskos"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -1318,7 +1318,7 @@ periodics:
         - --ttl=6h
         - --path=s3://provider-aws-test-infra/objs.json
         - --region=us-east-1
-        image: gcr.io/k8s-staging-boskos/aws-janitor:v20240731-da026bb
+        image: gcr.io/k8s-staging-boskos/aws-janitor:v20240416-59dbd6c
         resources:
           requests:
             cpu: 1

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -10,7 +10,7 @@ periodics:
     testgrid-tab-name: api-review-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -58,7 +58,7 @@ periodics:
     testgrid-tab-name: stable-metrics-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -97,7 +97,7 @@ periodics:
     testgrid-tab-name: cla
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -140,7 +140,7 @@ periodics:
     testgrid-tab-name: close-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -201,7 +201,7 @@ periodics:
     testgrid-tab-name: close-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -258,7 +258,7 @@ periodics:
     description: Automatically /retest for approved PRs that are failing tests
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -326,7 +326,7 @@ periodics:
     testgrid-tab-name: rotten-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -387,7 +387,7 @@ periodics:
     testgrid-tab-name: rotten-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -445,7 +445,7 @@ periodics:
     testgrid-tab-name: stale-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -506,7 +506,7 @@ periodics:
     testgrid-tab-name: stale-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -564,7 +564,7 @@ periodics:
     testgrid-tab-name: thaw-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -612,7 +612,7 @@ periodics:
     testgrid-tab-name: re-triage
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -661,7 +661,7 @@ periodics:
     testgrid-tab-name: re-triage-important
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -711,7 +711,7 @@ periodics:
     testgrid-tab-name: re-triage-critical
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/commenter:v20240729-5ecc23f8fa
       command:
       - commenter
       args:
@@ -762,7 +762,7 @@ periodics:
     description: Creates github issues based on data from various 'IssueSource's.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/issue-creator:v20240731-a5d9345e59
+    - image: gcr.io/k8s-prow/issue-creator:v20240729-5ecc23f8fa
       command:
       - issue-creator
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -38,7 +38,7 @@ postsubmits:
       serviceAccountName: k8s-testgrid-config-updater
       containers:
       # TODO: Switch this to use the k8s-staging-infra-tools/k8s-infra image instead.
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-prow/configurator:v20240729-5ecc23f8fa
         command:
         - configurator
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
@@ -8,7 +8,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+      image: gcr.io/k8s-prow/label_sync:v20240729-5ecc23f8fa
       command:
       - label_sync
       args:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -14,7 +14,7 @@ periodics:
       args:
       - --ttl=12h
       - --path=s3://k8s-infra-kops-scale-tests/objs.json
-      image: gcr.io/k8s-staging-boskos/aws-janitor:v20240731-da026bb
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20240416-59dbd6c
       resources:
         requests:
           cpu: 1

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -15,7 +15,7 @@ periodics:
       - --ttl=6h
       - --path=s3://cloud-provider-aws-shared-e2e/objs.json
       - --exclude-tags=Shared=Ignore
-      image: gcr.io/k8s-staging-boskos/aws-janitor:v20240731-da026bb
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20240416-59dbd6c
       resources:
         requests:
           cpu: 1
@@ -43,7 +43,7 @@ periodics:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json
       - --exclude-tags=Shared=Ignore
-      image: gcr.io/k8s-staging-boskos/aws-janitor:v20240731-da026bb
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20240416-59dbd6c
   annotations:
     testgrid-dashboards: sig-testing-maintenance
     testgrid-tab-name: ci-aws-janitor

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -168,7 +168,7 @@ postsubmits:
       serviceAccountName: gencred-refresher
       containers:
       - name: gencred
-        image: gcr.io/k8s-prow/gencred:v20240731-a5d9345e59
+        image: gcr.io/k8s-prow/gencred:v20240729-5ecc23f8fa
         command:
         - gencred
         args:
@@ -268,7 +268,7 @@ periodics:
     serviceAccountName: gencred-refresher
     containers:
     - name: gencred
-      image: gcr.io/k8s-prow/gencred:v20240731-a5d9345e59
+      image: gcr.io/k8s-prow/gencred:v20240729-5ecc23f8fa
       command:
       - gencred
       args:

--- a/config/prow/cluster/build/boskos-janitor.yaml
+++ b/config/prow/cluster/build/boskos-janitor.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor-nongke
-        image: gcr.io/k8s-staging-boskos/janitor:v20240731-da026bb
+        image: gcr.io/k8s-staging-boskos/janitor:v20240416-59dbd6c
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-presubmit-5k-project,scalability-project,node-e2e-project
@@ -47,7 +47,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-aws
-        image: gcr.io/k8s-staging-boskos/aws-janitor-boskos:v20240731-da026bb
+        image: gcr.io/k8s-staging-boskos/aws-janitor-boskos:v20240416-59dbd6c
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
 ---

--- a/config/prow/cluster/build/boskos-reaper_deployment.yaml
+++ b/config/prow/cluster/build/boskos-reaper_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-staging-boskos/reaper:v20240731-da026bb
+        image: gcr.io/k8s-staging-boskos/reaper:v20240416-59dbd6c
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-presubmit-5k-project,scalability-project,aws-account,node-e2e-project

--- a/config/prow/cluster/build/boskos.yaml
+++ b/config/prow/cluster/build/boskos.yaml
@@ -199,7 +199,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-staging-boskos/boskos:v20240731-da026bb
+        image: gcr.io/k8s-staging-boskos/boskos:v20240416-59dbd6c
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/config/prow/cluster/halogen.yaml
+++ b/config/prow/cluster/halogen.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: halogen
       containers:
       - name: halogen
-        image: gcr.io/k8s-prow/analyze:v20240731-a5d9345e59
+        image: gcr.io/k8s-prow/analyze:v20240729-5ecc23f8fa
         args:
         - --project=k8s-prow
         - --region=us-central1

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+              image: gcr.io/k8s-prow/label_sync:v20240729-5ecc23f8fa
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+        image: gcr.io/k8s-prow/label_sync:v20240729-5ecc23f8fa
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true


### PR DESCRIPTION
Issue with aws-janitor image, gotta revert...

https://storage.googleapis.com/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1818777530593710080/build-log.txt
```
/app: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /app)
/app: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /app)
```

This reverts commit 0f10152900604976984ba68a8d342a8bd69a9050.