### PR TITLE
Bump ci-boskos-build-test-verify to use golang 1.22.5

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
@@ -7,7 +7,7 @@ postsubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.21.4
+          - image: public.ecr.aws/docker/library/golang:1.22.5
             imagePullPolicy: Always
             command:
               - make


### PR DESCRIPTION
forgot to update this when updating https://github.com/kubernetes/test-infra/commit/064cb8c783ff6aed9b2f4b0dd8bc0293b25521d2